### PR TITLE
Add opcode_exists metarule

### DIFF
--- a/sfall_testing/gl_test_metarule_exists.ssl
+++ b/sfall_testing/gl_test_metarule_exists.ssl
@@ -15,9 +15,12 @@ procedure start begin
         #define opcode_exists(opcode) sfall_func1("opcode_exists", opcode)
         #define OP_GET_UPTIME 0x81B3
         #define OP_NOOP 0x8000
+        #define OP_WRITE_INT 0x81D1
 
         call assertEquals("opcode_exists OP_GET_UPTIME", opcode_exists(OP_GET_UPTIME), 1);
         call assertEquals("opcode_exists OP_NOOP", opcode_exists(OP_NOOP), 1);
+        // Probably will never be implemented on fallout2-ce
+        call assertEquals("opcode_exists OP_WRITE_INT", opcode_exists(OP_WRITE_INT), 0);
         call assertEquals("opcode_exists 0xFFFF", opcode_exists(0xFFFF), 0);
     end else begin
         display_msg("Opcode exists metarule is not available, skipping tests.");

--- a/sfall_testing/gl_test_metarule_exists.ssl
+++ b/sfall_testing/gl_test_metarule_exists.ssl
@@ -8,7 +8,10 @@ procedure start begin
     call assertEquals("string_format", metarule_exist("string_format"), 1);
     call assertEquals("metarule_exist", metarule_exist("metarule_exist"), 1);
 
-    if metarule_exist("opcode_exists") then begin
+    // This will fail on sFall
+    call assertEquals("opcode_exists", metarule_exist("opcode_exists"), 1);
+
+    if metarule_exist("opcode_exists") then begin // And example if how to use it
         #define opcode_exists(opcode) sfall_func1("opcode_exists", opcode)
         #define OP_GET_UPTIME 0x81B3
         #define OP_NOOP 0x8000

--- a/sfall_testing/gl_test_metarule_exists.ssl
+++ b/sfall_testing/gl_test_metarule_exists.ssl
@@ -16,9 +16,9 @@ procedure start begin
         #define OP_GET_UPTIME 0x81B3
         #define OP_NOOP 0x8000
 
-        call assertEquals("opcode_exists", opcode_exists(OP_GET_UPTIME), 1);
-        call assertEquals("opcode_exists", opcode_exists(OP_NOOP), 1);
-        call assertEquals("opcode_exists", opcode_exists(0xFFFF), 0);
+        call assertEquals("opcode_exists OP_GET_UPTIME", opcode_exists(OP_GET_UPTIME), 1);
+        call assertEquals("opcode_exists OP_NOOP", opcode_exists(OP_NOOP), 1);
+        call assertEquals("opcode_exists 0xFFFF", opcode_exists(0xFFFF), 0);
     end else begin
         display_msg("Opcode exists metarule is not available, skipping tests.");
     end

--- a/sfall_testing/gl_test_metarule_exists.ssl
+++ b/sfall_testing/gl_test_metarule_exists.ssl
@@ -1,0 +1,12 @@
+#include "test_utils.h"
+#include "sfall.h"
+
+procedure start begin
+
+    display_msg("Testing metarule_exist functions...");
+
+    call assertEquals("string_format", metarule_exist("string_format"), 1);
+    call assertEquals("metarule_exist", metarule_exist("metarule_exist"), 1);
+    
+    call report_test_results("metarule_exist");
+end

--- a/sfall_testing/gl_test_metarule_exists.ssl
+++ b/sfall_testing/gl_test_metarule_exists.ssl
@@ -7,6 +7,18 @@ procedure start begin
 
     call assertEquals("string_format", metarule_exist("string_format"), 1);
     call assertEquals("metarule_exist", metarule_exist("metarule_exist"), 1);
+
+    if metarule_exist("opcode_exists") then begin
+        #define opcode_exists(opcode) sfall_func1("opcode_exists", opcode)
+        #define OP_GET_UPTIME 0x81B3
+        #define OP_NOOP 0x8000
+
+        call assertEquals("opcode_exists", opcode_exists(OP_GET_UPTIME), 1);
+        call assertEquals("opcode_exists", opcode_exists(OP_NOOP), 1);
+        call assertEquals("opcode_exists", opcode_exists(0xFFFF), 0);
+    end else begin
+        display_msg("Opcode exists metarule is not available, skipping tests.");
+    end
     
     call report_test_results("metarule_exist");
 end

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -155,7 +155,7 @@ static int (*_outputFunc)(char*) = _outputStr;
 static int _cpuBurstSize = 10;
 
 // 0x59E230
