### PR TITLE
Fix visibility of city circles and names

### DIFF
--- a/src/worldmap.cc
+++ b/src/worldmap.cc
@@ -5227,8 +5227,9 @@ static int wmInterfaceRefresh()
             CitySizeDescription* citySizeDescription = &(wmSphereData[cityInfo->size]);
             int cityX = cityInfo->x - wmWorldOffsetX;
             int cityY = cityInfo->y - wmWorldOffsetY;
-            if (cityX >= 0 && cityX <= 472 - citySizeDescription->frmImage.getWidth()
-                && cityY >= 0 && cityY <= 465 - citySizeDescription->frmImage.getHeight()) {
+            // Modified check to draw circle if any part of it is visible on screen
+            if (cityX + citySizeDescription->frmImage.getWidth() > 0 && cityX < 472
+                && cityY + citySizeDescription->frmImage.getHeight() > 0 && cityY < 465) {
                 wmInterfaceDrawCircleOverlay(cityInfo, citySizeDescription, wmBkWinBuf, cityX, cityY);
             }
         }
@@ -5401,7 +5402,7 @@ static int wmInterfaceDrawCircleOverlay(CityInfo* city, CitySizeDescription* cit
 
     // CE: Slightly increase whitespace between cirle and city name.
     int nameY = y + citySizeDescription->frmImage.getHeight() + 3;
-    int maxY = 464 - fontGetLineHeight();
+    int maxY = 464;
     if (nameY < maxY) {
         MessageListItem messageListItem;
         char name[40];


### PR DESCRIPTION
### Description

Currently, cities are not drawn until at least half of it is onscreen, meaning they "pop in" suddenly.  This fixes that problem.

Also, the check for city name was too aggressive, meaning the name of small cities (e.g. Motel in Sonora) would fail to render near the bottom of the screen.

### Reproduction Steps and Savefile (if available)

Scroll around worldmap until a city is halfway obscured.  It will disappear (see #130)

### Screenshots

Example from #130 :

<img width="533" alt="image" src="https://github.com/user-attachments/assets/5522a9d4-4dc9-4cdd-bcb2-3c5f22f1e740" />


Fixes #130 