### PR TITLE
Add sprintf, add test utils

### DIFF
--- a/sfall_testing/README.md
+++ b/sfall_testing/README.md
@@ -34,12 +34,12 @@ compile.exe -q -p -l -O2 -d -s -n -I<sfall_headers_id> <script_name.ssl>
 
 ## Run test script
 
-1. Move compiled `.int` file into game folder as `data/SCRIPTS/gl_<script_name>.int`
+1. Move compiled `.int` file into game folder as `data/scripts/gl_<script_name>.int`
 
 2. Change `ddraw.ini` and add this section:
 ```ini
 [Scripts]
-GlobalScriptPaths=data/SCRIPTS/gl*.int
+GlobalScriptPaths=data/scripts/gl*.int
 ```
 
 (or add new path using comma as separator)

--- a/sfall_testing/gl_test_arrays.ssl
+++ b/sfall_testing/gl_test_arrays.ssl
@@ -165,6 +165,8 @@ procedure array_test_suite begin
    */
 
    display_msg("All tests finished with "+test_suite_errors+" errors.");
+
+   call report_test_results("Arrays");
 end
 
 

--- a/sfall_testing/gl_test_arrays.ssl
+++ b/sfall_testing/gl_test_arrays.ssl
@@ -1,30 +1,8 @@
 #include "lib.arrays.h"
-
+#include "test_utils.ssl"
 // #include "define_lite.h"
 
 
-variable test_suite_errors := 0;
-variable test_suite_verbose := true;
-
-#ifndef assertEquals
-procedure assertEquals(variable desc, variable a, variable b) begin
-   if (a != b or typeof(a) != typeof(b)) then begin
-      display_msg("Assertion failed \""+desc+"\": "+a+" != "+b);
-      test_suite_errors ++;
-   end else if (test_suite_verbose) then begin
-      display_msg("Assert \""+desc+"\" ok");
-   end
-end
-
-procedure assertNotEquals(variable desc, variable a, variable b) begin
-   if (a == b) then begin
-      display_msg("Assertion failed \""+desc+"\": "+a+" == "+b);
-      test_suite_errors ++;
-   end else if (test_suite_verbose) then begin
-      display_msg("Assert \""+desc+"\" ok");
-   end
-end
-#endif
 
 #define ARRAY_MAX_STRING	   (255)
 #define ARRAY_MAX_SIZE		 (100000)

--- a/sfall_testing/gl_test_sprintf.ssl
+++ b/sfall_testing/gl_test_sprintf.ssl
@@ -34,8 +34,20 @@ procedure start begin
     call assertEquals("string_format2 hello world", string_format2("Hello %s%s!", "Wo","rld"), "Hello World!");
     call assertEquals("string_format2 auto hello world", string_format("Hello %s%s!", "Wo","rld"), "Hello World!");
 
-    call assertEquals("string_format7 auto hello world", 
-      string_format("%s%s%s%s%s %s%s!", "H", "e", "l", "l", "o", "Wo","rld"), "Hello World!");
+    call assertEquals("string_format3 hello world", string_format3("Hell%s %s%s!", "o", "Wo","rld"), "Hello World!");
+    call assertEquals("string_format3 auto hello world", string_format("Hell%s %s%s!", "o", "Wo","rld"), "Hello World!");
+
+    call assertEquals("string_format4 hello world", string_format4("Hel%s%s %s%s!", "l", "o", "Wo","rld"), "Hello World!");
+    call assertEquals("string_format4 auto hello world", string_format("Hel%s%s %s%s!", "l", "o", "Wo","rld"), "Hello World!");
+
+    call assertEquals("string_format5 hello world", string_format5("He%s%s%s %s%s!", "l", "l", "o", "Wo","rld"), "Hello World!");
+    call assertEquals("string_format5 auto hello world", string_format("He%s%s%s %s%s!", "l", "l", "o", "Wo","rld"), "Hello World!");
+
+    call assertEquals("string_format6 hello world", string_format6("H%s%s%s%s %s%s!", "e", "l", "l", "o", "Wo","rld"), "Hello World!");
+    call assertEquals("string_format6 auto hello world", string_format("H%s%s%s%s %s%s!", "e", "l", "l", "o", "Wo","rld"), "Hello World!");
+
+    call assertEquals("string_format7 hello world", string_format7("%s%s%s%s%s %s%s!", "H", "e", "l", "l", "o", "Wo","rld"), "Hello World!");
+    call assertEquals("string_format7 auto hello world", string_format("%s%s%s%s%s %s%s!", "H", "e", "l", "l", "o", "Wo","rld"), "Hello World!");
 
     call report_test_results("sprintf");
 end

--- a/sfall_testing/gl_test_sprintf.ssl
+++ b/sfall_testing/gl_test_sprintf.ssl
@@ -1,4 +1,5 @@
 #include "test_utils.ssl"
