### PR TITLE
Implement `show/hide_iface_tag,is_iface_tag_active` for vanilla tags

### DIFF
--- a/sfall_testing/gl_test_iface_tag.ssl
+++ b/sfall_testing/gl_test_iface_tag.ssl
@@ -3,7 +3,7 @@
 
 procedure start begin
     display_msg("Testing iface_tag functions...");
-    // assumes no iface tags active in the save game, otherwise will wipe that state
+    // assumes no iface tags active in the save game
 
     // SNEAK
     show_iface_tag(0);
@@ -22,6 +22,12 @@ procedure start begin
     call assertTrue("show_iface_tag(ADDICTED)", is_iface_tag_active(4));
     hide_iface_tag(4);
     call assertFalse("hide_iface_tag(ADDICTED)", is_iface_tag_active(4));
+
+    // POISONED
+    call assertFalse("hide_iface_tag(POISONED)", is_iface_tag_active(1));
+
+    // RADIATED
+    call assertFalse("hide_iface_tag(RADIATED)", is_iface_tag_active(2));
 
     call report_test_results("iface_tag");
 end

--- a/sfall_testing/gl_test_iface_tag.ssl
+++ b/sfall_testing/gl_test_iface_tag.ssl
@@ -1,0 +1,27 @@
+#include "test_utils.h"
+#include "sfall.h"
+
+procedure start begin
+    display_msg("Testing iface_tag functions...");
+    // assumes no iface tags active in the save game, otherwise will wipe that state
+
+    // SNEAK
+    show_iface_tag(0);
+    call assertTrue("show_iface_tag(SNEAK)", is_iface_tag_active(0));
+    hide_iface_tag(0);
+    call assertFalse("hide_iface_tag(SNEAK)", is_iface_tag_active(0));
+
+    // LEVEL
+    show_iface_tag(3);
+    call assertTrue("show_iface_tag(LEVEL)", is_iface_tag_active(3));
+    hide_iface_tag(3);
+    call assertFalse("hide_iface_tag(LEVEL)", is_iface_tag_active(3));
+
+    // ADDICTED
+    show_iface_tag(4);
+    call assertTrue("show_iface_tag(ADDICTED)", is_iface_tag_active(4));
+    hide_iface_tag(4);
+    call assertFalse("hide_iface_tag(ADDICTED)", is_iface_tag_active(4));
+
+    call report_test_results("iface_tag");
+end

--- a/sfall_testing/test_utils.h
+++ b/sfall_testing/test_utils.h
@@ -18,6 +18,17 @@ procedure assertTrue(variable desc, variable a) begin
    end
 end
 
