### PR TITLE
Fix bug that stopped music when reloading on the same map

### DIFF
--- a/src/game_sound.cc
+++ b/src/game_sound.cc
@@ -69,6 +69,7 @@ static bool gSoundEffectsEnabled = false;
 static int _gsound_active_effect_counter;
 
 // 0x518E50
+// background music
 static Sound* gBackgroundSound = nullptr;
 
 // 0x518E54
@@ -593,9 +594,32 @@ int backgroundSoundGetDuration()
     return soundGetDuration(gBackgroundSound);
 }
 
-// [fileName] is base file name, without path and extension.
-//
-// 0x45067C
+/* 
+    [fileName] is base file name, without path and extension.
+
+    a2
+        10 = don't auto play sound after load (unused?)
+        11 = set read limit before soundLoad, !11 = set after soundLoad
+        12 = usually used when value is not 11
+    a3 relates to sound type
+        13 = MEMORY
+        14 = STREAMING
+    a4 relates to sound flags
+        15 = fire and forget
+        16 = looping
+
+    examples:
+        backgroundSoundLoad("akiss", 12, 14, 15) (endgame)
+        backgroundSoundLoad("10labone", 11, 14, 16); (endgame)
+        backgroundSoundLoad(fileName, a2, 14, 16); (map music) // 11 = main menu music, 12 = map/world map music
+        backgroundSoundLoad("wind2", 12, 13, 16); (map load sound)
+
+        these use the last settings for a3/a4 that were passed to backgroundSoundLoad
+        backgroundSoundRestart(11); (end of of script)
+        backgroundSoundRestart(12); (game init, volume change)
+
+    0x45067C
+*/
 int backgroundSoundLoad(const char* fileName, int a2, int a3, int a4)
 {
     int rc;
@@ -750,7 +774,7 @@ int _gsound_background_play_level_music(const char* fileName, int a2)
 {
     int gaplessMusic = 0;
     configGetInt(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_GAPLESS_MUSIC, &gaplessMusic);
-    if (gaplessMusic) {
+    if (backgoundSoundIsPlaying() && gaplessMusic) {
         if (!strcmp(fileName, gBackgroundSoundFileName)) {
             return 0;
         }
@@ -800,6 +824,11 @@ void backgroundSoundResume()
     if (gBackgroundSound != nullptr) {
         soundResume(gBackgroundSound);
     }
+}
+
+// TODO: could be made more precise by querying the sound, checking volume, &c.
+bool backgoundSoundIsPlaying() {
+    return gBackgroundSound != nullptr;
 }
 
 // NOTE: Inlined.
@@ -1688,6 +1717,8 @@ void soundEffectCallback(void* userData, int a2)
 }
 
 // 0x451ADC
+// a2 relates to sound type
+// a3 relates to sound flags
 int _gsound_background_allocate(Sound** soundPtr, int a2, int a3)
 {
     int soundFlags = SOUND_FLAG_0x02 | SOUND_16BIT;

--- a/src/game_sound.h
+++ b/src/game_sound.h
@@ -53,6 +53,7 @@ void backgroundSoundDelete();
 void backgroundSoundRestart(int value);
 void backgroundSoundPause();
 void backgroundSoundResume();
+bool backgoundSoundIsPlaying();
 int speechIsEnabled();
 void speechSetVolume(int value);
 int speechGetVolume();

--- a/src/map.cc
+++ b/src/map.cc
@@ -822,7 +822,8 @@ static int mapLoad(File* stream)
     _map_save_in_game(true);
     int gaplessMusic = 0;
     configGetInt(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_GAPLESS_MUSIC, &gaplessMusic);
-    if (!gaplessMusic) {
+    if (backgoundSoundIsPlaying() && !gaplessMusic) {
+        // playing the loading sound might interrupt continuous music playback
         backgroundSoundLoad("wind2", 12, 13, 16);
     }
     isoDisable();

--- a/src/window_manager.cc
+++ b/src/window_manager.cc
@@ -110,7 +110,7 @@ static void* _GNW_texture;
 static ButtonGroup gButtonGroups[BUTTON_GROUP_LIST_CAPACITY];
 
 // 0x4D5C30
-int windowManagerInit(VideoSystemInitProc* videoSystemInitProc, VideoSystemExitProc* videoSystemExitProc, int a3)
+int windowManagerInit(VideoSystemInitProc* videoSystemInitProc, VideoSystemExitProc* videoSystemExitProc, int flags)
 {
 #ifdef _WIN32
     CloseHandle(GNW95_mutex);
@@ -163,7 +163,7 @@ int windowManagerInit(VideoSystemInitProc* videoSystemInitProc, VideoSystemExitP
         return WINDOW_MANAGER_ERR_8;
     }
 
-    if (a3 & 1) {
+    if (flags & 1) {
         _screen_buffer = (unsigned char*)internal_malloc((_scr_size.bottom - _scr_size.top + 1) * (_scr_size.right - _scr_size.left + 1));
         if (_screen_buffer == nullptr) {
             if (gVideoSystemExitProc != nullptr) {
@@ -205,7 +205,7 @@ int windowManagerInit(VideoSystemInitProc* videoSystemInitProc, VideoSystemExitP
 
     _GNW_debug_init();
 
-    if (inputInit(a3) == -1) {
+    if (inputInit(flags) == -1) {
         return WINDOW_MANAGER_ERR_INITIALIZING_INPUT;
     }
 
@@ -251,7 +251,7 @@ int windowManagerInit(VideoSystemInitProc* videoSystemInitProc, VideoSystemExitP
     _GNW_texture = nullptr;
     _bk_color = 0;
     _GNW_wcolor[0] = 10570;
-    _window_flags = a3;
+    _window_flags = flags;
     _GNW_wcolor[2] = 8456;
     _GNW_wcolor[1] = 15855;
 

--- a/src/window_manager.h
+++ b/src/window_manager.h
@@ -153,7 +153,7 @@ typedef void(VideoSystemExitProc)();
 extern bool gWindowSystemInitialized;
 extern int _GNW_wcolor[6];
 
-int windowManagerInit(VideoSystemInitProc* videoSystemInitProc, VideoSystemExitProc* videoSystemExitProc, int a3);
+int windowManagerInit(VideoSystemInitProc* videoSystemInitProc, VideoSystemExitProc* videoSystemExitProc, int flags);
 void windowManagerExit(void);
 int windowCreate(int x, int y, int width, int height, int color, int flags);
 void windowDestroy(int win);


### PR DESCRIPTION
If you have GaplessMusic=1 and load a saved game on the same map you're currently on, we erroneously skip playing music.  This fixes that problem.

Also, still playing loading sound if no background music is playing (not sure there can actually happen).  I still want to get the loading sound back in eventually.

Finally, added a bit of decyption.  It's not complete yet but has some deciphering

### Description

<!--- Clearly describe the changes introduced by this PR. What was fixed, added, or updated? --->

### Reproduction Steps and Savefile (if available)

<!--- Provide detailed steps to reproduce the issue. Include a savefile if applicable, preferrably for Sonora --->

### Screenshots

<!--- If the PR includes visual changes, add screenshots here. --->


<!--- 

**Important Notes** 

- *Preview builds are not available for pull requests from forked repositories.* To enable preview builds, submit the PR from a branch within this repository. 

- *Formatting issues? You have two options:*
1. **Fix formatting automatically** using the following Docker command: *(If you're using Windows, remove `--user $(id -u):$(id -g)`)* 
```bash
docker run --rm \
  -v $(pwd):/app --workdir /app  \
  --user $(id -u):$(id -g) silkeh/clang:18 \
  bash -c 'find src -type f -name \*.cc -o -name \*.h | xargs clang-format -i'
```
2. **Skip formatting check** by adding the `skip-formatting` label to this PR.

--->

