### PR TITLE
Ignore map edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,17 @@ IFACE_BAR_SIDES_ORI=0
 ;if IFACE_BAR_WIDTH=640 - Interface bar will remain at it's original width.
 ;if IFACE_BAR_WIDTH=800 - Interface bar will use 800pix wide asset from f2_res.dat.
 ;IFACE_BAR_WIDTH=640
+
+[STATIC_SCREENS]
+;if SPLASH_SCRN_SIZE=0 - Splash screen shows at original size if it fits, otherwise scales down while preserving aspect ratio.
+;if SPLASH_SCRN_SIZE=1 - Splash screen scales to fit the screen while preserving aspect ratio.
+;if SPLASH_SCRN_SIZE=2 - Splash screen stretches to fill the entire screen.
+SPLASH_SCRN_SIZE=0
+
+[MAPS]
+;if IGNORE_MAP_EDGES=0 - Hi-Res map scroll edges are enabled.
+;if IGNORE_MAP_EDGES=1 - Hi-Res map scroll edges are ignored.
+IGNORE_MAP_EDGES=0
 ```
 
 Recommendations:

--- a/src/game.cc
+++ b/src/game.cc
@@ -120,6 +120,8 @@ int _game_user_wants_to_quit = 0;
 // 0x58E940
 MessageList gMiscMessageList;
 
+int gSplashScreenScaling = 0;
+
 // CE: Sonora folks like to store objects in global variables.
 static void** gGameGlobalPointers = nullptr;
 
@@ -1492,17 +1494,7 @@ static void showSplash()
         }
     }
 
-    int size = 0;
-
-    // TODO: Move to settings.
-    Config config;
-    if (configInit(&config)) {
-        if (configRead(&config, "f2_res.ini", false)) {
-            configGetInt(&config, "STATIC_SCREENS", "SPLASH_SCRN_SIZE", &size);
-        }
-
-        configFree(&config);
-    }
+    int size = gSplashScreenScaling;
 
     int screenWidth = screenGetWidth();
     int screenHeight = screenGetHeight();

--- a/src/game.h
+++ b/src/game.h
@@ -20,6 +20,7 @@ extern int* gGameGlobalVars;
 extern int gGameGlobalVarsLength;
 extern const char* asc_5186C8;
 extern int _game_user_wants_to_quit;
+extern int gSplashScreenScaling;
 
 extern MessageList gMiscMessageList;
 

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -668,7 +668,7 @@ static void opDoCheck(Program* program)
     programStackPushInteger(program, roll);
 }
 
-// success
+// is_success
 // 0x4549A8
 static void opSuccess(Program* program)
 {
@@ -690,7 +690,7 @@ static void opSuccess(Program* program)
     programStackPushInteger(program, result);
 }
 
-// critical
+// is_critical
 // 0x454A44
 static void opCritical(Program* program)
 {
@@ -3079,6 +3079,7 @@ static void opSetObjectLightLevel(Program* program)
     tileWindowRefreshRect(&rect, object->elevation);
 }
 
+// world_map
 // 0x459170
 static void opWorldmap(Program* program)
 {

--- a/src/sfall_config.cc
+++ b/src/sfall_config.cc
@@ -7,8 +7,6 @@
 
 namespace fallout {
 
-#define SFALL_CONFIG_FILE_NAME "ddraw.ini"
-
 bool gSfallConfigInitialized = false;
 Config gSfallConfig;
 
@@ -88,7 +86,7 @@ bool sfallConfigInit(int argc, char** argv)
         strcpy(path, SFALL_CONFIG_FILE_NAME);
     }
 
-    auto configChecker = ConfigChecker(gSfallConfig, "ddraw.ini");
+    auto configChecker = ConfigChecker(gSfallConfig, SFALL_CONFIG_FILE_NAME);
 
     configRead(&gSfallConfig, path, false);
 

--- a/src/sfall_opcodes.cc
+++ b/src/sfall_opcodes.cc
@@ -982,7 +982,7 @@ static void op_party_member_list(Program* program)
     programStackPushInteger(program, arrayId);
 }
 
-// type_of
+// typeof
 static void op_type_of(Program* program)
 {
     auto value = programStackPopValue(program);
@@ -1106,13 +1106,13 @@ static void op_sfall_func6(Program* program)
     sfall_metarule(program, 6);
 }
 
-// sfall_func6
+// sfall_func7
 static void op_sfall_func7(Program* program)
 {
     sfall_metarule(program, 7);
 }
 
-// sfall_func6
+// sfall_func8
 static void op_sfall_func8(Program* program)
 {
     sfall_metarule(program, 8);

--- a/src/svga.cc
+++ b/src/svga.cc
@@ -7,10 +7,12 @@
 
 #include "config.h"
 #include "draw.h"
+#include "game.h"
 #include "interface.h"
 #include "memory.h"
 #include "mouse.h"
 #include "scan_unimplemented.h"
+#include "tile.h"
 #include "win32.h"
 #include "window_manager.h"
 #include "window_manager_private.h"
@@ -140,6 +142,10 @@ int _GNW95_init_mode_ex(int width, int height, int bpp)
             configGetInt(&resolutionConfig, "IFACE", "IFACE_BAR_SIDE_ART", &gInterfaceSidePanelsImageId);
             configGetBool(&resolutionConfig, "IFACE", "IFACE_BAR_SIDES_ORI", &gInterfaceSidePanelsExtendFromScreenEdge);
 
+            configGetBool(&resolutionConfig, "MAPS", "IGNORE_MAP_EDGES", &gTileIgnoreMapEdges);
+
+            configGetInt(&resolutionConfig, "STATIC_SCREENS", "SPLASH_SCRN_SIZE", &gSplashScreenScaling);
+
             {
                 ConfigMap f2_res_defaults;
                 f2_res_defaults["MAIN"]["SCR_WIDTH"] = "640";
@@ -151,6 +157,7 @@ int _GNW95_init_mode_ex(int width, int height, int bpp)
                 f2_res_defaults["IFACE"]["IFACE_BAR_SIDE_ART"] = "0";
                 f2_res_defaults["IFACE"]["IFACE_BAR_SIDES_ORI"] = "0";
                 f2_res_defaults["STATIC_SCREENS"]["SPLASH_SCRN_SIZE"] = "0";
+                f2_res_defaults["MAPS"]["IGNORE_MAP_EDGES"] = "0";
 
                 auto configChecker = ConfigChecker(f2_res_defaults, "f2_res.ini");
                 configChecker.check(resolutionConfig);

--- a/src/tile.cc
+++ b/src/tile.cc
@@ -9,7 +9,6 @@
 
 #include "art.h"
 #include "color.h"
-#include "config.h"
 #include "debug.h"
 #include "draw.h"
 #include "game_mouse.h"
@@ -89,6 +88,9 @@ static TileWindowRefreshElevationProc* gTileWindowRefreshElevationProc = tileRef
 
 // 0x51D968
 static bool gTileEnabled = true;
+
+// Controls whether map edge borders and scroll blockers are enforced.
+bool gTileIgnoreMapEdges = false;
 
 // 0x51D96C
 const int _off_tile[6] = {
@@ -562,7 +564,7 @@ int tileSetCenter(int tile, int flags)
             }
         }
 
-        if (gTileScrollBlockingEnabled) {
+        if (gTileScrollBlockingEnabled && !gTileIgnoreMapEdges) {
             if (_obj_scroll_blocking_at(tile, gElevation) == 0) {
                 return -1;
             }
@@ -572,7 +574,7 @@ int tileSetCenter(int tile, int flags)
     int tile_x = gHexGridWidth - 1 - tile % gHexGridWidth;
     int tile_y = tile / gHexGridWidth;
 
-    if (gTileBorderInitialized) {
+    if (gTileBorderInitialized && !gTileIgnoreMapEdges) {
         if (tile_x <= gTileBorderMinX || tile_x >= gTileBorderMaxX || tile_y <= gTileBorderMinY || tile_y >= gTileBorderMaxY) {
             return -1;
         }

--- a/src/tile.h
+++ b/src/tile.h
@@ -18,6 +18,7 @@ extern int gHexGridSize;
 extern int gCenterTile;
 
 extern bool gTileBorderInitialized;
+extern bool gTileIgnoreMapEdges;
 extern int gTileBorderMinX;
 extern int gTileBorderMinY;
 extern int gTileBorderMaxX;

--- a/src/tile_hires_stencil.cc
+++ b/src/tile_hires_stencil.cc
@@ -252,16 +252,17 @@ void tile_hires_stencil_on_center_tile_or_elevation_change()
             if (tileInfo.tile < 0 || tileInfo.tile >= HEX_GRID_SIZE) {
                 continue;
             }
-            if (_obj_scroll_blocking_at(tileInfo.tile, gElevation) == 0) {
-                continue;
-            }
+            if (!gTileIgnoreMapEdges) {
+                if (_obj_scroll_blocking_at(tileInfo.tile, gElevation) == 0) {
+                    continue;
+                }
 
-            // TODO: Maybe create new function in tile.cc and use it here
-            int tile_x = HEX_GRID_WIDTH - 1 - tileInfo.tile % HEX_GRID_WIDTH;
-            int tile_y = tileInfo.tile / HEX_GRID_WIDTH;
-            if (
-                tile_x <= gTileBorderMinX || tile_x >= gTileBorderMaxX || tile_y <= gTileBorderMinY || tile_y >= gTileBorderMaxY) {
-                continue;
+                // TODO: Maybe create new function in tile.cc and use it here
+                int tile_x = HEX_GRID_WIDTH - 1 - tileInfo.tile % HEX_GRID_WIDTH;
+                int tile_y = tileInfo.tile / HEX_GRID_WIDTH;
+                if (tile_x <= gTileBorderMinX || tile_x >= gTileBorderMaxX || tile_y <= gTileBorderMinY || tile_y >= gTileBorderMaxY) {
+                    continue;
+                }
             }
         }
 


### PR DESCRIPTION
### Description

Added new configuration option `IGNORE_MAP_EDGES` into f2_res.ini from [sfall HRP](https://github.com/sfall-team/sfall/blob/84d8d80d30687d7c8635f4c902c0d3881a028ed2/sfall/HRP/Init.cpp#L258). 

Moved `SPLASH_SCRN_SIZE` config reading to the centralized f2_res.ini initialization.

Fixed some SSL function names in comments.

### Reproduction Steps and Savefile (if available)

Download and install the latest [Restoration Project](https://github.com/BGforgeNet/Fallout2_Restoration_Project) mod. With the default settings, you will not be able to scroll your screen when you enter the Arroyo temple. When you enable `IGNORE_MAP_EDGES` in f2_res.ini, the scroll blocking will be disabled. 

This is a workaround for playing the RP until the map edge support is implemented.

<!--- 

**Important Notes** 

- *Preview builds are not available for pull requests from forked repositories.* To enable preview builds, submit the PR from a branch within this repository. 

- *Formatting issues? You have two options:*
1. **Fix formatting automatically** using the following Docker command: *(If you're using Windows, remove `--user $(id -u):$(id -g)`)* 
```bash
docker run --rm \
  -v $(pwd):/app --workdir /app  \
  --user $(id -u):$(id -g) silkeh/clang:18 \
  bash -c 'find src -type f -name \*.cc -o -name \*.h | xargs clang-format -i'
```
2. **Skip formatting check** by adding the `skip-formatting` label to this PR.

--->

