### PR TITLE
Add additinal mouse sensivity scaling based on DPI

### DIFF
--- a/src/mouse.cc
+++ b/src/mouse.cc
@@ -56,6 +56,7 @@ static double gMouseSensitivity = 1.0;
 
 static double gMouseSensitivityDpiHorizontal = 1.0;
 static double gMouseSensitivityDpiVertical = 1.0;
+double gMouseSensitivityScale2Xoption = 1.0;
 
 // 0x51E2AC
 static int last_buttons = 0;
@@ -458,8 +459,8 @@ void _mouse_info()
     }
 
     // Adjust for mouse senstivity.
-    x = (int)(x * gMouseSensitivity * gMouseSensitivityDpiHorizontal);
-    y = (int)(y * gMouseSensitivity * gMouseSensitivityDpiVertical);
+    x = (int)(x * gMouseSensitivity * gMouseSensitivityDpiHorizontal * gMouseSensitivityScale2Xoption);
+    y = (int)(y * gMouseSensitivity * gMouseSensitivityDpiVertical * gMouseSensitivityScale2Xoption);
 
     _mouse_simulate_input(x, y, buttons);
 

--- a/src/mouse.cc
+++ b/src/mouse.cc
@@ -681,20 +681,23 @@ void mouseSetSensitivity(double value)
         gMouseSensitivity = value;
     }
 
+    gMouseSensitivityDpiHorizontal = 1.0;
+    gMouseSensitivityDpiVertical = 1.0;
     if (gSdlWindow) {
         int displayIndex = SDL_GetWindowDisplayIndex(gSdlWindow);
         float ddpi, hdpi, vdpi;
-        SDL_GetDisplayDPI(displayIndex, &ddpi, &hdpi, &vdpi);
-        hdpi /= 96.0f; // 96 is standard DPI
-        vdpi /= 96.0f; // 96 is standard DPI
-        gMouseSensitivityDpiHorizontal = 1 / hdpi;
-        gMouseSensitivityDpiVertical = 1 / vdpi;
-        debugPrint("Mouse DPI scaling: horizontal = %.2f, vertical = %.2f", hdpi, vdpi);
-        debugPrint("Mouse DPI sensitivity: horizontal = %.2f, vertical = %.2f", gMouseSensitivityDpiHorizontal, gMouseSensitivityDpiVertical);
+        if (SDL_GetDisplayDPI(displayIndex, &ddpi, &hdpi, &vdpi) == 0) {
+            hdpi /= 96.0f; // 96 is standard DPI
+            vdpi /= 96.0f; // 96 is standard DPI
+            gMouseSensitivityDpiHorizontal = 1 / hdpi;
+            gMouseSensitivityDpiVertical = 1 / vdpi;
+            debugPrint("Mouse DPI scaling: horizontal = %.2f, vertical = %.2f", hdpi, vdpi);
+            debugPrint("Mouse DPI sensitivity: horizontal = %.2f, vertical = %.2f", gMouseSensitivityDpiHorizontal, gMouseSensitivityDpiVertical);
+        } else {
+            debugPrint("Mouse DPI sensitivity is not available, SDL_GetDisplayDPI failed");
+        }
     } else {
         debugPrint("Mouse DPI sensitivity is not available, SDL window is null");
-        gMouseSensitivityDpiHorizontal = 1.0;
-        gMouseSensitivityDpiVertical = 1.0;
     }
 }
 

--- a/src/mouse.cc
+++ b/src/mouse.cc
@@ -1,6 +1,7 @@
 #include "mouse.h"
 
 #include "color.h"
+#include "debug.h"
 #include "dinput.h"
 #include "input.h"
 #include "kb.h"
@@ -52,6 +53,9 @@ static unsigned char* _mouse_fptr = nullptr;
 
 // 0x51E2A0
 static double gMouseSensitivity = 1.0;
+
+static double gMouseSensitivityDpiHorizontal = 1.0;
+static double gMouseSensitivityDpiVertical = 1.0;
 
 // 0x51E2AC
 static int last_buttons = 0;
@@ -454,8 +458,8 @@ void _mouse_info()
     }
 
     // Adjust for mouse senstivity.
-    x = (int)(x * gMouseSensitivity);
-    y = (int)(y * gMouseSensitivity);
+    x = (int)(x * gMouseSensitivity * gMouseSensitivityDpiHorizontal);
+    y = (int)(y * gMouseSensitivity * gMouseSensitivityDpiVertical);
 
     _mouse_simulate_input(x, y, buttons);
 
