### PR TITLE
Deobfuscate one function in interpreter_extra.cc

### DIFF
--- a/src/art.cc
+++ b/src/art.cc
@@ -1006,6 +1006,13 @@ static void artCacheFreeImpl(void* ptr)
     internal_free(ptr);
 }
 
+/* FID Structure:
+    3 bits for rotation
+    4 bits for object type
+    8 bits for animation type
+    4 bits for weapon code
+    12 bits for frame ID
+*/
 static int buildFidInternal(unsigned short frmId, unsigned char weaponCode, unsigned char animType, unsigned char objectType, unsigned char rotation)
 {
     return ((rotation << 28) & 0x70000000) | (objectType << 24) | ((animType << 16) & 0xFF0000) | ((weaponCode << 12) & 0xF000) | (frmId & 0xFFF);

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -2614,7 +2614,7 @@ static void _adjust_fid()
         }
 
         int animationCode = 0;
-        if (interfaceGetCurrentHand()) {
+        if (interfaceGetCurrentHand() == HAND_RIGHT) {
             if (gInventoryRightHandItem != nullptr) {
                 protoGetProto(gInventoryRightHandItem->pid, &proto);
                 if (proto->item.type == ITEM_TYPE_WEAPON) {

--- a/src/obj_types.h
+++ b/src/obj_types.h
@@ -33,7 +33,7 @@ enum {
 #define PID_TYPE(value) (value) >> 24
 #define SID_TYPE(value) (value) >> 24
 
-#define FID_WEAPON_CODE(fid)  (((fid) & 0xF000) >> 12)
+#define FID_WEAPON_CODE(fid) (((fid) & 0xF000) >> 12)
 #define FID_ROTATION(fid) (((fid) & 0x70000000) >> 28)
 
 typedef enum OutlineType {

--- a/src/obj_types.h
+++ b/src/obj_types.h
@@ -33,6 +33,9 @@ enum {
 #define PID_TYPE(value) (value) >> 24
 #define SID_TYPE(value) (value) >> 24
 
+#define FID_WEAPON_CODE(fid)  (((fid) & 0xF000) >> 12)
+#define FID_ROTATION(fid) (((fid) & 0x70000000) >> 28)
+
 typedef enum OutlineType {
     OUTLINE_TYPE_HOSTILE = 1,
     OUTLINE_TYPE_2 = 2,


### PR DESCRIPTION
Introduces FID_WEAPON_CODE and FID_ROTATION.  In future PRs we can use these to eliminate a lot of inlined bit shifts
