### PR TITLE
Fix off-by-one error in duplicates cleanup

### DIFF
--- a/src/db.cc
+++ b/src/db.cc
@@ -621,12 +621,20 @@ int fileNameListInit(const char* pattern, char*** fileNameListPtr, int a3, int a
         int fileNamesLength = xlist->fileNamesLength;
         for (int index = 0; index < fileNamesLength - 1; index++) {
             if (compat_stricmp(xlist->fileNames[index], xlist->fileNames[index + 1]) == 0) {
-                char* temp = xlist->fileNames[index + 1];
-                memmove(&(xlist->fileNames[index + 1]), &(xlist->fileNames[index + 2]), sizeof(*xlist->fileNames) * (xlist->fileNamesLength - index - 1));
+                // If the current item is equal to the next one, then remove it.
+                // Example 1:
+                //  fileNamesLength = 6
+                //   0  1  2   3   4  5
+                //  [a, b, c1, c2, d, e]
+                //  duplicate found at index=2
+                //    move items 3,4,5 to 2,3,4 and move duplicate to the end
+                //    [a, b, c2, d, e, c1]
+                char* temp = xlist->fileNames[index];
+                memmove(&(xlist->fileNames[index]), &(xlist->fileNames[index + 1]), sizeof(*xlist->fileNames) * (xlist->fileNamesLength - index - 1));
                 xlist->fileNames[xlist->fileNamesLength - 1] = temp;
 
                 fileNamesLength--;
-                index--;
+                index--; // Repeat the same index if there are more duplicates.
             }
         }
 


### PR DESCRIPTION
### Description

There is a off-by-one error in duplicates cleanup.

### Reproduction Steps and Savefile (if available)

Build with sanitizer, use Sonora, unpack all `.dat` files, start the game

### Screenshots

<!--- If the PR includes visual changes, add screenshots here. --->


<!--- 

**Important Notes** 

- *Preview builds are not available for pull requests from forked repositories.* To enable preview builds, submit the PR from a branch within this repository. 

- *Formatting issues? You have two options:*
1. **Fix formatting automatically** using the following Docker command: *(If you're using Windows, remove `--user $(id -u):$(id -g)`)* 
```bash
docker run --rm \
  -v $(pwd):/app --workdir /app  \
  --user $(id -u):$(id -g) silkeh/clang:18 \
  bash -c 'find src -type f -name \*.cc -o -name \*.h | xargs clang-format -i'
```
2. **Skip formatting check** by adding the `skip-formatting` label to this PR.

--->