+#include "sfall.h"
 
 #define REPEAT_64 "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 #define REPEAT_512 REPEAT_64 REPEAT_64 REPEAT_64 REPEAT_64 REPEAT_64 REPEAT_64 REPEAT_64 REPEAT_64
@@ -25,6 +26,16 @@ procedure start begin
     call assertEquals("Long string", sprintf(REPEAT_1024"x", 1), "Error");
 
     call assertEquals("Not so long", sprintf(REPEAT_1024, 1), REPEAT_1024);
+
+
+    call assertEquals("string_format1 hello world", string_format1("Hello %s!", "World"), "Hello World!");
+    call assertEquals("string_format1 auto hello world", string_format("Hello %s!", "World"), "Hello World!");
+
+    call assertEquals("string_format2 hello world", string_format2("Hello %s%s!", "Wo","rld"), "Hello World!");
+    call assertEquals("string_format2 auto hello world", string_format("Hello %s%s!", "Wo","rld"), "Hello World!");
+
+    call assertEquals("string_format7 auto hello world", 
+      string_format("%s%s%s%s%s %s%s!", "H", "e", "l", "l", "o", "Wo","rld"), "Hello World!");
 
     call report_test_results("sprintf");
 end

--- a/sfall_testing/gl_test_sprintf.ssl
+++ b/sfall_testing/gl_test_sprintf.ssl
@@ -51,5 +51,18 @@ procedure start begin
     call assertEquals("string_format7 hello world", string_format7("%s%s%s%s%s %s%s!", "H", "e", "l", "l", "o", "Wo","rld"), "Hello World!");
     call assertEquals("string_format7 auto hello world", string_format("%s%s%s%s%s %s%s!", "H", "e", "l", "l", "o", "Wo","rld"), "Hello World!");
 
+    call assertEquals("formatted string length 1024", strlen(sprintf(REPEAT_1024, 1)), 1024);
+
+    call assertEquals("formatted string length 5119", strlen(
+         string_format7(
+            "%s%s%s%s%s%s%s",
+            REPEAT_1024,
+            REPEAT_1024,
+            REPEAT_1024,
+            REPEAT_1024,
+            REPEAT_1024,
+            REPEAT_1024,
+            REPEAT_1024)), 5119);
+
     call report_test_results("sprintf");
 end

--- a/sfall_testing/gl_test_sprintf.ssl
+++ b/sfall_testing/gl_test_sprintf.ssl
@@ -12,15 +12,13 @@ procedure start begin
 
     call assertEquals("sprintf empty string", sprintf("", 123), "");
 
-    call assertEquals("sprintf number string", sprintf("Hello%d!", 123), "Hello123!");
+    call assertEquals("sprintf number string", sprintf("Hello %d !", 123), "Hello 123 !");
 
     call assertEquals("sprintf ascii code", sprintf("Hello %c !", 123), "Hello { !");
 
-    // This gives weird results in sFall
-    // call assertEquals("sprintf float string", sprintf("Hello%d!", 3.4), "Hello"+3.4+"!");
+    call assertEquals("sprintf float string", sprintf("Hello %f !", 3.4), "Hello 3.400000 !");
 
-    // This is not a float!
-    call assertEquals("sprintf float string", sprintf("Hello%d!", 10/4), "Hello2!");
+    call assertEquals("sprintf float string", sprintf("Hello %d !", 10/4), "Hello 2 !");
 
     call assertEquals("sprintf two strings", sprintf("Hello %s %s", "World"), "Hello World World");
 

--- a/sfall_testing/gl_test_sprintf.ssl
+++ b/sfall_testing/gl_test_sprintf.ssl
@@ -13,7 +13,9 @@ procedure start begin
 
     call assertEquals("sprintf empty string", sprintf("", 123), "");
 
-    call assertEquals("sprintf number string", sprintf("Hello %d !", 123), "Hello 123 !");
+    call assertEquals("sprintf number string", sprintf("%d", 123), "123");
+
+    call assertEquals("sprintf number inside string", sprintf("Hello %d !", 123), "Hello 123 !");
 
     call assertEquals("sprintf ascii code", sprintf("Hello %c !", 123), "Hello { !");
 

--- a/sfall_testing/gl_test_sprintf.ssl
+++ b/sfall_testing/gl_test_sprintf.ssl
@@ -1,0 +1,20 @@
+#include "test_utils.ssl"
+
+procedure start begin
+
+    display_msg("Testing sprintf...");
+
+    call assertEquals("sprintf hello world", sprintf("Hello %s", "World"), "Hello World");
+
+    call assertEquals("sprintf empty string", sprintf("", 123), "");
+
+    call assertEquals("sprintf number string", sprintf("Hello%d!", 123), "Hello123!");
+
+    call assertEquals("sprintf float string", sprintf("Hello%d!", 3.4), "Hello3.4!");
+
+    call assertEquals("sprintf two strings", sprintf("Hello %s %s", "World"), "Hello World %s");
+
+    // TODO Huge length string
+
+    call report_test_results("sprintf");
+end

