### PR TITLE
Add Windows XP x86 support

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -300,13 +300,13 @@ jobs:
 
       - name: Build
         run: |
-          cmake --build --preset windows-${{ matrix.arch }}-debug
+          cmake --build --preset windows-${{ matrix.arch }} --config RelWithDebInfo
 
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
           name: fallout2-ce-windows-${{ matrix.arch }}
-          path:  out/build/windows-${{ matrix.arch }}/Debug/fallout2-ce.exe
+          path:  out/build/windows-${{ matrix.arch }}/RelWithDebInfo/fallout2-ce-${{ matrix.arch }}.exe
           retention-days: 7
 
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -306,7 +306,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: fallout2-ce-windows-${{ matrix.arch }}
-          path:  out/build/windows-${{ matrix.arch }}/RelWithDebInfo/fallout2-ce-${{ matrix.arch }}.exe
+          path:  out/build/windows-${{ matrix.arch }}/RelWithDebInfo/fallout2-ce.exe
           retention-days: 7
 
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -306,7 +306,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: fallout2-ce-windows-${{ matrix.arch }}
-          path:  out/build/windows-${{ matrix.arch }}/Release/fallout2-ce-${{ matrix.arch }}.exe
+          path:  out/build/windows-${{ matrix.arch }}/RelWithDebInfo/fallout2-ce-${{ matrix.arch }}.exe
           retention-days: 7
 
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -300,13 +300,13 @@ jobs:
 
       - name: Build
         run: |
-          cmake --build --preset windows-${{ matrix.arch }} --config RelWithDebInfo
+          cmake --build --preset windows-${{ matrix.arch }}-release
 
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
           name: fallout2-ce-windows-${{ matrix.arch }}
-          path:  out/build/windows-${{ matrix.arch }}/RelWithDebInfo/fallout2-ce-${{ matrix.arch }}.exe
+          path:  out/build/windows-${{ matrix.arch }}/Release/fallout2-ce-${{ matrix.arch }}.exe
           retention-days: 7
 
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -43,7 +43,10 @@
                 "windows-base"
             ],
             "generator": "Visual Studio 16 2019",
-            "architecture": "x64"
+            "architecture": "x64",
+            "cacheVariables": {
+                "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded$<$<CONFIG:Debug>:Debug>"
+            }
         },
         {
             "name": "linux-base",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -29,7 +29,13 @@
                 "windows-base"
             ],
             "generator": "Visual Studio 16 2019",
