### PR TITLE
(sfall) Implement `set_map_time_multi`

### DIFF
--- a/sfall_testing/gl_test_worldmap.ssl
+++ b/sfall_testing/gl_test_worldmap.ssl
@@ -1,0 +1,7 @@
+#include "sfall.h"
+
+procedure start begin
+    // this isn't a unit test, just a way to easily test different values manually
+    display_msg("Setting world map mult");
+    set_map_time_multi(1.0);
+end

--- a/src/sfall_opcodes.cc
+++ b/src/sfall_opcodes.cc
@@ -223,6 +223,13 @@ static void op_get_world_map_y_pos(Program* program)
     programStackPushInteger(program, y);
 }
 
+// set_map_time_multi
+void op_set_map_time_multi(Program* program)
+{
+    ProgramValue value = programStackPopValue(program);
+    wmSetScriptWorldMapMulti(value.asFloat());
+}
+
 // active_hand
 static void op_active_hand(Program* program)
 {
@@ -1256,6 +1263,7 @@ void sfallOpcodesInit()
     // 0x8229 - void force_encounter_with_flags(int map, int flags)
     interpreterRegisterOpcode(0x8229, op_force_encounter_with_flags);
     // 0x822a - void set_map_time_multi(float multi)
+    interpreterRegisterOpcode(0x822A, op_set_map_time_multi);
 
     // 0x8172 - void set_world_map_pos(int x, int y)
     interpreterRegisterOpcode(0x8172, op_set_world_map_pos);

--- a/src/worldmap.cc
+++ b/src/worldmap.cc
@@ -459,7 +459,7 @@ typedef struct WmGenData {
     int oldFont;
 } WmGenData;
 
-// CE/SFALL: control world map time via script 
+// CE/SFALL: control world map time via script
 float gScriptWorldMapMulti = 1.0f;
 void wmSetScriptWorldMapMulti(float value)
 {

--- a/src/worldmap.cc
+++ b/src/worldmap.cc
@@ -459,6 +459,13 @@ typedef struct WmGenData {
     int oldFont;
 } WmGenData;
 
+// CE/SFALL: control world map time via script 
+float gScriptWorldMapMulti = 1.0f;
+void wmSetScriptWorldMapMulti(float value)
+{
+    gScriptWorldMapMulti = value;
+}
+
 static void wmSetFlags(int* flagsPtr, int flag, int value);
 static int wmGenDataInit();
 static int wmGenDataReset();
@@ -4188,9 +4195,9 @@ static bool wmGameTimeIncrement(int ticksToAdd)
 
     // SFALL: Fix Pathfinder perk.
     int pathfinderRank = perkGetRank(gDude, PERK_PATHFINDER);
-    double bonus = static_cast<double>(ticksToAdd) * static_cast<double>(pathfinderRank) * 0.25 + gGameTimeIncRemainder;
-    gGameTimeIncRemainder = modf(bonus, &bonus);
-    ticksToAdd -= static_cast<int>(bonus);
+    double newTicks = static_cast<double>(ticksToAdd) * (1.0 - static_cast<double>(pathfinderRank) * 0.25) * gScriptWorldMapMulti + gGameTimeIncRemainder;
+    gGameTimeIncRemainder = modf(newTicks, &newTicks);
+    ticksToAdd = static_cast<int>(newTicks);
 
     while (ticksToAdd != 0) {
         unsigned int gameTime = gameTimeGetTime();

--- a/src/worldmap.h
+++ b/src/worldmap.h
@@ -283,9 +283,11 @@ int wmSetMapMusic(int mapIdx, const char* name);
 int wmMatchAreaContainingMapIdx(int mapIdx, int* areaIdxPtr);
 int wmTeleportToArea(int areaIdx);
 
+// CE
 void wmSetPartyWorldPos(int x, int y);
 void wmCarSetCurrentArea(int area);
 void wmForceEncounter(int map, unsigned int flags);
+void wmSetScriptWorldMapMulti(float value);
 
 } // namespace fallout
 


### PR DESCRIPTION
No unittest for this one, but added a script for manual testing.

I inverted the travel time calculation since it was a bit confusing.  It now more closely matches sfall: https://github.com/sfall-team/sfall/blob/0e2317fd4c8b2eca4be11add377c6776f07c6354/sfall/Modules/Worldmap.cpp#L220

This is used by Et Tu