### PR TITLE
Fix missing cursor on the right (mirrored) context menu

### DIFF
--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -1776,7 +1776,9 @@ int gameMouseRenderActionMenuItems(int x, int y, const int* menuItems, int menuI
     CacheEntry* arrowFrmHandle;
     Art* arrowFrm = artLock(fid, &arrowFrmHandle);
     if (arrowFrm == nullptr) {
-        // FIXME: Unlock arts.
+        for (int index = 0; index < menuItemsLength; index++) {
+            artUnlock(menuItemFrmHandles[index]);
+        }
         return -1;
     }
 
@@ -1792,43 +1794,45 @@ int gameMouseRenderActionMenuItems(int x, int y, const int* menuItems, int menuI
     gGameMouseActionMenuFrm->xOffsets[0] = gGameMouseActionMenuFrmWidth / 2;
     gGameMouseActionMenuFrm->yOffsets[0] = gGameMouseActionMenuFrmHeight - 1;
 
-    int v60 = y + menuItemsLength * menuItemHeight - 1;
-    int v24 = v60 - height + 2;
+    int maxY = y + menuItemsLength * menuItemHeight - 1;
+    int shiftY = maxY - height + 2;
     unsigned char* arrowFrmDest = gGameMouseActionMenuFrmData;
-    unsigned char* v58 = arrowFrmDest;
+    unsigned char* menuItemFrmDest = arrowFrmDest;
 
     unsigned char* arrowData;
     if (x + arrowWidth + menuItemWidth - 1 < width) {
         arrowData = artGetFrameData(arrowFrm, 0, 0);
-        v58 = arrowFrmDest + arrowWidth;
-        if (height <= v60) {
-            _gmouse_3d_menu_frame_hot_y += v24;
-            arrowFrmDest += gGameMouseActionMenuFrmWidth * v24;
-            gGameMouseActionMenuFrm->yOffsets[0] -= v24;
+        menuItemFrmDest = arrowFrmDest + arrowWidth;
+        if (height <= maxY) {
+            _gmouse_3d_menu_frame_hot_y += shiftY;
+            arrowFrmDest += gGameMouseActionMenuFrmWidth * shiftY;
+            gGameMouseActionMenuFrm->yOffsets[0] -= shiftY;
         }
     } else {
         // Mirrored arrow (from left to right).
+        artUnlock(arrowFrmHandle);
         fid = buildFid(OBJ_TYPE_INTERFACE, 285, 0, 0, 0);
         arrowFrm = artLock(fid, &arrowFrmHandle);
         arrowData = artGetFrameData(arrowFrm, 0, 0);
         arrowFrmDest += menuItemWidth;
+
         gGameMouseActionMenuFrm->xOffsets[0] = -gGameMouseActionMenuFrm->xOffsets[0];
         _gmouse_3d_menu_frame_hot_x += menuItemWidth + arrowWidth;
-        if (v60 >= height) {
-            _gmouse_3d_menu_frame_hot_y += v24;
-            gGameMouseActionMenuFrm->yOffsets[0] -= v24;
-            arrowFrmDest += gGameMouseActionMenuFrmWidth * v24;
+        if (maxY >= height) {
+            _gmouse_3d_menu_frame_hot_y += shiftY;
+            gGameMouseActionMenuFrm->yOffsets[0] -= shiftY;
+            arrowFrmDest += gGameMouseActionMenuFrmWidth * shiftY;
         }
     }
 
     memset(gGameMouseActionMenuFrmData, 0, gGameMouseActionMenuFrmDataSize);
     blitBufferToBuffer(arrowData, arrowWidth, arrowHeight, arrowWidth, arrowFrmDest, gGameMouseActionPickFrmWidth);
 
-    unsigned char* v38 = v58;
+    unsigned char* dest = menuItemFrmDest;
     for (int index = 0; index < menuItemsLength; index++) {
         unsigned char* data = artGetFrameData(menuItemFrms[index], 0, 0);
-        blitBufferToBuffer(data, menuItemWidth, menuItemHeight, menuItemWidth, v38, gGameMouseActionPickFrmWidth);
-        v38 += gGameMouseActionMenuFrmWidth * menuItemHeight;
+        blitBufferToBuffer(data, menuItemWidth, menuItemHeight, menuItemWidth, dest, gGameMouseActionPickFrmWidth);
+        dest += gGameMouseActionMenuFrmWidth * menuItemHeight;
     }
 
     artUnlock(arrowFrmHandle);
@@ -1839,7 +1843,7 @@ int gameMouseRenderActionMenuItems(int x, int y, const int* menuItems, int menuI
 
     memcpy(gGameMouseActionMenuItems, menuItems, sizeof(*gGameMouseActionMenuItems) * menuItemsLength);
     gGameMouseActionMenuItemsLength = menuItemsLength;
-    _gmouse_3d_menu_actions_start = v58;
+    _gmouse_3d_menu_actions_start = menuItemFrmDest;
 
     Sound* sound = soundEffectLoad("iaccuxx1", nullptr);
     if (sound != nullptr) {

--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -1699,6 +1699,7 @@ int gameMouseRenderPrimaryAction(int x, int y, int menuItem, int width, int heig
             arrowFrmDest += gGameMouseActionPickFrmWidth * shiftY;
         }
     } else {
+        // mirrored cursor for far-right side of screen
         artUnlock(arrowFrmHandle);
 
         arrowFid = buildFid(OBJ_TYPE_INTERFACE, 285, 0, 0, 0);
@@ -1793,16 +1794,16 @@ int gameMouseRenderActionMenuItems(int x, int y, const int* menuItems, int menuI
 
     int v60 = y + menuItemsLength * menuItemHeight - 1;
     int v24 = v60 - height + 2;
-    unsigned char* v22 = gGameMouseActionMenuFrmData;
-    unsigned char* v58 = v22;
+    unsigned char* arrowFrmDest = gGameMouseActionMenuFrmData;
+    unsigned char* v58 = arrowFrmDest;
 
     unsigned char* arrowData;
     if (x + arrowWidth + menuItemWidth - 1 < width) {
         arrowData = artGetFrameData(arrowFrm, 0, 0);
-        v58 = v22 + arrowWidth;
+        v58 = arrowFrmDest + arrowWidth;
         if (height <= v60) {
             _gmouse_3d_menu_frame_hot_y += v24;
-            v22 += gGameMouseActionMenuFrmWidth * v24;
+            arrowFrmDest += gGameMouseActionMenuFrmWidth * v24;
             gGameMouseActionMenuFrm->yOffsets[0] -= v24;
         }
     } else {
@@ -1810,17 +1811,18 @@ int gameMouseRenderActionMenuItems(int x, int y, const int* menuItems, int menuI
         fid = buildFid(OBJ_TYPE_INTERFACE, 285, 0, 0, 0);
         arrowFrm = artLock(fid, &arrowFrmHandle);
         arrowData = artGetFrameData(arrowFrm, 0, 0);
+        arrowFrmDest += menuItemWidth;
         gGameMouseActionMenuFrm->xOffsets[0] = -gGameMouseActionMenuFrm->xOffsets[0];
         _gmouse_3d_menu_frame_hot_x += menuItemWidth + arrowWidth;
         if (v60 >= height) {
             _gmouse_3d_menu_frame_hot_y += v24;
             gGameMouseActionMenuFrm->yOffsets[0] -= v24;
-            v22 += gGameMouseActionMenuFrmWidth * v24;
+            arrowFrmDest += gGameMouseActionMenuFrmWidth * v24;
         }
     }
 
     memset(gGameMouseActionMenuFrmData, 0, gGameMouseActionMenuFrmDataSize);
-    blitBufferToBuffer(arrowData, arrowWidth, arrowHeight, arrowWidth, v22, gGameMouseActionPickFrmWidth);
+    blitBufferToBuffer(arrowData, arrowWidth, arrowHeight, arrowWidth, arrowFrmDest, gGameMouseActionPickFrmWidth);
 
     unsigned char* v38 = v58;
     for (int index = 0; index < menuItemsLength; index++) {


### PR DESCRIPTION
Fixes #226

### Description

Cursor is missing when using context menu on an object at the far right side of the screen (see screenshot in issue)

### Reproduction Steps and Savefile (if available)

Hover over an item right next the right side of the screen, and long-left-click

### Screenshots

Fixed:

<img width="270" height="467" alt="image" src="https://github.com/user-attachments/assets/c45cc5b3-57af-4409-b12a-6eaa5ed0b2fc" />

Reviewer's note: the bugfix is in the first commit—it might be easier to review just that commit.

Originally reported and fix in fallout1-ce here: https://github.com/alexbatalov/fallout1-ce/pull/221