### PR TITLE
Update windows runner

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -313,7 +313,7 @@ jobs:
   windows:
     name: Windows (${{ matrix.arch }})
 
-    runs-on: windows-2019
+    runs-on: windows-2025
 
     strategy:
       fail-fast: false
@@ -328,19 +328,34 @@ jobs:
       - name: Clone
         uses: actions/checkout@v4
 
+      - name: Cache Visual Studio Build Tools (basic)
+        uses: actions/cache@v4
+        with:
+          path: C:\ProgramData\chocolatey\lib
+          key: choco-vs2019-xp-${{ runner.os }}
+
+      - name: Install Visual Studio 2019 Build Tools with v141_xp
+        shell: cmd
+        run: |
+          choco install visualstudio2019buildtools -y --package-parameters="'--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.v141.x86.x64 --add Microsoft.VisualStudio.Component.VC.v141.xp --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK.10240 --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.WinXP --add Microsoft.VisualStudio.Component.WinXP'"
+
       - name: Cache cmake build
         uses: actions/cache@v4
         with:
           path: out
-          key: windows-${{ matrix.arch }}-cmake-v2
+          key: windows-${{ matrix.arch }}-cmake-v3
 
       - name: Configure
+        shell: cmd
         run: |
-          cmake --preset windows-${{ matrix.arch }}
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\Tools\VsDevCmd.bat" ^
+          && cmake --preset windows-${{ matrix.arch }}
 
       - name: Build
+        shell: cmd
         run: |
-          cmake --build --preset windows-${{ matrix.arch }}-release
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\Tools\VsDevCmd.bat" ^
+          && cmake --build --preset windows-${{ matrix.arch }}-release
 
       - name: Change executable file name
         run: |

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -337,7 +337,7 @@ jobs:
       - name: Install Visual Studio 2019 Build Tools with v141_xp
         shell: cmd
         run: |
-          choco install visualstudio2019buildtools -y --force --package-parameters="'--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.v141.x86.x64 --add Microsoft.VisualStudio.Component.VC.v141.xp --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK.10240 --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.WinXP --add Microsoft.VisualStudio.Component.WinXP'"
+          choco install visualstudio2019buildtools -y --package-parameters="'--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.v141.x86.x64 --add Microsoft.VisualStudio.Component.VC.v141.xp --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK.10240 --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.WinXP --add Microsoft.VisualStudio.Component.WinXP'"
 
       - name: Cache cmake build
         uses: actions/cache@v4

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -328,12 +328,6 @@ jobs:
       - name: Clone
         uses: actions/checkout@v4
 
-      - name: Cache Visual Studio Build Tools (basic)
-        uses: actions/cache@v4
-        with:
-          path: C:\ProgramData\chocolatey\lib
-          key: choco-vs2019-xp-${{ runner.os }}-${{ matrix.arch }}
-
       - name: Install Visual Studio 2019 Build Tools with v141_xp
         shell: cmd
         run: |

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -332,7 +332,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: C:\ProgramData\chocolatey\lib
-          key: choco-vs2019-xp-${{ runner.os }}
+          key: choco-vs2019-xp-${{ runner.os }}-${{ matrix.arch }}
 
       - name: Install Visual Studio 2019 Build Tools with v141_xp
         shell: cmd

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -337,7 +337,7 @@ jobs:
       - name: Install Visual Studio 2019 Build Tools with v141_xp
         shell: cmd
         run: |
-          choco install visualstudio2019buildtools -y --package-parameters="'--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.v141.x86.x64 --add Microsoft.VisualStudio.Component.VC.v141.xp --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK.10240 --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.WinXP --add Microsoft.VisualStudio.Component.WinXP'"
+          choco install visualstudio2019buildtools -y --force --package-parameters="'--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.v141.x86.x64 --add Microsoft.VisualStudio.Component.VC.v141.xp --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK.10240 --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.WinXP --add Microsoft.VisualStudio.Component.WinXP'"
 
       - name: Cache cmake build
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,7 +267,7 @@ jobs:
       - name: Install Visual Studio 2019 Build Tools with v141_xp
         shell: cmd
         run: |
