### PR TITLE
sfall: `get_ini_section(s)`

### DIFF
--- a/sfall_testing/gl_test_ini.ssl
+++ b/sfall_testing/gl_test_ini.ssl
@@ -1,0 +1,86 @@
+#include "lib.arrays.h" // For arrays_equal, len_array, etc.
+#include "test_utils.h"   // For assertEquals, VALTYPE_STR, report_test_results
+
+procedure ini_test_suite begin
+    variable result_array, expected_array, key_type, value_type, count;
+
+    // Reset errors for this suite if test_utils.h doesn't do it per suite
+    // test_suite_errors := 0; // Assuming test_utils.h manages this globally or per call to report_test_results
+
+    display_msg("--- Testing get_ini_section ---");
+
+    // Test Case 1: Valid file, valid section
+    display_msg("Test Case 1: Valid file, valid section ('ValidSection')");
+    result_array := get_ini_section("test.ini", "ValidSection");
+    expected_array := {"Key1": "Value1", "Key2": "Another Value", "Key WithSpace": "Value With Space"};
+    call assertEquals("TC1 Size", len_array(result_array), 3);
+    call assertEquals("TC1 Content", arrays_equal(result_array, expected_array), true);
+    // Detailed type and content check for TC1
+    count := 0;
+    foreach key_val_pair in result_array begin
+        count += 1;
+        call assertEquals("TC1 Key Type " + count, typeof(key_val_pair[0]), VALTYPE_STR);
+        call assertEquals("TC1 Value Type " + count, typeof(key_val_pair[1]), VALTYPE_STR);
+    end
+    // Specific check for one key-value pair from TC1 to ensure iteration works as expected by key name
+    call assertEquals("TC1 Specific Key1 Value", result_array["Key1"], "Value1");
+    call assertEquals("TC1 Specific Key WithSpace Value", result_array["Key WithSpace"], "Value With Space");
+
+
+    // Test Case 2: Valid file, section with spaces (keys/values should be trimmed by INI parser)
+    // Note: The current INI parser in config.c (configTrimString) trims leading/trailing whitespace from keys and values.
+    display_msg("Test Case 2: Valid file, section with spaces ('SectionWithSpaces')");
+    result_array := get_ini_section("test.ini", "SectionWithSpaces");
+    expected_array := {
+        "LeadingSpaceKey": "LeadingSpaceValue",
+        "TrailingSpaceKey": "TrailingSpaceValue",
+        "Both Sides Space Key": "Both Sides Space Value",
+        "SimpleKey": "SimpleValue"
+    };
+    call assertEquals("TC2 Size", len_array(result_array), 4);
+    call assertEquals("TC2 Content", arrays_equal(result_array, expected_array), true);
+    call assertEquals("TC2 Specific LeadingSpaceKey Value", result_array["LeadingSpaceKey"], "LeadingSpaceValue");
+    call assertEquals("TC2 Specific TrailingSpaceKey Value", result_array["TrailingSpaceKey"], "TrailingSpaceValue");
+    call assertEquals("TC2 Specific Both Sides Space Key Value", result_array["Both Sides Space Key"], "Both Sides Space Value");
+
+
+    // Test Case 3: INI file not found
+    display_msg("Test Case 3: INI file not found ('nonexistent.ini')");
+    result_array := get_ini_section("nonexistent.ini", "AnySection");
+    expected_array := {}; // Empty associative array
+    call assertEquals("TC3 Size", len_array(result_array), 0);
+    call assertEquals("TC3 Content", arrays_equal(result_array, expected_array), true);
+    call assertEquals("TC3 Is Map", array_key(result_array, -1), 1); // Should still be an associative array
+
+    // Test Case 4: Valid file, section not found
+    display_msg("Test Case 4: Valid file, section not found ('NonExistentSection')");
+    result_array := get_ini_section("test.ini", "NonExistentSection");
+    // expected_array is still {}
+    call assertEquals("TC4 Size", len_array(result_array), 0);
+    call assertEquals("TC4 Content", arrays_equal(result_array, expected_array), true);
+    call assertEquals("TC4 Is Map", array_key(result_array, -1), 1);
+
+    // Test Case 5: Valid file, empty section
+    display_msg("Test Case 5: Valid file, empty section ('EmptySection')");
+    result_array := get_ini_section("test.ini", "EmptySection");
+    // expected_array is still {}
+    call assertEquals("TC5 Size", len_array(result_array), 0);
+    call assertEquals("TC5 Content", arrays_equal(result_array, expected_array), true);
+    call assertEquals("TC5 Is Map", array_key(result_array, -1), 1);
+
+    display_msg("--- get_ini_section tests finished ---");
+    call report_test_results("get_ini_section");
+end
+
+procedure start begin
+    // Initialize test suite variables if they are not reset by report_test_results
+    // test_suite_errors := 0;
+    // test_suite_assertions := 0;
+    display_msg("Starting INI function tests");
+    call ini_test_suite();
+end
+
+// It's good practice to ensure this new test suite is called if there's a main test runner.
+// For now, this file will be self-contained. If sfall_testing/gl_test_main.ssl exists and
+// is used to run all tests, this suite might need to be added there.
+// For this subtask, creating the file is sufficient.

