### PR TITLE
Animations behind worldmap fix

### DIFF
--- a/src/worldmap.h
+++ b/src/worldmap.h
@@ -237,7 +237,6 @@ typedef enum Map {
 
 extern unsigned char* circleBlendTable;
 
-bool isWorldMapActive();
 int wmWorldMap_init();
 void wmWorldMap_exit();
 int wmWorldMap_reset();


### PR DESCRIPTION
### Description

This fixes idle animations that are sometimes playing behind the World Map, as described in #122 
Fixes #122

### Reproduction Steps and Savefile (if available)

Exiting and entering the map and waiting in the World Map is the only way to trigger the bug. It happens fairly randomly, but is happening.

This fix adds a global 'isWorldMapActive' then returns out of the idle animation if true.