@@ -675,6 +679,22 @@ void mouseSetSensitivity(double value)
 {
     if (value >= 1.0 && value <= 2.5) {
         gMouseSensitivity = value;
+    }
+
+    if (gSdlWindow) {
+        int displayIndex = SDL_GetWindowDisplayIndex(gSdlWindow);
+        float ddpi, hdpi, vdpi;
+        SDL_GetDisplayDPI(displayIndex, &ddpi, &hdpi, &vdpi);
+        hdpi /= 96.0f; // 96 is standard DPI
+        vdpi /= 96.0f; // 96 is standard DPI
+        gMouseSensitivityDpiHorizontal = 1 / hdpi;
+        gMouseSensitivityDpiVertical = 1 / vdpi;
+        debugPrint("Mouse DPI scaling: horizontal = %.2f, vertical = %.2f", hdpi, vdpi);
+        debugPrint("Mouse DPI sensitivity: horizontal = %.2f, vertical = %.2f", gMouseSensitivityDpiHorizontal, gMouseSensitivityDpiVertical);
+    } else {
+        debugPrint("Mouse DPI sensitivity is not available, SDL window is null");
+        gMouseSensitivityDpiHorizontal = 1.0;
+        gMouseSensitivityDpiVertical = 1.0;
     }
 }
 

--- a/src/mouse.h
+++ b/src/mouse.h
@@ -54,6 +54,7 @@ void mouseGetWheel(int* x, int* y);
 void convertMouseWheelToArrowKey(int* keyCodePtr);
 int mouse_get_last_buttons();
 
+extern double gMouseSensitivityScale2Xoption;
 } // namespace fallout
 
 #endif /* FALLOUT_MOUSE_H_ */

--- a/src/svga.cc
+++ b/src/svga.cc
@@ -6,6 +6,7 @@
 #include <SDL.h>
 
 #include "config.h"
+#include "debug.h"
 #include "draw.h"
 #include "interface.h"
 #include "memory.h"
@@ -185,6 +186,14 @@ int _GNW95_init_mode_ex(int width, int height, int bpp)
     _scr_blit = _GNW95_ShowRect;
     _zero_mem = _GNW95_zero_vid_mem;
     _mouse_blit = _GNW95_ShowRect;
+
+    if (scale != 1) {
+        gMouseSensitivityScale2Xoption = 1.0 / scale;
+        debugPrint("Mouse sensitivity adjusted according to scale into %f\n", gMouseSensitivityScale2Xoption);
+    } else {
+        gMouseSensitivityScale2Xoption = 1.0;
+        debugPrint("Mouse sensitivity not adjusted for 2X scale\n");
+    }
 
     return 0;
 }


### PR DESCRIPTION
### Description

Should solve https://github.com/fallout2-ce/fallout2-ce/issues/255

### Reproduction Steps

When I run game on my laptop I also see that in-game mouse is more sensitive than on my desktop.

### Concerns about having it as option

Players can always increase sensitivity in options (valid ranges are `1.0-2.5`). Adding this as option (even enabled by default) might bloat `ddraw.ini`.

Also this is basically a workaround for what should work out-of-the-box.

### Concert about SCALE_2X

As I understand by default SDL should apply mouse scaling when game is using `SCALE_2X` option. This PR adds manual scaling too

### Investigation 

If I disable `SDL_SetRelativeMouseMode` then sensitivity is the same as in the system.

Briefly looking into SDL code I noticed that on Linux it uses `XI_RawMotion` when mouse is in relative mode and `XI_Motion` when mouse is in normal mode.

I tried to add SDL hints `SDL_HINT_MOUSE_RELATIVE_SCALING` (enabled by default) and `SDL_HINT_MOUSE_RELATIVE_SYSTEM_SCALE` but it did not help.

This solution is driven by ChatGPT so it might be it is a crap.

SDL docs propose to use `SDL_GetWindowSize + SDL_GetRendererOutputSize` but it returns the same value. Maybe I should use `SDL_GL_GetDrawableSize` (opengl) but I am not sure how it will work on Mac or other systems.


### Other thoughts

Maybe it will be easier to allow lower values for sensitivity? For example, `0.25 - 2.5` instead of `1.0 - 2.5`?