--- a/sfall_testing/gl_test_ini.ssl
+++ b/sfall_testing/gl_test_ini.ssl
@@ -1,14 +1,13 @@
 #include "lib.arrays.h" // For arrays_equal, len_array, etc.
 #include "test_utils.h"   // For assertEquals, VALTYPE_STR, report_test_results
 
-// To test: copy test.ini into the game folder
+// To test: copy test.ini into the game folder before running
 procedure ini_test_suite begin
     variable result_array, expected_array, key_type, value_type, count, key_val_pair;
 
     display_msg("--- Testing get_ini_section ---");
 
     // Test Case 1: Valid file, valid section
-    display_msg("Test Case 1: Valid file, valid section ('ValidSection')");
     result_array := get_ini_section("test.ini", "ValidSection");
     expected_array := {"Key1": "Value1", "Key2": "2"};
     call assertEquals("TC1 Size", len_array(result_array), 2);
@@ -23,33 +22,27 @@ procedure ini_test_suite begin
     call assertEquals("TC1 get_ini_setting string", get_ini_setting("test.ini|ValidSection|Key1"), 0);
     call assertEquals("TC1 get_ini_string string", get_ini_string("test.ini|ValidSection|Key1"), "Value1");
     call assertEquals("TC1 get_ini_setting int", get_ini_setting("test.ini|ValidSection|Key2"), 2);
-    call assertEquals("TC1 get_ini_string int", get_ini_setting("test.ini|ValidSection|Key2"), 2); // TODO: "2"?
+    call assertEquals("TC1 get_ini_string int", get_ini_string("test.ini|ValidSection|Key2"), "2");
 
-    // Test Case 3: INI file not found
+    // TODO: this crashes, possibly due to wrong parameter order?
+    // set_ini_setting("test.ini|ValidSection|Key2", 2);
+
+    // INI file not found
     display_msg("Test Case 3: INI file not found ('nonexistent.ini')");
     result_array := get_ini_section("nonexistent.ini", "AnySection");
-    expected_array := {}; // Empty associative array
     call assertEquals("TC3 Size", len_array(result_array), 0);
-    call assertEquals("TC3 Content", arrays_equal(result_array, expected_array), true);
     call assertEquals("TC3 Is Map", array_key(result_array, -1), 1); // Should still be an associative array
 
-    // Test Case 4: Valid file, section not found
-    display_msg("Test Case 4: Valid file, section not found ('NonExistentSection')");
+    // Valid file, section not found
     result_array := get_ini_section("test.ini", "NonExistentSection");
-    // expected_array is still {}
     call assertEquals("TC4 Size", len_array(result_array), 0);
-    call assertEquals("TC4 Content", arrays_equal(result_array, expected_array), true);
     call assertEquals("TC4 Is Map", array_key(result_array, -1), 1);
 
-    // Test Case 5: Valid file, empty section
-    display_msg("Test Case 5: Valid file, empty section ('EmptySection')");
+    // Valid file, empty section
     result_array := get_ini_section("test.ini", "EmptySection");
-    // expected_array is still {}
     call assertEquals("TC5 Size", len_array(result_array), 0);
-    call assertEquals("TC5 Content", arrays_equal(result_array, expected_array), true);
     call assertEquals("TC5 Is Map", array_key(result_array, -1), 1);
 
-    display_msg("--- get_ini_section tests finished ---");
     call report_test_results("get_ini_section");
 end
 

--- a/sfall_testing/gl_test_ini.ssl
+++ b/sfall_testing/gl_test_ini.ssl
@@ -5,7 +5,7 @@
 procedure ini_test_suite begin
     variable result_array, expected_array, key_type, value_type, count, key_val_pair;
 
-    display_msg("--- Testing get_ini_section ---");
+    display_msg("--- Testing ini functions");
 
     // Test Case 1: Valid file, valid section
     result_array := get_ini_section("test.ini", "ValidSection");
@@ -18,35 +18,47 @@ procedure ini_test_suite begin
         call assertEquals("TC1 Key Type " + count, typeof(key_val_pair[0]), VALTYPE_STR);
         call assertEquals("TC1 Value Type " + count, typeof(key_val_pair[1]), VALTYPE_STR);
     end
-    call assertEquals("TC1 Specific Key1 Value", result_array["Key1"], "Value1");
-    call assertEquals("TC1 get_ini_setting string", get_ini_setting("test.ini|ValidSection|Key1"), 0);
-    call assertEquals("TC1 get_ini_string string", get_ini_string("test.ini|ValidSection|Key1"), "Value1");
-    call assertEquals("TC1 get_ini_setting int", get_ini_setting("test.ini|ValidSection|Key2"), 2);
-    call assertEquals("TC1 get_ini_string int", get_ini_string("test.ini|ValidSection|Key2"), "2");
 
-    // TODO: this crashes, possibly due to wrong parameter order?
-    // set_ini_setting("test.ini|ValidSection|Key2", 2);
+    // basic fetchers
+    call assertEquals("TC2 Specific Key1 Value", result_array["Key1"], "Value1");
+    call assertEquals("TC2 get_ini_setting string", get_ini_setting("test.ini|ValidSection|Key1"), 0);
+    call assertEquals("TC2 get_ini_string string", get_ini_string("test.ini|ValidSection|Key1"), "Value1");
+    call assertEquals("TC2 get_ini_setting int", get_ini_setting("test.ini|ValidSection|Key2"), 2);
+    call assertEquals("TC2 get_ini_string int", get_ini_string("test.ini|ValidSection|Key2"), "2");
 
     // INI file not found
