### PR TITLE
Rename sfall opcodes to use underscores for consistency.

### DIFF
--- a/src/sfall_opcodes.cc
+++ b/src/sfall_opcodes.cc
@@ -51,7 +51,7 @@ static constexpr int kVersionMinor = 3;
 static constexpr int kVersionPatch = 4;
 
 // read_byte
-static void opReadByte(Program* program)
+static void op_read_byte(Program* program)
 {
     int addr = programStackPopInteger(program);
 
@@ -91,7 +91,7 @@ static void op_set_critter_base_stat(Program* program)
 }
 
 // set_pc_extra_stat
-static void opSetPcBonusStat(Program* program)
+static void op_set_pc_bonus_stat(Program* program)
 {
     // CE: Implementation is different. Sfall changes value directly on the
     // dude's proto, without calling |critterSetBonusStat|. This function has
@@ -133,7 +133,7 @@ static void op_get_critter_base_stat(Program* program)
 }
 
 // get_pc_extra_stat
-static void opGetPcBonusStat(Program* program)
+static void op_get_pc_bonus_stat(Program* program)
 {
     int stat = programStackPopInteger(program);
     int value = critterGetBonusStat(gDude, stat);
@@ -207,7 +207,7 @@ static void op_set_world_map_pos(Program* program)
 }
 
 // active_hand
-static void opGetCurrentHand(Program* program)
+static void op_get_current_hand(Program* program)
 {
     programStackPushInteger(program, interfaceGetCurrentHand());
 }
@@ -220,7 +220,7 @@ static void op_set_global_script_type(Program* program)
 }
 
 // set_sfall_global
-static void opSetGlobalVar(Program* program)
+static void op_set_sfall_global(Program* program)
 {
     ProgramValue value = programStackPopValue(program);
     ProgramValue variable = programStackPopValue(program);
@@ -234,7 +234,7 @@ static void opSetGlobalVar(Program* program)
 }
 
 // get_sfall_global_int
-static void opGetGlobalInt(Program* program)
+static void op_get_sfall_global_int(Program* program)
 {
     ProgramValue variable = programStackPopValue(program);
 
@@ -263,7 +263,7 @@ static void op_get_ini_setting(Program* program)
 }
 
 // get_game_mode
-static void opGetGameMode(Program* program)
+static void op_get_game_mode(Program* program)
 {
     programStackPushInteger(program, GameMode::getCurrentGameMode());
 }
@@ -399,7 +399,7 @@ static void op_set_self(Program* program)
 }
 
 // list_begin
-static void opListBegin(Program* program)
+static void op_list_begin(Program* program)
 {
     int listType = programStackPopInteger(program);
     int listId = sfallListsCreate(listType);
@@ -407,7 +407,7 @@ static void opListBegin(Program* program)
 }
 
 // list_next
-static void opListNext(Program* program)
+static void op_list_next(Program* program)
 {
     int listId = programStackPopInteger(program);
     Object* obj = sfallListsGetNext(listId);
@@ -415,32 +415,32 @@ static void opListNext(Program* program)
 }
 
 // list_end
-static void opListEnd(Program* program)
+static void op_list_end(Program* program)
 {
     int listId = programStackPopInteger(program);
     sfallListsDestroy(listId);
 }
 
 // sfall_ver_major
-static void opGetVersionMajor(Program* program)
+static void op_get_version_major(Program* program)
 {
     programStackPushInteger(program, kVersionMajor);
 }
 
 // sfall_ver_minor
-static void opGetVersionMinor(Program* program)
+static void op_get_version_minor(Program* program)
 {
     programStackPushInteger(program, kVersionMinor);
 }
 
 // sfall_ver_build
-static void opGetVersionPatch(Program* program)
+static void op_get_version_patch(Program* program)
 {
     programStackPushInteger(program, kVersionPatch);
 }
 
 // get_weapon_ammo_pid
