### PR TITLE
Character Screen Button Fix

### DIFF
--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -61,13 +61,13 @@ namespace fallout {
 #define TAG_SKILLS_BUTTON_Y 26
 #define TAG_SKILLS_BUTTON_CODE 536
 
-#define PRINT_BTN_X 364
+#define PRINT_BTN_X 363
 #define PRINT_BTN_Y 454
 
-#define DONE_BTN_X 476
+#define DONE_BTN_X 475
 #define DONE_BTN_Y 454
 
-#define CANCEL_BTN_X 572
+#define CANCEL_BTN_X 571
 #define CANCEL_BTN_Y 454
 
 #define NAME_BTN_CODE 517
@@ -1769,7 +1769,7 @@ static int characterEditorWindowInit()
 
     btn = buttonCreate(
         gCharacterEditorWindow,
-        343,
+        344, // one pixel right shift to align with background
         454,
         _editorFrmImages[EDITOR_GRAPHIC_LITTLE_RED_BUTTON_UP].getWidth(),
         _editorFrmImages[EDITOR_GRAPHIC_LITTLE_RED_BUTTON_UP].getHeight(),
@@ -1787,7 +1787,7 @@ static int characterEditorWindowInit()
 
     btn = buttonCreate(
         gCharacterEditorWindow,
-        552,
+        553, // one pixel right shift to align with background
         454,
         _editorFrmImages[EDITOR_GRAPHIC_LITTLE_RED_BUTTON_UP].getWidth(),
         _editorFrmImages[EDITOR_GRAPHIC_LITTLE_RED_BUTTON_UP].getHeight(),
@@ -1805,7 +1805,7 @@ static int characterEditorWindowInit()
 
     btn = buttonCreate(
         gCharacterEditorWindow,
-        455,
+        456, // one pixel right shift to align with background
         454,
         _editorFrmImages[23].getWidth(),
         _editorFrmImages[23].getHeight(),


### PR DESCRIPTION
Moved 3 bottom buttons 1 pixel to right. Affects both screens, and aligns them better to the baked in buttons. As per @NovaRain 's suggestion
Fixes #154 

### Description

Current mis-aligned buttons on character screens (only in game screen misaligned):

![Screenshot 2025-05-26 at 21 35 33](https://github.com/user-attachments/assets/f9ddd9d0-d28b-4a3e-a594-39adedaf0d3f)
![Screenshot 2025-05-26 at 21 35 20](https://github.com/user-attachments/assets/135aa2b6-44bc-4b44-954b-359eb7800578)

### Screenshots

Fix in game:

![Screenshot 2025-05-26 at 21 34 32](https://github.com/user-attachments/assets/41028602-db04-4fa2-8964-bba3e52c67b6)
![Screenshot 2025-05-26 at 21 34 17](https://github.com/user-attachments/assets/f2a43794-e069-4e02-85ed-b2b03f8a254d)

