### PR TITLE
Don't crash if game resolution is <800 with custom interface bar

### DIFF
--- a/src/interface.cc
+++ b/src/interface.cc
@@ -2483,12 +2483,15 @@ bool indicatorBarHide()
 static void customInterfaceBarInit()
 {
     gInterfaceBarContentOffset = gInterfaceBarWidth - 640;
+    if (gInterfaceBarContentOffset > 0) {
+        if (screenGetWidth() > 640 && gInterfaceBarWidth <= screenGetWidth()) {
+            char path[COMPAT_MAX_PATH];
+            snprintf(path, sizeof(path), "art\\intrface\\HR_IFACE_%d.FRM", gInterfaceBarWidth);
 
-    if (gInterfaceBarContentOffset > 0 && screenGetWidth() > 640) {
-        char path[COMPAT_MAX_PATH];
-        snprintf(path, sizeof(path), "art\\intrface\\HR_IFACE_%d.FRM", gInterfaceBarWidth);
-
-        gCustomInterfaceBarBackground = artLoad(path);
+            gCustomInterfaceBarBackground = artLoad(path);
+        } else{
+            debugPrint("\nINTRFACE: Custom interface bar width (%d) is greater than screen width (%d). Using default interface bar.\n", gInterfaceBarWidth, screenGetWidth());
+        }
     }
 
     if (gCustomInterfaceBarBackground != nullptr) {

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -2489,7 +2489,7 @@ static void customInterfaceBarInit()
             snprintf(path, sizeof(path), "art\\intrface\\HR_IFACE_%d.FRM", gInterfaceBarWidth);
 
             gCustomInterfaceBarBackground = artLoad(path);
-        } else{
+        } else {
             debugPrint("\nINTRFACE: Custom interface bar width (%d) is greater than screen width (%d). Using default interface bar.\n", gInterfaceBarWidth, screenGetWidth());
         }
     }


### PR DESCRIPTION
### Description

A different fix for https://github.com/alexbatalov/fallout2-ce/pull/364

### Reproduction Steps and Savefile (if available)

Use a custom interface bar (usually 800px), with screen width >640 but smaller than 800:

e.g. f2_res.ini
```
[MAIN]
SCR_WIDTH=650
SCR_HEIGHT=480

[IFACE]
IFACE_BAR_WIDTH=800 
```

Without this patch, the game will crash.  With it, it'll just use the normal iface bar
