### PR TITLE
Fix overlapping memory copy

### DIFF
--- a/src/message.cc
+++ b/src/message.cc
@@ -623,8 +623,8 @@ void messageListFilterGenderWords(MessageList* messageList, int gender)
                     length = sep - start - 1;
                 }
 
-                strncpy(start, src, length);
-                strcpy(start + length, end + 1);
+                memmove(start, src, length);
+                memmove(start + length, end + 1, strlen(end + 1) + 1);
             } else {
                 text = sep + 1;
             }


### PR DESCRIPTION
### Description

A pretty fair nitpick from address sanitizer. Calling `strcpy` on overlapping strings is undefined behavior

### Reproduction Steps and Savefile (if available)

Compile with address sanitizer, talk to character who has `DialogGenderWords`

### Screenshots

<!--- If the PR includes visual changes, add screenshots here. --->


<!--- 

**Important Notes** 

- *Preview builds are not available for pull requests from forked repositories.* To enable preview builds, submit the PR from a branch within this repository. 

- *Formatting issues? You have two options:*
1. **Fix formatting automatically** using the following Docker command: *(If you're using Windows, remove `--user $(id -u):$(id -g)`)* 
```bash
docker run --rm \
  -v $(pwd):/app --workdir /app  \
  --user $(id -u):$(id -g) silkeh/clang:18 \
  bash -c 'find src -type f -name \*.cc -o -name \*.h | xargs clang-format -i'
```
2. **Skip formatting check** by adding the `skip-formatting` label to this PR.

--->

