### PR TITLE
[emscripten] do not lock mouse; improve mobile browsers compatibility;

### DIFF
--- a/src/dinput.cc
+++ b/src/dinput.cc
@@ -1,5 +1,7 @@
 #include "dinput.h"
 
+#include "svga.h"
+
 namespace fallout {
 
 static int gMouseWheelDeltaX = 0;
@@ -52,8 +54,9 @@ bool mouseDeviceGetData(MouseData* mouseState)
     // TODO: Move mouse events processing into `GNW95_process_message` and
     // update mouse position manually.
     SDL_PumpEvents();
-
-    Uint32 buttons = SDL_GetRelativeMouseState(&(mouseState->x), &(mouseState->y));
+    Uint32 buttons = screenIsFullscreen()
+        ? SDL_GetRelativeMouseState(&(mouseState->x), &(mouseState->y))
+        : SDL_GetMouseState(&(mouseState->x), &(mouseState->y));
     mouseState->buttons[0] = (buttons & SDL_BUTTON(SDL_BUTTON_LEFT)) != 0;
     mouseState->buttons[1] = (buttons & SDL_BUTTON(SDL_BUTTON_RIGHT)) != 0;
     mouseState->wheelX = gMouseWheelDeltaX;
@@ -93,7 +96,9 @@ bool keyboardDeviceGetData(KeyboardData* keyboardData)
 // 0x4E070C
 bool mouseDeviceInit()
 {
-    return SDL_SetRelativeMouseMode(SDL_TRUE) == 0;
+    return screenIsFullscreen()
+        ? SDL_SetRelativeMouseMode(SDL_TRUE) == 0
+        : true;
 }
 
 // 0x4E078C

--- a/src/mouse.cc
+++ b/src/mouse.cc
@@ -388,10 +388,19 @@ void _mouse_info()
 
         switch (gesture.type) {
         case kTap:
-            if (gesture.numberOfTouches == 1) {
-                _mouse_simulate_input(0, 0, MOUSE_STATE_LEFT_BUTTON_DOWN);
-            } else if (gesture.numberOfTouches == 2) {
-                _mouse_simulate_input(0, 0, MOUSE_STATE_RIGHT_BUTTON_DOWN);
+            if (screenIsFullscreen()) {
+                if (gesture.numberOfTouches == 1) {
+                    _mouse_simulate_input(0, 0, MOUSE_STATE_LEFT_BUTTON_DOWN);
+                } else if (gesture.numberOfTouches == 2) {
+                    _mouse_simulate_input(0, 0, MOUSE_STATE_RIGHT_BUTTON_DOWN);
+                }
+            }
+            else {
+                if (gesture.numberOfTouches == 1) {
+                    _mouse_simulate_input(gesture.x, gesture.y, MOUSE_STATE_LEFT_BUTTON_DOWN);
+                } else if (gesture.numberOfTouches == 2) {
+                    _mouse_simulate_input(gesture.x, gesture.y, MOUSE_STATE_RIGHT_BUTTON_DOWN);
+                }
             }
             break;
         case kLongPress:
@@ -399,6 +408,10 @@ void _mouse_info()
             if (gesture.state == kBegan) {
                 prevx = gesture.x;
                 prevy = gesture.y;
+            }
+            if (!screenIsFullscreen()) {
+                prevx = 0;
+                prevy = 0;
             }
 
             if (gesture.type == kLongPress) {
@@ -548,9 +561,14 @@ void _mouse_simulate_input(int delta_x, int delta_y, int buttons)
         mouseRect.top = gMouseCursorY;
         mouseRect.right = gMouseCursorWidth + gMouseCursorX - 1;
         mouseRect.bottom = gMouseCursorHeight + gMouseCursorY - 1;
-
-        gMouseCursorX += delta_x;
-        gMouseCursorY += delta_y;
+        if (screenIsFullscreen()) {
+            gMouseCursorX += delta_x;
+            gMouseCursorY += delta_y;
+        }
+        else {
+            gMouseCursorX = delta_x;
+            gMouseCursorY = delta_y;
+        }
         _mouse_clip();
 
         windowRefreshAll(&mouseRect);
@@ -654,8 +672,14 @@ void _mouse_get_raw_state(int* out_x, int* out_y, int* out_buttons)
     }
 
     _raw_buttons = 0;
-    _raw_x += mouseData.x;
-    _raw_y += mouseData.y;
+    if (screenIsFullscreen()) {
+        _raw_x += mouseData.x;
+        _raw_y += mouseData.y;
+    }
+    else {
+        _raw_x = mouseData.x;
+        _raw_y = mouseData.y;
+    }
 
     if (mouseData.buttons[0] != 0) {
         _raw_buttons |= MOUSE_EVENT_LEFT_BUTTON_DOWN;

--- a/src/svga.cc
+++ b/src/svga.cc
@@ -387,6 +387,12 @@ int screenGetVisibleHeight()
     return screenGetHeight() - windowBottomMargin;
 }
 
+bool screenIsFullscreen()
+{
+    Uint32 flags = SDL_GetWindowFlags(gSdlWindow);
+    return (flags & (SDL_WINDOW_FULLSCREEN | SDL_WINDOW_FULLSCREEN_DESKTOP)) != 0;
+}
+
 static bool createRenderer(int width, int height)
 {
     gSdlRenderer = SDL_CreateRenderer(gSdlWindow, -1, 0);

--- a/src/svga.h
+++ b/src/svga.h
@@ -45,6 +45,7 @@ int screenGetHeight();
 int screenGetVisibleHeight();
 void handleWindowSizeChanged();
 void renderPresent();
+bool screenIsFullscreen();
 
 } // namespace fallout
 


### PR DESCRIPTION
### Description

Do not use SDL_SetRelativeMouseMode in browser builds. In browser mouse/touch events always use "global" position.

### Reproduction Steps and Savefile (if available)

not an issue, just UX improvement

### Screenshots

Demo with new mouse and touch behaviour is available here https://turch.in/fallout+nevada/index.html
