### PR TITLE
QoL: Ctrl-click to equip in inventory screen

### DIFF
--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -2286,23 +2286,23 @@ static void _inven_pickup(int buttonCode, int indexOffset)
     Rect rect;
 
     switch (buttonCode) {
-    case 1006:
-        rect.left = 245;
-        rect.top = 286;
+    case 1006: // right hand slot
+        rect.left = INVENTORY_RIGHT_HAND_SLOT_X;
+        rect.top = INVENTORY_RIGHT_HAND_SLOT_Y;
         if (_inven_dude == gDude && interfaceGetCurrentHand() != HAND_LEFT) {
             itemInHand = item;
         }
         break;
-    case 1007:
-        rect.left = 154;
-        rect.top = 286;
+    case 1007: // left hand slot
+        rect.left = INVENTORY_LEFT_HAND_SLOT_X;
+        rect.top = INVENTORY_LEFT_HAND_SLOT_Y;
         if (_inven_dude == gDude && interfaceGetCurrentHand() == HAND_LEFT) {
             itemInHand = item;
         }
         break;
-    case 1008:
-        rect.left = 154;
-        rect.top = 183;
+    case 1008: // armor slot
+        rect.left = INVENTORY_ARMOR_SLOT_X;
+        rect.top = INVENTORY_ARMOR_SLOT_Y;
         break;
     default:
         // NOTE: Original code a little bit different, this code path
@@ -2313,50 +2313,39 @@ static void _inven_pickup(int buttonCode, int indexOffset)
         break;
     }
 