-static void opGetWeaponAmmoPid(Program* program)
+static void op_get_weapon_ammo_pid(Program* program)
 {
     Object* obj = static_cast<Object*>(programStackPopPointer(program));
 
@@ -469,7 +469,7 @@ static void opGetWeaponAmmoPid(Program* program)
 // quantity/capacity which can probably lead to bad things.
 //
 // set_weapon_ammo_pid
-static void opSetWeaponAmmoPid(Program* program)
+static void op_set_weapon_ammo_pid(Program* program)
 {
     int ammoTypePid = programStackPopInteger(program);
     Object* obj = static_cast<Object*>(programStackPopPointer(program));
@@ -486,7 +486,7 @@ static void opSetWeaponAmmoPid(Program* program)
 }
 
 // get_weapon_ammo_count
-static void opGetWeaponAmmoCount(Program* program)
+static void op_get_weapon_ammo_count(Program* program)
 {
     Object* obj = static_cast<Object*>(programStackPopPointer(program));
 
@@ -510,7 +510,7 @@ static void opGetWeaponAmmoCount(Program* program)
 }
 
 // set_weapon_ammo_count
-static void opSetWeaponAmmoCount(Program* program)
+static void op_set_weapon_ammo_count(Program* program)
 {
     int ammoQuantityOrCharges = programStackPopInteger(program);
     Object* obj = static_cast<Object*>(programStackPopPointer(program));
@@ -532,7 +532,7 @@ static void opSetWeaponAmmoCount(Program* program)
 }
 
 // get_mouse_x
-static void opGetMouseX(Program* program)
+static void op_get_mouse_x(Program* program)
 {
     int x;
     int y;
@@ -541,7 +541,7 @@ static void opGetMouseX(Program* program)
 }
 
 // get_mouse_y
-static void opGetMouseY(Program* program)
+static void op_get_mouse_y(Program* program)
 {
     int x;
     int y;
@@ -558,13 +558,13 @@ static void op_get_mouse_buttons(Program* program)
 }
 
 // get_screen_width
-static void opGetScreenWidth(Program* program)
+static void op_get_screen_width(Program* program)
 {
     programStackPushInteger(program, screenGetWidth());
 }
 
 // get_screen_height
-static void opGetScreenHeight(Program* program)
+static void op_get_screen_height(Program* program)
 {
     programStackPushInteger(program, screenGetHeight());
 }
@@ -638,7 +638,7 @@ static void op_list_as_array(Program* program)
 }
 
 // atoi
-static void opParseInt(Program* program)
+static void op_parse_int(Program* program)
 {
     const char* string = programStackPopString(program);
     programStackPushInteger(program, static_cast<int>(strtol(string, nullptr, 0)));
@@ -663,7 +663,7 @@ static void op_tile_under_cursor(Program* program)
 }
 
 // substr
-static void opSubstr(Program* program)
+static void op_substr(Program* program)
 {
     auto length = programStackPopInteger(program);
     auto startPos = programStackPopInteger(program);
@@ -710,7 +710,7 @@ static void opSubstr(Program* program)
 }
 
 // strlen
-static void opGetStringLength(Program* program)
+static void op_get_string_length(Program* program)
 {
     const char* string = programStackPopString(program);
     programStackPushInteger(program, static_cast<int>(strlen(string)));
@@ -791,7 +791,7 @@ static void op_power(Program* program)
 }
 
 // message_str_game
-static void opGetMessage(Program* program)
+static void op_get_message(Program* program)
 {
     int messageId = programStackPopInteger(program);
     int messageListId = programStackPopInteger(program);
@@ -800,7 +800,7 @@ static void opGetMessage(Program* program)
 }
 
 // array_key
-static void opGetArrayKey(Program* program)
+static void op_get_array_key(Program* program)
 {
     auto index = programStackPopInteger(program);
     auto arrayId = programStackPopInteger(program);
@@ -809,7 +809,7 @@ static void opGetArrayKey(Program* program)
 }
 
 // create_array
-static void opCreateArray(Program* program)
+static void op_create_array(Program* program)
 {
     auto flags = programStackPopInteger(program);
     auto len = programStackPopInteger(program);
@@ -818,7 +818,7 @@ static void opCreateArray(Program* program)
 }
 
 // temp_array
