### PR TITLE
Use global variables and arrays to show tests summary

### DIFF
--- a/sfall_testing/gl_test_arrays.ssl
+++ b/sfall_testing/gl_test_arrays.ssl
@@ -166,7 +166,7 @@ procedure array_test_suite begin
 
    display_msg("All tests finished with "+test_suite_errors+" errors.");
 
-   call report_test_results("Arrays");
+   call report_test_results("arrays");
 end
 
 

--- a/sfall_testing/gl_test_stats.ssl
+++ b/sfall_testing/gl_test_stats.ssl
@@ -154,7 +154,7 @@ procedure start begin
     call test_derived_base_stat_critter(dude_obj);
     call test_derived_base_stat_critter(closest_critter);
 
-    call report_test_results("Stats");
+    call report_test_results("stats");
     
 
     // set_pc_base_stat(STAT_lu, 10);

--- a/sfall_testing/test_utils.h
+++ b/sfall_testing/test_utils.h
@@ -29,18 +29,37 @@ procedure assertNotEquals(variable desc, variable a, variable b) begin
    end
 end
 
+
+
 procedure report_test_results(variable desc) begin
    
    display_msg("DONE " + desc + " " + 
      (test_suite_assertions-test_suite_errors) + "/" + test_suite_assertions + "");
    display_msg("================");
 
-   if (test_suite_errors == 0) then begin
-      float_msg(dude_obj, desc + " tests passed " + 
-         (test_suite_assertions-test_suite_errors) + "/" +test_suite_assertions + "!", FLOAT_MSG_GREEN);        
+   #define TEST_CASES "TstCases"
+   #define TEST_ASSERTIONS_TOTAL "TestTota"
+   #define TEST_ASSERTIONS_FAILED "TestFail"
+
+   //set_sfall_global("test_suite_errors", test_suite_errors);
+   variable gl_cases = get_sfall_global_int(TEST_CASES);
+   variable gl_assertions_total = get_sfall_global_int(TEST_ASSERTIONS_TOTAL);
+   variable gl_assertions_failed = get_sfall_global_int(TEST_ASSERTIONS_FAILED);
+   gl_cases += 1;
+   gl_assertions_total = gl_assertions_total + test_suite_assertions;
+   gl_assertions_failed = gl_assertions_failed + test_suite_errors;
+   set_sfall_global(TEST_CASES, gl_cases);
+   set_sfall_global(TEST_ASSERTIONS_TOTAL, gl_assertions_total);
+   set_sfall_global(TEST_ASSERTIONS_FAILED, gl_assertions_failed);
+
+   if (gl_assertions_failed == 0) then begin
+      float_msg(dude_obj, "Tested " + gl_cases + " cases, " +
+          (gl_assertions_total-gl_assertions_failed) + "/" + gl_assertions_total +
+          " assertions passed!", FLOAT_MSG_GREEN);
    end else begin
-      float_msg(dude_obj, desc + " failed " + test_suite_errors + " tests from " +
-         test_suite_assertions + "!", FLOAT_MSG_RED);        
+      float_msg(dude_obj, "Tested " + gl_cases + " cases, " +
+          (gl_assertions_total-gl_assertions_failed) + "/" + gl_assertions_total +
+           " assertions passed", FLOAT_MSG_RED);
    end
 end
 

--- a/sfall_testing/test_utils.h
+++ b/sfall_testing/test_utils.h
@@ -11,10 +11,10 @@ procedure assertEquals(variable desc, variable a, variable b) begin
    test_suite_assertions++;
 
    if (a != b or typeof(a) != typeof(b)) then begin
-      display_msg("Assertion failed \""+desc+"\": "+a+" != "+b);
+      display_msg("FAIL \""+desc+"\": "+a+" != "+b);
       test_suite_errors ++;
    end else if (test_suite_verbose) then begin
-      display_msg("Assert \""+desc+"\" ok");
+      display_msg("ok \""+desc+"\"");
    end
 end
 
