### PR TITLE
Keep original scrolling coefficient for main game scrolling

### DIFF
--- a/src/mouse.cc
+++ b/src/mouse.cc
@@ -411,8 +411,9 @@ void _mouse_info()
                 if (!touch_get_pan_mode() && gesture.numberOfTouches == 1) {
                     _mouse_simulate_input(gesture.x - prevx, gesture.y - prevy, 0);
                 } else if (touch_get_pan_mode() || gesture.numberOfTouches == 2) {
-                    gMouseWheelX = (prevx - gesture.x) / 8;
-                    gMouseWheelY = (gesture.y - prevy) / 8;
+                    int coefficient = touch_get_pan_mode() ? 8 : 2;
+                    gMouseWheelX = (prevx - gesture.x) / coefficient;
+                    gMouseWheelY = (gesture.y - prevy) / coefficient;
 
                     if (gMouseWheelX != 0 || gMouseWheelY != 0) {
                         gMouseEvent |= MOUSE_EVENT_WHEEL;


### PR DESCRIPTION
I discovered that original coefficient was more comfortable for main game scrolling https://github.com/alexbatalov/fallout2-ce/blob/main/src/mouse.cc#L414