-    // fix for disappearing/not disappearing inventory items
-    if (itemIndex == -1 || _pud->items[_pud->length - (itemIndex + indexOffset + 1)].quantity <= 1) { // slots
+    bool pickUpFromSlot = itemIndex == -1; // true if item was picked up from armor or weapon slots
+    if (pickUpFromSlot || _pud->items[indexOffset + itemIndex].quantity <= 1) { 
+        // erase background unless item is part of a 2+ quantity stack
         unsigned char* windowBuffer = windowGetBuffer(gInventoryWindow);
+        int width, height;
         if (gInventoryRightHandItem != gInventoryLeftHandItem || item != gInventoryLeftHandItem) {
-            int height;
-            int width;
-            if (itemIndex == -1) {
+            if (pickUpFromSlot) {
                 height = INVENTORY_LARGE_SLOT_HEIGHT;
                 width = INVENTORY_LARGE_SLOT_WIDTH;
             } else {
                 height = INVENTORY_SLOT_HEIGHT;
                 width = INVENTORY_SLOT_WIDTH;
             }
-
-            FrmImage backgroundFrmImage;
-            int backgroundFid = buildFid(OBJ_TYPE_INTERFACE, 48, 0, 0, 0);
-            if (backgroundFrmImage.lock(backgroundFid)) {
-                blitBufferToBuffer(backgroundFrmImage.getData() + INVENTORY_WINDOW_WIDTH * rect.top + rect.left,
-                    width,
-                    height,
-                    INVENTORY_WINDOW_WIDTH,
-                    windowBuffer + INVENTORY_WINDOW_WIDTH * rect.top + rect.left,
-                    INVENTORY_WINDOW_WIDTH);
-            }
-
-            rect.right = rect.left + width - 1;
-            rect.bottom = rect.top + height - 1;
-        } else {
-            FrmImage backgroundFrmImage;
-            int backgroundFid = buildFid(OBJ_TYPE_INTERFACE, 48, 0, 0, 0);
-            if (backgroundFrmImage.lock(backgroundFid)) {
-                blitBufferToBuffer(backgroundFrmImage.getData() + INVENTORY_WINDOW_WIDTH * 286 + 154,
-                    180,
-                    61,
-                    INVENTORY_WINDOW_WIDTH,
-                    windowBuffer + INVENTORY_WINDOW_WIDTH * 286 + 154,
-                    INVENTORY_WINDOW_WIDTH);
-            }
-
-            rect.left = 154;
-            rect.top = 286;
-            rect.right = rect.left + 180 - 1;
-            rect.bottom = rect.top + 61 - 1;
+        } else { 
+            // seems to wipe both hand slots at once, but I don't know how to trigger this in game
+            height = INVENTORY_LARGE_SLOT_HEIGHT;
+            width = 180;
+            rect.left = INVENTORY_LEFT_HAND_SLOT_X;
+            rect.top = INVENTORY_LEFT_HAND_SLOT_Y;
         }
+        rect.right = rect.left + width - 1;
+        rect.bottom = rect.top + height - 1;
+        FrmImage backgroundFrmImage;
+        int backgroundFid = buildFid(OBJ_TYPE_INTERFACE, 48, 0, 0, 0);
+        if (backgroundFrmImage.lock(backgroundFid)) {
+            blitBufferToBuffer(backgroundFrmImage.getData() + INVENTORY_WINDOW_WIDTH * rect.top + rect.left,
+                width,
+                height,
+                INVENTORY_WINDOW_WIDTH,
+                windowBuffer + INVENTORY_WINDOW_WIDTH * rect.top + rect.left,
+                INVENTORY_WINDOW_WIDTH);
+        }
+
         windowRefreshRect(gInventoryWindow, &rect);
     } else {
         _display_inventory(indexOffset, itemIndex, INVENTORY_WINDOW_TYPE_NORMAL);
@@ -2366,11 +2355,12 @@ static void _inven_pickup(int buttonCode, int indexOffset)
         _inven_update_lighting(nullptr);
     }
 
-    // SFALL: allow ctrl-click to unequip
-    bool immediate = itemIndex == -1 && _ctrl_pressed();
+    // allow ctrl-click to quick unequip or equip item
+    bool immediate = _ctrl_pressed();
     _drag_item_loop(item, immediate);
 
-    if (immediate || mouseHitTestInWindow(gInventoryWindow, INVENTORY_SCROLLER_X, INVENTORY_SCROLLER_Y, INVENTORY_SCROLLER_MAX_X, INVENTORY_SLOT_HEIGHT * gInventorySlotsCount + INVENTORY_SCROLLER_Y)) {
+    // drag into inventory list, or ctrl-click from slot
+    if (pickUpFromSlot && (immediate || mouseHitTestInWindow(gInventoryWindow, INVENTORY_SCROLLER_X, INVENTORY_SCROLLER_Y, INVENTORY_SCROLLER_MAX_X, INVENTORY_SLOT_HEIGHT * gInventorySlotsCount + INVENTORY_SCROLLER_Y))) {
         int x;
         int y;
         mouseGetPositionInWindow(gInventoryWindow, &x, &y);
@@ -2392,31 +2382,46 @@ static void _inven_pickup(int buttonCode, int indexOffset)
             }
         }
 
-        if (immediate || itemIndex == -1) {
+        if (immediate || pickUpFromSlot) {
             // TODO: Holy shit, needs refactoring.
             *itemSlot = nullptr;
             if (itemAdd(_inven_dude, item, 1)) {
                 *itemSlot = item;
             } else if (itemSlot == &gInventoryArmor) {
                 _adjust_ac(_stack[0], item, nullptr);
-            } else if (gInventoryRightHandItem == gInventoryLeftHandItem) {
+            } else if (gInventoryRightHandItem == gInventoryLeftHandItem) { 
                 gInventoryLeftHandItem = nullptr;
                 gInventoryRightHandItem = nullptr;
             }
         }
+
+    } else if (!pickUpFromSlot && immediate && itemGetType(item) != ITEM_TYPE_ARMOR) {
+        // ctrl-click non-armor to quick-equip:
+        // default to first empty hand, or left hand if both are full
+        bool left = gInventoryLeftHandItem == nullptr || gInventoryRightHandItem != nullptr;
+        if (left) {
+            _switch_hand(item, &gInventoryLeftHandItem, itemSlot, buttonCode);
+        } else {
+            _switch_hand(item, &gInventoryRightHandItem, itemSlot, buttonCode);
+        }
+
+    // drop in left hand slot
     } else if (mouseHitTestInWindow(gInventoryWindow, INVENTORY_LEFT_HAND_SLOT_X, INVENTORY_LEFT_HAND_SLOT_Y, INVENTORY_LEFT_HAND_SLOT_MAX_X, INVENTORY_LEFT_HAND_SLOT_MAX_Y)) {
         if (gInventoryLeftHandItem != nullptr && itemGetType(gInventoryLeftHandItem) == ITEM_TYPE_CONTAINER && gInventoryLeftHandItem != item) {
             _drop_into_container(gInventoryLeftHandItem, item, itemIndex, itemSlot, count);
         } else if (gInventoryLeftHandItem == nullptr || _drop_ammo_into_weapon(gInventoryLeftHandItem, item, itemSlot, count, buttonCode)) {
             _switch_hand(item, &gInventoryLeftHandItem, itemSlot, buttonCode);
         }
+
+    // drop in right hand slot
     } else if (mouseHitTestInWindow(gInventoryWindow, INVENTORY_RIGHT_HAND_SLOT_X, INVENTORY_RIGHT_HAND_SLOT_Y, INVENTORY_RIGHT_HAND_SLOT_MAX_X, INVENTORY_RIGHT_HAND_SLOT_MAX_Y)) {
         if (gInventoryRightHandItem != nullptr && itemGetType(gInventoryRightHandItem) == ITEM_TYPE_CONTAINER && gInventoryRightHandItem != item) {
             _drop_into_container(gInventoryRightHandItem, item, itemIndex, itemSlot, count);
         } else if (gInventoryRightHandItem == nullptr || _drop_ammo_into_weapon(gInventoryRightHandItem, item, itemSlot, count, buttonCode)) {
             _switch_hand(item, &gInventoryRightHandItem, itemSlot, itemIndex);
         }
-    } else if (mouseHitTestInWindow(gInventoryWindow, INVENTORY_ARMOR_SLOT_X, INVENTORY_ARMOR_SLOT_Y, INVENTORY_ARMOR_SLOT_MAX_X, INVENTORY_ARMOR_SLOT_MAX_Y)) {
+
+    } else if ((immediate && itemGetType(item) == ITEM_TYPE_ARMOR) || mouseHitTestInWindow(gInventoryWindow, INVENTORY_ARMOR_SLOT_X, INVENTORY_ARMOR_SLOT_Y, INVENTORY_ARMOR_SLOT_MAX_X, INVENTORY_ARMOR_SLOT_MAX_Y)) {
         if (itemGetType(item) == ITEM_TYPE_ARMOR) {
             Object* currentArmor = gInventoryArmor;
             int itemAddResult = 0;
@@ -2453,7 +2458,8 @@ static void _inven_pickup(int buttonCode, int indexOffset)
             // So we drop item into it.
             _drop_into_container(_stack[_curr_stack - 1], item, itemIndex, itemSlot, count);
         }
-    }
+    } 
+    
 
     _adjust_fid();
     inventoryRenderSummary();

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -2314,7 +2314,7 @@ static void _inven_pickup(int buttonCode, int indexOffset)
     }
 
     bool pickUpFromSlot = itemIndex == -1; // true if item was picked up from armor or weapon slots
