### PR TITLE
Engine versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -391,3 +391,6 @@ FodyWeavers.xsd
 # CMake
 /out
 /build
+
+# versioning header
+src/platform/git_version.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,9 @@ else()
     add_executable(${EXECUTABLE_NAME} WIN32 MACOSX_BUNDLE)
 endif()
 
+# Git Info
+include("cmake/gitver.cmake")
+
 target_sources(${EXECUTABLE_NAME} PUBLIC
     "src/actions.cc"
     "src/actions.h"

--- a/cmake/gitver.cmake
+++ b/cmake/gitver.cmake
@@ -1,0 +1,48 @@
+# Get author name
+execute_process(
+    COMMAND git log -1 --pretty=format:%an
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE AUTHOR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# Get current branch
+execute_process(
+    COMMAND git branch --show-current
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE BRANCH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# Get hash of the latest commit
+execute_process(
+    COMMAND git log --pretty=format:%h -n 1
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# Get last tag
+execute_process(
+    COMMAND git describe --tags --abbrev=0
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE LATEST_TAG
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# Get date of the latest commit
+execute_process(
+    COMMAND git log -1 --date=format:"%b %d %Y %H:%M:%S" --pretty=format:%cd
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE DATE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# Define a variable for CI_BUILD
+set(CI_BUILD 0)
+
+# Create git_version.h file
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/platform/git_version.h.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/platform/git_version.h
+)

--- a/src/game.cc
+++ b/src/game.cc
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include "platform/git_version.h"
 
 #include "actions.h"
 #include "animation.h"
@@ -67,7 +68,6 @@
 #include "window_manager.h"
 #include "window_manager_private.h"
 #include "worldmap.h"
-#include "platform/git_version.h"
 
 namespace fallout {
 

--- a/src/game.cc
+++ b/src/game.cc
@@ -67,6 +67,7 @@
 #include "window_manager.h"
 #include "window_manager_private.h"
 #include "worldmap.h"
+#include "platform/git_version.h"
 
 namespace fallout {
 
@@ -88,7 +89,8 @@ static void showSplash();
 static char _aGame_0[] = "game\\";
 
 // 0x5020B8
-static char _aDec11199816543[] = VERSION_BUILD_TIME;
+static char _aBuildDate[] = _BUILD_DATE;
+static char _aBuildHash[] = _BUILD_HASH;
 
 // 0x5186B4
 static bool gGameUiDisabled = false;
@@ -927,7 +929,8 @@ int gameHandleKey(int eventCode, bool isInCombatMode)
             char version[VERSION_MAX];
             versionGetVersion(version, sizeof(version));
             displayMonitorAddMessage(version);
-            displayMonitorAddMessage(_aDec11199816543);
+            displayMonitorAddMessage(_aBuildHash);
+            displayMonitorAddMessage(_aBuildDate);
         }
         break;
     case KEY_ARROW_LEFT:

--- a/src/game.cc
+++ b/src/game.cc
@@ -1,8 +1,8 @@
 #include "game.h"
+#include "platform/git_version.h"
 
 #include <stdio.h>
 #include <string.h>
-#include "platform/git_version.h"
 
 #include "actions.h"
 #include "animation.h"

--- a/src/mainmenu.cc
+++ b/src/mainmenu.cc
@@ -18,6 +18,8 @@
 #include "version.h"
 #include "window_manager.h"
 
+#include "platform/git_version.h"
+
 namespace fallout {
 
 #define MAIN_MENU_WINDOW_WIDTH 640
@@ -152,7 +154,17 @@ int mainMenuWindowInit()
     char version[VERSION_MAX];
     versionGetVersion(version, sizeof(version));
     len = fontGetStringWidth(version);
-    windowDrawText(gMainMenuWindow, version, 0, 615 - len, 460, fontSettings | 0x06000000);
+    windowDrawText(gMainMenuWindow, version, 0, 615 - len, 440, fontSettings | 0x06000000);
+
+    char commitHash[VERSION_MAX] = "BUILD HASH: ";
+    strcat(commitHash, _BUILD_HASH);
+    len = fontGetStringWidth(commitHash);
+    windowDrawText(gMainMenuWindow, commitHash, 0, 615 - len, 450, fontSettings | 0x06000000);
+
+    char buildDate[VERSION_MAX] = "DATE: ";
+    strcat(buildDate, _BUILD_DATE);
+    len = fontGetStringWidth(buildDate);
+    windowDrawText(gMainMenuWindow, buildDate, 0, 615 - len, 460, fontSettings | 0x06000000);
 
     // menuup.frm
     fid = buildFid(OBJ_TYPE_INTERFACE, 299, 0, 0, 0);

--- a/src/platform/git_version.h.in
+++ b/src/platform/git_version.h.in
@@ -1,0 +1,9 @@
+#pragma once
+
+#define _BUILD_AUTHOR "@AUTHOR@"
+#define _BUILD_BRANCH "@BRANCH@"
+#define _BUILD_HASH   "@HASH@"
+#define _BUILD_VER    "@LATEST_TAG@"
+#define _BUILD_DATE   @DATE@
+
+#define CI_BUILD @CI_BUILD@

--- a/src/version.h
+++ b/src/version.h
@@ -11,7 +11,6 @@ namespace fallout {
 #define VERSION_MAJOR (1)
 #define VERSION_MINOR (2)
 #define VERSION_RELEASE ('R')
-#define VERSION_BUILD_TIME ("Dec 11 1998 16:54:30")
 
 void versionGetVersion(char* dest, size_t size);
 


### PR DESCRIPTION
Makes engine display some info about itself.
1. Commit hash that was used as source for code.
2. Date, when commit was made.
![25_01_02_23_594](https://github.com/user-attachments/assets/4066af06-e12a-47e6-a78c-5c95512a9b52)
![25_01_02_25_373](https://github.com/user-attachments/assets/7529f927-f95b-4432-a010-e6be928bf42e)