-    display_msg("Test Case 3: INI file not found ('nonexistent.ini')");
     result_array := get_ini_section("nonexistent.ini", "AnySection");
     call assertEquals("TC3 Size", len_array(result_array), 0);
     call assertEquals("TC3 Is Map", array_key(result_array, -1), 1); // Should still be an associative array
+    call assertEquals("TC3 get_ini_setting", get_ini_setting("notexist.ini|ValidSection|Key2"), 0);
+    call assertEquals("TC3 get_ini_string", get_ini_string("notexist.ini|ValidSection|Key2"), "");
 
     // Valid file, section not found
     result_array := get_ini_section("test.ini", "NonExistentSection");
     call assertEquals("TC4 Size", len_array(result_array), 0);
     call assertEquals("TC4 Is Map", array_key(result_array, -1), 1);
+    call assertEquals("TC4 get_ini_setting", get_ini_setting("test.ini|NonExistentSection|Key2"), 0);
+    call assertEquals("TC4 get_ini_string", get_ini_string("test.ini|NonExistentSection|Key2"), "");
+
 
     // Valid file, empty section
     result_array := get_ini_section("test.ini", "EmptySection");
     call assertEquals("TC5 Size", len_array(result_array), 0);
     call assertEquals("TC5 Is Map", array_key(result_array, -1), 1);
+    call assertEquals("TC5 get_ini_setting", get_ini_setting("test.ini|EmptySection|Key2"), 0);
+    call assertEquals("TC5 get_ini_string", get_ini_string("test.ini|EmptySection|Key2"), "");
 
-    call report_test_results("get_ini_section");
+    // set ini setting
+    set_ini_setting("test_set.ini|ValidSection|Key3", "OldValue");
+    call assertEquals("TC6 set_ini_setting 1", get_ini_string("test_set.ini|ValidSection|Key3"), "OldValue");
+    set_ini_setting("test_set.ini|ValidSection|Key3", "NewValue");
+    call assertEquals("TC6 set_ini_setting 2", get_ini_string("test_set.ini|ValidSection|Key3"), "NewValue");
+    set_ini_setting("test_set.ini|ValidSection|Key3", 2);
+    call assertEquals("TC6 set_ini_setting int", get_ini_setting("test_set.ini|ValidSection|Key3"), 2);
+
+    call report_test_results("ini");
 end
 
 procedure start begin
-    display_msg("Starting INI function tests");
     call ini_test_suite();
 end

--- a/sfall_testing/gl_test_ini.ssl
+++ b/sfall_testing/gl_test_ini.ssl
@@ -1,48 +1,29 @@
 #include "lib.arrays.h" // For arrays_equal, len_array, etc.
 #include "test_utils.h"   // For assertEquals, VALTYPE_STR, report_test_results
 
+// To test: copy test.ini into the game folder
 procedure ini_test_suite begin
-    variable result_array, expected_array, key_type, value_type, count;
-
-    // Reset errors for this suite if test_utils.h doesn't do it per suite
-    // test_suite_errors := 0; // Assuming test_utils.h manages this globally or per call to report_test_results
+    variable result_array, expected_array, key_type, value_type, count, key_val_pair;
 
     display_msg("--- Testing get_ini_section ---");
 
     // Test Case 1: Valid file, valid section
     display_msg("Test Case 1: Valid file, valid section ('ValidSection')");
     result_array := get_ini_section("test.ini", "ValidSection");
-    expected_array := {"Key1": "Value1", "Key2": "Another Value", "Key WithSpace": "Value With Space"};
-    call assertEquals("TC1 Size", len_array(result_array), 3);
+    expected_array := {"Key1": "Value1", "Key2": "2"};
+    call assertEquals("TC1 Size", len_array(result_array), 2);
     call assertEquals("TC1 Content", arrays_equal(result_array, expected_array), true);
-    // Detailed type and content check for TC1
     count := 0;
     foreach key_val_pair in result_array begin
         count += 1;
         call assertEquals("TC1 Key Type " + count, typeof(key_val_pair[0]), VALTYPE_STR);
         call assertEquals("TC1 Value Type " + count, typeof(key_val_pair[1]), VALTYPE_STR);
     end
-    // Specific check for one key-value pair from TC1 to ensure iteration works as expected by key name
     call assertEquals("TC1 Specific Key1 Value", result_array["Key1"], "Value1");