--- a/sfall_testing/gl_test_sprintf.ssl
+++ b/sfall_testing/gl_test_sprintf.ssl
@@ -14,6 +14,8 @@ procedure start begin
 
     call assertEquals("sprintf number string", sprintf("Hello%d!", 123), "Hello123!");
 
+    call assertEquals("sprintf ascii code", sprintf("Hello %c !", 123), "Hello { !");
+
     // This gives weird results in sFall
     // call assertEquals("sprintf float string", sprintf("Hello%d!", 3.4), "Hello"+3.4+"!");
 

--- a/sfall_testing/gl_test_sprintf.ssl
+++ b/sfall_testing/gl_test_sprintf.ssl
@@ -1,5 +1,9 @@
 #include "test_utils.ssl"
 
+#define REPEAT_64 "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+#define REPEAT_512 REPEAT_64 REPEAT_64 REPEAT_64 REPEAT_64 REPEAT_64 REPEAT_64 REPEAT_64 REPEAT_64
+#define REPEAT_1024 REPEAT_512 REPEAT_512
+
 procedure start begin
 
     display_msg("Testing sprintf...");
@@ -10,11 +14,17 @@ procedure start begin
 
     call assertEquals("sprintf number string", sprintf("Hello%d!", 123), "Hello123!");
 
-    call assertEquals("sprintf float string", sprintf("Hello%d!", 3.4), "Hello3.4!");
+    // This gives weird results in sFall
+    // call assertEquals("sprintf float string", sprintf("Hello%d!", 3.4), "Hello"+3.4+"!");
 
-    call assertEquals("sprintf two strings", sprintf("Hello %s %s", "World"), "Hello World %s");
+    // This is not a float!
+    call assertEquals("sprintf float string", sprintf("Hello%d!", 10/4), "Hello2!");
 
-    // TODO Huge length string
+    call assertEquals("sprintf two strings", sprintf("Hello %s %s", "World"), "Hello World World");
+
+    call assertEquals("Long string", sprintf(REPEAT_1024"x", 1), "Error");
+
+    call assertEquals("Not so long", sprintf(REPEAT_1024, 1), REPEAT_1024);
 
     call report_test_results("sprintf");
 end

--- a/sfall_testing/gl_test_stats.ssl
+++ b/sfall_testing/gl_test_stats.ssl
@@ -21,7 +21,7 @@ procedure test_stat_pc(variable stat_id) begin
        get_pc_extra_stat(stat_id));
     if (stat_id > STAT_lu) then begin
         call assertNotEquals("Base stat was updated while it shouldn't",
-            get_pc_base_stat(stat_id), old_base_stat);
+            get_pc_base_stat(stat_id), old_base_stat + 2);
     end else begin
         call assertEquals("Base stat updated",
             get_pc_base_stat(stat_id), old_base_stat + 2);
@@ -59,7 +59,7 @@ procedure test_stat_critter(variable critter, variable stat_id) begin
        get_critter_extra_stat(critter, stat_id));
     if (stat_id > STAT_lu) then begin
         call assertNotEquals("Base stat was updated while it shouldn't",
-            get_critter_base_stat(critter, stat_id), old_base_stat);
+            get_critter_base_stat(critter, stat_id), old_base_stat + 2);
     end else begin
         call assertEquals("Base stat updated",
             get_critter_base_stat(critter, stat_id), old_base_stat + 2);

--- a/sfall_testing/gl_test_stats.ssl
+++ b/sfall_testing/gl_test_stats.ssl
@@ -8,11 +8,8 @@ procedure test_stat_pc(variable stat_id) begin
        get_pc_base_stat(stat_id) + " + " +
        get_pc_extra_stat(stat_id));
 
-    if (get_pc_base_stat(stat_id) == 0) then begin
-        display_msg("FAIL: Not interesting stat, base stat is zero");
-        test_suite_errors++;
-        return;
-    end
+
+    call assertNotEquals("Not interesting stat, base stat is zero", get_pc_base_stat(stat_id), 0);
     
     variable old_base_stat := get_pc_base_stat(stat_id);
     variable old_extra_stat := get_pc_extra_stat(stat_id);
@@ -23,34 +20,25 @@ procedure test_stat_pc(variable stat_id) begin
        get_pc_base_stat(stat_id) + " + " +
        get_pc_extra_stat(stat_id));
     if (stat_id > STAT_lu) then begin
