### PR TITLE
Mark CI as done when preview is actually deployed

### DIFF
--- a/.github/workflows/ci-build-web.yml
+++ b/.github/workflows/ci-build-web.yml
@@ -86,6 +86,10 @@ jobs:
           SITE_BASE:  ${{ steps.set-path.outputs.SITE_BASE }}
           F2_GAME_VERSION: Game=${{github.event.pull_request.head.sha || github.sha }}
 
+      - name: Place hash file
+        if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+        run: echo "$GITHUB_SHA" > fallout2-ce-ems/dist/site_hash.txt
+
       - name: Install rsync (required for the next step)
         if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
         run: |
@@ -112,4 +116,25 @@ jobs:
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
           ref: ${{ github.event.pull_request.head.sha }}
           env_url: https://${{ github.repository_owner }}.github.io/fallout2-ce/PR-${{ github.event.pull_request.number }}/
+
+
+      - name: Check that site is deployed
+        if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+        run: |
+          URL="$SITE_ORIGIN""$SITE_BASE""site_hash.txt"
+          echo "Expecting $GITHUB_SHA from $URL"
+          for i in `seq 1 60`; do
+            got="$(curl -fsSL --max-time 10 "$URL" | tr -d '\r\n' || true)"
+            if [ "$got" = "$GITHUB_SHA" ]; then
+              echo "✅ Match on attempt $i: ${got}"
+              exit 0
+            fi
+            echo "Received $got, waiting"
+            sleep 5
+          done
+          exit 1
+
+        env:
+          SITE_ORIGIN: https://${{ github.repository_owner }}.github.io
+          SITE_BASE: ${{ steps.set-path.outputs.SITE_BASE }}
 


### PR DESCRIPTION
### Description

It might take 10-30 seconds for github to propagate `gh-pages` update into actual github pages.

This PR fixes an issue when CI says "it is deployed into preview" but developers see old version

### Reproduction Steps and Savefile (if available)

<!--- Provide detailed steps to reproduce the issue. Include a savefile if applicable, preferrably for Sonora --->

### Screenshots

<!--- If the PR includes visual changes, add screenshots here. --->


<!--- 

**Important Notes** 

- *Preview builds are not available for pull requests from forked repositories.* To enable preview builds, submit the PR from a branch within this repository. 

- *Formatting issues? You have two options:*
1. **Fix formatting automatically** using the following Docker command: *(If you're using Windows, remove `--user $(id -u):$(id -g)`)* 
```bash
docker run --rm \
  -v $(pwd):/app --workdir /app  \
  --user $(id -u):$(id -g) silkeh/clang:18 \
  bash -c 'find src -type f -name \*.cc -o -name \*.h | xargs clang-format -i'
```
2. **Skip formatting check** by adding the `skip-formatting` label to this PR.

--->