-    call assertEquals("TC1 Specific Key WithSpace Value", result_array["Key WithSpace"], "Value With Space");
-
-
-    // Test Case 2: Valid file, section with spaces (keys/values should be trimmed by INI parser)
-    // Note: The current INI parser in config.c (configTrimString) trims leading/trailing whitespace from keys and values.
-    display_msg("Test Case 2: Valid file, section with spaces ('SectionWithSpaces')");
-    result_array := get_ini_section("test.ini", "SectionWithSpaces");
-    expected_array := {
-        "LeadingSpaceKey": "LeadingSpaceValue",
-        "TrailingSpaceKey": "TrailingSpaceValue",
-        "Both Sides Space Key": "Both Sides Space Value",
-        "SimpleKey": "SimpleValue"
-    };
-    call assertEquals("TC2 Size", len_array(result_array), 4);
-    call assertEquals("TC2 Content", arrays_equal(result_array, expected_array), true);
-    call assertEquals("TC2 Specific LeadingSpaceKey Value", result_array["LeadingSpaceKey"], "LeadingSpaceValue");
-    call assertEquals("TC2 Specific TrailingSpaceKey Value", result_array["TrailingSpaceKey"], "TrailingSpaceValue");
-    call assertEquals("TC2 Specific Both Sides Space Key Value", result_array["Both Sides Space Key"], "Both Sides Space Value");
-
+    call assertEquals("TC1 get_ini_setting string", get_ini_setting("test.ini|ValidSection|Key1"), 0);
+    call assertEquals("TC1 get_ini_string string", get_ini_string("test.ini|ValidSection|Key1"), "Value1");
+    call assertEquals("TC1 get_ini_setting int", get_ini_setting("test.ini|ValidSection|Key2"), 2);
+    call assertEquals("TC1 get_ini_string int", get_ini_setting("test.ini|ValidSection|Key2"), 2); // TODO: "2"?
 
     // Test Case 3: INI file not found
     display_msg("Test Case 3: INI file not found ('nonexistent.ini')");
@@ -73,14 +54,6 @@ procedure ini_test_suite begin
 end
 
 procedure start begin
-    // Initialize test suite variables if they are not reset by report_test_results
-    // test_suite_errors := 0;
-    // test_suite_assertions := 0;
     display_msg("Starting INI function tests");
     call ini_test_suite();
 end
-
-// It's good practice to ensure this new test suite is called if there's a main test runner.
-// For now, this file will be self-contained. If sfall_testing/gl_test_main.ssl exists and
-// is used to run all tests, this suite might need to be added there.
-// For this subtask, creating the file is sufficient.

--- a/sfall_testing/gl_test_ini.ssl
+++ b/sfall_testing/gl_test_ini.ssl
@@ -56,6 +56,11 @@ procedure ini_test_suite begin
     set_ini_setting("test_set.ini|ValidSection|Key3", 2);
     call assertEquals("TC6 set_ini_setting int", get_ini_setting("test_set.ini|ValidSection|Key3"), 2);
 
+    // get_init_sections
+    result_array := get_ini_sections("test.ini");
+    call assertEquals("TC7 get_ini_sections size", len_array(result_array), 3);
+    call assertTrue("TC7 get_ini_sections", scan_array(result_array, "TestMisc") >= 0);
+
     call report_test_results("ini");
 end
 

--- a/sfall_testing/test.ini
+++ b/sfall_testing/test.ini
@@ -1,7 +1,6 @@
 [ValidSection]
 Key1=Value1
-Key2=Another Value
-Key WithSpace=Value With Space
+Key2=2
 
 [SectionWithSpaces]
   LeadingSpaceKey = LeadingSpaceValue

--- a/sfall_testing/test.ini
+++ b/sfall_testing/test.ini
@@ -1,0 +1,17 @@
+[ValidSection]
+Key1=Value1
+Key2=Another Value
+Key WithSpace=Value With Space
+
+[SectionWithSpaces]
+  LeadingSpaceKey = LeadingSpaceValue
+TrailingSpaceKey  =  TrailingSpaceValue
+  Both Sides Space Key  =  Both Sides Space Value
+SimpleKey=SimpleValue
+
+[EmptySection]
+
+; This is TestMisc, it's not empty but won't be directly tested for content here.
+[TestMisc]
+Alpha=Beta
+Gamma=Delta

--- a/sfall_testing/test_utils.h
+++ b/sfall_testing/test_utils.h
@@ -7,6 +7,17 @@ variable test_suite_errors := 0;
 variable test_suite_verbose := false;
 variable test_suite_assertions := 0;
 
+procedure assertTrue(variable desc, variable a) begin
+   test_suite_assertions++;
+
+   if (not a) then begin
+      display_msg("Assertion failed \""+desc+"\": is not true");
+      test_suite_errors ++;
+   end else if (test_suite_verbose) then begin
+      display_msg("Assert \""+desc+"\" ok");
+   end
+end
+
 procedure assertEquals(variable desc, variable a, variable b) begin
    test_suite_assertions++;
 

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -3347,14 +3347,16 @@ int ProgramValue::asInt() const
 }
 
 // CE
-ProgramValue programMakeString(Program* program, const char *str) {
+ProgramValue programMakeString(Program* program, const char* str)
+{
     ProgramValue valuePv;
     valuePv.opcode = VALUE_TYPE_DYNAMIC_STRING;
     valuePv.integerValue = programPushString(program, str);
     return valuePv;
 }
 
-ProgramValue programMakeInt(Program* program, int val) {
+ProgramValue programMakeInt(Program* program, int val)
+{
     ProgramValue valuePv;
     valuePv.opcode = VALUE_TYPE_INT;
     valuePv.integerValue = val;

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -3346,4 +3346,19 @@ int ProgramValue::asInt() const
     }
 }
 
+// CE
+ProgramValue programMakeString(Program* program, const char *str) {
+    ProgramValue valuePv;
+    valuePv.opcode = VALUE_TYPE_DYNAMIC_STRING;
+    valuePv.integerValue = programPushString(program, str);
+    return valuePv;
+}
+
+ProgramValue programMakeInt(Program* program, int val) {
+    ProgramValue valuePv;
+    valuePv.opcode = VALUE_TYPE_INT;
+    valuePv.integerValue = val;
+    return valuePv;
+}
+
 } // namespace fallout

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -241,6 +241,10 @@ ProgramValue programReturnStackPopValue(Program* program);
 int programReturnStackPopInteger(Program* program);
 void* programReturnStackPopPointer(Program* program);
 
