### PR TITLE
Add single-commit option for preview deployments

### DIFF
--- a/.github/workflows/ci-build-web.yml
+++ b/.github/workflows/ci-build-web.yml
@@ -89,6 +89,7 @@ jobs:
           folder: fallout2-ce-ems/dist
           target-folder: ${{ steps.set-path.outputs.DEST_DIR }}
           clean: false
+          single-commit: true
 
       - name: Comment preview URL on PR
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/ci-delete-pr-preview.yml
+++ b/.github/workflows/ci-delete-pr-preview.yml
@@ -29,6 +29,15 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+          echo "Current branch: $CURRENT_BRANCH"
+
+          if [ "$CURRENT_BRANCH" != "gh-pages" ]; then
+            echo "❌ Refusing to force-push to non-gh-pages branch: $CURRENT_BRANCH"
+            exit 1
+          fi
+
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else

--- a/.github/workflows/ci-delete-pr-preview.yml
+++ b/.github/workflows/ci-delete-pr-preview.yml
@@ -29,5 +29,9 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -am "🚮 Remove preview for closed PR #${{ github.event.pull_request.number }}"
-          git push
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit --amend -m "🚮 Remove preview for closed PR #${{ github.event.pull_request.number }}"
+            git push --force
+          fi


### PR DESCRIPTION
### Description

Fetching this repo takes some time because of `gh-pages` branch which holds all history of deployments. In this PR I am trying to use single-commit option to reduce checkout size.

Let's hope it will not break preview deployments

### Reproduction Steps and Savefile (if available)


### Screenshots

<!--- If the PR includes visual changes, add screenshots here. --->


<!--- 

**Important Notes** 

- *Preview builds are not available for pull requests from forked repositories.* To enable preview builds, submit the PR from a branch within this repository. 

- *Formatting issues? You have two options:*
1. **Fix formatting automatically** using the following Docker command: *(If you're using Windows, remove `--user $(id -u):$(id -g)`)* 
```bash
docker run --rm \
  -v $(pwd):/app --workdir /app  \
  --user $(id -u):$(id -g) silkeh/clang:18 \
  bash -c 'find src -type f -name \*.cc -o -name \*.h | xargs clang-format -i'
```
2. **Skip formatting check** by adding the `skip-formatting` label to this PR.

--->

