### PR TITLE
Endslides Stretching

### DIFF
--- a/src/endgame.cc
+++ b/src/endgame.cc
@@ -91,7 +91,7 @@ static int originalHeight = ENDGAME_ENDING_WINDOW_HEIGHT;
 static int scaledWidth = ENDGAME_ENDING_WINDOW_WIDTH;
 static int scaledHeight = ENDGAME_ENDING_WINDOW_HEIGHT;
 
-// The number of lines in current subtitles file.
+// The number of lines in current subtitles file
 //
 // It's used as a length for two arrays:
 // - [gEndgameEndingSubtitles]


### PR DESCRIPTION
### Description

Adds stretching for 'Endslides'. Handles both regular slides, and panning slides. Stretching is controlled through `END_SLIDE_SIZE=` in `[STATIC_SCREENS]`of f2_res.ini. 0 for no stretching, 1 for aspect ration stretching, and 2 for fullscreen stretching. `STRETCH_GAME` override setting is also respected.

Panning slides can now be 'modded', meaning the panning slide number is no longer hardcoded. Settings in endgame.txt of Fallout 2:
`#408, 1, 327, nar_ar1, 1`
are still honored. Final entry (1) can be unset, 1 or -1, with 1,-1 setting the direction of the pan.

This PR relies on changes in #137 (draw.cc)

### Screenshots

![Screenshot 2025-05-19 at 7 28 20](https://github.com/user-attachments/assets/92cffbaf-58fc-43ea-91a1-549bd0cbaafb)

