### PR TITLE
Turn on hires stencils by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,12 +137,9 @@ In time this stuff will receive in-game interface, right now you have to do it m
 
 *Note*: use of the IFACE_BAR settings requires the f2_res.dat file, which contains graphical assets. Various versions are available, but one compatible with the above f2_res.ini be found here: [f2_res.dat](https://github.com/fallout2-ce/fallout2-ce/raw/refs/heads/mainmenu/files/f2_res.dat)
 
-The third configuration file is `ddraw.ini` (part of Sfall). There are dozens of options that adjust or override engine behaviour and gameplay mechanics. This file is intended for modders and advanced users. Currently only a small subset of these settings are actually implemented.  For high res configs, the following is recommended:
-```[Main]
-HiResMode=1
-```
-For a sample ddraw.ini configuration file, containing all currently working settings use this link: [ddraw.ini](https://raw.githubusercontent.com/fallout2-ce/fallout2-ce/refs/heads/mainmenu/files/ddraw.ini)
+The third configuration file is `ddraw.ini` (part of Sfall). There are dozens of options that adjust or override engine behaviour and gameplay mechanics. This file is intended for modders and advanced users.
 
+For a sample ddraw.ini configuration file, containing all currently working settings use this link: [ddraw.ini](https://raw.githubusercontent.com/fallout2-ce/fallout2-ce/refs/heads/main/files/ddraw.ini)
 
 ## Contributing
 

--- a/files/ddraw.ini
+++ b/files/ddraw.ini
@@ -3,8 +3,8 @@
 ;XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 [Main]
 
-;Set to one to hide areas outside map bounds when using higher than 640x480 resolution
-HiResMode=1
+;Set to one to hide areas outside map bounds when using higher than 640x480 resolution, and to zero to disable
+;HiResMode=1
 
 ;XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 [Misc]

--- a/src/sfall_config.h
+++ b/src/sfall_config.h
@@ -80,7 +80,7 @@ namespace fallout {
 #define SFALL_CONFIG_PIPBOY_AVAILABLE_AT_GAMESTART "PipBoyAvailableAtGameStart"
 #define SFALL_CONFIG_USE_WALK_DISTANCE "UseWalkDistance"
 #define SFALL_CONFIG_AUTO_OPEN_DOORS "AutoOpenDoors"
-#define SFALL_CONFIG_GAPLESS_MUSIC "GaplessMusic"
+#define SFALL_CONFIG_GAPLESS_MUSIC "GaplessMusic" // note: this isn't an sfall config
 
 #define SFALL_CONFIG_BURST_MOD_DEFAULT_CENTER_MULTIPLIER 1
 #define SFALL_CONFIG_BURST_MOD_DEFAULT_CENTER_DIVISOR 3

--- a/src/tile_hires_stencil.cc
+++ b/src/tile_hires_stencil.cc
@@ -63,7 +63,7 @@ static_assert(screen_view_width % (2 * square_width) == 0);
 // which is covered by squares but theoretically could be seen in the original game
 static_assert(screen_view_height % (2 * square_height) == 20);
 
-static bool gIsTileHiresStencilEnabled = false;
+static bool gIsTileHiresStencilEnabled = true;
 
 static void clean_cache()
 {


### PR DESCRIPTION
I can't think of a reason why someone would want to do hires without the stencils.  Nevertheless it's still turn off-able using `HiResMode=0` if desired.

In addition, updated the Readme to not mention it (since only very few people would care about turning it off), and fixed the link to the sample ddraw.ini
