### PR TITLE
Update game_mouse.cc to fix context menu

### DIFF
--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -1175,7 +1175,7 @@ void _gmouse_handle_event(int mouseX, int mouseY, int mouseState)
                     gGameMouseLastY = mouseY;
                     _gmouse_3d_last_move_time = getTicks();
 
-                    _mouse_set_position(mouseX, newMouseY);
+                    _mouse_set_position(mouseX, mouseY);
 
                     if (gameMouseUpdateHexCursorFid(&cursorRect) == 0) {
                         tileWindowRefreshRect(&cursorRect, gElevation);


### PR DESCRIPTION
This fixes #278 - simply sets the mouse-y position back to the original, rather than the updated (new) one from scrolling.

