### PR TITLE
`message_box` metarule

### DIFF
--- a/sfall_testing/gl_test_message_box.ssl
+++ b/sfall_testing/gl_test_message_box.ssl
@@ -1,0 +1,14 @@
+
+#include "sfall.h"
+
+// this is the basic message_box function used by RPU and Et Tu
+#define message_box_warning(text)      message_box4(text, 0x01, 134, 145)
+
+procedure start begin
+    // I don't see a practice way to auto test message_box, so this is just a way to do manual testing
+    variable ret = message_box1("Basic Dialog\nwith multiple lines\nand such.");
+    display_msg("chose: " + ret);
+    message_box2("Basic Dialog\nwith default flags.", -1); // -1 means use default flags
+    message_box2("Basic Dialog\nsmall.", 0x02);
+    message_box_warning("Missing config values\n(just testing).");
+end

--- a/src/dbox.cc
+++ b/src/dbox.cc
@@ -154,10 +154,11 @@ int showDialogBox(const char* title, const char** body, int bodyLength, int x, i
     MessageListItem messageListItem;
     int savedFont = fontGetCurrent();
 
-    bool v86 = false;
+    bool initializedButtons = false;
 
     bool hasTwoButtons = false;
     if (a8 != nullptr) {
+        // TODO: a8 seems to be a way to customize "NO", but is unused.
         hasTwoButtons = true;
     }
 
@@ -169,7 +170,7 @@ int showDialogBox(const char* title, const char** body, int bodyLength, int x, i
     if ((flags & DIALOG_BOX_YES_NO) != 0) {
         hasTwoButtons = true;
         flags |= DIALOG_BOX_LARGE;
-        flags &= ~DIALOG_BOX_0x20;
+        flags &= ~DIALOG_BOX_NO_BUTTONS;
     }
 
     int maximumLineWidth = 0;
@@ -227,7 +228,7 @@ int showDialogBox(const char* title, const char** body, int bodyLength, int x, i
     FrmImage buttonNormalFrmImage;
     FrmImage buttonPressedFrmImage;
 
-    if ((flags & DIALOG_BOX_0x20) == 0) {
+    if ((flags & DIALOG_BOX_NO_BUTTONS) == 0) {
         int doneBoxFid = buildFid(OBJ_TYPE_INTERFACE, 209, 0, 0, 0);
         if (!doneBoxFrmImage.lock(doneBoxFid)) {
             fontSetCurrent(savedFont);
@@ -304,13 +305,13 @@ int showDialogBox(const char* title, const char** body, int bodyLength, int x, i
             buttonSetCallbacks(btn, _gsound_red_butt_press, _gsound_red_butt_release);
         }
 
-        v86 = true;
+        initializedButtons = true;
     }
 
     if (hasTwoButtons && dialogType == DIALOG_TYPE_LARGE) {
-        if (v86) {
+        if (initializedButtons) {
             if ((flags & DIALOG_BOX_YES_NO) != 0) {
-                a8 = getmsg(&messageList, &messageListItem, 102);
+                a8 = getmsg(&messageList, &messageListItem, 102); // 102 - NO
             }
 
             fontSetCurrent(103);
@@ -410,7 +411,7 @@ int showDialogBox(const char* title, const char** body, int bodyLength, int x, i
                 buttonSetCallbacks(btn, _gsound_red_butt_press, _gsound_red_butt_release);
             }
 
-            v86 = true;
+            initializedButtons = true;
         }
     }
 
@@ -537,7 +538,7 @@ int showDialogBox(const char* title, const char** body, int bodyLength, int x, i
         } else if (keyCode == KEY_ESCAPE || keyCode == 501) {
             rc = 0;
         } else {
-            if ((flags & 0x10) != 0) {
+            if ((flags & DIALOG_BOX_YES_NO) != 0) {
                 if (keyCode == KEY_UPPERCASE_Y || keyCode == KEY_LOWERCASE_Y) {
                     rc = 1;
                 } else if (keyCode == KEY_UPPERCASE_N || keyCode == KEY_LOWERCASE_N) {
@@ -557,7 +558,7 @@ int showDialogBox(const char* title, const char** body, int bodyLength, int x, i
     windowDestroy(win);
     fontSetCurrent(savedFont);
 
-    if (v86) {
+    if (initializedButtons) {
         messageListFree(&messageList);
     }
 

--- a/src/dbox.h
+++ b/src/dbox.h
@@ -4,12 +4,12 @@
 namespace fallout {
 
 typedef enum DialogBoxOptions {
-    DIALOG_BOX_LARGE = 0x01,
-    DIALOG_BOX_MEDIUM = 0x02,
-    DIALOG_BOX_NO_HORIZONTAL_CENTERING = 0x04,
-    DIALOG_BOX_NO_VERTICAL_CENTERING = 0x08,
+    DIALOG_BOX_LARGE = 0x01, // sfall calls this NORMAL
+    DIALOG_BOX_MEDIUM = 0x02, // sfall: SMALL
+    DIALOG_BOX_NO_HORIZONTAL_CENTERING = 0x04, // sfall: ALIGN_LEFT
+    DIALOG_BOX_NO_VERTICAL_CENTERING = 0x08, // sfall: ALIGN_TOP
     DIALOG_BOX_YES_NO = 0x10,
-    DIALOG_BOX_0x20 = 0x20,
+    DIALOG_BOX_NO_BUTTONS = 0x20, // sfall: CLEAN
 } DialogBoxOptions;
 
 int showDialogBox(const char* title, const char** body, int bodyLength, int x, int y, int titleColor, const char* a8, int bodyColor, int flags);

--- a/src/sfall_metarules.cc
+++ b/src/sfall_metarules.cc
@@ -9,8 +9,8 @@
 #include "color.h"
 #include "combat.h"
 #include "config.h" // For Config, configInit, configFree
-#include "debug.h"
 #include "dbox.h"
+#include "debug.h"
 #include "game.h"
 #include "game_dialog.h"
 #include "game_mouse.h"
@@ -110,7 +110,7 @@ const MetaruleInfo kMetarules[] = {
     // {"item_weight",               mf_item_weight,               1, 1,  0, {ARG_OBJECT}},
     // {"lock_is_jammed",            mf_lock_is_jammed,            1, 1,  0, {ARG_OBJECT}},
     { "loot_obj", mf_loot_obj, 0, 0 },
-    {"message_box",               mf_message_box,               1, 4}, // {ARG_STRING, ARG_INT, ARG_INT, ARG_INT}},
+    { "message_box", mf_message_box, 1, 4 }, // {ARG_STRING, ARG_INT, ARG_INT, ARG_INT}},
     { "metarule_exist", mf_metarule_exist, 1, 1 },
     // {"npc_engine_level_up",       mf_npc_engine_level_up,       1, 1},
     // {"obj_is_openable",           mf_obj_is_openable,           1, 1,  0, {ARG_OBJECT}},
@@ -573,7 +573,8 @@ void sprintf_lite(Program* program, int args, const char* infoOpcodeName)
 }
 
 // message_box
-void mf_message_box(Program* program, int args) {
+void mf_message_box(Program* program, int args)
+{
     static int dialogShowCount = 0;
 
     const char* string = programStackPopString(program);
@@ -602,18 +603,18 @@ void mf_message_box(Program* program, int args) {
     }
 
     // note: most of the CE code uses colorTable indices, but this metarule expects palette values.
-    // Default: yellow (145) = _colorTable[32328]         
+    // Default: yellow (145) = _colorTable[32328]
     int color1 = _colorTable[32328], color2 = _colorTable[32328];
     if (args > 2) {
         color1 = programStackPopInteger(program);
     }
     if (args > 3) {
         color2 = programStackPopInteger(program);
-	}
+    }
 
     dialogShowCount++;
     scriptsDisable();
-    int rc = showDialogBox(copy,body,count,192,116,color1,nullptr,color2,flags);
+    int rc = showDialogBox(copy, body, count, 192, 116, color1, nullptr, color2, flags);
     if (--dialogShowCount == 0) {
         scriptsEnable();
     }


### PR DESCRIPTION
This is used by Et Tu and RPU.

Also: some decryption of the underlying dialog box code

### Reproduction Steps and Savefile (if available)

Use the included test script

### Screenshots
<img width="667" alt="image" src="https://github.com/user-attachments/assets/4242a681-5030-4f2b-9c1a-2937c74ecbd0" />
<img width="542" alt="image" src="https://github.com/user-attachments/assets/d593f514-e06e-4455-a284-c3072f6e8320" />
<img width="724" alt="image" src="https://github.com/user-attachments/assets/5633f5b8-ac47-41db-a4b0-11d251bcb0a8" />
