### PR TITLE
Allow lower mouse sensitivity

### DIFF
--- a/src/mouse.cc
+++ b/src/mouse.cc
@@ -673,7 +673,7 @@ void _mouse_get_raw_state(int* out_x, int* out_y, int* out_buttons)
 // 0x4CAC3C
 void mouseSetSensitivity(double value)
 {
-    if (value >= MOUSE_SENSIVITY_MIN && value <= MOUSE_SENSIVITY_MAX) {
+    if (value >= MOUSE_SENSITIVITY_MIN && value <= MOUSE_SENSITIVITY_MAX) {
         gMouseSensitivity = value;
     }
 }

--- a/src/mouse.h
+++ b/src/mouse.h
@@ -28,8 +28,8 @@ namespace fallout {
 
 #define BUTTON_REPEAT_TIME 250
 
-#define MOUSE_SENSIVITY_MIN 0.25
-#define MOUSE_SENSIVITY_MAX 2.5
+#define MOUSE_SENSITIVITY_MIN 0.25
+#define MOUSE_SENSITIVITY_MAX 2.5
 
 extern WindowDrawingProc2* _mouse_blit_trans;
 extern WINDOWDRAWINGPROC _mouse_blit;

--- a/src/preferences.cc
+++ b/src/preferences.cc
@@ -386,7 +386,7 @@ static PreferenceDescription gPreferenceDescriptions[PREF_COUNT] = {
     { 4, 0, 374, 298, 0, 0, { 202, 221, 209, 222 }, 0, GAME_CONFIG_SNDFX_VOLUME_KEY, 0, 32767.0, &gPreferencesSoundEffectsVolume1 },
     { 4, 0, 374, 349, 0, 0, { 202, 221, 209, 222 }, 0, GAME_CONFIG_SPEECH_VOLUME_KEY, 0, 32767.0, &gPreferencesSpeechVolume1 },
     { 2, 0, 374, 400, 0, 0, { 207, 223, 0, 0 }, 0, GAME_CONFIG_BRIGHTNESS_KEY, 1.0, 1.17999267578125, nullptr },
-    { 2, 0, 374, 451, 0, 0, { 207, 218, 0, 0 }, 0, GAME_CONFIG_MOUSE_SENSITIVITY_KEY, MOUSE_SENSIVITY_MIN, MOUSE_SENSIVITY_MAX, nullptr },
+    { 2, 0, 374, 451, 0, 0, { 207, 218, 0, 0 }, 0, GAME_CONFIG_MOUSE_SENSITIVITY_KEY, MOUSE_SENSITIVITY_MIN, MOUSE_SENSITIVITY_MAX, nullptr },
 };
 
 static FrmImage _preferencesFrmImages[PREFERENCES_WINDOW_FRM_COUNT];
@@ -540,7 +540,7 @@ static void _JustUpdate_()
     gPreferencesSoundEffectsVolume1 = std::clamp(gPreferencesSoundEffectsVolume1, 0, VOLUME_MAX);
     gPreferencesSpeechVolume1 = std::clamp(gPreferencesSpeechVolume1, 0, VOLUME_MAX);
     gPreferencesBrightness1 = std::clamp(gPreferencesBrightness1, 1.0, 1.17999267578125);
-    gPreferencesMouseSensitivity1 = std::clamp(gPreferencesMouseSensitivity1, MOUSE_SENSIVITY_MIN, MOUSE_SENSIVITY_MAX);
+    gPreferencesMouseSensitivity1 = std::clamp(gPreferencesMouseSensitivity1, MOUSE_SENSITIVITY_MIN, MOUSE_SENSITIVITY_MAX);
 
     textObjectsSetBaseDelay(gPreferencesTextBaseDelay1);
     gameMouseLoadItemHighlight();


### PR DESCRIPTION
### Description

This PR change `mouse_sensitivity` minimum value from `1.0` into `0.25`.

Should fix very sensitive mouse on high-DPI monitors https://github.com/fallout2-ce/fallout2-ce/issues/255

This PR is alternative to https://github.com/fallout2-ce/fallout2-ce/pull/257

### Reproduction Steps and Savefile (if available)

<!--- Provide detailed steps to reproduce the issue. Include a savefile if applicable, preferrably for Sonora --->

### Screenshots

This how it looks when sensitivity is `1.0`

<img width="523" height="118" alt="image" src="https://github.com/user-attachments/assets/b0223ef4-3c47-4ef0-835e-d49db947492f" />
 

<!--- 

**Important Notes** 

- *Preview builds are not available for pull requests from forked repositories.* To enable preview builds, submit the PR from a branch within this repository. 

- *Formatting issues? You have two options:*
1. **Fix formatting automatically** using the following Docker command: *(If you're using Windows, remove `--user $(id -u):$(id -g)`)* 
```bash
docker run --rm \
  -v $(pwd):/app --workdir /app  \
  --user $(id -u):$(id -g) silkeh/clang:18 \
  bash -c 'find src -type f -name \*.cc -o -name \*.h | xargs clang-format -i'
```
2. **Skip formatting check** by adding the `skip-formatting` label to this PR.

--->

