### PR TITLE
first pass on transparent windows

### DIFF
--- a/src/window_manager.cc
+++ b/src/window_manager.cc
@@ -323,17 +323,15 @@ static void applyWindowTransparency(Window* window)
     unsigned char* bg = (unsigned char*)internal_malloc(width * height);
     if (!bg) return;
 
-    context = {x, y, width, height, bg};
+    context = { x, y, width, height, bg };
 
     static auto blitter = [](unsigned char* src, int srcPitch, int,
-                             int srcX, int srcY, int blitWidth, int blitHeight,
-                             int destX, int destY) {
+                              int srcX, int srcY, int blitWidth, int blitHeight,
+                              int destX, int destY) {
         int bufferX = destX - context.x;
         int bufferY = destY - context.y;
 
-        if (bufferX >= 0 && bufferY >= 0 &&
-            bufferX + blitWidth <= context.width &&
-            bufferY + blitHeight <= context.height) {
+        if (bufferX >= 0 && bufferY >= 0 && bufferX + blitWidth <= context.width && bufferY + blitHeight <= context.height) {
             for (int row = 0; row < blitHeight; row++) {
                 memcpy(
                     context.buffer + (bufferY + row) * context.width + bufferX,
@@ -346,7 +344,7 @@ static void applyWindowTransparency(Window* window)
     WINDOWDRAWINGPROC oldBlitter = _scr_blit;
     _scr_blit = blitter;
 
-    Rect rect = {x, y, x + width - 1, y + height - 1};
+    Rect rect = { x, y, x + width - 1, y + height - 1 };
     windowRefreshAll(&rect);
 
     _scr_blit = oldBlitter;
@@ -457,7 +455,7 @@ int windowCreate(int x, int y, int width, int height, int color, int flags)
             gWindowIndexes[id] = v25;
         }
     }
-    
+
     // apply new window transparency
     if ((flags & WINDOW_TRANSPARENT) != 0) {
         applyWindowTransparency(window);


### PR DESCRIPTION
This adds a helper function for windowCreate that is applied when a window has the 'WINDOW_TRANSPARENT' flag.

The helper function copies the background (behind where the window will appear) to the windows buffer, so that a blitBufferToBufferTrans of the windows frm background, while actually be 'transparent' (i.e. the corners will be transparent)

### Description

Adds helper function `static void applyWindowTransparency(Window* window)` that handles the `WINDOW_TRANSPARENT` flag

### Screenshots

Window with `WINDOW_TRANSPARENT` flag, and background not-blitted:
![Screenshot 2025-06-19 at 15 08 59](https://github.com/user-attachments/assets/9679a130-7499-497e-9126-96c1ec98b994)

Window with `WINDOW_TRANSPARENT` flag, and background blitted with blitBufferToBufferTrans (and transparent background frm)
![Screenshot 2025-06-19 at 15 09 33](https://github.com/user-attachments/assets/bd90cfc0-5696-42dd-ad15-7bcdfbe170a0)