### PR TITLE
Update xfile.cc

### DIFF
--- a/src/xfile.cc
+++ b/src/xfile.cc
@@ -532,7 +532,6 @@ bool xbaseOpen(const char* path)
 
     char workingDirectory[COMPAT_MAX_PATH];
     if (getcwd(workingDirectory, COMPAT_MAX_PATH) == nullptr) {
-        // FIXME: Leaking xbase and path. Fixed?
         free(xbase->path);
         free(xbase);
         return false;
@@ -545,11 +544,9 @@ bool xbaseOpen(const char* path)
         return true;
     }
 
-    chdir(workingDirectory);
-
-    xbase->next = gXbaseHead;
-    gXbaseHead = xbase;
-
+    // Cleanup if chdir(path) failed
+    free(xbase->path);
+    free(xbase);
     return false; // return false to trigger messages on game load
 }
 


### PR DESCRIPTION
Fixes #172 

### Description

This removes the creation of a 'dat' folder when opening or path finding fails. This may have been a leftover from development, or part of the mapper, however, in practice it prevents users getting correct error messages when opening the app with missing dats or incorrect dat paths.

With this fix, missing dats or paths should give a popup message to the user, instead of the ubiquitous 'cannot find fonts error'