### PR TITLE
Update worldmap.cc

### DIFF
--- a/src/worldmap.cc
+++ b/src/worldmap.cc
@@ -4390,12 +4390,12 @@ static void wmInterfaceScrollTabsStart(int delta)
     // in the disabled state.
     if (delta >= 0) {
         if (wmGenData.tabsOffsetY < wmGenData.tabsBackgroundFrmImage.getHeight() - 230) {
-            wmGenData.oldTabsOffsetY = std::min(wmGenData.tabsOffsetY + 7 * delta, wmGenData.tabsBackgroundFrmImage.getHeight() - 230);
+            wmGenData.oldTabsOffsetY = std::min(wmGenData.tabsOffsetY + delta, wmGenData.tabsBackgroundFrmImage.getHeight() - 230);
             wmGenData.tabsScrollingDelta = delta;
         }
     } else {
         if (wmGenData.tabsOffsetY > 0) {
-            wmGenData.oldTabsOffsetY = std::max(wmGenData.tabsOffsetY + 7 * delta, 0);
+            wmGenData.oldTabsOffsetY = std::max(wmGenData.tabsOffsetY + delta, 0);
             wmGenData.tabsScrollingDelta = delta;
         }
     }


### PR DESCRIPTION
### Description

Reduced scrolling from 7! lines at a time, to 1. This also makes mouse scrolling actually work as it should as well.

### Reproduction Steps and Savefile (if available)

Use the scroll (arrow) buttons on the World Map location list. Try before and after.

Fixes #123