-static void opTempArray(Program* program)
+static void op_temp_array(Program* program)
 {
     auto flags = programStackPopInteger(program);
     auto len = programStackPopInteger(program);
@@ -827,14 +827,14 @@ static void opTempArray(Program* program)
 }
 
 // fix_array
-static void opFixArray(Program* program)
+static void op_fix_array(Program* program)
 {
     auto arrayId = programStackPopInteger(program);
     FixArray(arrayId);
 }
 
 // string_split
-static void opStringSplit(Program* program)
+static void op_string_split(Program* program)
 {
     auto split = programStackPopString(program);
     auto str = programStackPopString(program);
@@ -843,7 +843,7 @@ static void opStringSplit(Program* program)
 }
 
 // set_array
-static void opSetArray(Program* program)
+static void op_set_array(Program* program)
 {
     auto value = programStackPopValue(program);
     auto key = programStackPopValue(program);
@@ -852,7 +852,7 @@ static void opSetArray(Program* program)
 }
 
 // arrayexpr
-static void opStackArray(Program* program)
+static void op_stack_array(Program* program)
 {
     auto value = programStackPopValue(program);
     auto key = programStackPopValue(program);
@@ -861,7 +861,7 @@ static void opStackArray(Program* program)
 }
 
 // scan_array
-static void opScanArray(Program* program)
+static void op_scan_array(Program* program)
 {
     auto value = programStackPopValue(program);
     auto arrayId = programStackPopInteger(program);
@@ -870,7 +870,7 @@ static void opScanArray(Program* program)
 }
 
 // get_array
-static void opGetArray(Program* program)
+static void op_get_array(Program* program)
 {
     auto key = programStackPopValue(program);
     auto arrayId = programStackPopValue(program);
@@ -893,21 +893,21 @@ static void opGetArray(Program* program)
 }
 
 // free_array
-static void opFreeArray(Program* program)
+static void op_free_array(Program* program)
 {
     auto arrayId = programStackPopInteger(program);
     FreeArray(arrayId);
 }
 
 // len_array
-static void opLenArray(Program* program)
+static void op_len_array(Program* program)
 {
     auto arrayId = programStackPopInteger(program);
     programStackPushInteger(program, LenArray(arrayId));
 }
 
 // resize_array
-static void opResizeArray(Program* program)
+static void op_resize_array(Program* program)
 {
     auto newLen = programStackPopInteger(program);
     auto arrayId = programStackPopInteger(program);
@@ -915,7 +915,7 @@ static void opResizeArray(Program* program)
 }
 
 // party_member_list
-static void opPartyMemberList(Program* program)
+static void op_party_member_list(Program* program)
 {
     auto includeHidden = programStackPopInteger(program);
     auto objects = get_all_party_members_objects(includeHidden);
@@ -927,7 +927,7 @@ static void opPartyMemberList(Program* program)
 }
 
 // type_of
