### PR TITLE
Temp workaround: add commit hash for web interface

### DIFF
--- a/.github/workflows/ci-build-web.yml
+++ b/.github/workflows/ci-build-web.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: fallout2-ce/fallout2-ce-ems
-          hash: 8dc61ba6e8e62116f4810ffe89d0cece00f508d7
+          ref: 8dc61ba6e8e62116f4810ffe89d0cece00f508d7
           path: fallout2-ce-ems
 
       - name: Set deployment path

--- a/.github/workflows/ci-build-web.yml
+++ b/.github/workflows/ci-build-web.yml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: fallout2-ce/fallout2-ce-ems
+          hash: 8dc61ba6e8e62116f4810ffe89d0cece00f508d7
           path: fallout2-ce-ems
 
       - name: Set deployment path


### PR DESCRIPTION
Right now web interface builds failing. This PR adds a last working commit for web UI.

Revert this PR when web UI issue is fixed