### PR TITLE
Update mainmenu.cc for Stretching

### DIFF
--- a/src/mainmenu.cc
+++ b/src/mainmenu.cc
@@ -35,13 +35,13 @@ typedef enum MainMenuButton {
 } MainMenuButton;
 
 static int main_menu_fatal_error();
-static void main_menu_play_sound(const char *fileName);
+static void main_menu_play_sound(const char* fileName);
 
 // 0x5194F0
 static int gMainMenuWindow = -1;
 
 // 0x5194F4
-static unsigned char *gMainMenuWindowBuffer = nullptr;
+static unsigned char* gMainMenuWindowBuffer = nullptr;
 
 // 0x519504
 static bool _in_main_menu = false;
@@ -54,18 +54,22 @@ static unsigned int gMainMenuScreensaverDelay = 120000;
 
 // 0x519510
 static const int gMainMenuButtonKeyBindings[MAIN_MENU_BUTTON_COUNT] = {
-    KEY_LOWERCASE_I, // intro
-    KEY_LOWERCASE_N, // new game
-    KEY_LOWERCASE_L, // load game
-    KEY_LOWERCASE_O, // options
-    KEY_LOWERCASE_C, // credits
-    KEY_LOWERCASE_E, // exit
+  KEY_LOWERCASE_I, // intro
+  KEY_LOWERCASE_N, // new game
+  KEY_LOWERCASE_L, // load game
+  KEY_LOWERCASE_O, // options
+  KEY_LOWERCASE_C, // credits
+  KEY_LOWERCASE_E, // exit
 };
 
 // 0x519528
 static const int _return_values[MAIN_MENU_BUTTON_COUNT] = {
-    MAIN_MENU_INTRO,   MAIN_MENU_NEW_GAME, MAIN_MENU_LOAD_GAME,
-    MAIN_MENU_OPTIONS, MAIN_MENU_CREDITS,  MAIN_MENU_EXIT,
+  MAIN_MENU_INTRO,
+  MAIN_MENU_NEW_GAME,
+  MAIN_MENU_LOAD_GAME,
+  MAIN_MENU_OPTIONS,
+  MAIN_MENU_CREDITS,
+  MAIN_MENU_EXIT,
 };
 
 // 0x614840
@@ -79,7 +83,8 @@ static FrmImage _mainMenuButtonNormalFrmImage;
 static FrmImage _mainMenuButtonPressedFrmImage;
 
 // 0x481650
