### PR TITLE
Pvs studio fixes

### DIFF
--- a/src/art.cc
+++ b/src/art.cc
@@ -633,11 +633,11 @@ char* artBuildFilePath(int fid)
     v5 = (v2 & 0xF000) >> 12;
     type = FID_TYPE(v2);
 
-    if (v3 >= gArtListDescriptions[type].fileNamesLength) {
+    if (type < OBJ_TYPE_ITEM || type >= OBJ_TYPE_COUNT) {
         return nullptr;
     }
 
-    if (type < OBJ_TYPE_ITEM || type >= OBJ_TYPE_COUNT) {
+    if (v3 >= gArtListDescriptions[type].fileNamesLength) {
         return nullptr;
     }
 

--- a/src/art.cc
+++ b/src/art.cc
@@ -525,7 +525,7 @@ int artCopyFileName(int objectType, int id, char* dest)
 {
     ArtListDescription* ptr;
 
-    if (objectType < OBJ_TYPE_ITEM && objectType >= OBJ_TYPE_COUNT) {
+    if (objectType < OBJ_TYPE_ITEM || objectType >= OBJ_TYPE_COUNT) {
         return -1;
     }
 

--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -7250,7 +7250,7 @@ static int customKarmaFolderGetFrmId()
             return entry.frmId;
         }
     }
-    return gCustomKarmaFolderDescriptions.end()->frmId;
+    return gCustomKarmaFolderDescriptions.back().frmId;
 }
 
 static void customTownReputationInit()


### PR DESCRIPTION
src/character_editor.cc 7253 err V783 Dereferencing of the invalid iterator 'gCustomKarmaFolderDescriptions.end()' might take place.
src/art.cc 636 err V781 The value of the 'type' variable is checked after it was used. Perhaps there is a mistake in program logic. Check lines: 636, 640.
src/art.cc 528 err V547 Expression is always false.

https://github.com/alexbatalov/fallout2-ce/issues/433