-    if (pickUpFromSlot || _pud->items[indexOffset + itemIndex].quantity <= 1) { 
+    if (pickUpFromSlot || _pud->items[indexOffset + itemIndex].quantity <= 1) {
         // erase background unless item is part of a 2+ quantity stack
         unsigned char* windowBuffer = windowGetBuffer(gInventoryWindow);
         int width, height;
@@ -2326,7 +2326,7 @@ static void _inven_pickup(int buttonCode, int indexOffset)
                 height = INVENTORY_SLOT_HEIGHT;
                 width = INVENTORY_SLOT_WIDTH;
             }
-        } else { 
+        } else {
             // seems to wipe both hand slots at once, but I don't know how to trigger this in game
             height = INVENTORY_LARGE_SLOT_HEIGHT;
             width = 180;
@@ -2389,7 +2389,7 @@ static void _inven_pickup(int buttonCode, int indexOffset)
                 *itemSlot = item;
             } else if (itemSlot == &gInventoryArmor) {
                 _adjust_ac(_stack[0], item, nullptr);
-            } else if (gInventoryRightHandItem == gInventoryLeftHandItem) { 
+            } else if (gInventoryRightHandItem == gInventoryLeftHandItem) {
                 gInventoryLeftHandItem = nullptr;
                 gInventoryRightHandItem = nullptr;
             }
@@ -2405,7 +2405,7 @@ static void _inven_pickup(int buttonCode, int indexOffset)
             _switch_hand(item, &gInventoryRightHandItem, itemSlot, buttonCode);
         }
 
-    // drop in left hand slot
+        // drop in left hand slot
     } else if (mouseHitTestInWindow(gInventoryWindow, INVENTORY_LEFT_HAND_SLOT_X, INVENTORY_LEFT_HAND_SLOT_Y, INVENTORY_LEFT_HAND_SLOT_MAX_X, INVENTORY_LEFT_HAND_SLOT_MAX_Y)) {
         if (gInventoryLeftHandItem != nullptr && itemGetType(gInventoryLeftHandItem) == ITEM_TYPE_CONTAINER && gInventoryLeftHandItem != item) {
             _drop_into_container(gInventoryLeftHandItem, item, itemIndex, itemSlot, count);
@@ -2413,7 +2413,7 @@ static void _inven_pickup(int buttonCode, int indexOffset)
             _switch_hand(item, &gInventoryLeftHandItem, itemSlot, buttonCode);
         }
 
-    // drop in right hand slot
+        // drop in right hand slot
     } else if (mouseHitTestInWindow(gInventoryWindow, INVENTORY_RIGHT_HAND_SLOT_X, INVENTORY_RIGHT_HAND_SLOT_Y, INVENTORY_RIGHT_HAND_SLOT_MAX_X, INVENTORY_RIGHT_HAND_SLOT_MAX_Y)) {
         if (gInventoryRightHandItem != nullptr && itemGetType(gInventoryRightHandItem) == ITEM_TYPE_CONTAINER && gInventoryRightHandItem != item) {
             _drop_into_container(gInventoryRightHandItem, item, itemIndex, itemSlot, count);
@@ -2458,8 +2458,7 @@ static void _inven_pickup(int buttonCode, int indexOffset)
             // So we drop item into it.
             _drop_into_container(_stack[_curr_stack - 1], item, itemIndex, itemSlot, count);
         }
-    } 
-    
+    }
 
     _adjust_fid();
     inventoryRenderSummary();


### PR DESCRIPTION
### Description

Ctrl-click to equip in inventory screen:

1. Armor gets equipped to the armor slot
2. Any other item gets equipped to the first free hand slot, or the left hand if both are occupied 

Continues missing work from:
https://github.com/fallout2-ce/fallout2-ce/pull/133

This is very similar to the sfall feature.
