### PR TITLE
Update preferences window slider when +/- is pressed

### DIFF
--- a/src/preferences.cc
+++ b/src/preferences.cc
@@ -357,6 +357,11 @@ static void preferencesRefreshBrightnessSlider()
     windowRefresh(gPreferencesWindow);
 }
 
+static bool preferencesWindowIsOpen()
+{
+    return gPreferencesWindow != -1;
+}
+
 // 0x6639AC
 static int gPreferencesCombatMessages1;
 
@@ -919,7 +924,9 @@ err:
 // Note: this can be called from many different contexts, not just the preferences window.
 void brightnessIncrease()
 {
-    gPreferencesBrightness1 = settings.preferences.brightness;
+    if (!preferencesWindowIsOpen()) {
+        gPreferencesBrightness1 = settings.preferences.brightness;
+    }
 
     if (gPreferencesBrightness1 < kBrightnessMax) {
         gPreferencesBrightness1 += kBrightnessStep;
@@ -934,17 +941,21 @@ void brightnessIncrease()
 
         colorSetBrightness(gPreferencesBrightness1);
         preferencesRefreshBrightnessSlider();
-
-        settings.preferences.brightness = gPreferencesBrightness1;
-
-        settingsSave();
+        if (preferencesWindowIsOpen()) {
+            _changed = true;
+        } else {
+            settings.preferences.brightness = gPreferencesBrightness1;
+            settingsSave();
+        }
     }
 }
 
 // 0x4929C8
 void brightnessDecrease()
 {
-    gPreferencesBrightness1 = settings.preferences.brightness;
+    if (!preferencesWindowIsOpen()) {
+        gPreferencesBrightness1 = settings.preferences.brightness;
+    }
 
     if (gPreferencesBrightness1 > 1.0) {
         gPreferencesBrightness1 += kBrightnessStepNegative;
@@ -959,10 +970,12 @@ void brightnessDecrease()
 
         colorSetBrightness(gPreferencesBrightness1);
         preferencesRefreshBrightnessSlider();
-
-        settings.preferences.brightness = gPreferencesBrightness1;
-
-        settingsSave();
+        if (preferencesWindowIsOpen()) {
+            _changed = true;
+        } else {
+            settings.preferences.brightness = gPreferencesBrightness1;
+            settingsSave();
+        }
     }
 }
 


### PR DESCRIPTION
### Description

Fixes +/- not updating brightness slider when used on the Options screen.

### Screenshots
Didn't take a video, but this used not move and now it does.  Might be cool for the red light to light up when doing so, but didn't seem worth doing now.

<img width="541" height="136" alt="image" src="https://github.com/user-attachments/assets/a7a83655-11c0-4316-aa2a-e87fab384ce1" />

Fixes https://github.com/fallout2-ce/fallout2-ce/issues/296

Tested both in options menu and elsewhere.

Note: consulted https://github.com/cambragol/fission-ce/pull/45, though this is a different fix