+// CE
+ProgramValue programMakeString(Program* program, const char *str);
+ProgramValue programMakeInt(Program* program, int val);
+
 } // namespace fallout
 
 #endif /* INTERPRETER_H */

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -242,7 +242,7 @@ int programReturnStackPopInteger(Program* program);
 void* programReturnStackPopPointer(Program* program);
 
 // CE
-ProgramValue programMakeString(Program* program, const char *str);
+ProgramValue programMakeString(Program* program, const char* str);
 ProgramValue programMakeInt(Program* program, int val);
 
 } // namespace fallout

--- a/src/sfall_ini.cc
+++ b/src/sfall_ini.cc
@@ -1,7 +1,8 @@
 #include "sfall_ini.h"
 
 #include <algorithm>
-#include <cstring>
+#include <cstdio> // for snprintf
+#include <cstring> // for strncpy, strlen
 
 #include "config.h"
 #include "platform_compat.h"
@@ -192,6 +193,42 @@ bool sfall_ini_set_string(const char* triplet, const char* value)
     configFree(&config);
 
     return saved;
+}
+
+bool sfall_load_named_ini_file(const char* ini_file_name, Config* config_out) {
+    if (ini_file_name == nullptr || config_out == nullptr) {
+        return false;
+    }
+
+    char path[COMPAT_MAX_PATH];
+    bool loaded = false;
+
+    if (basePath[0] != '\0' && !is_system_file_name(ini_file_name)) {
+        snprintf(path, sizeof(path), "%s\\%s", basePath, ini_file_name);
+        loaded = configRead(config_out, path, false);
+    }
+
+    if (!loaded) {
+        strncpy(path, ini_file_name, sizeof(path) - 1);
+        path[sizeof(path) - 1] = '\0';
+        loaded = configRead(config_out, path, false);
+    }
+
+    return loaded;
+}
+
+const ConfigSection* sfall_find_section_in_config(const Config* config, const char* section_name) {
+    if (config == nullptr || section_name == nullptr) {
+        return nullptr;
+    }
+
+    int sectionIndex = dictionaryGetIndexByKey(config, section_name);
+    if (sectionIndex == -1) {
+        return nullptr;
+    }
+
+    DictionaryEntry* sectionEntry = &(config->entries[sectionIndex]);
+    return static_cast<const ConfigSection*>(sectionEntry->value);
 }
 
 } // namespace fallout

--- a/src/sfall_ini.cc
+++ b/src/sfall_ini.cc
@@ -217,7 +217,7 @@ bool sfall_load_named_ini_file(const char* ini_file_name, Config* config_out) {
     return loaded;
 }
 
-const ConfigSection* sfall_find_section_in_config(const Config* config, const char* section_name) {
+const ConfigSection* sfall_find_section_in_config(Config* config, const char* section_name) {
     if (config == nullptr || section_name == nullptr) {
         return nullptr;
     }

--- a/src/sfall_ini.cc
+++ b/src/sfall_ini.cc
@@ -291,15 +291,7 @@ void mf_get_ini_section(Program* program, int args)
                 const char* value = *(static_cast<char**>(entry->value));
 
                 if (key != nullptr && value != nullptr) {
-                    ProgramValue keyPv;
-                    keyPv.opcode = VALUE_TYPE_DYNAMIC_STRING;
-                    keyPv.integerValue = programPushString(program, key);
-
-                    ProgramValue valuePv;
-                    valuePv.opcode = VALUE_TYPE_DYNAMIC_STRING;
-                    valuePv.integerValue = programPushString(program, value);
-
-                    SetArray(arrayId, keyPv, valuePv, false, program);
+                    SetArray(arrayId, programMakeString(program, key), programMakeString(program, value), false, program);
                 }
             }
         }
@@ -337,15 +329,7 @@ void mf_get_ini_sections(Program* program, int args)
                 const char* sectionName = entry->key;
 
                 if (sectionName != nullptr) {
-                    ProgramValue keyPv;
-                    keyPv.opcode = VALUE_TYPE_INT;
-                    keyPv.integerValue = i;
-
-                    ProgramValue valuePv;
-                    valuePv.opcode = VALUE_TYPE_DYNAMIC_STRING;
-                    valuePv.integerValue = programPushString(program, sectionName);
-
-                    SetArray(arrayId, keyPv, valuePv, false, program);
+                    SetArray(arrayId, programMakeInt(program, i), programMakeString(program, sectionName), false, program);
                 }
             }
         }
@@ -358,6 +342,32 @@ void mf_get_ini_sections(Program* program, int args)
     }
 
     programStackPushInteger(program, arrayId);
