### PR TITLE
Contradictory workaround for use-after-free errors

### DIFF
--- a/src/object.cc
+++ b/src/object.cc
@@ -3767,6 +3767,8 @@ static void objectDeallocate(Object** objectPtr)
         return;
     }
 
+#if defined(__SANITIZE_ADDRESS__)
+#warning "Address sanitizer detected. Delayed free is enabled."
     {
         // Sometimes game scripts are using object
         // after it has been destroyed.
@@ -3791,6 +3793,9 @@ static void objectDeallocate(Object** objectPtr)
         deleteQueue[deleteQueueIndex] = *objectPtr;
         deleteQueueIndex = (deleteQueueIndex + 1) % DELAY;
     }
+#else
+    internal_free(*objectPtr);
+#endif
 
     *objectPtr = nullptr;
 }

--- a/src/scripts.cc
+++ b/src/scripts.cc
@@ -1338,11 +1338,14 @@ int scriptExecProc(int sid, int proc)
 
     _executeProcedure(program, v9);
 
+#if defined(__SANITIZE_ADDRESS__)
+#warning "Address sanitizer detected. Adding extra script existence check."
     // Check if script still exists after procedure execution.
     // The script may have been destroyed during execution (e.g., via destroy_object).
     if (scriptGetScript(sid, &script) == -1) {
         return 0;
     }
+#endif
 
     script->source = nullptr;
 


### PR DESCRIPTION
### Description

Sometimes game scripts can use object when it is already deallocated.

This was reported in multiple issues, for example https://github.com/fallout2-ce/fallout2-ce/issues/246 , https://github.com/fallout2-ce/fallout2-ce/issues/158 , https://github.com/fallout2-ce/fallout2-ce/issues/126

Most of the time this is not a problem, but it is annoying when debugging the game with address sanitizer.

To be on the safe side, this PR adds a small delay for object deallocations. If the game is using de-allocated memory and we can not do anything with this then let's just at least keep this memory reserved for a while for new allocations.

### Reproduction Steps and Savefile (if available)

Check issues, there are few

### Screenshots

<!--- If the PR includes visual changes, add screenshots here. --->


<!--- 

**Important Notes** 

- *Preview builds are not available for pull requests from forked repositories.* To enable preview builds, submit the PR from a branch within this repository. 

- *Formatting issues? You have two options:*
1. **Fix formatting automatically** using the following Docker command: *(If you're using Windows, remove `--user $(id -u):$(id -g)`)* 
```bash
docker run --rm \
  -v $(pwd):/app --workdir /app  \
  --user $(id -u):$(id -g) silkeh/clang:18 \
  bash -c 'find src -type f -name \*.cc -o -name \*.h | xargs clang-format -i'
```
2. **Skip formatting check** by adding the `skip-formatting` label to this PR.

--->