-        if (get_pc_base_stat(stat_id) != old_base_stat) then begin
-            display_msg("FAIL: Base stat was updated while it shouldn't");
-            test_suite_errors++;
-            return;
-        end
+        call assertNotEquals("Base stat was updated while it shouldn't",
+            get_pc_base_stat(stat_id), old_base_stat);
     end else begin
-        if (get_pc_base_stat(stat_id) != old_base_stat + 2) then begin
-            display_msg("FAIL: Base stat not updated correctly");
-            test_suite_errors++;
-            return;
-        end
+        call assertEquals("Base stat updated",
+            get_pc_base_stat(stat_id), old_base_stat + 2);
     end
     
     set_pc_base_stat(stat_id, old_base_stat);
     set_pc_extra_stat(stat_id, old_extra_stat);
+
     display_msg("Stat after reset " + stat_id + " = " +
        get_pc_base_stat(stat_id) + " + " +
        get_pc_extra_stat(stat_id));
-    if (get_pc_base_stat(stat_id) != old_base_stat) then begin
-        display_msg("FAIL: Base stat not reset correctly");
-        test_suite_errors++;
-        return;
-    end
-    if (get_pc_extra_stat(stat_id) != old_extra_stat) then begin
-        display_msg("FAIL: Extra stat not reset correctly");
-        test_suite_errors++;
-        return;
-    end
+    
+    call assertEquals("Base stat reset",
+        get_pc_base_stat(stat_id), old_base_stat);
+ 
+    call assertEquals("Extra stat reset",
+        get_pc_extra_stat(stat_id), old_extra_stat);    
 end
 
 procedure test_stat_critter(variable critter, variable stat_id) begin
@@ -58,11 +46,8 @@ procedure test_stat_critter(variable critter, variable stat_id) begin
        get_critter_base_stat(critter, stat_id) + " + " +
        get_critter_extra_stat(critter, stat_id));
 
-    if (get_critter_base_stat(critter, stat_id) == 0) then begin
-        display_msg("FAIL: Not interesting stat, base stat is zero");
-        test_suite_errors++;
-        return;
-    end
+    call assertNotEquals("Not interesting stat, base stat is zero",
+        get_critter_base_stat(critter, stat_id), 0);
     
     variable old_base_stat := get_critter_base_stat(critter, stat_id);
     variable old_extra_stat := get_critter_extra_stat(critter, stat_id);
@@ -73,17 +58,11 @@ procedure test_stat_critter(variable critter, variable stat_id) begin
        get_critter_base_stat(critter, stat_id) + " + " +
        get_critter_extra_stat(critter, stat_id));
     if (stat_id > STAT_lu) then begin
-        if (get_critter_base_stat(critter, stat_id) != old_base_stat) then begin
-            display_msg("FAIL: Base stat was updated while it shouldn't");
-            test_suite_errors++;
-            return;
-        end
+        call assertNotEquals("Base stat was updated while it shouldn't",
+            get_critter_base_stat(critter, stat_id), old_base_stat);
     end else begin
-        if (get_critter_base_stat(critter, stat_id) != old_base_stat + 2) then begin
-            display_msg("FAIL: Base stat not updated correctly");
-            test_suite_errors++;
-            return;
-        end
+        call assertEquals("Base stat updated",
+            get_critter_base_stat(critter, stat_id), old_base_stat + 2);
     end
     
     set_critter_base_stat(critter, stat_id, old_base_stat);
@@ -91,16 +70,10 @@ procedure test_stat_critter(variable critter, variable stat_id) begin
     display_msg("Stat after reset " + stat_id + " = " +
        get_critter_base_stat(critter, stat_id) + " + " +
        get_critter_extra_stat(critter, stat_id));
-    if (get_critter_base_stat(critter, stat_id) != old_base_stat) then begin
-        display_msg("FAIL: Base stat not reset correctly");
-        test_suite_errors++;
-        return;
-    end
-    if (get_critter_extra_stat(critter, stat_id) != old_extra_stat) then begin
-        display_msg("FAIL: Extra stat not reset correctly");
-        test_suite_errors++;
-        return;
-    end
+    call assertEquals("Base stat reset",
+        get_critter_base_stat(critter, stat_id), old_base_stat);
+    call assertEquals("Extra stat reset",
+        get_critter_extra_stat(critter, stat_id), old_extra_stat);
 end
 
 procedure start begin

--- a/sfall_testing/gl_test_stats.ssl
+++ b/sfall_testing/gl_test_stats.ssl
@@ -1,7 +1,7 @@
 #include "define_lite.h"
 #include "sfall.h"
 #include "test_utils.ssl"
