### PR TITLE
Reformat sfall opcode list to contain all opcodes

### DIFF
--- a/src/sfall_opcodes.cc
+++ b/src/sfall_opcodes.cc
@@ -1158,143 +1158,470 @@ static void op_charcode(Program* program)
 void sfallOpcodesInit()
 {
     // ref. https://github.com/sfall-team/sfall/blob/71ecec3d405bd5e945f157954618b169e60068fe/artifacts/scripting/sfall%20opcode%20list.txt#L145
+    // Note: we can't really implement these since address space is different.
+    // We can potentially special case some of them, but we should try to avoid that.
+    // 0x8156 - int   read_byte(int address)
     interpreterRegisterOpcode(0x8156, op_read_byte);
-    // missing: read_short, read_int, read_string
+    // 0x8157 - int   read_short(int address)
+    // 0x8158 - int   read_int(int address)
+    // 0x8159 - string read_string(int address)
+
+    // ^ 0x81cf - void  write_byte(int address, int value)
+    // ^ 0x81d0 - void  write_short(int address, int value)
+    // ^ 0x81d1 - void  write_int(int address, int value)
+    // ^ 0x821b - void  write_string(int address, string value)
+
+    // ^ 0x81d2 - void  call_offset_v0(int address)
+    // ^ 0x81d3 - void  call_offset_v1(int address, int arg1)
+    // ^ 0x81d4 - void  call_offset_v2(int address, int arg1, int arg2)
+    // ^ 0x81d5 - void  call_offset_v3(int address, int arg1, int arg2, int arg3)
+    // ^ 0x81d6 - void  call_offset_v4(int address, int arg1, int arg2, int arg3, int arg4)
+    // ^ 0x81d7 - int   call_offset_r0(int address)
+    // ^ 0x81d8 - int   call_offset_r1(int address, int arg1)
+    // ^ 0x81d9 - int   call_offset_r2(int address, int arg1, int arg2)
+    // ^ 0x81da - int   call_offset_r3(int address, int arg1, int arg2, int arg3)
+    // ^ 0x81db - int   call_offset_r4(int address, int arg1, int arg2, int arg3, int arg4)
+
+    // 0x815a - void set_pc_base_stat(int StatID, int value)
     interpreterRegisterOpcode(0x815A, op_set_pc_base_stat);
+    // 0x815b - void set_pc_extra_stat(int StatID, int value)
     interpreterRegisterOpcode(0x815B, op_set_pc_bonus_stat);
+    // 0x815c - int  get_pc_base_stat(int StatID)
     interpreterRegisterOpcode(0x815C, op_get_pc_base_stat);
+    // 0x815d - int  get_pc_extra_stat(int StatID)
     interpreterRegisterOpcode(0x815D, op_get_pc_bonus_stat);
+
+    // 0x815e - void set_critter_base_stat(object, int StatID, int value)
     interpreterRegisterOpcode(0x815E, op_set_critter_base_stat);
+    // 0x815f - void set_critter_extra_stat(object, int StatID, int value)
     interpreterRegisterOpcode(0x815F, op_set_critter_extra_stat);
+    // 0x8160 - int  get_critter_base_stat(object, int StatID)
     interpreterRegisterOpcode(0x8160, op_get_critter_base_stat);
+    // 0x8161 - int  get_critter_extra_stat(object, int StatID)
     interpreterRegisterOpcode(0x8161, op_get_critter_extra_stat);
-    interpreterRegisterOpcode(0x8162, op_tap_key);
-    interpreterRegisterOpcode(0x8163, op_get_year);
-    interpreterRegisterOpcode(0x8164, op_game_loaded);
-    // missing: graphics_funcs_available, load_shader, free_shader, activate_shader, deactivate_shader
-    interpreterRegisterOpcode(0x816A, op_set_global_script_repeat);
-    // missing: input_funcs_available
+    // 0x8242 - void set_critter_skill_points(int critter, int skill, int value)
+    // 0x8243 - int  get_critter_skill_points(int critter, int skill)
+    // 0x8244 - void set_available_skill_points(int value)
+    // 0x8245 - int  get_available_skill_points()
+    // 0x8246 - void mod_skill_points_per_level(int value)
+
+    // 0x81b4 - void set_stat_max(int stat, int value)
+    // 0x81b5 - void set_stat_min(int stat, int value)
+    // 0x81b7 - void set_pc_stat_max(int stat, int value)
+    // 0x81b8 - void set_pc_stat_min(int stat, int value)
+    // 0x81b9 - void set_npc_stat_max(int stat, int value)
+    // 0x81ba - void set_npc_stat_min(int stat, int value)
+
+    // 0x816b - int  input_funcs_available()
+    // 0x816c - int  key_pressed(int dxScancode)
     interpreterRegisterOpcode(0x816C, op_key_pressed);
-    // missing: set_shader_int, set_shader_float, set_shader_vector
-    interpreterRegisterOpcode(0x8170, op_in_world_map);
-    interpreterRegisterOpcode(0x8171, op_force_encounter);
-    interpreterRegisterOpcode(0x8172, op_set_world_map_pos);
-    // missing: many set_perk, kill_counter, critter_ap, dm/df_model functions
-    interpreterRegisterOpcode(0x8193, op_get_current_hand);
-    // missing: toggle_active_hand, 6 knockback functions
-    interpreterRegisterOpcode(0x819B, op_set_global_script_type);
-    interpreterRegisterOpcode(0x819D, op_set_sfall_global);
-    interpreterRegisterOpcode(0x819E, op_get_sfall_global_int);
-    // missing: get_sfall_global_float, skill_max, eax (deprecated), npc_level, viewport, mod
-    interpreterRegisterOpcode(0x81AC, op_get_ini_setting);
-    // missing: get_shader_version, get_shader_mode
-    interpreterRegisterOpcode(0x81AF, op_get_game_mode);
-    interpreterRegisterOpcode(0x81B3, op_get_uptime);
-    // missing: set_stat_max, set_stat_min
-    interpreterRegisterOpcode(0x81B6, op_set_car_current_town);
-    // missing: set_pc/npc_stat_max/min, many fake_perk, fake_trait functions
-    // missing: set_critter/base_hit_chance_mod
-    // missing: write_byte/short/int
-    // missing: call_offset_v/r0-4
-    // missing: show/hide_iface_tag, is_face_tag_active
-    interpreterRegisterOpcode(0x81DF, op_get_bodypart_hit_modifier);
-    interpreterRegisterOpcode(0x81E0, op_set_bodypart_hit_modifier);
-    // missing: set/get/reset_critical_table
-    // missing: get_sfall_arg, set_sfall_return
-    // missing: set/get_unspend_ap_bonus/ebonus
-    // missing: init_hook
-    interpreterRegisterOpcode(0x81EB, op_get_ini_string);
-    interpreterRegisterOpcode(0x81EC, op_sqrt);
-    interpreterRegisterOpcode(0x81ED, op_abs);
-    interpreterRegisterOpcode(0x81EE, op_sin);
-    interpreterRegisterOpcode(0x81EF, op_cos);
-    interpreterRegisterOpcode(0x81F0, op_tan);
-    interpreterRegisterOpcode(0x81F1, op_arctan);
-    // missing: set_palette
-    // missing: remove_script, set_script
-    interpreterRegisterOpcode(0x81F5, op_get_script);
-    // missing: nb_create_char, fs_*
-    interpreterRegisterOpcode(0x8204, op_get_proto_data);
-    interpreterRegisterOpcode(0x8205, op_set_proto_data);
-    interpreterRegisterOpcode(0x8206, op_set_self);
-    // missing: register_hook, more fs_*
-    interpreterRegisterOpcode(0x820D, op_list_begin);
-    interpreterRegisterOpcode(0x820E, op_list_next);
-    interpreterRegisterOpcode(0x820F, op_list_end);
-    interpreterRegisterOpcode(0x8210, op_get_version_major);
-    interpreterRegisterOpcode(0x8211, op_get_version_minor);
-    interpreterRegisterOpcode(0x8212, op_get_version_patch);
-    // missing: hero_select_win, set_hero_race, set_hero_style, set_critter_burst_disable
-    interpreterRegisterOpcode(0x8217, op_get_weapon_ammo_pid);
-    interpreterRegisterOpcode(0x8218, op_set_weapon_ammo_pid);
-    interpreterRegisterOpcode(0x8219, op_get_weapon_ammo_count);
-    interpreterRegisterOpcode(0x821A, op_set_weapon_ammo_count);
-    // missing: write_string
+    // 0x8162 - void tap_key(int dxScancode)
+    interpreterRegisterOpcode(0x8162, op_tap_key);
+    // 0x821c - int  get_mouse_x()
     interpreterRegisterOpcode(0x821C, op_get_mouse_x);
+    // 0x821d - int  get_mouse_y()
     interpreterRegisterOpcode(0x821D, op_get_mouse_y);
+    // 0x821e - int  get_mouse_buttons()
     interpreterRegisterOpcode(0x821E, op_get_mouse_buttons);
-    // missing: get_window_under_mouse
-    interpreterRegisterOpcode(0x8220, op_get_screen_width);
-    interpreterRegisterOpcode(0x8221, op_get_screen_height);
-    // missing: stop_game, resume_game
-    interpreterRegisterOpcode(0x8224, op_create_message_window);
-    // missing: remove_trait, get_light_level, refresh_pc_art
-    interpreterRegisterOpcode(0x8228, op_get_attack_type);
+    // 0x821f - int  get_window_under_mouse()
+
+    // 0x8163 - int get_year()
+    interpreterRegisterOpcode(0x8163, op_get_year);
+
+    // 0x8164 - bool game_loaded()
+    interpreterRegisterOpcode(0x8164, op_game_loaded);
+
+    // 0x8165 - bool graphics_funcs_available()
+    // 0x8166 - int  load_shader(string path)
+    // 0x8167 - void free_shader(int ID)
+    // 0x8168 - void activate_shader(int ID)
+    // 0x8169 - void deactivate_shader(int ID)
+    // 0x816d - void set_shader_int(int ID, string param, int value)
+    // 0x816e - void set_shader_float(int ID, string param, float value)
+    // 0x816f - void set_shader_vector(int ID, string param, float f1, float f2, float f3, float f4)
+    // 0x81ad - int get_shader_version()
+    // 0x81ae - void set_shader_mode(int mode)
+    // 0x81b0 - void force_graphics_refresh(bool enabled)
+    // 0x81b1 - int get_shader_texture(int ID, int texture)
+    // 0x81b2 - void set_shader_texture(int ID, string param, int texID)
+
+    // 0x816a - void set_global_script_repeat(int frames)
+    interpreterRegisterOpcode(0x816A, op_set_global_script_repeat);
+    // 0x819b - void set_global_script_type(int type)
+    interpreterRegisterOpcode(0x819B, op_set_global_script_type);
+    // 0x819c - int available_global_script_types()
+
+    // 0x8170 - bool in_world_map()
+    interpreterRegisterOpcode(0x8170, op_in_world_map);
+
+    // 0x8171 - void force_encounter(int map)
+    interpreterRegisterOpcode(0x8171, op_force_encounter);
+    // 0x8229 - void force_encounter_with_flags(int map, int flags)
     interpreterRegisterOpcode(0x8229, op_force_encounter_with_flags);
-    // missing: set_map_time_multi, play_sfall_sound, stop_sfall_sound
+    // 0x822a - void set_map_time_multi(float multi)
+
+    // 0x8172 - void set_world_map_pos(int x, int y)
+    interpreterRegisterOpcode(0x8172, op_set_world_map_pos);
+    // 0x8173 - int get_world_map_x_pos()
+    // 0x8174 - int get_world_map_y_pos()
+
+    // 0x8175 - void set_dm_model(string name)
+    // 0x8176 - void set_df_model(string name)
+    // 0x8177 - void set_movie_path(string filename, int movieid)
+
+    // 0x8178 - void set_perk_image(int perkID, int value)
+    // 0x8179 - void set_perk_ranks(int perkID, int value)
+    // 0x817a - void set_perk_level(int perkID, int value)
+    // 0x817b - void set_perk_stat(int perkID, int value)
+    // 0x817c - void set_perk_stat_mag(int perkID, int value)
+    // 0x817d - void set_perk_skill1(int perkID, int value)
+    // 0x817e - void set_perk_skill1_mag(int perkID, int value)
+    // 0x817f - void set_perk_type(int perkID, int value)
+    // 0x8180 - void set_perk_skill2(int perkID, int value)
+    // 0x8181 - void set_perk_skill2_mag(int perkID, int value)
+    // 0x8182 - void set_perk_str(int perkID, int value)
+    // 0x8183 - void set_perk_per(int perkID, int value)
+    // 0x8184 - void set_perk_end(int perkID, int value)
+    // 0x8185 - void set_perk_chr(int perkID, int value)
+    // 0x8196 - void set_perk_int(int perkID, int value)
+    // 0x8187 - void set_perk_agl(int perkID, int value)
+    // 0x8188 - void set_perk_lck(int perkID, int value)
+    // 0x8189 - void set_perk_name(int perkID, string value)
+    // 0x818a - void set_perk_desc(int perkID, string value)
+    // 0x8247 - void set_perk_freq(int value)
+
+    // 0x818b - void set_pipboy_available(int available)
+
+    // 0x818c - int get_kill_counter(int critterType)
+    // 0x818d - void mod_kill_counter(int critterType, int amount)
+
+    // 0x818e - int get_perk_owed()
+    // 0x818f - void set_perk_owed(int value)
+    // 0x8190 - int get_perk_available(int perk)
+
+    // 0x8191 - int get_critter_current_ap(object critter)
+    // 0x8192 - void set_critter_current_ap(object critter, int ap)
+
+    // 0x8193 - int  active_hand()
+    interpreterRegisterOpcode(0x8193, op_get_current_hand);
+    // 0x8194 - void toggle_active_hand()
+
+    // 0x8195 - void set_weapon_knockback(object weapon, int type, int/float value)
+    // 0x8196 - void set_target_knockback(object critter, int type, int/float value)
+    // 0x8197 - void set_attacker_knockback(object critter, int type, int/float value)
+    // 0x8198 - void remove_weapon_knockback(object weapon)
+    // 0x8199 - void remove_target_knockback(object critter)
+    // 0x819a - void remove_attacker_knockback(object critter)
+
+    // 0x819d - void  set_sfall_global(string/int varname, int/float value)
+    interpreterRegisterOpcode(0x819D, op_set_sfall_global);
+    // 0x819e - int   get_sfall_global_int(string/int varname)
+    interpreterRegisterOpcode(0x819E, op_get_sfall_global_int);
+    // 0x819f - float get_sfall_global_float(string/int varname)
+    // 0x822d - int   create_array(int element_count, int flags)
     interpreterRegisterOpcode(0x822D, op_create_array);
+    // 0x822e - void  set_array(int array, any element, any value)
     interpreterRegisterOpcode(0x822E, op_set_array);
+    // 0x822f - any   get_array(int array, any element)
     interpreterRegisterOpcode(0x822F, op_get_array);
+    // 0x8230 - void  free_array(int array)
     interpreterRegisterOpcode(0x8230, op_free_array);
+    // 0x8231 - int   len_array(int array)
     interpreterRegisterOpcode(0x8231, op_len_array);
+    // 0x8232 - void  resize_array(int array, int new_element_count)
     interpreterRegisterOpcode(0x8232, op_resize_array);
+    // 0x8233 - int   temp_array(int element_count, int flags)
     interpreterRegisterOpcode(0x8233, op_temp_array);
+    // 0x8234 - void  fix_array(int array)
     interpreterRegisterOpcode(0x8234, op_fix_array);
-    interpreterRegisterOpcode(0x8235, op_string_split);
-    interpreterRegisterOpcode(0x8236, op_list_as_array);
-    interpreterRegisterOpcode(0x8237, op_parse_int);
-    interpreterRegisterOpcode(0x8238, op_atof);
+    // 0x8239 - int   scan_array(int array, int/float var)
     interpreterRegisterOpcode(0x8239, op_scan_array);
-    // missing: modified_ini, get_sfall_args, set_sfall_arg, bunch of aimed shot, skillpoint, combat funcs
-    interpreterRegisterOpcode(0x824B, op_tile_under_cursor);
-    // missing: get_barter_mod, set_inven_ap_cost
-    interpreterRegisterOpcode(0x824E, op_substr);
-    interpreterRegisterOpcode(0x824F, op_get_string_length);
-    interpreterRegisterOpcode(0x8250, op_sprintf);
-    interpreterRegisterOpcode(0x8251, op_charcode);
-    interpreterRegisterOpcode(0x8253, op_type_of);
-    // missing: save_array, load_array
+    // 0x8254 - void  save_array(any key, int array)
+    // 0x8255 - int   load_array(any key)
+    // 0x8256 - int   array_key(int array, int index)
     interpreterRegisterOpcode(0x8256, op_get_array_key);
+    // 0x8257 - int   arrayexpr(any key, any value)
     interpreterRegisterOpcode(0x8257, op_stack_array);
-    // missing: <reserved>x2, reg_anim_*
-    interpreterRegisterOpcode(0x8261, op_explosions_metarule);
-    // missing: register_hook_proc
+
+    // 0x81a0 - void set_pickpocket_max(int percentage)
+    // 0x81a1 - void set_hit_chance_max(int percentage)
+    // 0x81a2 - void set_skill_max(int value)
+    // 0x81aa - void set_xp_mod(int percentage)
+    // 0x81ab - void set_perk_level_mod(int levels)
+
+    // 0x81c5 - void set_critter_hit_chance_mod(object, int max, int mod)
+    // 0x81c6 - void set_base_hit_chance_mod(int max, int mod)
+    // 0x81c7 - void set_critter_skill_mod(object, int max)
+    // 0x81c8 - void set_base_skill_mod(int max)
+    // 0x81c9 - void set_critter_pickpocket_mod(object, int max, int mod)
+    // 0x81ca - void set_base_pickpocket_mod(int max, int mod)
+
+    // note: these are deprecated; do not implement
+    // 0x81a3 - int  eax_available()
+    // 0x81a4 - void set_eax_environment(int environment)
+
+    // 0x81a5 - void inc_npc_level(int pid/string name)
+    // 0x8241 - int  get_npc_level(int pid/string name)
+
+    // 0x81a6 - int get_viewport_x()
+    // 0x81a7 - int get_viewport_y()
+    // 0x81a8 - void set_viewport_x(int view_x)
+    // 0x81a9 - void set_viewport_y(int view_y)
+
+    // 0x81ac - int   get_ini_setting(string setting)
+    interpreterRegisterOpcode(0x81AC, op_get_ini_setting);
+    // 0x81eb - string get_ini_string(string setting)
+    interpreterRegisterOpcode(0x81EB, op_get_ini_string);
+
+    // 0x81af - int get_game_mode()
+    interpreterRegisterOpcode(0x81AF, op_get_game_mode);
+
+    // 0x81b3 - int get_uptime()
+    interpreterRegisterOpcode(0x81B3, op_get_uptime);
+
+    // 0x81b6 - void set_car_current_town(int town)
+    interpreterRegisterOpcode(0x81B6, op_set_car_current_town);
+
+    // 0x81bb - void set_fake_perk(string name, int level, int image, string desc)
+    // 0x81bc - void set_fake_trait(string name, int active, int image, string desc)
+    // 0x81bd - void set_selectable_perk(string name, int active, int image, string desc)
+    // 0x81be - void set_perkbox_title(string title)
+    // 0x81bf - void hide_real_perks()
+    // 0x81c0 - void show_real_perks()
+    // 0x81c1 - int has_fake_perk(string name/int extraPerkID)
+    // 0x81c2 - int has_fake_trait(string name)
+    // 0x81c3 - void perk_add_mode(int type)
+    // 0x81c4 - void clear_selectable_perks()
+    // 0x8225 - void remove_trait(int traitID)
+
+    // 0x81cb - void set_pyromaniac_mod(int bonus)
+    // 0x81cc - void apply_heaveho_fix()
+    // 0x81cd - void set_swiftlearner_mod(int bonus)
+    // 0x81ce - void set_hp_per_level_mod(int mod)
+
+    // 0x81dc - void show_iface_tag(int tag)
+    // 0x81dd - void hide_iface_tag(int tag)
+    // 0x81de - int  is_iface_tag_active(int tag)
+
+    // 0x81df - int  get_bodypart_hit_modifier(int bodypart)
+    interpreterRegisterOpcode(0x81DF, op_get_bodypart_hit_modifier);
+    // 0x81e0 - void set_bodypart_hit_modifier(int bodypart, int value)
+    interpreterRegisterOpcode(0x81E0, op_set_bodypart_hit_modifier);
+
+    // 0x81e1 - void set_critical_table(int crittertype, int bodypart, int level, int valuetype, int value)
+    // 0x81e2 - int  get_critical_table(int crittertype, int bodypart, int level, int valuetype)
+    // 0x81e3 - void reset_critical_table(int crittertype, int bodypart, int level, int valuetype)
+
+    // 0x81e4 - int   get_sfall_arg()
+    // 0x823c - array get_sfall_args()
+    // 0x823d - void  set_sfall_arg(int argnum, int value)
+    // 0x81e5 - void  set_sfall_return(any value)
+    // 0x81ea - int   init_hook()
+
+    // 0x81e6 - void set_unspent_ap_bonus(int multiplier)
+    // 0x81e7 - int  get_unspent_ap_bonus()
+    // 0x81e8 - void set_unspent_ap_perk_bonus(int multiplier)
+    // 0x81e9 - int  get_unspent_ap_perk_bonus()
+
+    // 0x81ec - float sqrt(float)
+    interpreterRegisterOpcode(0x81EC, op_sqrt);
+    // 0x81ed - int/float abs(int/float)
+    interpreterRegisterOpcode(0x81ED, op_abs);
+    // 0x81ee - float sin(float)
+    interpreterRegisterOpcode(0x81EE, op_sin);
+    // 0x81ef - float cos(float)
+    interpreterRegisterOpcode(0x81EF, op_cos);
+    // 0x81f0 - float tan(float)
+    interpreterRegisterOpcode(0x81F0, op_tan);
+    // 0x81f1 - float arctan(float x, float y)
+    interpreterRegisterOpcode(0x81F1, op_arctan);
+    // 0x8263 - ^ operator (exponentiation)
     interpreterRegisterOpcode(0x8263, op_power);
+    // 0x8264 - float log(float)
     interpreterRegisterOpcode(0x8264, op_log);
+    // 0x8265 - float exponent(float)
     interpreterRegisterOpcode(0x8265, op_exponent);
+    // 0x8266 - int ceil(float)
     interpreterRegisterOpcode(0x8266, op_ceil);
+    // 0x8267 - int round(float)
     interpreterRegisterOpcode(0x8267, op_round);
-    // 3 reserved opcodes
-    interpreterRegisterOpcode(0x826B, op_get_message);
-    // missing: sneak_success, tile_light
-    interpreterRegisterOpcode(0x826E, op_make_straight_path);
-    interpreterRegisterOpcode(0x826F, op_obj_blocking_at);
-    // missing: tile_get_objects
-    interpreterRegisterOpcode(0x8271, op_party_member_list);
-    // missing: path_find, create_spatial
-    interpreterRegisterOpcode(0x8274, op_art_exists);
-    // missing: is_carrying_obj
-    interpreterRegisterOpcode(0x8276, op_sfall_func0);
-    interpreterRegisterOpcode(0x8277, op_sfall_func1);
-    interpreterRegisterOpcode(0x8278, op_sfall_func2);
-    interpreterRegisterOpcode(0x8279, op_sfall_func3);
-    interpreterRegisterOpcode(0x827A, op_sfall_func4);
-    interpreterRegisterOpcode(0x827B, op_sfall_func5);
-    interpreterRegisterOpcode(0x827C, op_sfall_func6);
-    // missing: register_hook_proc2, reg_anim_callback
-    interpreterRegisterOpcode(0x8280, op_sfall_func7);
-    interpreterRegisterOpcode(0x8281, op_sfall_func8);
+    // 0x827f - div operator (unsigned integer division)
     interpreterRegisterOpcode(0x827F, op_div);
+
+    // 0x81f2 - void set_palette(string path)
+
+    // 0x81f3 - void remove_script(object)
+    // 0x81f4 - void set_script(object, int scriptid)
+    // 0x81f5 - int get_script(object)
+    interpreterRegisterOpcode(0x81F5, op_get_script);
+
+    // 0x81f6 - int nb_create_char()
+
+    // 0x81f7 - int   fs_create(string path, int size)
+    // 0x81f8 - int   fs_copy(string path, string source)
+    // 0x81f9 - int   fs_find(string path)
+    // 0x81fa - void  fs_write_byte(int id, int data)
+    // 0x81fb - void  fs_write_short(int id, int data)
+    // 0x81fc - void  fs_write_int(int id, int data)
+    // 0x81fd - void  fs_write_float(int id, int data)
+    // 0x81fe - void  fs_write_string(int id, string data)
+    // 0x8208 - void  fs_write_bstring(int id, string data)
+    // 0x8209 - int   fs_read_byte(int id)
+    // 0x820a - int   fs_read_short(int id)
+    // 0x820b - int   fs_read_int(int id)
+    // 0x820c - float fs_read_float(int id)
+    // 0x81ff - void  fs_delete(int id)
+    // 0x8200 - int   fs_size(int id)
+    // 0x8201 - int   fs_pos(int id)
+    // 0x8202 - void  fs_seek(int id, int pos)
+    // 0x8203 - void  fs_resize(int id, int size)
+
+    // 0x8204 - int  get_proto_data(int pid, int offset)
+    interpreterRegisterOpcode(0x8204, op_get_proto_data);
+    // 0x8205 - void set_proto_data(int pid, int offset, int value)
+    interpreterRegisterOpcode(0x8205, op_set_proto_data);
+
+    // 0x8206 - void set_self(object)
+    interpreterRegisterOpcode(0x8206, op_set_self);
+    // 0x8207 - void register_hook(int hook)
+
+    // 0x820d - int   list_begin(int type)
+    interpreterRegisterOpcode(0x820D, op_list_begin);
+    // 0x820e - int   list_next(int listid)
+    interpreterRegisterOpcode(0x820E, op_list_next);
+    // 0x820f - void  list_end(int listid)
+    interpreterRegisterOpcode(0x820F, op_list_end);
+    // 0x8236 - array list_as_array(int type)
+    interpreterRegisterOpcode(0x8236, op_list_as_array);
+
+    // 0x8210 - int sfall_ver_major()
+    interpreterRegisterOpcode(0x8210, op_get_version_major);
+    // 0x8211 - int sfall_ver_minor()
+    interpreterRegisterOpcode(0x8211, op_get_version_minor);
+    // 0x8212 - int sfall_ver_build()
+    interpreterRegisterOpcode(0x8212, op_get_version_patch);
+
+    // 0x8213 - void hero_select_win(int)
+    // 0x8214 - void set_hero_race(int style)
+    // 0x8215 - void set_hero_style(int style)
+
+    // 0x8216 - void set_critter_burst_disable(object critter, int disable)
+
+    // 0x8217 - int  get_weapon_ammo_pid(object weapon)
+    interpreterRegisterOpcode(0x8217, op_get_weapon_ammo_pid);
+    // 0x8218 - void set_weapon_ammo_pid(object weapon, int pid)
+    interpreterRegisterOpcode(0x8218, op_set_weapon_ammo_pid);
+    // 0x8219 - int  get_weapon_ammo_count(object weapon)
+    interpreterRegisterOpcode(0x8219, op_get_weapon_ammo_count);
+    // 0x821a - void set_weapon_ammo_count(object weapon, int count)
+    interpreterRegisterOpcode(0x821A, op_set_weapon_ammo_count);
+
+    // 0x8220 - int get_screen_width()
+    interpreterRegisterOpcode(0x8220, op_get_screen_width);
+    // 0x8221 - int get_screen_height()
+    interpreterRegisterOpcode(0x8221, op_get_screen_height);
+
+    // 0x8222 - void stop_game()
+    // 0x8223 - void resume_game()
+    // 0x8224 - void create_message_window(string message)
+    interpreterRegisterOpcode(0x8224, op_create_message_window);
+
+    // 0x8226 - int get_light_level()
+
+    // 0x8227 - void refresh_pc_art()
+
+    // 0x8228 - int get_attack_type()
+    interpreterRegisterOpcode(0x8228, op_get_attack_type);
+
+    // 0x822b - int  play_sfall_sound(string file, int mode)
+    // 0x822c - void stop_sfall_sound(int soundID)
+
+    // 0x8235 - array string_split(string string, string split)
+    interpreterRegisterOpcode(0x8235, op_string_split);
+    // 0x8237 - int   atoi(string string)
+    interpreterRegisterOpcode(0x8237, op_parse_int);
+    // 0x8238 - float atof(string string)
+    interpreterRegisterOpcode(0x8238, op_atof);
+    // 0x824e - string substr(string string, int start, int length)
+    interpreterRegisterOpcode(0x824E, op_substr);
+    // 0x824f - int   strlen(string string)
+    interpreterRegisterOpcode(0x824F, op_get_string_length);
+    // 0x8250 - string sprintf(string format, any value)
+    interpreterRegisterOpcode(0x8250, op_sprintf);
+    // 0x8251 - int   charcode(string string)
+    interpreterRegisterOpcode(0x8251, op_charcode);
+    // 0x8253 - int   typeof(any value)
+    interpreterRegisterOpcode(0x8253, op_type_of);
+
+    // 0x823a - int get_tile_fid(int tileData)
+
+    // 0x823b - int modified_ini()
+
+    // 0x823e - void force_aimed_shots(int pid)
+    // 0x823f - void disable_aimed_shots(int pid)
+
+    // 0x8240 - void mark_movie_played(int id)
+
+    // 0x8248 - object get_last_target(object critter)
+    // 0x8249 - object get_last_attacker(object critter)
+    // 0x824a - void block_combat(int enable)
+
+    // 0x824b - int tile_under_cursor()
+    interpreterRegisterOpcode(0x824B, op_tile_under_cursor);
+    // 0x824c - int gdialog_get_barter_mod()
+    // 0x824d - void set_inven_ap_cost(int cost)
+
+    // 0x825c - void reg_anim_combat_check(int enable)
+    // 0x825a - void reg_anim_destroy(object object)
+    // 0x825b - void reg_anim_animate_and_hide(object object, int animID, int delay)
+    // 0x825d - void reg_anim_light(object object, int radius, int delay)
+    // 0x825e - void reg_anim_change_fid(object object, int FID, int delay)
+    // 0x825f - void reg_anim_take_out(object object, int holdFrameID, int delay)
+    // 0x8260 - void reg_anim_turn_towards(object object, int tile/targetObj, int delay)
+
+    // 0x8261 - int metarule2_explosions(object object)
+    interpreterRegisterOpcode(0x8261, op_explosions_metarule);
+
+    // 0x8262 - void register_hook_proc(int hook, procedure proc)
+
+    // 0x826b - string message_str_game(int fileId, int messageId)
+    interpreterRegisterOpcode(0x826B, op_get_message);
+    // 0x826c - int sneak_success()
+    // 0x826d - int tile_light(int elevation, int tileNum)
+    // 0x826e - object obj_blocking_line(object objFrom, int tileTo, int blockingType)
+    interpreterRegisterOpcode(0x826E, op_make_straight_path);
+    // 0x826f - object obj_blocking_tile(int tileNum, int elevation, int blockingType)
+    interpreterRegisterOpcode(0x826F, op_obj_blocking_at);
+    // 0x8270 - array tile_get_objs(int tileNum, int elevation)
+    // 0x8271 - array party_member_list(int includeHidden)
+    interpreterRegisterOpcode(0x8271, op_party_member_list);
+    // 0x8272 - array path_find_to(object objFrom, int tileTo, int blockingType)
+    // 0x8273 - object create_spatial(int scriptID, int tile, int elevation, int radius)
+    // 0x8274 - int art_exists(int artFID)
+    interpreterRegisterOpcode(0x8274, op_art_exists);
+    // 0x8275 - int obj_is_carrying_obj(object invenObj, object itemObj)
+
+    // 0x8276 - any sfall_func0(string funcName)
+    interpreterRegisterOpcode(0x8276, op_sfall_func0);
+    // 0x8277 - any sfall_func1(string funcName, arg1)
+    interpreterRegisterOpcode(0x8277, op_sfall_func1);
+    // 0x8278 - any sfall_func2(string funcName, arg1, arg2)
+    interpreterRegisterOpcode(0x8278, op_sfall_func2);
+    // 0x8279 - any sfall_func3(string funcName, arg1, arg2, arg3)
+    interpreterRegisterOpcode(0x8279, op_sfall_func3);
+    // 0x827a - any sfall_func4(string funcName, arg1, arg2, arg3, arg4)
+    interpreterRegisterOpcode(0x827A, op_sfall_func4);
+    // 0x827b - any sfall_func5(string funcName, arg1, arg2, arg3, arg4, arg5)
+    interpreterRegisterOpcode(0x827B, op_sfall_func5);
+    // 0x827c - any sfall_func6(string funcName, arg1, arg2, arg3, arg4, arg5, arg6)
+    interpreterRegisterOpcode(0x827C, op_sfall_func6);
+    // 0x8280 - any sfall_func7(string funcName, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+    interpreterRegisterOpcode(0x8280, op_sfall_func7);
+    // 0x8281 - any sfall_func8(string funcName, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+    interpreterRegisterOpcode(0x8281, op_sfall_func8);
+
+    // 0x827d - void register_hook_proc_spec(int hook, procedure proc)
+    // 0x827e - void reg_anim_callback(procedure proc)
 }
 
 void sfallOpcodesExit()


### PR DESCRIPTION
This pulls in every sfall opcode, including param types and returnval.  It is grouped in a more "natural" order (i.e. what the sfall doc lists) instead of numeric order, which helps see which opcodes from a logical group are missing.  

For now, the grouping follows https://github.com/sfall-team/sfall/blob/71ecec3d405bd5e945f157954618b169e60068fe/artifacts/scripting/sfall%20opcode%20list.txt#L145, but there are a few more places with natural grouping we could tweak in subsequent PRs.

No functional changes were made.  .ssl tests pass