@@ -22,10 +22,10 @@ procedure assertNotEquals(variable desc, variable a, variable b) begin
    test_suite_assertions++;
 
    if (a == b) then begin
-      display_msg("Assertion failed \""+desc+"\": "+a+" == "+b);
+      display_msg("FAIL \""+desc+"\": "+a+" == "+b);
       test_suite_errors ++;
    end else if (test_suite_verbose) then begin
-      display_msg("Assert \""+desc+"\" ok");
+      display_msg("ok \""+desc+"\"");
    end
 end
 
@@ -35,10 +35,10 @@ procedure assertFloat(variable desc, variable a, variable b, variable tolerance 
 
    variable diff := abs(a - b);
    if (diff > tolerance) then begin
-      display_msg("Assertion failed \""+desc+"\": "+a+" != "+b+" (diff: "+diff+")");
+      display_msg("FAIL \""+desc+"\": "+a+" != "+b+" (diff: "+diff+")");
       test_suite_errors ++;
    end else if (test_suite_verbose) then begin
-      display_msg("Assert \""+desc+"\" ok");
+      display_msg("ok \""+desc+"\"");
    end
 end
 
@@ -98,14 +98,14 @@ procedure report_test_results(variable desc) begin
    end
    
 
+   variable assertions_stats_str = (arr_id[TEST_ASSERTIONS_TOTAL]-arr_id[TEST_ASSERTIONS_FAILED]) + 
+      "/" + arr_id[TEST_ASSERTIONS_TOTAL];
    if (arr_id[TEST_ASSERTIONS_FAILED] == 0) then begin
       float_msg(dude_obj, "Tested " + total_suites_count + " cases: " + total_suites_names + ". " +
-          (arr_id[TEST_ASSERTIONS_TOTAL]-arr_id[TEST_ASSERTIONS_FAILED]) + "/" + arr_id[TEST_ASSERTIONS_TOTAL] +
-          " assertions passed!", FLOAT_MSG_GREEN);
+          assertions_stats_str + " assertions passed!", FLOAT_MSG_GREEN);
    end else begin
       float_msg(dude_obj, "Tested " + total_suites_count + " cases: " + total_suites_names + ". " +
-          (arr_id[TEST_ASSERTIONS_TOTAL]-arr_id[TEST_ASSERTIONS_FAILED]) + "/" + arr_id[TEST_ASSERTIONS_TOTAL] +
-           " assertions passed", FLOAT_MSG_RED);
+          assertions_stats_str + " assertions passed", FLOAT_MSG_RED);
    end
 end
 


### PR DESCRIPTION
### Description

This PR uses global variables and arrays for testing, so it will show full summary in float message.

To reset tests stats after reload this PR uses arrays

### Reproduction Steps and Savefile (if available)

Copy all `.int` files from `sfall_testing` folder and run the game

### Screenshots

![image](https://github.com/user-attachments/assets/0f4e8a32-1d35-4adc-952d-8401e1bec10a)


![image](https://github.com/user-attachments/assets/3c5c61a9-dc5d-429b-bb32-528a13fad136)

![image](https://github.com/user-attachments/assets/4b487c9b-c825-4e22-844f-7b4ca14cafdb)

<!--- 

**Important Notes** 

- *Preview builds are not available for pull requests from forked repositories.* To enable preview builds, submit the PR from a branch within this repository. 

- *Formatting issues? You have two options:*
1. **Fix formatting automatically** using the following Docker command: *(If you're using Windows, remove `--user $(id -u):$(id -g)`)* 
```bash
docker run --rm \
  -v $(pwd):/app --workdir /app  \
  --user $(id -u):$(id -g) silkeh/clang:18 \
  bash -c 'find src -type f -name \*.cc -o -name \*.h | xargs clang-format -i'
```
2. **Skip formatting check** by adding the `skip-formatting` label to this PR.

--->

