### PR TITLE
Add click when using `a` to `Take all` or move `All`

### DIFF
--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -1378,7 +1378,7 @@ static bool _setup_inventory(int inventoryWindowType)
                         41,
                         -1,
                         -1,
-                        KEY_UPPERCASE_A,
+                        2502,
                         -1,
                         _inventoryFrmImages[8].getData(),
                         _inventoryFrmImages[9].getData(),
@@ -4254,8 +4254,11 @@ int inventoryOpenLooting(Object* looter, Object* target)
             break;
         }
 
-        if (keyCode == KEY_UPPERCASE_A || keyCode == KEY_LOWERCASE_A) {
+        if (keyCode == 2502 || keyCode == KEY_LOWERCASE_A) {
             if (!_gIsSteal) {
+                if (keyCode == KEY_LOWERCASE_A) {
+                    soundPlayFile("ib1p1xx1");
+                }
                 int maxCarryWeight = critterGetStat(looter, STAT_CARRY_WEIGHT);
                 int currentWeight = objectGetInventoryWeight(looter);
                 int newInventoryWeight = objectGetInventoryWeight(target);
@@ -5621,6 +5624,9 @@ static int inventoryQuantitySelect(int inventoryWindowType, Object* item, int ma
             break;
 
         } else if (keyCode == 5000 || keyCode == KEY_LOWERCASE_A) {
+            if (keyCode == KEY_LOWERCASE_A) {
+                soundPlayFile("ib1p1xx1");
+            }
             isTyping = false;
             value = max;
             _draw_amount(value, inventoryWindowType);


### PR DESCRIPTION


### Description

Most other button make a sound when you use the keyboard shortcut, and so ought these.

### Reproduction Steps and Savefile (if available)

Loot a container and type `a`.  Or move a >1 qty stack, and type `a`
