### PR TITLE
Remove floaters when moving to a new world map location

### DIFF
--- a/src/map.cc
+++ b/src/map.cc
@@ -1248,12 +1248,16 @@ int mapHandleTransition()
     if (gMapTransition.map == -1) {
         if (!isInCombat()) {
             animationStop();
-            wmTownMap();
+            // SFALL: Remove text floaters when moving to the world map
+            textObjectsReset();
+            wmTownMap(); // nb this is a world map transition
             memset(&gMapTransition, 0, sizeof(gMapTransition));
         }
     } else if (gMapTransition.map == -2) {
         if (!isInCombat()) {
             animationStop();
+            // SFALL: Remove text floaters when moving to the world map
+            textObjectsReset();
             wmWorldMap();
             memset(&gMapTransition, 0, sizeof(gMapTransition));
         }


### PR DESCRIPTION
Fixes #115

### Description

Clear floating text on other types of transitions

### Reproduction Steps and Savefile (if available)

See issue details

If you want to test in depth, making the text last a lot longer is helpful:

```
diff --git a/src/text_object.cc b/src/text_object.cc
index a851c8e..03fb276 100644
--- a/src/text_object.cc
+++ b/src/text_object.cc
@@ -335,7 +335,7 @@ static void textObjectsTicker()
     for (int index = 0; index < gTextObjectsCount; index++) {
         TextObject* textObject = gTextObjects[index];
 
-        unsigned int delay = gTextObjectsLineDelay * textObject->linesCount + gTextObjectsBaseDelay;
+        unsigned int delay = gTextObjectsLineDelay * textObject->linesCount + gTextObjectsBaseDelay*10;
         if ((textObject->flags & TEXT_OBJECT_MARKED_FOR_REMOVAL) != 0 || (getTicksBetween(_get_bk_time(), textObject->time) > delay)) {
             tileToScreenXY(textObject->tile, &(textObject->x), &(textObject->y), gElevation);
             textObject->x += textObject->sx;
```