### PR TITLE
Use `FID_ROTATION` macro to remove manual bit shifting

### DIFF
--- a/src/art.cc
+++ b/src/art.cc
@@ -619,7 +619,7 @@ char* artBuildFilePath(int fid)
 
     v2 = fid;
 
-    v10 = (fid & 0x70000000) >> 28;
+    v10 = FID_ROTATION(fid);
 
     v1 = artAliasFid(fid);
     if (v1 != -1) {

--- a/src/combat.cc
+++ b/src/combat.cc
@@ -2620,7 +2620,7 @@ static void _combat_begin(Object* attacker)
                 100,
                 FID_ANIM_TYPE(v1->fid),
                 (v1->fid & 0xF000) >> 12,
-                (v1->fid & 0x70000000) >> 28);
+                FID_ROTATION(v1->fid));
 
             reg_anim_clear(v1);
             reg_anim_begin(ANIMATION_REQUEST_RESERVED);
@@ -2788,7 +2788,7 @@ static void _combat_over()
                 99,
                 FID_ANIM_TYPE(critter->fid),
                 (critter->fid & 0xF000) >> 12,
-                (critter->fid & 0x70000000) >> 28);
+                FID_ROTATION(critter->fid));
             reg_anim_clear(critter);
             reg_anim_begin(ANIMATION_REQUEST_RESERVED);
             animationRegisterAnimate(critter, ANIM_UP_STAIRS_RIGHT, -1);
@@ -3490,7 +3490,7 @@ void attackInit(Attack* attack, Object* attacker, Object* defender, int hitMode,
 int _combat_attack(Object* attacker, Object* defender, int hitMode, int hitLocation)
 {
     if (attacker != gDude && hitMode == HIT_MODE_PUNCH && randomBetween(1, 4) == 1) {
-        int fid = buildFid(OBJ_TYPE_CRITTER, attacker->fid & 0xFFF, ANIM_KICK_LEG, (attacker->fid & 0xF000) >> 12, (attacker->fid & 0x70000000) >> 28);
+        int fid = buildFid(OBJ_TYPE_CRITTER, attacker->fid & 0xFFF, ANIM_KICK_LEG, (attacker->fid & 0xF000) >> 12, FID_ROTATION(attacker->fid));
         if (artExists(fid)) {
             hitMode = HIT_MODE_KICK;
         }

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -2035,7 +2035,7 @@ static void opMetarule3(Program* program)
                 frmId,
                 FID_ANIM_TYPE(obj->fid),
                 (obj->fid & 0xF000) >> 12,
-                (obj->fid & 0x70000000) >> 28);
+                FID_ROTATION(obj->fid));
 
             Rect updatedRect;
             objectSetFid(obj, fid, &updatedRect);
@@ -3393,7 +3393,7 @@ static void opAnim(Program* program)
         if (frame == 0) {
             animationRegisterAnimate(obj, anim, 0);
             if (anim >= ANIM_FALL_BACK && anim <= ANIM_FALL_FRONT_BLOOD) {
-                int fid = buildFid(OBJ_TYPE_CRITTER, obj->fid & 0xFFF, anim + 28, (obj->fid & 0xF000) >> 12, (obj->fid & 0x70000000) >> 28);
+                int fid = buildFid(OBJ_TYPE_CRITTER, obj->fid & 0xFFF, anim + 28, (obj->fid & 0xF000) >> 12, FID_ROTATION(obj->fid));
                 animationRegisterSetFid(obj, fid, -1);
             }
 
@@ -3401,6 +3401,7 @@ static void opAnim(Program* program)
                 combatData->results &= DAM_KNOCKED_DOWN;
             }
         } else {
+            // XXX: >> 24 seems like a bug here, it shoudl be >> 28 I believe
             int fid = buildFid(FID_TYPE(obj->fid), obj->fid & 0xFFF, anim, (obj->fid & 0xF000) >> 12, (obj->fid & 0x70000000) >> 24);
             animationRegisterAnimateReversed(obj, anim, 0);
 

--- a/src/item.cc
+++ b/src/item.cc
@@ -634,7 +634,7 @@ int itemDropAll(Object* critter, int tile)
 
     if (hasEquippedItems) {
         Rect updatedRect;
-        int fid = buildFid(OBJ_TYPE_CRITTER, frmId, FID_ANIM_TYPE(critter->fid), 0, (critter->fid & 0x70000000) >> 28);
+        int fid = buildFid(OBJ_TYPE_CRITTER, frmId, FID_ANIM_TYPE(critter->fid), 0, FID_ROTATION(critter->fid));
         objectSetFid(critter, fid, &updatedRect);
         if (FID_ANIM_TYPE(critter->fid) == ANIM_STAND) {
             tileWindowRefreshRect(&updatedRect, gElevation);

--- a/src/mapper/mapper.cc
+++ b/src/mapper/mapper.cc
@@ -1689,7 +1689,7 @@ int mapper_inven_unwield(Object* obj, int right_hand)
 
     animationRegisterAnimate(obj, ANIM_PUT_AWAY, 0);
 
-    fid = buildFid(OBJ_TYPE_CRITTER, obj->fid & 0xFFF, 0, 0, (obj->fid & 0x70000000) >> 28);
+    fid = buildFid(OBJ_TYPE_CRITTER, obj->fid & 0xFFF, 0, 0, FID_ROTATION(obj->fid));
     animationRegisterSetFid(obj, fid, 0);
 
     return reg_anim_end();

--- a/src/object.cc
+++ b/src/object.cc
@@ -5147,7 +5147,7 @@ void _obj_fix_violence_settings(int* fid)
         anim = (anim == ANIM_FALL_BACK_BLOOD_SF)
             ? ANIM_FALL_BACK_SF
             : ANIM_FALL_FRONT_SF;
-        *fid = buildFid(OBJ_TYPE_CRITTER, *fid & 0xFFF, anim, (*fid & 0xF000) >> 12, (*fid & 0x70000000) >> 28);
+        *fid = buildFid(OBJ_TYPE_CRITTER, *fid & 0xFFF, anim, (*fid & 0xF000) >> 12, FID_ROTATION(*fid));
     }
 
     if (shouldResetViolenceLevel) {


### PR DESCRIPTION
This is a purely mechanical change.

Note: this uncovered what I'm almost certain is a bug in the interpreter code.  I can fix it based on code inspection... this is how it's used everywhere else.  I'm not confident about reproducing it in game though, so open to thoughts on how to proceed here.