### PR TITLE
Inventory Item not Disappearing Fix

### DIFF
--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -2312,7 +2312,7 @@ static void _inven_pickup(int buttonCode, int indexOffset)
         rect.top = INVENTORY_SLOT_HEIGHT * itemIndex + INVENTORY_SCROLLER_Y;
         break;
     }
-        
+
     // fix for disappearing/not disappearing inventory items
     if (itemIndex == -1 || _pud->items[_pud->length - (itemIndex + indexOffset + 1)].quantity <= 1) { // slots
         unsigned char* windowBuffer = windowGetBuffer(gInventoryWindow);

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -2312,8 +2312,9 @@ static void _inven_pickup(int buttonCode, int indexOffset)
         rect.top = INVENTORY_SLOT_HEIGHT * itemIndex + INVENTORY_SCROLLER_Y;
         break;
     }
-
-    if (itemIndex == -1 || _pud->items[indexOffset + itemIndex].quantity <= 1) { // slots
+        
+    // fix for disappearing/not disappearing inventory items
+    if (itemIndex == -1 || _pud->items[_pud->length - (itemIndex + indexOffset + 1)].quantity <= 1) { // slots
         unsigned char* windowBuffer = windowGetBuffer(gInventoryWindow);
         if (gInventoryRightHandItem != gInventoryLeftHandItem || item != gInventoryLeftHandItem) {
             int height;


### PR DESCRIPTION
Fixes #160 

Conditional was incorrect. Searched around for the correct setting for 'quantity', found that, used it, and the inventory 'moving' of items seems to be working correctly now.

