### PR TITLE
QoL: Add Ctrl-click to move items in inventory, barter, looting/stealing

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,17 @@ The third configuration file is `ddraw.ini` (part of Sfall). There are dozens of
 
 For a sample ddraw.ini configuration file, containing all currently working settings use this link: [ddraw.ini](https://raw.githubusercontent.com/fallout2-ce/fallout2-ce/refs/heads/main/files/ddraw.ini)
 
+## Quality of life benefits over vanilla Fallout
+
+* High resolution support
+* Increased pathfinding nodes 5x for more accurate pathfinding
+* Ctrl-click to quickly move items when bartering, looting, or stealing
+* _a_ to select "all" when selecting item quantity
+* _a_ to `Take All` when looting
+* When bartering, caps default to the right amount to balance the trade (if possible)
+* Music continues playing between maps (requires config)
+* Auto open doors (requires config)
+
 ## Contributing
 
 Integrating Sfall goodies is the top priority. Quality of life updates are OK too. Please no large scale refactorings at this time as we need to reconcile changes from Reference Edition, which will make this process slow and error-prone. In any case open up an issue with your suggestion or to notify other people that something is being worked on.

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -4142,7 +4142,6 @@ int _gdCustomSelect(int a1)
     if (btn2 != -1) {
         buttonSetCallbacks(btn2, _gsound_red_butt_press, _gsound_red_butt_release);
     }
-
     
     fontSetCurrent(103);
 
@@ -4186,7 +4185,7 @@ int _gdCustomSelect(int a1)
                 STRUCT_5189E4* ptr = &(_custom_settings[a1][value]);
                 _custom_current_selected[a1] = value;
                 _gdCustomUpdateSetting(a1, ptr->value);
-                if (keyCode != 500){
+                if (keyCode != 500) {
                     soundPlayFile("ib1p1xx1");
                 }
                 done = true;
@@ -4364,7 +4363,7 @@ int _gdialog_window_create()
 
             // BARTER/TRADE - button moved here to set above background window
             _gdialog_buttons[0] = buttonCreate(gGameDialogWindow, 593, 41, 14, 14, -1, -1, -1, -1, _redButtonNormalFrmImage.getData(), _redButtonPressedFrmImage.getData(), nullptr, BUTTON_FLAG_TRANSPARENT);
-            
+
             if (_dialogue_just_started) {
                 windowRefresh(gGameDialogBackgroundWindow);
                 _gdialog_scroll_subwin(gGameDialogWindow, true, backgroundFrmData, windowBuf, nullptr, _dialogue_subwin_len, true);

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -4142,7 +4142,7 @@ int _gdCustomSelect(int a1)
     if (btn2 != -1) {
         buttonSetCallbacks(btn2, _gsound_red_butt_press, _gsound_red_butt_release);
     }
-    
+
     fontSetCurrent(103);
 
     MessageListItem messageListItem;

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -4816,7 +4816,7 @@ static void _barter_move_inventory(Object* item, int quantity, int slotIndex, in
 
     if (fromDude) {
         if (immediate || mouseHitTestInWindow(gInventoryWindow, INVENTORY_TRADE_INNER_LEFT_SCROLLER_TRACKING_X, INVENTORY_TRADE_INNER_LEFT_SCROLLER_TRACKING_Y, INVENTORY_TRADE_INNER_LEFT_SCROLLER_TRACKING_MAX_X, INVENTORY_SLOT_HEIGHT * gInventorySlotsCount + INVENTORY_TRADE_INNER_LEFT_SCROLLER_TRACKING_Y)) {
-            int quantityToMove =  _barter_get_quantity_moved_items(item, quantity, true, true, immediate);
+            int quantityToMove = _barter_get_quantity_moved_items(item, quantity, true, true, immediate);
             if (quantityToMove != -1) {
                 if (itemMoveForce(_inven_dude, sourceTable, item, quantityToMove) == -1) {
                     // There is no space left for that item.

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -4254,7 +4254,7 @@ int inventoryOpenLooting(Object* looter, Object* target)
             break;
         }
 
-        if (keyCode == KEY_UPPERCASE_A) {
+        if (keyCode == KEY_UPPERCASE_A || keyCode == KEY_LOWERCASE_A) {
             if (!_gIsSteal) {
                 int maxCarryWeight = critterGetStat(looter, STAT_CARRY_WEIGHT);
                 int currentWeight = objectGetInventoryWeight(looter);
@@ -4725,7 +4725,7 @@ static int _barter_attempt_transaction(Object* dude, Object* offerTable, Object*
 
 static int _barter_get_quantity_moved_items(Object* item, int maxQuantity, bool fromPlayer, bool fromInventory, bool immediate)
 {
-    if (maxQuantity <= 1 || immediate) {
+    if (maxQuantity <= 1) {
         return maxQuantity;
     }
 
@@ -4739,8 +4739,16 @@ static int _barter_get_quantity_moved_items(Object* item, int maxQuantity, bool 
 
         if ((balance < 0 && fromInventory) || (balance > 0 && !fromInventory)) {
             suggestedValue = std::min(std::abs(balance), maxQuantity);
+            if (immediate) {
+                return suggestedValue;
+            }
         }
     }
+
+    if (immediate) {
+        return maxQuantity;
+    }
+
     return inventoryQuantitySelect(INVENTORY_WINDOW_TYPE_MOVE_ITEMS, item, maxQuantity, suggestedValue);
 }
 
@@ -5612,7 +5620,7 @@ static int inventoryQuantitySelect(int inventoryWindowType, Object* item, int ma
             }
             break;
 
-        } else if (keyCode == 5000 || keyCode == 'a') {
+        } else if (keyCode == 5000 || keyCode == KEY_LOWERCASE_A) {
             isTyping = false;
             value = max;
             _draw_amount(value, inventoryWindowType);

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -5611,7 +5611,8 @@ static int inventoryQuantitySelect(int inventoryWindowType, Object* item, int ma
                 soundPlayFile("iisxxxx1");
             }
             break;
-        } else if (keyCode == 5000) {
+
+        } else if (keyCode == 5000 || keyCode == 'a') {
             isTyping = false;
             value = max;
             _draw_amount(value, inventoryWindowType);

--- a/src/pipboy.cc
+++ b/src/pipboy.cc
@@ -689,7 +689,7 @@ static int pipboyWindowInit(int intent)
 
     int y = 340;
     int eventCode = 500;
-    int yOffsets[] = {27, 27, 29, 25, 27};  // handles slighlty misaligned buttons on background
+    int yOffsets[] = { 27, 27, 29, 25, 27 }; // handles slighlty misaligned buttons on background
     for (int index = 0; index < 5; index += 1) {
         if (index != 1) {
             int btn = buttonCreate(gPipboyWindow,


### PR DESCRIPTION
### Description

Ctrl-click does a "fast move" of item when the destination is obvious, meaning you don't have to drag it.  This is especially helpful if you have multiple things to move (in practice this is one reason why `Take All` was added in F2)

Ctrl-click will automatically move the entire stack, so it's also a way of avoiding the item quantity screen.  The exception to this is when moving money in the barter screen, in which case the amount moved is the amount needed to balance the trade (this is much more useful than moving your entire stack of money).  In the future, we could add something like Ctrl-Shift-click for moving a single item from a stack.  

Barter: move from table (offer) to inventory and back, on both merchant and pc.
Looting/stealing: move from one side to the other.
Inventory: ctrl-click to unequip armor or item in hand.

This is pretty similar to the Sfall [feature](https://github.com/sfall-team/sfall/issues/526), though slightly less configurable (Sfall has separate configurable keys for "fast move" and "skip qty picker", which didn't seem needed to me).

Sfall also has a feature for ctrl-click to transfer from inventory to armor or hand slot.  I didn't do this because it's not always obvious which "hand" to transfer the item to.  Could be added in the future.

Bonus: there was a lot of repeated code in these functions, so the net change size is negative despite adding a bunch of comments.

### "a" shortcuts

I also fixed the shortcut _a_ to `Take All` and added _a_ to set qty to max in the quantity picker.
