### PR TITLE
Set hitLocation when return status is not -1

### DIFF
--- a/src/combat.cc
+++ b/src/combat.cc
@@ -5476,10 +5476,12 @@ static void _draw_loc_(int eventCode, int color)
 static int calledShotSelectHitLocation(Object* critter, int* hitLocation, int hitMode)
 {
     if (critter == nullptr) {
+        *hitLocation = HIT_LOCATION_HEAD;
         return 0;
     }
 
     if (critter->pid >> 24 != OBJ_TYPE_CRITTER) {
+        *hitLocation = HIT_LOCATION_HEAD;
         return 0;
     }
 


### PR DESCRIPTION
In some cases function `calledShotSelectHitLocation` can return not a `-1` value but not to set `hitLocation`. This causes undefined behavior when `hitLocation` is used later, and it can cause the game to crash with segfault because `hitLocation` is used as array index later.

This PR ensures that if `calledShotSelectHitLocation` function reports a success then `hitLocation` value will always be set

Originally reported in https://www.nma-fallout.com/threads/fallout-nevada-and-sonora-in-the-browser.222617/#post-4529005