### PR TITLE
Fixed AI loading single-rounds in magazines.

### DIFF
--- a/src/combat_ai.cc
+++ b/src/combat_ai.cc
@@ -2733,7 +2733,7 @@ static int _ai_try_attack(Object* attacker, Object* defender)
             // out of ammo
             int roundsLoaded = 0;
             if (aiHaveAmmo(attacker, weapon, &ammo)) {
-                for (;;) {
+                while (aiHaveAmmo(attacker, weapon, &ammo)) {
                     int remainingAmmoQuantity = weaponReload(weapon, ammo);
                     if (remainingAmmoQuantity == 0 && ammo != nullptr) {
                         _obj_destroy(ammo);

--- a/src/combat_ai.cc
+++ b/src/combat_ai.cc
@@ -2731,13 +2731,19 @@ static int _ai_try_attack(Object* attacker, Object* defender)
         int reason = _combat_check_bad_shot(attacker, defender, hitMode, false);
         if (reason == COMBAT_BAD_SHOT_NO_AMMO) {
             // out of ammo
+            int roundsLoaded = 0;
             if (aiHaveAmmo(attacker, weapon, &ammo)) {
-                int remainingAmmoQuantity = weaponReload(weapon, ammo);
-                if (remainingAmmoQuantity == 0 && ammo != nullptr) {
-                    _obj_destroy(ammo);
+                for (;;) {
+                    int remainingAmmoQuantity = weaponReload(weapon, ammo);
+                    if (remainingAmmoQuantity == 0 && ammo != nullptr) {
+                        _obj_destroy(ammo);
+                        ++roundsLoaded;
+                    } else {
+                        break;
+                    }
                 }
 
-                if (remainingAmmoQuantity != -1) {
+                if (roundsLoaded > 0) {
                     int volume = _gsound_compute_relative_volume(attacker);
                     const char* sfx = sfxBuildWeaponName(WEAPON_SOUND_EFFECT_READY, weapon, hitMode, nullptr);
                     _gsound_play_sfx_file_volume(sfx, volume);
@@ -2920,22 +2926,30 @@ void aiAttemptWeaponReload(Object* critter, int animate)
 
     int ammoQuantity = ammoGetQuantity(weapon);
     int ammoCapacity = ammoGetCapacity(weapon);
+    int loadedRounds = 0;
     if (ammoQuantity < ammoCapacity) {
-        Object* ammo;
-        if (aiHaveAmmo(critter, weapon, &ammo)) {
-            int rc = weaponReload(weapon, ammo);
-            if (rc == 0) {
-                _obj_destroy(ammo);
-            }
-
-            if (rc != -1 && objectIsPartyMember(critter)) {
-                int volume = _gsound_compute_relative_volume(critter);
-                const char* sfx = sfxBuildWeaponName(WEAPON_SOUND_EFFECT_READY, weapon, HIT_MODE_RIGHT_WEAPON_PRIMARY, nullptr);
-                _gsound_play_sfx_file_volume(sfx, volume);
-
-                if (animate) {
-                    _ai_magic_hands(critter, weapon, 5002);
+        for (int i = 0; i < (ammoCapacity - ammoQuantity); ++i) {
+            Object* ammo;
+            if (aiHaveAmmo(critter, weapon, &ammo)) {
+                int rc = weaponReload(weapon, ammo);
+                if (rc == 0) {
+                    _obj_destroy(ammo);
+                    ++loadedRounds;
+                } else {
+                    break;
                 }
+            } else {
+                break;
+            }
+        }
+
+        if (loadedRounds != 0 && objectIsPartyMember(critter)) {
+            int volume = _gsound_compute_relative_volume(critter);
+            const char* sfx = sfxBuildWeaponName(WEAPON_SOUND_EFFECT_READY, weapon, HIT_MODE_RIGHT_WEAPON_PRIMARY, nullptr);
+            _gsound_play_sfx_file_volume(sfx, volume);
+
+            if (animate) {
+                _ai_magic_hands(critter, weapon, 5002);
             }
         }
     }


### PR DESCRIPTION
IIRC, the "unit" for things like 10mm ammo in F1 used to be a dozen (12x). In F2CE, the unit of ammo seems to be a single round. Prior to this patch, AI companions (in my case, the Mercenary in Sonora) would reload a single round into their weapon when they run out, so turns in combat become a loop of fire, reload, fire, reload, etc.

With this patch, AI reloading keeps inserting ammo into the weapon until capacity is reached or the critter runs out of ammo.