### PR TITLE
Disable hi-res stencil if ignoreMapEdges is enabled

### DIFF
--- a/src/tile_hires_stencil.cc
+++ b/src/tile_hires_stencil.cc
@@ -411,7 +411,11 @@ void tile_hires_stencil_init()
     }
 
     if (gTileIgnoreMapEdges) {
-        showMesageBox("Tile hires stencil is disabled because map edges are ignored.");
+        static bool isMessageShown = false;
+        if (!isMessageShown) {
+            showMesageBox("Tile hires stencil is disabled because map edges are ignored.");
+            isMessageShown = true;
+        }
         gIsTileHiresStencilEnabled = false;
         return;
     }


### PR DESCRIPTION
### Description

Follow-up PR for https://github.com/fallout2-ce/fallout2-ce/pull/274  : disable stencil if ignoreMapEdges is enabled

### Reproduction Steps and Savefile (if available)

Enable both options, observe message window

### Screenshots

<!--- If the PR includes visual changes, add screenshots here. --->


<!--- 

**Important Notes** 

- *Preview builds are not available for pull requests from forked repositories.* To enable preview builds, submit the PR from a branch within this repository. 

- *Formatting issues? You have two options:*
1. **Fix formatting automatically** using the following Docker command: *(If you're using Windows, remove `--user $(id -u):$(id -g)`)* 
```bash
docker run --rm \
  -v $(pwd):/app --workdir /app  \
  --user $(id -u):$(id -g) silkeh/clang:18 \
  bash -c 'find src -type f -name \*.cc -o -name \*.h | xargs clang-format -i'
```
2. **Skip formatting check** by adding the `skip-formatting` label to this PR.

--->