-static void opTypeOf(Program* program)
+static void op_type_of(Program* program)
 {
     auto value = programStackPopValue(program);
     if (value.isInt()) {
@@ -940,7 +940,7 @@ static void opTypeOf(Program* program)
 }
 
 // round
-static void opRound(Program* program)
+static void op_round(Program* program)
 {
     float floatValue = programStackPopFloat(program);
     int integerValue = static_cast<int>(floatValue);
@@ -1007,7 +1007,7 @@ static void op_obj_blocking_at(Program* program)
 }
 
 // art_exists
-static void opArtExists(Program* program)
+static void op_art_exists(Program* program)
 {
     int fid = programStackPopInteger(program);
     programStackPushInteger(program, artExists(fid));
@@ -1079,11 +1079,11 @@ static void op_div(Program* program)
 
 void sfallOpcodesInit()
 {
-    interpreterRegisterOpcode(0x8156, opReadByte);
+    interpreterRegisterOpcode(0x8156, op_read_byte);
     interpreterRegisterOpcode(0x815A, op_set_pc_base_stat);
-    interpreterRegisterOpcode(0x815B, opSetPcBonusStat);
+    interpreterRegisterOpcode(0x815B, op_set_pc_bonus_stat);
     interpreterRegisterOpcode(0x815C, op_get_pc_base_stat);
-    interpreterRegisterOpcode(0x815D, opGetPcBonusStat);
+    interpreterRegisterOpcode(0x815D, op_get_pc_bonus_stat);
     interpreterRegisterOpcode(0x815E, op_set_critter_base_stat);
     interpreterRegisterOpcode(0x815F, op_set_critter_extra_stat);
     interpreterRegisterOpcode(0x8160, op_get_critter_base_stat);
@@ -1096,12 +1096,12 @@ void sfallOpcodesInit()
     interpreterRegisterOpcode(0x8170, op_in_world_map);
     interpreterRegisterOpcode(0x8171, op_force_encounter);
     interpreterRegisterOpcode(0x8172, op_set_world_map_pos);
-    interpreterRegisterOpcode(0x8193, opGetCurrentHand);
+    interpreterRegisterOpcode(0x8193, op_get_current_hand);
     interpreterRegisterOpcode(0x819B, op_set_global_script_type);
-    interpreterRegisterOpcode(0x819D, opSetGlobalVar);
-    interpreterRegisterOpcode(0x819E, opGetGlobalInt);
+    interpreterRegisterOpcode(0x819D, op_set_sfall_global);
+    interpreterRegisterOpcode(0x819E, op_get_sfall_global_int);
     interpreterRegisterOpcode(0x81AC, op_get_ini_setting);
-    interpreterRegisterOpcode(0x81AF, opGetGameMode);
+    interpreterRegisterOpcode(0x81AF, op_get_game_mode);
     interpreterRegisterOpcode(0x81B3, op_get_uptime);
     interpreterRegisterOpcode(0x81B6, op_set_car_current_town);
     interpreterRegisterOpcode(0x81DF, op_get_bodypart_hit_modifier);
@@ -1113,51 +1113,51 @@ void sfallOpcodesInit()
     interpreterRegisterOpcode(0x8204, op_get_proto_data);
     interpreterRegisterOpcode(0x8205, op_set_proto_data);
     interpreterRegisterOpcode(0x8206, op_set_self);
-    interpreterRegisterOpcode(0x820D, opListBegin);
-    interpreterRegisterOpcode(0x820E, opListNext);
-    interpreterRegisterOpcode(0x820F, opListEnd);
-    interpreterRegisterOpcode(0x8210, opGetVersionMajor);
-    interpreterRegisterOpcode(0x8211, opGetVersionMinor);
-    interpreterRegisterOpcode(0x8212, opGetVersionPatch);
-    interpreterRegisterOpcode(0x8217, opGetWeaponAmmoPid);
-    interpreterRegisterOpcode(0x8218, opSetWeaponAmmoPid);
-    interpreterRegisterOpcode(0x8219, opGetWeaponAmmoCount);
-    interpreterRegisterOpcode(0x821A, opSetWeaponAmmoCount);
-    interpreterRegisterOpcode(0x821C, opGetMouseX);
-    interpreterRegisterOpcode(0x821D, opGetMouseY);
+    interpreterRegisterOpcode(0x820D, op_list_begin);
+    interpreterRegisterOpcode(0x820E, op_list_next);
+    interpreterRegisterOpcode(0x820F, op_list_end);
+    interpreterRegisterOpcode(0x8210, op_get_version_major);
+    interpreterRegisterOpcode(0x8211, op_get_version_minor);
+    interpreterRegisterOpcode(0x8212, op_get_version_patch);
+    interpreterRegisterOpcode(0x8217, op_get_weapon_ammo_pid);
+    interpreterRegisterOpcode(0x8218, op_set_weapon_ammo_pid);
+    interpreterRegisterOpcode(0x8219, op_get_weapon_ammo_count);
+    interpreterRegisterOpcode(0x821A, op_set_weapon_ammo_count);
+    interpreterRegisterOpcode(0x821C, op_get_mouse_x);
+    interpreterRegisterOpcode(0x821D, op_get_mouse_y);
     interpreterRegisterOpcode(0x821E, op_get_mouse_buttons);
-    interpreterRegisterOpcode(0x8220, opGetScreenWidth);
-    interpreterRegisterOpcode(0x8221, opGetScreenHeight);
+    interpreterRegisterOpcode(0x8220, op_get_screen_width);
+    interpreterRegisterOpcode(0x8221, op_get_screen_height);
     interpreterRegisterOpcode(0x8224, op_create_message_window);
     interpreterRegisterOpcode(0x8228, op_get_attack_type);
     interpreterRegisterOpcode(0x8229, op_force_encounter_with_flags);
-    interpreterRegisterOpcode(0x822D, opCreateArray);
-    interpreterRegisterOpcode(0x822E, opSetArray);
-    interpreterRegisterOpcode(0x822F, opGetArray);
-    interpreterRegisterOpcode(0x8230, opFreeArray);
-    interpreterRegisterOpcode(0x8231, opLenArray);
-    interpreterRegisterOpcode(0x8232, opResizeArray);
-    interpreterRegisterOpcode(0x8233, opTempArray);
-    interpreterRegisterOpcode(0x8234, opFixArray);
-    interpreterRegisterOpcode(0x8235, opStringSplit);
+    interpreterRegisterOpcode(0x822D, op_create_array);
+    interpreterRegisterOpcode(0x822E, op_set_array);
+    interpreterRegisterOpcode(0x822F, op_get_array);
+    interpreterRegisterOpcode(0x8230, op_free_array);
+    interpreterRegisterOpcode(0x8231, op_len_array);
+    interpreterRegisterOpcode(0x8232, op_resize_array);
+    interpreterRegisterOpcode(0x8233, op_temp_array);
+    interpreterRegisterOpcode(0x8234, op_fix_array);
+    interpreterRegisterOpcode(0x8235, op_string_split);
     interpreterRegisterOpcode(0x8236, op_list_as_array);
-    interpreterRegisterOpcode(0x8237, opParseInt);
+    interpreterRegisterOpcode(0x8237, op_parse_int);
     interpreterRegisterOpcode(0x8238, op_atof);
-    interpreterRegisterOpcode(0x8239, opScanArray);
+    interpreterRegisterOpcode(0x8239, op_scan_array);
     interpreterRegisterOpcode(0x824B, op_tile_under_cursor);
-    interpreterRegisterOpcode(0x824E, opSubstr);
-    interpreterRegisterOpcode(0x824F, opGetStringLength);
-    interpreterRegisterOpcode(0x8253, opTypeOf);
-    interpreterRegisterOpcode(0x8256, opGetArrayKey);
-    interpreterRegisterOpcode(0x8257, opStackArray);
+    interpreterRegisterOpcode(0x824E, op_substr);
+    interpreterRegisterOpcode(0x824F, op_get_string_length);
+    interpreterRegisterOpcode(0x8253, op_type_of);
+    interpreterRegisterOpcode(0x8256, op_get_array_key);
+    interpreterRegisterOpcode(0x8257, op_stack_array);
     interpreterRegisterOpcode(0x8261, op_explosions_metarule);
     interpreterRegisterOpcode(0x8263, op_power);
-    interpreterRegisterOpcode(0x8267, opRound);
-    interpreterRegisterOpcode(0x826B, opGetMessage);
+    interpreterRegisterOpcode(0x8267, op_round);
+    interpreterRegisterOpcode(0x826B, op_get_message);
     interpreterRegisterOpcode(0x826E, op_make_straight_path);
     interpreterRegisterOpcode(0x826F, op_obj_blocking_at);
-    interpreterRegisterOpcode(0x8271, opPartyMemberList);
-    interpreterRegisterOpcode(0x8274, opArtExists);
+    interpreterRegisterOpcode(0x8271, op_party_member_list);
+    interpreterRegisterOpcode(0x8274, op_art_exists);
     interpreterRegisterOpcode(0x8276, op_sfall_func0);
     interpreterRegisterOpcode(0x8277, op_sfall_func1);
     interpreterRegisterOpcode(0x8278, op_sfall_func2);


### PR DESCRIPTION
This also makes them significantly easier to find sfall opcode implementations in the codebase.

Note: the vanilla opcode implementations are in camelCase.  I don't think we necessarily need to change those since they are unlikely to be worked on frequently.
