### PR TITLE
Proper scrollwheel support in Perks/Karma/Kills folder

### DIFF
--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -883,17 +883,16 @@ int characterEditorShow(bool isCreationMode)
         int keyCode = inputGetInput();
 
         // check for mouse wheel over the "folder" area (perks/karma/kills)
-        if (keyCode == -1 && (mouseGetEvent() & MOUSE_EVENT_WHEEL) != 0 && !gCharacterEditorIsCreationMode &&
-            mouseHitTestInWindow(gCharacterEditorWindow, 34, 364, 314, 364 + 9 * (fontGetLineHeight() + 1))) {
-                int wheelX, wheelY;
-                mouseGetWheel(&wheelX, &wheelY);
-                if (wheelY > 0) { // Scroll up
-                    characterEditorFolderViewScroll(-1);
-                } else if (wheelY < 0) { // Scroll down
-                    characterEditorFolderViewScroll(1);
-                }
-                characterEditorDrawCard();
-                windowRefresh(gCharacterEditorWindow);
+        if (keyCode == -1 && (mouseGetEvent() & MOUSE_EVENT_WHEEL) != 0 && !gCharacterEditorIsCreationMode && mouseHitTestInWindow(gCharacterEditorWindow, 34, 364, 314, 364 + 9 * (fontGetLineHeight() + 1))) {
+            int wheelX, wheelY;
+            mouseGetWheel(&wheelX, &wheelY);
+            if (wheelY > 0) { // Scroll up
+                characterEditorFolderViewScroll(-1);
+            } else if (wheelY < 0) { // Scroll down
+                characterEditorFolderViewScroll(1);
+            }
+            characterEditorDrawCard();
+            windowRefresh(gCharacterEditorWindow);
         } else {
             convertMouseWheelToArrowKey(&keyCode);
         }


### PR DESCRIPTION
### Description

Currently the scroll wheel is quite funky on the character screen, and doesn't work nicely to scroll these "folder" windows.  This makes it work smoothly (tested with a trackpad, but should work with a mouse wheel too)

### Reproduction Steps and Savefile (if available)

You need a character with a decent number of perks, karma, and kills.  Here's one with all three:
[SLOT20.zip](https://github.com/user-attachments/files/20499611/SLOT20.zip) (sonora)

### Screenshots

This is the area affected:

<img width="642" alt="image" src="https://github.com/user-attachments/assets/34a637e5-f041-4d67-ad06-faee069c4ae1" />

