### PR TITLE
Do not copy the same string, prevent sanitizer crash

### DIFF
--- a/src/game_sound.cc
+++ b/src/game_sound.cc
@@ -627,7 +627,9 @@ int backgroundSoundLoad(const char* fileName, int a2, int a3, int a4)
     _background_storage_requested = a3;
     _background_loop_requested = a4;
 
-    strcpy(gBackgroundSoundFileName, fileName);
+    if (gBackgroundSoundFileName != fileName) {
+        strcpy(gBackgroundSoundFileName, fileName);
+    }
 
     if (!gGameSoundInitialized) {
         return -1;


### PR DESCRIPTION
### Description

Small fix to be able to re-load game when compiled with address sanitizer

### Reproduction Steps and Savefile (if available)

Compile with sanitizer, load game, load game again

### Screenshots

<!--- If the PR includes visual changes, add screenshots here. --->


<!--- 

**Important Notes** 

- *Preview builds are not available for pull requests from forked repositories.* To enable preview builds, submit the PR from a branch within this repository. 

- *Formatting issues? You have two options:*
1. **Fix formatting automatically** using the following Docker command: *(If you're using Windows, remove `--user $(id -u):$(id -g)`)* 
```bash
docker run --rm \
  -v $(pwd):/app --workdir /app  \
  --user $(id -u):$(id -g) silkeh/clang:18 \
  bash -c 'find src -type f -name \*.cc -o -name \*.h | xargs clang-format -i'
```
2. **Skip formatting check** by adding the `skip-formatting` label to this PR.

--->