-
+#include "command_lite.h"
 
 procedure test_stat_pc(variable stat_id) begin
     display_msg("Stat " + stat_id + " = " +
@@ -16,9 +16,9 @@ procedure test_stat_pc(variable stat_id) begin
 
     set_pc_base_stat(stat_id, old_base_stat + 2);
     set_pc_extra_stat(stat_id, old_extra_stat + 4);
-    display_msg("Stat after update " + stat_id + " = " +
-       get_pc_base_stat(stat_id) + " + " +
-       get_pc_extra_stat(stat_id));
+    // display_msg("Stat after update " + stat_id + " = " +
+    //    get_pc_base_stat(stat_id) + " + " +
+    //    get_pc_extra_stat(stat_id));
     if (stat_id > STAT_lu) then begin
         call assertNotEquals("Base stat was updated while it shouldn't",
             get_pc_base_stat(stat_id), old_base_stat + 2);
@@ -30,9 +30,9 @@ procedure test_stat_pc(variable stat_id) begin
     set_pc_base_stat(stat_id, old_base_stat);
     set_pc_extra_stat(stat_id, old_extra_stat);
 
-    display_msg("Stat after reset " + stat_id + " = " +
-       get_pc_base_stat(stat_id) + " + " +
-       get_pc_extra_stat(stat_id));
+    // display_msg("Stat after reset " + stat_id + " = " +
+    //    get_pc_base_stat(stat_id) + " + " +
+    //    get_pc_extra_stat(stat_id));
     
     call assertEquals("Base stat reset",
         get_pc_base_stat(stat_id), old_base_stat);
@@ -54,9 +54,9 @@ procedure test_stat_critter(variable critter, variable stat_id) begin
 
     set_critter_base_stat(critter, stat_id, old_base_stat + 2);
     set_critter_extra_stat(critter, stat_id, old_extra_stat + 4);
-    display_msg("Stat after update " + stat_id + " = " +
-       get_critter_base_stat(critter, stat_id) + " + " +
-       get_critter_extra_stat(critter, stat_id));
+    // display_msg("Stat after update " + stat_id + " = " +
+    //    get_critter_base_stat(critter, stat_id) + " + " +
+    //    get_critter_extra_stat(critter, stat_id));
     if (stat_id > STAT_lu) then begin
         call assertNotEquals("Base stat was updated while it shouldn't",
             get_critter_base_stat(critter, stat_id), old_base_stat + 2);
@@ -67,9 +67,9 @@ procedure test_stat_critter(variable critter, variable stat_id) begin
     
     set_critter_base_stat(critter, stat_id, old_base_stat);
     set_critter_extra_stat(critter, stat_id, old_extra_stat);
-    display_msg("Stat after reset " + stat_id + " = " +
-       get_critter_base_stat(critter, stat_id) + " + " +
-       get_critter_extra_stat(critter, stat_id));
+    // display_msg("Stat after reset " + stat_id + " = " +
+    //    get_critter_base_stat(critter, stat_id) + " + " +
+    //    get_critter_extra_stat(critter, stat_id));
     call assertEquals("Base stat reset",
         get_critter_base_stat(critter, stat_id), old_base_stat);
     call assertEquals("Extra stat reset",

--- a/sfall_testing/gl_test_stats.ssl
+++ b/sfall_testing/gl_test_stats.ssl
@@ -77,7 +77,7 @@ procedure test_stat_critter(variable critter, variable stat_id) begin
 end
 
 procedure start begin
-    display_msg("===== stats test =====");
+    display_msg("Testing stats...");
     test_suite_errors := 0;
 
     call test_stat_pc(STAT_max_hit_points);

--- a/sfall_testing/gl_test_stats.ssl
+++ b/sfall_testing/gl_test_stats.ssl
@@ -1,7 +1,7 @@
 #include "define_lite.h"
 #include "sfall.h"
+#include "test_utils.ssl"
 
-variable test_suite_errors := 0;
 
 procedure test_stat_pc(variable stat_id) begin
     display_msg("Stat " + stat_id + " = " +
@@ -155,13 +155,8 @@ procedure start begin
         test_suite_errors++;
     end
 
-    display_msg("Done " + test_suite_errors + " errors");
-    if (test_suite_errors == 0) then begin
-        float_msg(dude_obj, "Stats tests passed!", FLOAT_MSG_GREEN);
-    end else begin
-        float_msg(dude_obj, "Stats " + test_suite_errors + " tests failed", FLOAT_MSG_RED);
-    end
 
+    call report_test_results("Stats");
     
 
     // set_pc_base_stat(STAT_lu, 10);

--- a/sfall_testing/test_utils.ssl
+++ b/sfall_testing/test_utils.ssl
@@ -1,0 +1,35 @@
+#include "define_lite.h"
+
+#ifndef assertEquals
+
+variable test_suite_errors := 0;
+variable test_suite_verbose := false;
+
+procedure assertEquals(variable desc, variable a, variable b) begin
+   if (a != b or typeof(a) != typeof(b)) then begin
+      display_msg("Assertion failed \""+desc+"\": "+a+" != "+b);
+      test_suite_errors ++;
+   end else if (test_suite_verbose) then begin
+      display_msg("Assert \""+desc+"\" ok");
+   end
+end
+
+procedure assertNotEquals(variable desc, variable a, variable b) begin
+   if (a == b) then begin
+      display_msg("Assertion failed \""+desc+"\": "+a+" == "+b);
+      test_suite_errors ++;
+   end else if (test_suite_verbose) then begin
+      display_msg("Assert \""+desc+"\" ok");
+   end
+end
+
+procedure report_test_results(variable desc) begin
+    display_msg("Done " + test_suite_errors + " errors");
+    if (test_suite_errors == 0) then begin
+        float_msg(dude_obj, "Stats tests passed!", FLOAT_MSG_GREEN);
+    end else begin
+        float_msg(dude_obj, "Stats " + test_suite_errors + " tests failed", FLOAT_MSG_RED);
+    end
+end
+
+#endif

--- a/sfall_testing/test_utils.ssl
+++ b/sfall_testing/test_utils.ssl
@@ -4,8 +4,11 @@
 
 variable test_suite_errors := 0;
 variable test_suite_verbose := false;
+variable test_suite_assertions := 0;
 
 procedure assertEquals(variable desc, variable a, variable b) begin
+   test_suite_assertions++;
+
    if (a != b or typeof(a) != typeof(b)) then begin
       display_msg("Assertion failed \""+desc+"\": "+a+" != "+b);
       test_suite_errors ++;
@@ -15,6 +18,8 @@ procedure assertEquals(variable desc, variable a, variable b) begin
 end
 
 procedure assertNotEquals(variable desc, variable a, variable b) begin
+   test_suite_assertions++;
+
    if (a == b) then begin
       display_msg("Assertion failed \""+desc+"\": "+a+" == "+b);
       test_suite_errors ++;
@@ -24,12 +29,16 @@ procedure assertNotEquals(variable desc, variable a, variable b) begin
 end
 
 procedure report_test_results(variable desc) begin
-    display_msg("Done " + test_suite_errors + " errors");
-    if (test_suite_errors == 0) then begin
-        float_msg(dude_obj, "Stats tests passed!", FLOAT_MSG_GREEN);
-    end else begin
-        float_msg(dude_obj, "Stats " + test_suite_errors + " tests failed", FLOAT_MSG_RED);
-    end
+   display_msg("Done " + test_suite_assertions +
+      " assertions with " + test_suite_errors + " errors");
+
+   if (test_suite_errors == 0) then begin
+      float_msg(dude_obj, desc + " tests passed " + 
+         (test_suite_assertions-test_suite_errors) + "/" +test_suite_assertions + "!", FLOAT_MSG_GREEN);        
+   end else begin
+      float_msg(dude_obj, desc + " failed " + test_suite_errors + " tests from " +
+         test_suite_assertions + "!", FLOAT_MSG_RED);        
+   end
 end
 
 #endif

--- a/sfall_testing/test_utils.ssl
+++ b/sfall_testing/test_utils.ssl
@@ -29,8 +29,10 @@ procedure assertNotEquals(variable desc, variable a, variable b) begin
 end
 
 procedure report_test_results(variable desc) begin
-   display_msg("Done " + test_suite_assertions +
-      " assertions with " + test_suite_errors + " errors");
+   
+   display_msg("DONE " + desc + " " + 
+     (test_suite_assertions-test_suite_errors) + "/" + test_suite_assertions + "");
+   display_msg("================");
 
    if (test_suite_errors == 0) then begin
       float_msg(dude_obj, desc + " tests passed " + 

--- a/src/sfall_metarules.cc
+++ b/src/sfall_metarules.cc
@@ -1,5 +1,6 @@
 #include "sfall_metarules.h"
 
+#include <algorithm>
 #include <string.h>
 
 #include "combat.h"
@@ -46,6 +47,7 @@ static void mf_set_ini_setting(Program* program, int args);
 static void mf_set_outline(Program* program, int args);
 static void mf_show_window(Program* program, int args);
 static void mf_tile_refresh_display(Program* program, int args);
+static void mf_string_format(Program* program, int args);
 
 constexpr MetaruleInfo kMetarules[] = {
     { "car_gas_amount", mf_car_gas_amount, 0, 0 },
@@ -66,6 +68,7 @@ constexpr MetaruleInfo kMetarules[] = {
     { "set_outline", mf_set_outline, 2, 2 },
     { "show_window", mf_show_window, 0, 1 },
     { "tile_refresh_display", mf_tile_refresh_display, 0, 0 },
+    { "string_format", mf_string_format, 2, 8 },
 };
 
 constexpr int kMetarulesMax = sizeof(kMetarules) / sizeof(kMetarules[0]);
@@ -253,6 +256,119 @@ void mf_tile_refresh_display(Program* program, int args)
 {
     tileWindowRefresh();
     programStackPushInteger(program, -1);
+}
+
+void mf_string_format(Program* program, int args)
+{
+    sprintf_lite(program, args, "string_format");
+}
+
+void sprintf_lite(Program* program, int args, const char* infoOpcodeName)
+{
+    auto format = programStackPopString(program); // Pop the format string
+
+    ProgramValue formatArgs[7]; // 8 arguments total, 1 for format string
+
+    for (int index = 0; index < args - 1; index++) {
+        formatArgs[index] = programStackPopValue(program);
+    }
+
+    int fmtLen = strlen(format);
+    if (fmtLen == 0) {
+        programStackPushString(program, "");
+        return;
+    }
+    if (fmtLen > 1024) {
+        debugPrint("%s(): format string exceeds maximum length of 1024 characters.", infoOpcodeName);
+        programStackPushString(program, "Error");
+        return;
+    }
+    int newFmtLen = fmtLen;
+
+    for (int i = 0; i < fmtLen; i++) {
+        if (format[i] == '%') newFmtLen++; // will possibly be escaped, need space for that
+    }
+
+    // parse format to make it safe
+    char* newFmt = new char[newFmtLen + 1];
+    bool conversion = false;
+    int j = 0;
+    int valIdx = 0;
+
+    char out[5120] = { 0 };
+
+    char* outBuf = out;
+    int bufCount = sizeof(outBuf) - 1;
+
+    int numArgs = args; // From 2 to 8
+
+    for (int i = 0; i < fmtLen; i++) {
+        char c = format[i];
+        if (!conversion) {
+            // Start conversion.
+            if (c == '%') conversion = true;
+        } else if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '%') {
+            int partLen;
+            if (c == '%') {
+                // escaped % sign, just copy newFmt up to (and including) the leading % sign
+                newFmt[j] = '\0';
+                // strncpy_s(outBuf, bufCount, newFmt, j);
+                strncpy(outBuf, newFmt, std::min(j, bufCount - 1));
+                partLen = j;
+            } else {
+                // ignore size prefixes
+                if (c == 'h' || c == 'l' || c == 'j' || c == 'z' || c == 't' || c == 'w' || c == 'L' || c == 'I') continue;
+                // Type specifier, perform conversion.
+                if (++valIdx == numArgs) {
+                    debugPrint("%s() - format string contains more conversions than passed arguments (%d): %s",
+                        infoOpcodeName, numArgs - 1, format);
+                }
+                const auto& arg = formatArgs[std::min(valIdx - 1, numArgs - 2)];
+
+                // ctx.arg(valIdx < numArgs ? valIdx : numArgs - 1);
+                if (c == 'S' || c == 'Z') {
+                    c = 's'; // don't allow wide strings
+                }
+                if (c == 's' && !arg.isString() || // don't allow treating non-string values as string pointers
+                    c == 'n') // don't allow "n" specifier
+                {
+                    c = 'd';
+                }
+                newFmt[j++] = c;
+                newFmt[j] = '\0';
+                partLen = arg.isFloat()
+                    ? snprintf(outBuf, bufCount, newFmt, arg.floatValue)
+                    : arg.isInt()    ? snprintf(outBuf, bufCount, newFmt, arg.integerValue)
+                    : arg.isString() ? snprintf(outBuf, bufCount, newFmt,
+                                           programGetString(program, arg.opcode, arg.integerValue))
+                                     : snprintf(outBuf, bufCount, newFmt, "<UNSUPPORTED TYPE>");
+            }
+            outBuf += partLen;
+            bufCount -= partLen;
+            conversion = false;
+            j = 0;
+            if (bufCount <= 0) {
+                break;
+            }
+            continue;
+        }
+        newFmt[j++] = c;
+    }
+    // Copy the remainder of the string.
+    if (bufCount > 0) {
+        newFmt[j] = '\0';
+        // strcpy_s(outBuf, bufCount, newFmt);
+        if (strlen(newFmt) < bufCount) {
+            strcpy(outBuf, newFmt);
+        } else {
+            strncpy(outBuf, newFmt, bufCount - 1);
+            outBuf[bufCount - 1] = '\0'; // Ensure null-termination
+        }
+    }
+
+    delete[] newFmt;
+
+    programStackPushString(program, out);
 }
 
 void sfall_metarule(Program* program, int args)

--- a/src/sfall_metarules.cc
+++ b/src/sfall_metarules.cc
@@ -257,7 +257,7 @@ void mf_tile_refresh_display(Program* program, int args)
 
 void sfall_metarule(Program* program, int args)
 {
-    static ProgramValue values[6];
+    static ProgramValue values[8];
 
     for (int index = 0; index < args; index++) {
         values[index] = programStackPopValue(program);

--- a/src/sfall_metarules.cc
+++ b/src/sfall_metarules.cc
@@ -297,7 +297,7 @@ void sprintf_lite(Program* program, int args, const char* infoOpcodeName)
     int j = 0;
     int valIdx = 0;
 
-    char out[5120] = { 0 };
+    char out[5120+1] = { 0 };
     int bufCount = sizeof(out) - 1;
     char* outBuf = out;
     

--- a/src/sfall_metarules.h
+++ b/src/sfall_metarules.h
@@ -7,6 +7,8 @@ namespace fallout {
 
 void sfall_metarule(Program* program, int args);
 
+void sprintf_lite(Program* program, int args, const char* infoOpcodeName);
+
 } // namespace fallout
 
 #endif /* FALLOUT_SFALL_METARULES_H_ */

--- a/src/sfall_opcodes.cc
+++ b/src/sfall_opcodes.cc
@@ -1055,6 +1055,18 @@ static void op_sfall_func6(Program* program)
     sfall_metarule(program, 6);
 }
 
+// sfall_func6
+static void op_sfall_func7(Program* program)
+{
+    sfall_metarule(program, 7);
+}
+
+// sfall_func6
+static void op_sfall_func8(Program* program)
+{
+    sfall_metarule(program, 8);
+}
+
 // div (/)
 static void op_div(Program* program)
 {
@@ -1075,6 +1087,13 @@ static void op_div(Program* program)
         // Unsigned divison.
         programStackPushInteger(program, static_cast<unsigned int>(dividendValue.integerValue) / static_cast<unsigned int>(divisorValue.integerValue));
     }
+}
+
+static void op_sprintf(Program* program)
+{
+  // TODO : Add the same for mf_string_format (metarule), move this code into metarules?
+  //   metarule can support from 2-8 arguments
+  
 }
 
 void sfallOpcodesInit()
@@ -1165,6 +1184,8 @@ void sfallOpcodesInit()
     interpreterRegisterOpcode(0x827A, op_sfall_func4);
     interpreterRegisterOpcode(0x827B, op_sfall_func5);
     interpreterRegisterOpcode(0x827C, op_sfall_func6);
+    interpreterRegisterOpcode(0x8280, op_sfall_func7);
+    interpreterRegisterOpcode(0x8281, op_sfall_func8);
     interpreterRegisterOpcode(0x827F, op_div);
 }
 

--- a/src/sfall_opcodes.cc
+++ b/src/sfall_opcodes.cc
@@ -1091,6 +1091,10 @@ static void op_div(Program* program)
 
 static void op_sprintf(Program* program)
 {
+    auto arg1 = programStackPopValue(program);
+    auto arg2 = programStackPopString(program);
+    programStackPushValue(program, arg1);
+    programStackPushString(program, arg2);
     sprintf_lite(program, 2, "op_sprintf");  
 }
 

--- a/src/sfall_opcodes.cc
+++ b/src/sfall_opcodes.cc
@@ -1091,9 +1091,7 @@ static void op_div(Program* program)
 
 static void op_sprintf(Program* program)
 {
-  // TODO : Add the same for mf_string_format (metarule), move this code into metarules?
-  //   metarule can support from 2-8 arguments
-  
+    sprintf_lite(program, 2, "op_sprintf");  
 }
 
 void sfallOpcodesInit()
@@ -1166,6 +1164,7 @@ void sfallOpcodesInit()
     interpreterRegisterOpcode(0x824B, op_tile_under_cursor);
     interpreterRegisterOpcode(0x824E, op_substr);
     interpreterRegisterOpcode(0x824F, op_get_string_length);
+    interpreterRegisterOpcode(0x8250, op_sprintf);
     interpreterRegisterOpcode(0x8253, op_type_of);
     interpreterRegisterOpcode(0x8256, op_get_array_key);
     interpreterRegisterOpcode(0x8257, op_stack_array);


### PR DESCRIPTION
### Description

Add sfall `sprintf` and `string_format`.

Add test utils.

### Reproduction Steps and Savefile (if available)

Follow the testing guide in the README.md file in the `sfall_testing` folder

### Screenshots

![image](https://github.com/user-attachments/assets/211a4921-1496-4656-ab81-1ab3ad237018)

<!--- 

**Important Notes** 

- *Preview builds are not available for pull requests from forked repositories.* To enable preview builds, submit the PR from a branch within this repository. 

- *Formatting issues? You have two options:*
1. **Fix formatting automatically** using the following Docker command: *(If you're using Windows, remove `--user $(id -u):$(id -g)`)* 
```bash
docker run --rm \
  -v $(pwd):/app --workdir /app  \
  --user $(id -u):$(id -g) silkeh/clang:18 \
  bash -c 'find src -type f -name \*.cc -o -name \*.h | xargs clang-format -i'
```
2. **Skip formatting check** by adding the `skip-formatting` label to this PR.

--->

