### PR TITLE
QoL: increased node expansion while pathing

### DIFF
--- a/src/animation.cc
+++ b/src/animation.cc
@@ -304,7 +304,7 @@ static bool _anim_in_bk = false;
 // 0x530014
 static AnimationSad gAnimationSads[ANIMATION_SAD_LIST_CAPACITY];
 
-#define PATH_NODE_CAPACITY 2000
+#define PATH_NODE_CAPACITY 10000
 
 // 0x542FD4
 static PathNode gClosedPathNodeList[PATH_NODE_CAPACITY];

--- a/src/animation.cc
+++ b/src/animation.cc
@@ -1791,7 +1791,7 @@ int pathfinderFindPath(Object* object, int from, int to, unsigned char* rotation
         closedPathNodeListLength += 1;
 
         if (closedPathNodeListLength == PATH_NODE_CAPACITY) {
-            //Search path node capacity exhausted
+            // Search path node capacity exhausted
             return 0;
         }
 

--- a/src/animation.cc
+++ b/src/animation.cc
@@ -304,8 +304,10 @@ static bool _anim_in_bk = false;
 // 0x530014
 static AnimationSad gAnimationSads[ANIMATION_SAD_LIST_CAPACITY];
 
+#define PATH_NODE_CAPACITY 2000
+
 // 0x542FD4
-static PathNode gClosedPathNodeList[2000];
+static PathNode gClosedPathNodeList[PATH_NODE_CAPACITY];
 
 // 0x54CC14
 static AnimationSequence gAnimationSequences[32];
@@ -314,7 +316,7 @@ static AnimationSequence gAnimationSequences[32];
 static unsigned char gPathfinderProcessedTiles[5000];
 
 // 0x562B9C
-static PathNode gOpenPathNodeList[2000];
+static PathNode gOpenPathNodeList[PATH_NODE_CAPACITY];
 
 // 0x56C7DC
 static int gAnimationDescriptionCurrentIndex;
@@ -1740,7 +1742,7 @@ int pathfinderFindPath(Object* object, int from, int to, unsigned char* rotation
     gOpenPathNodeList[0].estimate = _tile_idistance(from, to);
     gOpenPathNodeList[0].cost = 0;
 
-    for (int index = 1; index < 2000; index += 1) {
+    for (int index = 1; index < PATH_NODE_CAPACITY; index += 1) {
         gOpenPathNodeList[index].tile = -1;
     }
 
@@ -1788,7 +1790,8 @@ int pathfinderFindPath(Object* object, int from, int to, unsigned char* rotation
 
         closedPathNodeListLength += 1;
 
-        if (closedPathNodeListLength == 2000) {
+        if (closedPathNodeListLength == PATH_NODE_CAPACITY) {
+            //Search path node capacity exhausted
             return 0;
         }
 
@@ -1809,7 +1812,7 @@ int pathfinderFindPath(Object* object, int from, int to, unsigned char* rotation
             }
 
             int v25 = 0;
-            for (; v25 < 2000; v25++) {
+            for (; v25 < PATH_NODE_CAPACITY; v25++) {
                 if (gOpenPathNodeList[v25].tile == -1) {
                     break;
                 }
@@ -1817,7 +1820,7 @@ int pathfinderFindPath(Object* object, int from, int to, unsigned char* rotation
 
             openPathNodeListLength += 1;
 
-            if (openPathNodeListLength == 2000) {
+            if (openPathNodeListLength == PATH_NODE_CAPACITY) {
                 return 0;
             }
 


### PR DESCRIPTION
It's annoying to see a place you can walk to but still get the hex 'x' because path expansion exhausted limited node capacity. Increased memory usage and execution time are non-issues on modern and even non-modern systems by today's standards.