+procedure assertFalse(variable desc, variable a) begin
+   test_suite_assertions++;
+
+   if (a) then begin
+      display_msg("Assertion failed \""+desc+"\": is not false");
+      test_suite_errors ++;
+   end else if (test_suite_verbose) then begin
+      display_msg("Assert \""+desc+"\" ok");
+   end
+end
+
 procedure assertEquals(variable desc, variable a, variable b) begin
    test_suite_assertions++;
 

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -44,12 +44,6 @@ namespace fallout {
 // When displaying series of boxes they appear to be plugged into a chain.
 #define INDICATOR_BOX_CONNECTOR_WIDTH 3
 
-// Minimum radiation amount to display RADIATED indicator.
-#define RADATION_INDICATOR_THRESHOLD 65
-
-// Minimum poison amount to display POISONED indicator.
-#define POISON_INDICATOR_THRESHOLD 0
-
 // The maximum number of indicator boxes the indicator bar can display.
 //
 // For unknown reason this number is 6, even though there are only 5 different

--- a/src/interface.h
+++ b/src/interface.h
@@ -12,6 +12,12 @@ namespace fallout {
 #define INTERFACE_BAR_WIDTH 640
 #define INTERFACE_BAR_HEIGHT 100
 
+// Minimum radiation amount to display RADIATED indicator.
+#define RADATION_INDICATOR_THRESHOLD 65
+
+// Minimum poison amount to display POISONED indicator.
+#define POISON_INDICATOR_THRESHOLD 0
+
 typedef enum InterfaceItemAction {
     INTERFACE_ITEM_ACTION_DEFAULT = -1,
     INTERFACE_ITEM_ACTION_USE,

--- a/src/sfall_opcodes.cc
+++ b/src/sfall_opcodes.cc
@@ -1197,6 +1197,12 @@ static void op_is_iface_tag_active(fallout::Program* program) {
         case DudeState::DUDE_STATE_ADDICTED:
             isActive = fallout::dudeHasState(tag);
             break;
+        case 1: // POISONED
+            isActive = critterGetPoison(gDude) > POISON_INDICATOR_THRESHOLD;
+            break;
+        case 2: // RADIATED
+            isActive = critterGetRadiation(gDude) > RADATION_INDICATOR_THRESHOLD;
+            break;
         default:
             debugPrint("op_is_iface_tag_active: custom tag %d is not handled", tag);
     }

--- a/src/sfall_opcodes.cc
+++ b/src/sfall_opcodes.cc
@@ -1159,7 +1159,8 @@ static void op_charcode(Program* program)
     }
 }
 
-static void op_show_iface_tag(fallout::Program* program) {
+static void op_show_iface_tag(fallout::Program* program)
+{
     int tag = fallout::programStackPopInteger(program);
 
     switch (tag) {
@@ -1173,7 +1174,8 @@ static void op_show_iface_tag(fallout::Program* program) {
     }
 }
 
-static void op_hide_iface_tag(fallout::Program* program) {
+static void op_hide_iface_tag(fallout::Program* program)
+{
     int tag = fallout::programStackPopInteger(program);
 
     switch (tag) {
@@ -1187,24 +1189,25 @@ static void op_hide_iface_tag(fallout::Program* program) {
     }
 }
 
-static void op_is_iface_tag_active(fallout::Program* program) {
+static void op_is_iface_tag_active(fallout::Program* program)
+{
     int tag = fallout::programStackPopInteger(program);
     bool isActive = false;
 
     switch (tag) {
-        case DudeState::DUDE_STATE_SNEAKING:
-        case DudeState::DUDE_STATE_LEVEL_UP_AVAILABLE:
-        case DudeState::DUDE_STATE_ADDICTED:
-            isActive = fallout::dudeHasState(tag);
-            break;
-        case 1: // POISONED
-            isActive = critterGetPoison(gDude) > POISON_INDICATOR_THRESHOLD;
-            break;
-        case 2: // RADIATED
-            isActive = critterGetRadiation(gDude) > RADATION_INDICATOR_THRESHOLD;
-            break;
-        default:
-            debugPrint("op_is_iface_tag_active: custom tag %d is not handled", tag);
+    case DudeState::DUDE_STATE_SNEAKING:
+    case DudeState::DUDE_STATE_LEVEL_UP_AVAILABLE:
+    case DudeState::DUDE_STATE_ADDICTED:
+        isActive = fallout::dudeHasState(tag);
+        break;
+    case 1: // POISONED
+        isActive = critterGetPoison(gDude) > POISON_INDICATOR_THRESHOLD;
+        break;
+    case 2: // RADIATED
+        isActive = critterGetRadiation(gDude) > RADATION_INDICATOR_THRESHOLD;
+        break;
+    default:
+        debugPrint("op_is_iface_tag_active: custom tag %d is not handled", tag);
     }
 
     fallout::programStackPushInteger(program, isActive ? 1 : 0);

--- a/src/sfall_opcodes.cc
+++ b/src/sfall_opcodes.cc
@@ -7,6 +7,7 @@
 #include "art.h"
 #include "color.h"
 #include "combat.h"
+#include "critter.h"
 #include "dbox.h"
 #include "debug.h"
 #include "game.h"
@@ -1158,6 +1159,51 @@ static void op_charcode(Program* program)
     }
 }
 
+static void op_show_iface_tag(fallout::Program* program) {
+    int tag = fallout::programStackPopInteger(program);
+
+    switch (tag) {
+    case DudeState::DUDE_STATE_SNEAKING:
+    case DudeState::DUDE_STATE_LEVEL_UP_AVAILABLE:
+    case DudeState::DUDE_STATE_ADDICTED:
+        dudeEnableState(tag);
+        break;
+    default:
+        debugPrint("op_show_iface_tag: custom tag %d is not handled", tag);
+    }
+}
+
+static void op_hide_iface_tag(fallout::Program* program) {
+    int tag = fallout::programStackPopInteger(program);
+
+    switch (tag) {
+    case DudeState::DUDE_STATE_SNEAKING:
+    case DudeState::DUDE_STATE_LEVEL_UP_AVAILABLE:
+    case DudeState::DUDE_STATE_ADDICTED:
+        dudeDisableState(tag);
+        break;
+    default:
+        debugPrint("op_hide_iface_tag: custom tag %d is not handled", tag);
+    }
+}
+
+static void op_is_iface_tag_active(fallout::Program* program) {
+    int tag = fallout::programStackPopInteger(program);
+    bool isActive = false;
+
+    switch (tag) {
+        case DudeState::DUDE_STATE_SNEAKING:
+        case DudeState::DUDE_STATE_LEVEL_UP_AVAILABLE:
+        case DudeState::DUDE_STATE_ADDICTED:
+            isActive = fallout::dudeHasState(tag);
+            break;
+        default:
+            debugPrint("op_is_iface_tag_active: custom tag %d is not handled", tag);
+    }
+
+    fallout::programStackPushInteger(program, isActive ? 1 : 0);
+}
+
 // Note: opcodes should pop arguments off the stack in reverse order
 void sfallOpcodesInit()
 {
@@ -1408,8 +1454,11 @@ void sfallOpcodesInit()
     // 0x81ce - void set_hp_per_level_mod(int mod)
 
     // 0x81dc - void show_iface_tag(int tag)
+    interpreterRegisterOpcode(0x81DC, op_show_iface_tag);
     // 0x81dd - void hide_iface_tag(int tag)
+    interpreterRegisterOpcode(0x81DD, op_hide_iface_tag);
     // 0x81de - int  is_iface_tag_active(int tag)
+    interpreterRegisterOpcode(0x81DE, op_is_iface_tag_active);
 
     // 0x81df - int  get_bodypart_hit_modifier(int bodypart)
     interpreterRegisterOpcode(0x81DF, op_get_bodypart_hit_modifier);


### PR DESCRIPTION
Implement "interface tags" (called "indicators" in the code): https://sfall-team.github.io/sfall/tags/

This is all that is used by RPU (absent partycontrol mod)

Does *not* implement custom tags, yet.  That's a little more involved.

<img width="863" alt="image" src="https://github.com/user-attachments/assets/7bfb273d-e17e-4a9a-8a1f-1f01e249b6c4" />
