### PR TITLE
Default to 800px interface bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ IFACE_BAR_SIDES_ORI=0
 ;This will increase the width of the interface bar expanding the area used to display text.
 ;if IFACE_BAR_WIDTH=640 - Interface bar will remain at it's original width.
 ;if IFACE_BAR_WIDTH=800 - Interface bar will use 800pix wide asset from f2_res.dat.
-IFACE_BAR_WIDTH=640
+;IFACE_BAR_WIDTH=640
 ```
 
 Recommendations:

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -291,7 +291,7 @@ static FrmImage _yellowLightFrmImage;
 static FrmImage _redLightFrmImage;
 
 int gInterfaceBarContentOffset = 0;
-int gInterfaceBarWidth = -1;
+int gInterfaceBarWidth = 800; // will fall back to 640 if screen width is too narrow or asset is absent
 bool gInterfaceBarIsCustom = false;
 static Art* gCustomInterfaceBarBackground = nullptr;
 


### PR DESCRIPTION
(still can be overriden by config)

Will fall back to 640px version if screen is narrower than 800px or asset doesn't exist