+}
+
+// get_ini_setting
+void op_get_ini_setting(Program* program)
+{
+    const char* string = programStackPopString(program);
+
+    int value;
+    if (sfall_ini_get_int(string, &value)) {
+        programStackPushInteger(program, value);
+    } else {
+        programStackPushInteger(program, -1);
+    }
+}
+
+// get_ini_string
+void op_get_ini_string(Program* program)
+{
+    const char* string = programStackPopString(program);
+
+    char value[256];
+    if (sfall_ini_get_string(string, value, sizeof(value))) {
+        programStackPushString(program, value);
+    } else {
+        programStackPushInteger(program, -1);
+    }
 }
 
 } // namespace fallout

--- a/src/sfall_ini.cc
+++ b/src/sfall_ini.cc
@@ -4,11 +4,11 @@
 #include <cstdio> // for snprintf
 #include <cstring> // for strncpy, strlen
 
-#include "sfall_arrays.h"
 #include "config.h"
 #include "debug.h"
 #include "interpreter.h"
 #include "platform_compat.h"
+#include "sfall_arrays.h"
 
 namespace fallout {
 
@@ -198,7 +198,8 @@ bool sfall_ini_set_string(const char* triplet, const char* value)
     return saved;
 }
 
-bool sfall_load_named_ini_file(const char* ini_file_name, Config* config_out) {
+bool sfall_load_named_ini_file(const char* ini_file_name, Config* config_out)
+{
     if (ini_file_name == nullptr || config_out == nullptr) {
         return false;
     }
@@ -220,7 +221,8 @@ bool sfall_load_named_ini_file(const char* ini_file_name, Config* config_out) {
     return loaded;
 }
 
-const ConfigSection* sfall_find_section_in_config(Config* config, const char* section_name) {
+const ConfigSection* sfall_find_section_in_config(Config* config, const char* section_name)
+{
     if (config == nullptr || section_name == nullptr) {
         return nullptr;
     }
@@ -258,13 +260,13 @@ void mf_set_ini_setting(Program* program, int args)
     programStackPushInteger(program, -1);
 }
 
-
-void mf_get_ini_section(Program* program, int args) {
+void mf_get_ini_section(Program* program, int args)
+{
     // Arguments: file_path (string), section_name (string)
 
     const char* filePath = programStackPopString(program);
     const char* sectionName = programStackPopString(program);
-    
+
     ArrayId arrayId = CreateTempArray(-1, 0);
 
     if (filePath == nullptr || sectionName == nullptr) {

--- a/src/sfall_ini.h
+++ b/src/sfall_ini.h
@@ -39,6 +39,8 @@ const ConfigSection* sfall_find_section_in_config(Config* config, const char* se
 void mf_set_ini_setting(Program* program, int args);
 void mf_get_ini_section(Program* program, int args);
 void mf_get_ini_sections(Program* program, int args);
+void op_get_ini_setting(Program* program);
+void op_get_ini_string(Program* program);
 
 } // namespace fallout
 

--- a/src/sfall_ini.h
+++ b/src/sfall_ini.h
@@ -23,18 +23,6 @@ bool sfall_ini_set_int(const char* triplet, int value);
 /// Writes string key identified by "fileName|section|key" triplet.
 bool sfall_ini_set_string(const char* triplet, const char* value);
 
-// Loads an INI file specified by 'ini_file_name' (e.g., "myconfig.ini" or "ddraw.ini")
-// into the provided 'config_out' object.
-// The 'config_out' object must be initialized by the caller (using configInit).
-// The caller is also responsible for freeing 'config_out' (using configFree).
-// Returns true if the file was successfully found and read, false otherwise.
-bool sfall_load_named_ini_file(const char* ini_file_name, Config* config_out);
-
-// Finds a section within a loaded Config object.
-// Returns a pointer to the ConfigSection if found, otherwise nullptr.
-// The ConfigSection pointer is valid as long as the parent Config object is valid and unmodified.
-const ConfigSection* sfall_find_section_in_config(Config* config, const char* section_name);
-
 // metarule and opcode implementations
 void mf_set_ini_setting(Program* program, int args);
 void mf_get_ini_section(Program* program, int args);

--- a/src/sfall_ini.h
+++ b/src/sfall_ini.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include "dictionary.h"
 #include "config.h"
+#include "interpreter.h"
 
 namespace fallout {
 
@@ -33,6 +34,11 @@ bool sfall_load_named_ini_file(const char* ini_file_name, Config* config_out);
 // Returns a pointer to the ConfigSection if found, otherwise nullptr.
 // The ConfigSection pointer is valid as long as the parent Config object is valid and unmodified.
 const ConfigSection* sfall_find_section_in_config(Config* config, const char* section_name);
+
+// metarule and opcode implementations
+void mf_set_ini_setting(Program* program, int args);
+void mf_get_ini_section(Program* program, int args);
+void mf_get_ini_sections(Program* program, int args);
 
 } // namespace fallout
 

--- a/src/sfall_ini.h
+++ b/src/sfall_ini.h
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include "dictionary.h"
+#include "config.h"
 
 namespace fallout {
 
@@ -31,7 +32,7 @@ bool sfall_load_named_ini_file(const char* ini_file_name, Config* config_out);
 // Finds a section within a loaded Config object.
 // Returns a pointer to the ConfigSection if found, otherwise nullptr.
 // The ConfigSection pointer is valid as long as the parent Config object is valid and unmodified.
-const ConfigSection* sfall_find_section_in_config(const Config* config, const char* section_name);
+const ConfigSection* sfall_find_section_in_config(Config* config, const char* section_name);
 
 } // namespace fallout
 

--- a/src/sfall_ini.h
+++ b/src/sfall_ini.h
@@ -2,6 +2,7 @@
 #define FALLOUT_SFALL_INI_H_
 
 #include <cstddef>
+#include "dictionary.h"
 
 namespace fallout {
 
@@ -19,6 +20,18 @@ bool sfall_ini_set_int(const char* triplet, int value);
 
 /// Writes string key identified by "fileName|section|key" triplet.
 bool sfall_ini_set_string(const char* triplet, const char* value);
+
+// Loads an INI file specified by 'ini_file_name' (e.g., "myconfig.ini" or "ddraw.ini")
+// into the provided 'config_out' object.
+// The 'config_out' object must be initialized by the caller (using configInit).
+// The caller is also responsible for freeing 'config_out' (using configFree).
+// Returns true if the file was successfully found and read, false otherwise.
+bool sfall_load_named_ini_file(const char* ini_file_name, Config* config_out);
+
+// Finds a section within a loaded Config object.
+// Returns a pointer to the ConfigSection if found, otherwise nullptr.
+// The ConfigSection pointer is valid as long as the parent Config object is valid and unmodified.
+const ConfigSection* sfall_find_section_in_config(const Config* config, const char* section_name);
 
 } // namespace fallout
 

--- a/src/sfall_ini.h
+++ b/src/sfall_ini.h
@@ -1,10 +1,10 @@
 #ifndef FALLOUT_SFALL_INI_H_
 #define FALLOUT_SFALL_INI_H_
 
-#include <cstddef>
-#include "dictionary.h"
 #include "config.h"
+#include "dictionary.h"
 #include "interpreter.h"
+#include <cstddef>
 
 namespace fallout {
 

--- a/src/sfall_metarules.cc
+++ b/src/sfall_metarules.cc
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "combat.h"
+#include "config.h" // For Config, configInit, configFree
 #include "debug.h"
 #include "game.h"
 #include "game_dialog.h"
@@ -18,7 +19,6 @@
 #include "sfall_arrays.h" // For CreateTempArray, SetArray
 #include "sfall_ini.h"
 #include "text_font.h"
-#include "config.h" // For Config, configInit, configFree
 #include "tile.h"
 #include "window.h"
 #include "worldmap.h"
@@ -86,7 +86,7 @@ constexpr MetaruleInfo kMetarules[] = {
     { "get_flags", mf_get_flags, 1, 1 },
     // {"get_ini_config",            mf_get_ini_config,            2, 2,  0, {ARG_STRING, ARG_INT}},
     { "get_ini_section", mf_get_ini_section, 2, 2 },
-    { "get_ini_sections",          mf_get_ini_sections,          1, 1 }, 
+    { "get_ini_sections", mf_get_ini_sections, 1, 1 },
     // {"get_inven_ap_cost",         mf_get_inven_ap_cost,         0, 0},
     // {"get_map_enter_position",    mf_get_map_enter_position,    0, 0},
     // {"get_metarule_table",        mf_get_metarule_table,        0, 0},

--- a/src/sfall_metarules.cc
+++ b/src/sfall_metarules.cc
@@ -110,6 +110,7 @@ static void mf_get_ini_section(Program* program, int args) {
 }
 
 // ref. https://github.com/sfall-team/sfall/blob/42556141127895c27476cd5242a73739cbb0fade/sfall/Modules/Scripting/Handlers/Metarule.cpp#L72
+// Note: metarules should pop arguments off the stack in natural order
 constexpr MetaruleInfo kMetarules[] = {
     // {"add_extra_msg_file",        mf_add_extra_msg_file,        1, 2, -1, {ARG_STRING, ARG_INT}},
     // {"add_iface_tag",             mf_add_iface_tag,             0, 0},
@@ -121,7 +122,7 @@ constexpr MetaruleInfo kMetarules[] = {
     { "car_gas_amount", mf_car_gas_amount, 0, 0 },
     { "combat_data", mf_combat_data, 0, 0 },
     // {"create_win",                mf_create_win,                5, 6, -1, {ARG_STRING, ARG_INT, ARG_INT, ARG_INT, ARG_INT, ARG_INT}},
-    { "critter_inven_obj2", mf_critter_inven_obj2, 2, 2 },
+    { "critter_inven_obj2", mf_critter_inven_obj2, 2, 2 }, // XXX: likely parameter order mismatch
     // {"dialog_message",            mf_dialog_message,            1, 1, -1, {ARG_STRING}},
     { "dialog_obj", mf_dialog_obj, 0, 0 },
     // {"display_stats",             mf_display_stats,             0, 0}, // refresh
@@ -141,7 +142,7 @@ constexpr MetaruleInfo kMetarules[] = {
     // {"get_map_enter_position",    mf_get_map_enter_position,    0, 0},
     // {"get_metarule_table",        mf_get_metarule_table,        0, 0},
     // {"get_object_ai_data",        mf_get_object_ai_data,        2, 2, -1, {ARG_OBJECT, ARG_INT}},
-    { "get_object_data", mf_get_object_data, 2, 2 },
+    { "get_object_data", mf_get_object_data, 2, 2 }, // XXX: likely parameter order mismatch
     // {"get_outline",               mf_get_outline,               1, 1,  0, {ARG_OBJECT}},
     // {"get_sfall_arg_at",          mf_get_sfall_arg_at,          1, 1,  0, {ARG_INT}},
     // {"get_stat_max",              mf_get_stat_max,              1, 2,  0, {ARG_INT, ARG_INT}},
@@ -189,7 +190,7 @@ constexpr MetaruleInfo kMetarules[] = {
     { "set_ini_setting", mf_set_ini_setting, 2, 2 },
     // {"set_map_enter_position",    mf_set_map_enter_position,    3, 3, -1, {ARG_INT, ARG_INT, ARG_INT}},
     // {"set_object_data",           mf_set_object_data,           3, 3, -1, {ARG_OBJECT, ARG_INT, ARG_INT}},
-    { "set_outline", mf_set_outline, 2, 2 },
+    { "set_outline", mf_set_outline, 2, 2 }, // XXX: likely parameter order mismatch
     // {"set_quest_failure_value",   mf_set_quest_failure_value,   2, 2, -1, {ARG_INT, ARG_INT}},
     // {"set_rest_heal_time",        mf_set_rest_heal_time,        1, 1, -1, {ARG_INT}},
     // {"set_worldmap_heal_time",    mf_set_worldmap_heal_time,    1, 1, -1, {ARG_INT}},
@@ -352,8 +353,8 @@ void mf_set_flags(Program* program, int args)
 
 void mf_set_ini_setting(Program* program, int args)
 {
-    ProgramValue value = programStackPopValue(program);
     const char* triplet = programStackPopString(program);
+    ProgramValue value = programStackPopValue(program);
 
     if (value.isString()) {
         const char* stringValue = programGetString(program, value.opcode, value.integerValue);

--- a/src/sfall_metarules.cc
+++ b/src/sfall_metarules.cc
@@ -87,17 +87,15 @@ static void mf_get_ini_section(Program* program, int args) {
             for (int i = 0; i < section->entriesLength; ++i) {
                 DictionaryEntry* entry = &(section->entries[i]);
                 const char* key = entry->key;
-                // The value in ConfigSection's dictionary is char**
-                // Dereference once to get char*
                 const char* value = *(static_cast<char**>(entry->value));
 
                 if (key != nullptr && value != nullptr) {
                     ProgramValue keyPv;
-                    keyPv.opcode = VALUE_TYPE_STRING;
+                    keyPv.opcode = VALUE_TYPE_DYNAMIC_STRING;
                     keyPv.integerValue = programPushString(program, key);
 
                     ProgramValue valuePv;
-                    valuePv.opcode = VALUE_TYPE_STRING;
+                    valuePv.opcode = VALUE_TYPE_DYNAMIC_STRING;
                     valuePv.integerValue = programPushString(program, value);
 
                     SetArray(arrayId, keyPv, valuePv, false, program);
@@ -106,7 +104,7 @@ static void mf_get_ini_section(Program* program, int args) {
         }
     }
 
-    configFree(&iniConfig); // Clean up the Config structure.
+    configFree(&iniConfig);
 
     programStackPushInteger(program, arrayId);
 }

--- a/src/sfall_opcodes.cc
+++ b/src/sfall_opcodes.cc
@@ -250,19 +250,6 @@ static void op_get_sfall_global_int(Program* program)
     programStackPushInteger(program, value);
 }
 
-// get_ini_setting
-static void op_get_ini_setting(Program* program)
-{
-    const char* string = programStackPopString(program);
-
-    int value;
-    if (sfall_ini_get_int(string, &value)) {
-        programStackPushInteger(program, value);
-    } else {
-        programStackPushInteger(program, -1);
-    }
-}
-
 // get_game_mode
 static void op_get_game_mode(Program* program)
 {
@@ -295,19 +282,6 @@ static void op_set_bodypart_hit_modifier(Program* program)
     int penalty = programStackPopInteger(program);
     int hit_location = programStackPopInteger(program);
     combat_set_hit_location_penalty(hit_location, penalty);
-}
-
-// get_ini_string
-static void op_get_ini_string(Program* program)
-{
-    const char* string = programStackPopString(program);
-
-    char value[256];
-    if (sfall_ini_get_string(string, value, sizeof(value))) {
-        programStackPushString(program, value);
-    } else {
-        programStackPushInteger(program, -1);
-    }
 }
 
 // sqrt

--- a/src/sfall_opcodes.cc
+++ b/src/sfall_opcodes.cc
@@ -1155,6 +1155,7 @@ static void op_charcode(Program* program)
     }
 }
 
+// Note: opcodes should pop arguments off the stack in reverse order
 void sfallOpcodesInit()
 {
     // ref. https://github.com/sfall-team/sfall/blob/71ecec3d405bd5e945f157954618b169e60068fe/artifacts/scripting/sfall%20opcode%20list.txt#L145


### PR DESCRIPTION
### Description

Implements `get_ini_section`, needed for Et Tu, and `get_ini_sections`.  Fixes buggy `set_ini_setting`.  

Also includes tests for existing ini functions, and moves them all to `sfall_init.cc`.   (opcodes and metarules files were getting long, and this matches sfall's structure)

### Reproduction Steps and Savefile (if available)

Test using the gl_test script.  You'll also need `test.ini` in the game folder

<img width="573" alt="image" src="https://github.com/user-attachments/assets/d6cc5b06-a093-4f1c-897e-cfd455041ccf" />