-          choco install visualstudio2019buildtools -y --force --package-parameters="'--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.v141.x86.x64 --add Microsoft.VisualStudio.Component.VC.v141.xp --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK.10240 --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.WinXP --add Microsoft.VisualStudio.Component.WinXP'"
+          choco install visualstudio2019buildtools -y --package-parameters="'--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.v141.x86.x64 --add Microsoft.VisualStudio.Component.VC.v141.xp --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK.10240 --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.WinXP --add Microsoft.VisualStudio.Component.WinXP'"
 
       - name: Cache cmake build
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,7 +267,7 @@ jobs:
       - name: Install Visual Studio 2019 Build Tools with v141_xp
         shell: cmd
         run: |
-          choco install visualstudio2019buildtools -y --package-parameters="'--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.v141.x86.x64 --add Microsoft.VisualStudio.Component.VC.v141.xp --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK.10240 --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.WinXP --add Microsoft.VisualStudio.Component.WinXP'"
+          choco install visualstudio2019buildtools -y --force --package-parameters="'--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.v141.x86.x64 --add Microsoft.VisualStudio.Component.VC.v141.xp --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK.10240 --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.WinXP --add Microsoft.VisualStudio.Component.WinXP'"
 
       - name: Cache cmake build
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,12 +258,6 @@ jobs:
       - name: Clone
         uses: actions/checkout@v4
 
-      - name: Cache Visual Studio Build Tools (basic)
-        uses: actions/cache@v4
-        with:
-          path: C:\ProgramData\chocolatey\lib
-          key: choco-vs2019-xp-${{ runner.os }}-${{ matrix.arch }}
-
       - name: Install Visual Studio 2019 Build Tools with v141_xp
         shell: cmd
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,7 +262,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: C:\ProgramData\chocolatey\lib
-          key: choco-vs2019-xp-${{ runner.os }}
+          key: choco-vs2019-xp-${{ runner.os }}-${{ matrix.arch }}
 
       - name: Install Visual Studio 2019 Build Tools with v141_xp
         shell: cmd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,7 +243,7 @@ jobs:
   windows:
     name: Windows (${{ matrix.arch }})
 
-    runs-on: windows-2019
+    runs-on: windows-2025
 
     strategy:
       fail-fast: false
@@ -258,6 +258,17 @@ jobs:
       - name: Clone
         uses: actions/checkout@v4
 
+      - name: Cache Visual Studio Build Tools (basic)
+        uses: actions/cache@v4
+        with:
+          path: C:\ProgramData\chocolatey\lib
+          key: choco-vs2019-xp-${{ runner.os }}
+
+      - name: Install Visual Studio 2019 Build Tools with v141_xp
+        shell: cmd
+        run: |
+          choco install visualstudio2019buildtools -y --package-parameters="'--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.v141.x86.x64 --add Microsoft.VisualStudio.Component.VC.v141.xp --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK.10240 --add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.WinXP --add Microsoft.VisualStudio.Component.WinXP'"
+
       - name: Cache cmake build
         uses: actions/cache@v4
         with:
@@ -265,19 +276,16 @@ jobs:
           key: windows-${{ matrix.arch }}-cmake-v1
 
       - name: Configure
+        shell: cmd
         run: |
-          cmake \
-            -B build \
-            -G "Visual Studio 16 2019" \
-            -A ${{ matrix.generator-platform }} \
-            # EOL
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\Tools\VsDevCmd.bat" ^
+          && cmake -B build -G "Visual Studio 16 2019" -A ${{ matrix.generator-platform }}
 
       - name: Build
+        shell: cmd
         run: |
-          cmake \
-            --build build \
-            --config RelWithDebInfo \
-            # EOL
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\Tools\VsDevCmd.bat" ^
+          && cmake --build build --config RelWithDebInfo
 
       - name: Upload
         run: |


### PR DESCRIPTION
Github is going to disable our current windows runner

https://github.com/actions/runner-images/issues/12045

So we need to update.

I tried to cache `C:\ProgramData\chocolatey\lib` but then `cmake` fails to understand that `v141_xp` toolset is installed when cache is restored.

I tested Windows x86 build on virtual machine with Windows XP and it started (shows "Failed to load fonts" error)