-int mainMenuWindowInit() {
+int mainMenuWindowInit()
+{
   int fid;
   MessageListItem msg;
   int len;
@@ -99,8 +104,8 @@ int mainMenuWindowInit() {
   Config config;
   if (configInit(&config)) {
     if (configRead(&config, "f2_res.ini", false)) {
-      configGetInt(&config, "STATIC_SCREENS", "MAIN_MENU_SIZE",
-                   &menuStretchMode);
+      configGetInt(
+          &config, "STATIC_SCREENS", "MAIN_MENU_SIZE", &menuStretchMode);
     }
     configFree(&config);
   }
@@ -114,8 +119,8 @@ int mainMenuWindowInit() {
   int scaledHeight = originalHeight;
 
   // Figure out how to stretch the menu depending on resolution + settings
-  if (menuStretchMode != 0 || screenWidth < originalWidth ||
-      screenHeight < originalHeight) {
+  if (menuStretchMode != 0 || screenWidth < originalWidth
+      || screenHeight < originalHeight) {
     if (menuStretchMode == 2) {
       // Fullscreen stretch
       scaledWidth = screenWidth;
@@ -136,9 +141,8 @@ int mainMenuWindowInit() {
   int mainMenuWindowX = (screenWidth - scaledWidth) / 2;
   int mainMenuWindowY = (screenHeight - scaledHeight) / 2;
 
-  gMainMenuWindow =
-      windowCreate(mainMenuWindowX, mainMenuWindowY, scaledWidth, scaledHeight,
-                   0, WINDOW_HIDDEN | WINDOW_MOVE_ON_TOP);
+  gMainMenuWindow = windowCreate(mainMenuWindowX, mainMenuWindowY, scaledWidth,
+      scaledHeight, 0, WINDOW_HIDDEN | WINDOW_MOVE_ON_TOP);
   if (gMainMenuWindow == -1) {
     return main_menu_fatal_error();
   }
@@ -151,10 +155,10 @@ int mainMenuWindowInit() {
     return main_menu_fatal_error();
   }
 
-  unsigned char *backgroundData = _mainMenuBackgroundFrmImage.getData();
+  unsigned char* backgroundData = _mainMenuBackgroundFrmImage.getData();
 
   // Clone the background so we can draw text on it (before scaling)
-  unsigned char *compositeBuffer = reinterpret_cast<unsigned char *>(
+  unsigned char* compositeBuffer = reinterpret_cast<unsigned char*>(
       SDL_malloc(originalWidth * originalHeight));
   if (!compositeBuffer) {
     return main_menu_fatal_error();
@@ -168,23 +172,22 @@ int mainMenuWindowInit() {
   fontSetCurrent(100);
   int fontColor = _colorTable[21091], sfallOverride = 0;
   configGetInt(&gSfallConfig, SFALL_CONFIG_MISC_KEY,
-               SFALL_CONFIG_MAIN_MENU_FONT_COLOR_KEY, &sfallOverride);
+      SFALL_CONFIG_MAIN_MENU_FONT_COLOR_KEY, &sfallOverride);
   if (sfallOverride && !(sfallOverride & 0x010000))
     fontColor = sfallOverride & 0xFF;
 
   int offsetX = 0, offsetY = 0;
   configGetInt(&gSfallConfig, SFALL_CONFIG_MISC_KEY,
-               SFALL_CONFIG_MAIN_MENU_CREDITS_OFFSET_X_KEY, &offsetX);
+      SFALL_CONFIG_MAIN_MENU_CREDITS_OFFSET_X_KEY, &offsetX);
   configGetInt(&gSfallConfig, SFALL_CONFIG_MISC_KEY,
-               SFALL_CONFIG_MAIN_MENU_CREDITS_OFFSET_Y_KEY, &offsetY);
+      SFALL_CONFIG_MAIN_MENU_CREDITS_OFFSET_Y_KEY, &offsetY);
 
   msg.num = 20;
   if (messageListGetItem(&gMiscMessageList, &msg)) {
-    fontDrawText(compositeBuffer +
-                     (offsetY + originalHeight - 20) * originalWidth + offsetX +
-                     15,
-                 msg.text, originalWidth - offsetX - 15, originalWidth,
-                 fontColor | 0x06000000);
+    fontDrawText(compositeBuffer
+            + (offsetY + originalHeight - 20) * originalWidth + offsetX + 15,
+        msg.text, originalWidth - offsetX - 15, originalWidth,
+        fontColor | 0x06000000);
   }
 
   // Draw version number (bottom right)
@@ -194,32 +197,32 @@ int mainMenuWindowInit() {
   char version[VERSION_MAX];
   versionGetVersion(version, sizeof(version));
   len = fontGetStringWidth(version);
-  fontDrawText(compositeBuffer + (originalHeight - 40) * originalWidth +
-                   (originalWidth - 25 - len),
-               version, originalWidth - (originalWidth - 25 - len),
-               originalWidth, fontColor | 0x06000000);
+  fontDrawText(compositeBuffer + (originalHeight - 40) * originalWidth
+          + (originalWidth - 25 - len),
+      version, originalWidth - (originalWidth - 25 - len), originalWidth,
+      fontColor | 0x06000000);
 
   char commitHash[VERSION_MAX] = "BUILD HASH: ";
   strcat(commitHash, _BUILD_HASH);
   len = fontGetStringWidth(commitHash);
-  fontDrawText(compositeBuffer + (originalHeight - 30) * originalWidth +
-                   (originalWidth - 25 - len),
-               commitHash, originalWidth - (originalWidth - 25 - len),
-               originalWidth, fontColor | 0x06000000);
+  fontDrawText(compositeBuffer + (originalHeight - 30) * originalWidth
+          + (originalWidth - 25 - len),
+      commitHash, originalWidth - (originalWidth - 25 - len), originalWidth,
+      fontColor | 0x06000000);
 
   char buildDate[VERSION_MAX] = "DATE: ";
   strcat(buildDate, _BUILD_DATE);
   len = fontGetStringWidth(buildDate);
-  fontDrawText(compositeBuffer + (originalHeight - 20) * originalWidth +
-                   (originalWidth - 25 - len),
-               buildDate, originalWidth - (originalWidth - 25 - len),
-               originalWidth, fontColor | 0x06000000);
+  fontDrawText(compositeBuffer + (originalHeight - 20) * originalWidth
+          + (originalWidth - 25 - len),
+      buildDate, originalWidth - (originalWidth - 25 - len), originalWidth,
+      fontColor | 0x06000000);
 
   // Draw Main Menu labels for buttons (Start, Load, Exit...)
   fontSetCurrent(104);
   fontColor = _colorTable[21091];
   configGetInt(&gSfallConfig, SFALL_CONFIG_MISC_KEY,
-               SFALL_CONFIG_MAIN_MENU_BIG_FONT_COLOR_KEY, &sfallOverride);
+      SFALL_CONFIG_MAIN_MENU_BIG_FONT_COLOR_KEY, &sfallOverride);
   if (sfallOverride)
     fontColor = sfallOverride & 0xFF;
 
@@ -230,13 +233,13 @@ int mainMenuWindowInit() {
       int textX = 126 - (len / 2);
       int textY = 20 + index * 42 - index;
       fontDrawText(compositeBuffer + textY * originalWidth + textX, msg.text,
-                   originalWidth - textX, originalWidth, fontColor);
+          originalWidth - textX, originalWidth, fontColor);
     }
   }
 
   // Stretch and blit the text+background into our menu window
   if (scaledWidth != originalWidth || scaledHeight != originalHeight) {
-    unsigned char *stretched = reinterpret_cast<unsigned char *>(
+    unsigned char* stretched = reinterpret_cast<unsigned char*>(
         SDL_malloc(scaledWidth * scaledHeight));
     if (!stretched) {
       SDL_free(compositeBuffer);
@@ -244,25 +247,24 @@ int mainMenuWindowInit() {
     }
 
     blitBufferToBufferStretch(compositeBuffer, originalWidth, originalHeight,
-                              originalWidth, stretched, scaledWidth,
-                              scaledHeight, scaledWidth);
+        originalWidth, stretched, scaledWidth, scaledHeight, scaledWidth);
 
     // Fix the edge pixels to avoid glitches
     for (int y = 0; y < scaledHeight; y++) {
-      stretched[y * scaledWidth + (scaledWidth - 1)] =
-          stretched[y * scaledWidth + (scaledWidth - 2)];
+      stretched[y * scaledWidth + (scaledWidth - 1)]
+          = stretched[y * scaledWidth + (scaledWidth - 2)];
     }
     for (int x = 0; x < scaledWidth; x++) {
-      stretched[(scaledHeight - 1) * scaledWidth + x] =
-          stretched[(scaledHeight - 2) * scaledWidth + x];
+      stretched[(scaledHeight - 1) * scaledWidth + x]
+          = stretched[(scaledHeight - 2) * scaledWidth + x];
     }
 
     blitBufferToBuffer(stretched, scaledWidth, scaledHeight, scaledWidth,
-                       gMainMenuWindowBuffer, scaledWidth);
+        gMainMenuWindowBuffer, scaledWidth);
     SDL_free(stretched);
   } else {
     blitBufferToBuffer(compositeBuffer, originalWidth, originalHeight,
-                       originalWidth, gMainMenuWindowBuffer, scaledWidth);
+        originalWidth, gMainMenuWindowBuffer, scaledWidth);
   }
 
   SDL_free(compositeBuffer);
@@ -292,56 +294,54 @@ int mainMenuWindowInit() {
   int buttonWidth = static_cast<int>(buttonBaseWidth * buttonScale);
   int buttonHeight = static_cast<int>(buttonBaseHeight * buttonScale);
 
-  unsigned char *scaledNormal =
-      reinterpret_cast<unsigned char *>(SDL_malloc(buttonWidth * buttonHeight));
-  unsigned char *scaledPressed =
-      reinterpret_cast<unsigned char *>(SDL_malloc(buttonWidth * buttonHeight));
+  unsigned char* scaledNormal = reinterpret_cast<unsigned char*>(
+      SDL_malloc(buttonWidth * buttonHeight));
+  unsigned char* scaledPressed = reinterpret_cast<unsigned char*>(
+      SDL_malloc(buttonWidth * buttonHeight));
   if (!scaledNormal || !scaledPressed) {
     return main_menu_fatal_error();
   }
 
   // Stretch the button images
   blitBufferToBufferStretch(_mainMenuButtonNormalFrmImage.getData(),
-                            buttonBaseWidth, buttonBaseHeight, buttonBaseWidth,
-                            scaledNormal, buttonWidth, buttonHeight,
-                            buttonWidth);
+      buttonBaseWidth, buttonBaseHeight, buttonBaseWidth, scaledNormal,
+      buttonWidth, buttonHeight, buttonWidth);
   blitBufferToBufferStretch(_mainMenuButtonPressedFrmImage.getData(),
-                            buttonBaseWidth, buttonBaseHeight, buttonBaseWidth,
-                            scaledPressed, buttonWidth, buttonHeight,
-                            buttonWidth);
+      buttonBaseWidth, buttonBaseHeight, buttonBaseWidth, scaledPressed,
+      buttonWidth, buttonHeight, buttonWidth);
 
   // Fix the edge pixels to avoid glitches
   for (int y = 0; y < buttonHeight; y++) {
-    scaledPressed[y * buttonWidth + (buttonWidth - 1)] =
-        scaledPressed[y * buttonWidth + (buttonWidth - 2)];
-    scaledNormal[y * buttonWidth + (buttonWidth - 1)] =
-        scaledNormal[y * buttonWidth + (buttonWidth - 2)];
+    scaledPressed[y * buttonWidth + (buttonWidth - 1)]
+        = scaledPressed[y * buttonWidth + (buttonWidth - 2)];
+    scaledNormal[y * buttonWidth + (buttonWidth - 1)]
+        = scaledNormal[y * buttonWidth + (buttonWidth - 2)];
   }
   for (int x = 0; x < buttonWidth; x++) {
-    scaledPressed[(buttonHeight - 1) * buttonWidth + x] =
-        scaledPressed[(buttonHeight - 2) * buttonWidth + x];
-    scaledNormal[(buttonHeight - 1) * buttonWidth + x] =
-        scaledNormal[(buttonHeight - 2) * buttonWidth + x];
+    scaledPressed[(buttonHeight - 1) * buttonWidth + x]
+        = scaledPressed[(buttonHeight - 2) * buttonWidth + x];
+    scaledNormal[(buttonHeight - 1) * buttonWidth + x]
+        = scaledNormal[(buttonHeight - 2) * buttonWidth + x];
   }
 
   // Apply any user-configured button offsets from Sfall (for button position
   // tweaking)
   offsetX = offsetY = 0;
   configGetInt(&gSfallConfig, SFALL_CONFIG_MISC_KEY,
-               SFALL_CONFIG_MAIN_MENU_OFFSET_X_KEY, &offsetX);
+      SFALL_CONFIG_MAIN_MENU_OFFSET_X_KEY, &offsetX);
   configGetInt(&gSfallConfig, SFALL_CONFIG_MISC_KEY,
-               SFALL_CONFIG_MAIN_MENU_OFFSET_Y_KEY, &offsetY);
+      SFALL_CONFIG_MAIN_MENU_OFFSET_Y_KEY, &offsetY);
   offsetX = static_cast<int>(offsetX * scaleX);
   offsetY = static_cast<int>(offsetY * scaleY);
 
   // Create the actual buttons
   for (int index = 0; index < MAIN_MENU_BUTTON_COUNT; index++) {
-    gMainMenuButtons[index] = buttonCreate(
-        gMainMenuWindow, offsetX + static_cast<int>(30 * scaleX),
-        offsetY + static_cast<int>((19 + index * 42 - index) * scaleY),
-        buttonWidth, buttonHeight, -1, -1, 1111,
-        gMainMenuButtonKeyBindings[index], scaledNormal, scaledPressed, nullptr,
-        BUTTON_FLAG_TRANSPARENT);
+    gMainMenuButtons[index]
+        = buttonCreate(gMainMenuWindow, offsetX + static_cast<int>(30 * scaleX),
+            offsetY + static_cast<int>((19 + index * 42 - index) * scaleY),
+            buttonWidth, buttonHeight, -1, -1, 1111,
+            gMainMenuButtonKeyBindings[index], scaledNormal, scaledPressed,
+            nullptr, BUTTON_FLAG_TRANSPARENT);
     if (gMainMenuButtons[index] == -1) {
       return main_menu_fatal_error();
     }
@@ -356,7 +356,8 @@ int mainMenuWindowInit() {
 }
 
 // 0x481968
-void mainMenuWindowFree() {
+void mainMenuWindowFree()
+{
   if (!gMainMenuWindowInitialized) {
     return;
   }
@@ -379,7 +380,8 @@ void mainMenuWindowFree() {
 }
 
 // 0x481A00
-void mainMenuWindowHide(bool animate) {
+void mainMenuWindowHide(bool animate)
+{
   if (!gMainMenuWindowInitialized) {
     return;
   }
@@ -402,7 +404,8 @@ void mainMenuWindowHide(bool animate) {
 }
 
 // 0x481A48
-void mainMenuWindowUnhide(bool animate) {
+void mainMenuWindowUnhide(bool animate)
+{
   if (!gMainMenuWindowInitialized) {
     return;
   }
@@ -426,7 +429,8 @@ void mainMenuWindowUnhide(bool animate) {
 int _main_menu_is_enabled() { return 1; }
 
 // 0x481AEC
-int mainMenuWindowHandleEvents() {
+int mainMenuWindowHandleEvents()
+{
   _in_main_menu = true;
 
   bool oldCursorIsHidden = cursorIsHidden();
@@ -444,16 +448,16 @@ int mainMenuWindowHandleEvents() {
 
     for (int buttonIndex = 0; buttonIndex < MAIN_MENU_BUTTON_COUNT;
          buttonIndex++) {
-      if (keyCode == gMainMenuButtonKeyBindings[buttonIndex] ||
-          keyCode == toupper(gMainMenuButtonKeyBindings[buttonIndex])) {
+      if (keyCode == gMainMenuButtonKeyBindings[buttonIndex]
+          || keyCode == toupper(gMainMenuButtonKeyBindings[buttonIndex])) {
         // NOTE: Uninline.
         main_menu_play_sound("nmselec1");
 
         rc = _return_values[buttonIndex];
 
-        if (buttonIndex == MAIN_MENU_BUTTON_CREDITS &&
-            (gPressedPhysicalKeys[SDL_SCANCODE_RSHIFT] != KEY_STATE_UP ||
-             gPressedPhysicalKeys[SDL_SCANCODE_LSHIFT] != KEY_STATE_UP)) {
+        if (buttonIndex == MAIN_MENU_BUTTON_CREDITS
+            && (gPressedPhysicalKeys[SDL_SCANCODE_RSHIFT] != KEY_STATE_UP
+                || gPressedPhysicalKeys[SDL_SCANCODE_LSHIFT] != KEY_STATE_UP)) {
           rc = MAIN_MENU_QUOTES;
         }
 
@@ -511,7 +515,8 @@ int mainMenuWindowHandleEvents() {
 // NOTE: Inlined.
 //
 // 0x481C88
-static int main_menu_fatal_error() {
+static int main_menu_fatal_error()
+{
   mainMenuWindowFree();
 
   return -1;
@@ -520,7 +525,8 @@ static int main_menu_fatal_error() {
 // NOTE: Inlined.
 //
 // 0x481C94
-static void main_menu_play_sound(const char *fileName) {
+static void main_menu_play_sound(const char* fileName)
+{
   soundPlayFile(fileName);
 }
 


### PR DESCRIPTION
Another test for Clang - this uses latest version (20.1.3), though it is ahead of the version we are testing for.

Applies stretching to main menu based off MAIN_MENU_SIZE=1 in f2_res.ini

Supports Fulscreen stretching (2) and maintaining aspect ration (1) -- falls back to default with (0) or no ini entry

Stretches background + buttons + text