-            "architecture": "Win32"
+            "architecture": "Win32",
+            "cacheVariables": {
+                "CMAKE_GENERATOR_TOOLSET": "v141_xp",
+                "CMAKE_C_FLAGS": "/D_WIN32_WINNT=0x0501",
+                "CMAKE_CXX_FLAGS": "/D_WIN32_WINNT=0x0501",
+                "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded$<$<CONFIG:Debug>:Debug>"
+            }
         },
         {
             "name": "windows-x64",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -150,7 +150,7 @@
         {
             "name": "windows-x86-release",
             "configurePreset": "windows-x86",
-            "configuration": "Release"
+            "configuration": "RelWithDebInfo"
         },
         {
             "name": "windows-x64-debug",
@@ -160,7 +160,7 @@
         {
             "name": "windows-x64-release",
             "configurePreset": "windows-x64",
-            "configuration": "Release"
+            "configuration": "RelWithDebInfo"
         },
         {
             "name": "linux-x86-debug",

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -1,8 +1,8 @@
 #include "interface.h"
 
+#include <algorithm>
 #include <stdio.h>
 #include <string.h>
-#include <algorithm>
 
 #include "animation.h"
 #include "art.h"

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <algorithm>
 
 #include "animation.h"
 #include "art.h"

--- a/src/platform_compat.cc
+++ b/src/platform_compat.cc
@@ -14,14 +14,12 @@
 #endif
 
 #ifdef _WIN32
-// clang-format off
 #include <windows.h>
 #ifdef _WIN64
 #include <timeapi.h>
 #else
 #include <mmsystem.h>
 #endif
-// clang-format on
 #else
 #include <chrono>
 #endif

--- a/src/platform_compat.cc
+++ b/src/platform_compat.cc
@@ -3,10 +3,6 @@
 #include <string.h>
 
 #ifdef _WIN32
-#include <mmsystem.h>
-#endif
-
-#ifdef _WIN32
 #include <direct.h>
 #include <io.h>
 #include <stdio.h>
@@ -18,7 +14,7 @@
 #endif
 
 #ifdef _WIN32
-#include <timeapi.h>
+#include <mmsystem.h>
 #else
 #include <chrono>
 #endif

--- a/src/platform_compat.cc
+++ b/src/platform_compat.cc
@@ -14,17 +14,14 @@
 #endif
 
 #ifdef _WIN32
+// clang-format off
+#include <windows.h>
 #ifdef _WIN64
 #include <timeapi.h>
 #else
-// clang-format off
-// #define WIN32_LEAN_AND_MEAN
-// #define NOMINMAX
-// typedef unsigned int MMRESULT;
-#include <windows.h>
 #include <mmsystem.h>
-// clang-format on
 #endif
+// clang-format on
 #else
 #include <chrono>
 #endif

--- a/src/platform_compat.cc
+++ b/src/platform_compat.cc
@@ -14,7 +14,11 @@
 #endif
 
 #ifdef _WIN32
+#ifdef _WIN64
+#include <timeapi.h>
+#else
 #include <mmsystem.h>
+#endif
 #else
 #include <chrono>
 #endif

--- a/src/platform_compat.cc
+++ b/src/platform_compat.cc
@@ -3,7 +3,7 @@
 #include <string.h>
 
 #ifdef _WIN32
-#include <windows.h>
+#include <mmsystem.h>
 #endif
 
 #ifdef _WIN32

--- a/src/platform_compat.cc
+++ b/src/platform_compat.cc
@@ -16,6 +16,8 @@
 #ifdef _WIN32
 #ifdef _WIN64
 // clang-format off
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <windows.h>
 #include <timeapi.h>
 // clang-format on

--- a/src/platform_compat.cc
+++ b/src/platform_compat.cc
@@ -15,7 +15,10 @@
 
 #ifdef _WIN32
 #ifdef _WIN64
+// clang-format off
+#include <windows.h>
 #include <timeapi.h>
+// clang-format on
 #else
 #include <mmsystem.h>
 #endif

--- a/src/platform_compat.cc
+++ b/src/platform_compat.cc
@@ -18,6 +18,7 @@
 // clang-format off
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
+typedef unsigned int MMRESULT;
 #include <windows.h>
 #include <timeapi.h>
 // clang-format on

--- a/src/platform_compat.cc
+++ b/src/platform_compat.cc
@@ -15,15 +15,15 @@
 
 #ifdef _WIN32
 #ifdef _WIN64
-// clang-format off
-#define WIN32_LEAN_AND_MEAN
-#define NOMINMAX
-typedef unsigned int MMRESULT;
-#include <windows.h>
 #include <timeapi.h>
-// clang-format on
 #else
+// clang-format off
+// #define WIN32_LEAN_AND_MEAN
+// #define NOMINMAX
+// typedef unsigned int MMRESULT;
+#include <windows.h>
 #include <mmsystem.h>
+// clang-format on
 #endif
 #else
 #include <chrono>

--- a/src/text_object.cc
+++ b/src/text_object.cc
@@ -1,7 +1,7 @@
 #include "text_object.h"
 
-#include <string.h>
 #include <algorithm>
+#include <string.h>
 
 #include "debug.h"
 #include "draw.h"

--- a/src/text_object.cc
+++ b/src/text_object.cc
@@ -1,6 +1,7 @@
 #include "text_object.h"
 
 #include <string.h>
+#include <algorithm>
 
 #include "debug.h"
 #include "draw.h"


### PR DESCRIPTION
This PR is done via vibe coding


Additionally, this PR changes CI checks into Release mode (for Windows only) because debug versions needs `MSVCP140D.dll`

![image](https://github.com/user-attachments/assets/67270e8a-0803-4f73-83ce-8af43bf2436e)


![image](https://github.com/user-attachments/assets/27d820d9-0ac3-4010-8a7d-f63f631c805b)