-static OpcodeHandler* gInterpreterOpcodeHandlers[OPCODE_MAX_COUNT];
+OpcodeHandler* gInterpreterOpcodeHandlers[OPCODE_MAX_COUNT];
 
 // 0x59E78C
 static Program* gInterpreterCurrentProgram;

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -13,6 +13,7 @@ namespace fallout {
 // SFALL: Increase number of opcodes.
 #define OPCODE_MAX_COUNT 768
 
+
 typedef enum Opcode {
     OPCODE_NOOP = 0x8000,
     OPCODE_PUSH = 0x8001,
@@ -197,6 +198,8 @@ typedef struct Program {
 typedef unsigned int(InterpretTimerFunc)();
 typedef void OpcodeHandler(Program* program);
 
+extern OpcodeHandler* gInterpreterOpcodeHandlers[OPCODE_MAX_COUNT];
+
 extern int _TimeOut;
 
 char* _interpretMangleName(char* s);
@@ -240,6 +243,7 @@ void programReturnStackPushPointer(Program* program, void* value);
 ProgramValue programReturnStackPopValue(Program* program);
 int programReturnStackPopInteger(Program* program);
 void* programReturnStackPopPointer(Program* program);
+
 
 } // namespace fallout
 

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -13,7 +13,6 @@ namespace fallout {
 // SFALL: Increase number of opcodes.
 #define OPCODE_MAX_COUNT 768
 
-
 typedef enum Opcode {
     OPCODE_NOOP = 0x8000,
     OPCODE_PUSH = 0x8001,
@@ -243,7 +242,6 @@ void programReturnStackPushPointer(Program* program, void* value);
 ProgramValue programReturnStackPopValue(Program* program);
 int programReturnStackPopInteger(Program* program);
 void* programReturnStackPopPointer(Program* program);
-
 
 } // namespace fallout
 

--- a/src/sfall_metarules.cc
+++ b/src/sfall_metarules.cc
@@ -20,6 +20,7 @@
 #include "tile.h"
 #include "window.h"
 #include "worldmap.h"
+#include "interpreter.h"
 
 namespace fallout {
 
@@ -44,6 +45,7 @@ static void mf_get_text_width(Program* program, int args);
 static void mf_intface_redraw(Program* program, int args);
 static void mf_loot_obj(Program* program, int args);
 static void mf_metarule_exist(Program* program, int args);
+static void mf_opcode_exists(Program* program, int args);
 static void mf_outlined_object(Program* program, int args);
 static void mf_set_cursor_mode(Program* program, int args);
 static void mf_set_flags(Program* program, int args);
@@ -161,6 +163,7 @@ constexpr MetaruleInfo kMetarules[] = {
     // {"unjam_lock",                mf_unjam_lock,                1, 1, -1, {ARG_OBJECT}},
     // {"unwield_slot",              mf_unwield_slot,              2, 2, -1, {ARG_OBJECT, ARG_INT}},
     // {"win_fill_color",            mf_win_fill_color,            0, 5, -1, {ARG_INT, ARG_INT, ARG_INT, ARG_INT, ARG_INT}},
+    { "opcode_exists", mf_opcode_exists, 1, 1 },
 };
 
 constexpr int kMetarulesMax = sizeof(kMetarules) / sizeof(kMetarules[0]);
@@ -274,6 +277,19 @@ void mf_metarule_exist(Program* program, int args)
     }
 
     programStackPushInteger(program, 0);
+}
+
+void mf_opcode_exists(Program* program, int args)
+{
+    int opcode = programStackPopInteger(program);
+    int opcodeIndex = opcode & 0x3FFF;
+    if (opcodeIndex < 0 || opcodeIndex >= OPCODE_MAX_COUNT) {
+        programStackPushInteger(program, 0);
+        return;
+    }
+    auto opcodeHandler = gInterpreterOpcodeHandlers[opcodeIndex];
+    int opcodeExists = opcodeHandler != nullptr ? 1 : 0;
+    programStackPushInteger(program, opcodeExists);
 }
 
 void mf_outlined_object(Program* program, int args)

--- a/src/sfall_metarules.cc
+++ b/src/sfall_metarules.cc
@@ -12,6 +12,7 @@
 #include "game_dialog.h"
 #include "game_mouse.h"
 #include "interface.h"
+#include "interpreter.h"
 #include "inventory.h"
 #include "object.h"
 #include "platform_compat.h"
@@ -20,7 +21,6 @@
 #include "tile.h"
 #include "window.h"
 #include "worldmap.h"
-#include "interpreter.h"
 
 namespace fallout {
 


### PR DESCRIPTION
### Description

A non-sFall metarule to check if opcode is implemented in `fallout2-ce`.

It is safe to use it in scripts because a call into `metarule_exist` can be done prior to calling `opcode_exists`.

The main use case it to allow modders to skip some part of scripts if something is not implemented yet.

### Reproduction Steps and Savefile (if available)

Run tests

### Screenshots

<!--- If the PR includes visual changes, add screenshots here. --->


<!--- 

**Important Notes** 

- *Preview builds are not available for pull requests from forked repositories.* To enable preview builds, submit the PR from a branch within this repository. 

- *Formatting issues? You have two options:*
1. **Fix formatting automatically** using the following Docker command: *(If you're using Windows, remove `--user $(id -u):$(id -g)`)* 
```bash
docker run --rm \
  -v $(pwd):/app --workdir /app  \
  --user $(id -u):$(id -g) silkeh/clang:18 \
  bash -c 'find src -type f -name \*.cc -o -name \*.h | xargs clang-format -i'
```
2. **Skip formatting check** by adding the `skip-formatting` label to this PR.

--->

