### PR TITLE
Resize gMapGlobalPointers if inconsistency between .map and .gam file

### DIFF
--- a/src/map.cc
+++ b/src/map.cc
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <assert.h>
 
 #include <vector>
 
@@ -953,6 +954,10 @@ static int mapLoad(File* stream)
 
         strcat(path, ".GAM");
         globalVarsRead(path, "MAP_GLOBAL_VARS:", &gMapGlobalVarsLength, &gMapGlobalVars);
+        if (gMapHeader.globalVariablesCount != gMapGlobalVarsLength) {
+            assert(gMapHeader.globalVariablesCount == gMapGlobalPointers.size());
+            gMapGlobalPointers.resize(gMapGlobalVarsLength);
+        }
         gMapHeader.globalVariablesCount = gMapGlobalVarsLength;
     }
 

--- a/src/map.cc
+++ b/src/map.cc
@@ -1,8 +1,8 @@
 #include "map.h"
 
+#include <assert.h>
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
 
 #include <vector>
 


### PR DESCRIPTION
### Description

This fixes https://github.com/alexbatalov/fallout2-ce/issues/501

I compiled it with address sanitizer, and I was able to reproduce `heap-buffer-overflow`

It happens only when game decides to land Dude near hole (not near cave) on the Raiders map.

### Reproduction Steps and Savefile (if available)

Take a savefile from the issue above, use gog version, build with sanitizer, enter "unknown", be lucky to get nearby hole (as on screenshot)

### Screenshots

<!--- If the PR includes visual changes, add screenshots here. --->
<img width="665" height="409" alt="image" src="https://github.com/user-attachments/assets/87efe204-6284-46dd-9c3d-5ea250dd29d2" />


<!--- 

**Important Notes** 

- *Preview builds are not available for pull requests from forked repositories.* To enable preview builds, submit the PR from a branch within this repository. 

- *Formatting issues? You have two options:*
1. **Fix formatting automatically** using the following Docker command: *(If you're using Windows, remove `--user $(id -u):$(id -g)`)* 
```bash
docker run --rm \
  -v $(pwd):/app --workdir /app  \
  --user $(id -u):$(id -g) silkeh/clang:18 \
  bash -c 'find src -type f -name \*.cc -o -name \*.h | xargs clang-format -i'
```
2. **Skip formatting check** by adding the `skip-formatting` label to this PR.

--->

