### PR TITLE
Remove unused elevation from tileFromScreenXY call sites

### DIFF
--- a/src/animation.cc
+++ b/src/animation.cc
@@ -2021,7 +2021,7 @@ int _make_straight_path_func(Object* obj, int from, int to, StraightPathNode* st
     if (ddx <= ddy) {
         int middle = ddx - ddy / 2;
         while (true) {
-            tile = tileFromScreenXY(tileX, tileY, obj->elevation);
+            tile = tileFromScreenXY(tileX, tileY);
 
             v22 += 1;
             if (v22 == a6) {
@@ -2074,7 +2074,7 @@ int _make_straight_path_func(Object* obj, int from, int to, StraightPathNode* st
     } else {
         int middle = ddy - ddx / 2;
         while (true) {
-            tile = tileFromScreenXY(tileX, tileY, obj->elevation);
+            tile = tileFromScreenXY(tileX, tileY);
 
             v22 += 1;
             if (v22 == a6) {
@@ -2250,7 +2250,7 @@ int _make_stair_path(Object* object, int from, int fromElevation, int to, int to
     if (ddx > ddy) {
         int middle = ddy - ddx / 2;
         while (true) {
-            tile = tileFromScreenXY(tileX, tileY, elevation);
+            tile = tileFromScreenXY(tileX, tileY);
 
             iteration += 1;
             if (iteration == 16) {
@@ -2297,7 +2297,7 @@ int _make_stair_path(Object* object, int from, int fromElevation, int to, int to
     } else {
         int middle = ddx - ddy / 2;
         while (true) {
-            tile = tileFromScreenXY(tileX, tileY, elevation);
+            tile = tileFromScreenXY(tileX, tileY);
 
             iteration += 1;
             if (iteration == 16) {
@@ -2962,7 +2962,7 @@ int _check_move(int* actionPointsPtr)
     int y;
     mouseGetPosition(&x, &y);
 
-    int tile = tileFromScreenXY(x, y, gElevation);
+    int tile = tileFromScreenXY(x, y);
     if (tile == -1) {
         return -1;
     }

--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -2238,7 +2238,7 @@ int _gmouse_3d_move_to(int x, int y, int elevation, Rect* rect)
 
             _obj_move(gGameMouseHexCursor, x + offsetX, y + offsetY, elevation, rect);
         } else {
-            int tile = tileFromScreenXY(x, y, 0);
+            int tile = tileFromScreenXY(x, y);
             if (tile != -1) {
                 int screenX;
                 int screenY;
@@ -2289,7 +2289,7 @@ int _gmouse_3d_move_to(int x, int y, int elevation, Rect* rect)
             tile = -1;
         }
     } else {
-        tile = tileFromScreenXY(x, y, elevation);
+        tile = tileFromScreenXY(x, y);
     }
 
     if (tile != -1) {

--- a/src/map.cc
+++ b/src/map.cc
@@ -630,7 +630,7 @@ int mapScroll(int dx, int dy)
     centerScreenX += screenDx + 16;
     centerScreenY += screenDy + 8;
 
-    int newCenterTile = tileFromScreenXY(centerScreenX, centerScreenY, gElevation);
+    int newCenterTile = tileFromScreenXY(centerScreenX, centerScreenY);
     if (newCenterTile == -1) {
         return -1;
     }

--- a/src/mapper/map_func.cc
+++ b/src/mapper/map_func.cc
@@ -44,7 +44,7 @@ void place_entrance_hex()
         if (_mouse_click_in(0, 0, _scr_size.right - _scr_size.left, _scr_size.bottom - _scr_size.top - 100)) {
             mouseGetPosition(&x, &y);
 
-            tile = tileFromScreenXY(x, y, gElevation);
+            tile = tileFromScreenXY(x, y);
             if (tile != -1) {
                 if (tileSetCenter(tile, TILE_SET_CENTER_FLAG_IGNORE_SCROLL_RESTRICTIONS) == 0) {
                     mapSetEnteringLocation(tile, gElevation, rotation);

--- a/src/object.cc
+++ b/src/object.cc
@@ -323,7 +323,7 @@ int objectsInit(unsigned char* buf, int width, int height, int pitch)
     _obj_light_table_init();
     _obj_blend_table_init();
 
-    _centerToUpperLeft = tileFromScreenXY(gObjectsUpdateAreaPixelBounds.left, gObjectsUpdateAreaPixelBounds.top, 0) - gCenterTile;
+    _centerToUpperLeft = tileFromScreenXY(gObjectsUpdateAreaPixelBounds.left, gObjectsUpdateAreaPixelBounds.top) - gCenterTile;
     gObjectsWindowWidth = width;
     gObjectsWindowHeight = height;
     gObjectsWindowBuffer = buf;
@@ -775,7 +775,7 @@ void _obj_render_pre_roof(Rect* rect, int elevation)
     int minY = updatedRect.top - 240;
     int maxX = updatedRect.right + 320;
     int maxY = updatedRect.bottom + 240;
-    int upperLeftTile = tileFromScreenXY(minX, minY, elevation, true);
+    int upperLeftTile = tileFromScreenXY(minX, minY, true);
     int updateAreaHexWidth = (maxX - minX + 1) / 32;
     int updateAreaHexHeight = (maxY - minY + 1) / 12;
     int parity = gCenterTile & 1;
@@ -3011,7 +3011,7 @@ int _obj_intersects_with(Object* object, int x, int y)
 // 0x48C5C4
 int _obj_create_intersect_list(int x, int y, int elevation, int objectType, ObjectWithFlags** entriesPtr)
 {
-    int upperLeftTile = tileFromScreenXY(x - 320, y - 240, elevation, true);
+    int upperLeftTile = tileFromScreenXY(x - 320, y - 240, true);
     *entriesPtr = nullptr;
 
     if (gObjectsUpdateAreaHexSize <= 0) {
@@ -3275,7 +3275,7 @@ static int _obj_offset_table_init()
     }
 
     for (int parity = 0; parity < 2; parity++) {
-        int originTile = tileFromScreenXY(gObjectsUpdateAreaPixelBounds.left, gObjectsUpdateAreaPixelBounds.top, 0);
+        int originTile = tileFromScreenXY(gObjectsUpdateAreaPixelBounds.left, gObjectsUpdateAreaPixelBounds.top);
         if (originTile != -1) {
             int* offsets = _offsetTable[gCenterTile & 1];
             int originTileX;
@@ -3292,7 +3292,7 @@ static int _obj_offset_table_init()
             int tileX = originTileX;
             for (int y = 0; y < gObjectsUpdateAreaHexHeight; y++) {
                 for (int x = 0; x < gObjectsUpdateAreaHexWidth; x++) {
-                    int tile = tileFromScreenXY(tileX, originTileY, 0);
+                    int tile = tileFromScreenXY(tileX, originTileY);
                     if (tile == -1) {
                         goto err;
                     }

--- a/src/sfall_opcodes.cc
+++ b/src/sfall_opcodes.cc
@@ -730,7 +730,7 @@ static void op_tile_under_cursor(Program* program)
     int y;
     mouseGetPosition(&x, &y);
 
-    int tile = tileFromScreenXY(x, y, gElevation);
+    int tile = tileFromScreenXY(x, y);
     programStackPushInteger(program, tile);
 }
 

--- a/src/tile.cc
+++ b/src/tile.cc
@@ -468,8 +468,8 @@ static void tileSetBorder(int windowWidth, int windowHeight, int hexGridWidth, i
     // with 640x480 in mind, so using windowWidth and windowHeight is
     // meaningless for calculating borders. For now keep borders for original
     // resolution.
-    int v1 = tileFromScreenXY(-320, -240, 0);
-    int v2 = tileFromScreenXY(-320, ORIGINAL_ISO_WINDOW_HEIGHT + 240, 0);
+    int v1 = tileFromScreenXY(-320, -240);
+    int v2 = tileFromScreenXY(-320, ORIGINAL_ISO_WINDOW_HEIGHT + 240);
 
     gTileBorderMinX = abs(hexGridWidth - 1 - v2 % hexGridWidth - _tile_x) + 6;
     gTileBorderMinY = abs(_tile_y - v1 / hexGridWidth) + 7;
@@ -724,9 +724,8 @@ int tileToScreenXY(int tile, int* screenX, int* screenY)
 // validating hex grid bounds. The resulting invalid tile number serves as an
 // origin for calculations using prepared offsets table during objects
 // rendering.
-// Note: does not take "elevation" into account might need to be corrected.
 // 0x4B1754
-int tileFromScreenXY(int screenX, int screenY, int elevation, bool ignoreBounds)
+int tileFromScreenXY(int screenX, int screenY, bool ignoreBounds)
 {
     int x, y;
 
@@ -937,7 +936,7 @@ int _tile_num_beyond(int from, int to, int distance)
     if (v27 > v26) {
         int middle = v26 - v27 / 2;
         while (true) {
-            int tile = tileFromScreenXY(tileX, tileY, 0);
+            int tile = tileFromScreenXY(tileX, tileY);
             if (tile != v28) {
                 v6 += 1;
                 if (v6 == distance || tileIsEdge(tile)) {
@@ -958,7 +957,7 @@ int _tile_num_beyond(int from, int to, int distance)
     } else {
         int middle = v27 - v26 / 2;
         while (true) {
-            int tile = tileFromScreenXY(tileX, tileY, 0);
+            int tile = tileFromScreenXY(tileX, tileY);
             if (tile != v28) {
                 v6 += 1;
                 if (v6 == distance || tileIsEdge(tile)) {
@@ -1478,7 +1477,7 @@ void _grid_render(Rect* rect, int elevation)
 
     for (int y = rect->top - 12; y < rect->bottom + 12; y += 6) {
         for (int x = rect->left - 32; x < rect->right + 32; x += 16) {
-            int tile = tileFromScreenXY(x, y, elevation);
+            int tile = tileFromScreenXY(x, y);
             _draw_grid(tile, elevation, rect);
         }
     }
@@ -1615,7 +1614,7 @@ static void tileRenderFloor(int fid, int x, int y, Rect* rect)
 
     if (v77 <= 0 || v76 <= 0) goto out;
 
-    tile = tileFromScreenXY(savedX, savedY + 13, gElevation);
+    tile = tileFromScreenXY(savedX, savedY + 13);
     if (tile != -1) {
         int parity = tile & 1;
         int ambientIntensity = lightGetAmbientIntensity();
@@ -1824,7 +1823,7 @@ static int _tile_make_line(int from, int to, int* tiles, int tilesCapacity)
     if (v28 <= v27) {
         int middleX = v28 - v27 / 2;
         while (true) {
-            int tile = tileFromScreenXY(tileX, tileY, gElevation);
+            int tile = tileFromScreenXY(tileX, tileY);
             tiles[count] = tile;
 
             if (tile == to) {
@@ -1854,7 +1853,7 @@ static int _tile_make_line(int from, int to, int* tiles, int tilesCapacity)
     } else {
         int middleY = v27 - v28 / 2;
         while (true) {
-            int tile = tileFromScreenXY(tileX, tileY, gElevation);
+            int tile = tileFromScreenXY(tileX, tileY);
             tiles[count] = tile;
 
             if (tile == to) {

--- a/src/tile.h
+++ b/src/tile.h
@@ -36,7 +36,7 @@ int tileSetCenter(int tile, int flags);
 void tile_toggle_roof(bool refresh);
 int tileRoofIsVisible();
 int tileToScreenXY(int tile, int* x, int* y);
-int tileFromScreenXY(int x, int y, int elevation, bool ignoreBounds = false);
+int tileFromScreenXY(int x, int y, bool ignoreBounds = false);
 int tileDistanceBetween(int tile1, int tile2);
 bool tileIsInFrontOf(int tile1, int tile2);
 bool tileIsToRightOf(int tile1, int tile2);

--- a/src/tile_hires_stencil.cc
+++ b/src/tile_hires_stencil.cc
@@ -301,22 +301,22 @@ void tile_hires_stencil_on_center_tile_or_elevation_change()
         tiles_to_visit.push_back({ tileFromScreenXY(
                                        tileScreenX - pixels_per_horizontal_move + tile_center_offset_x,
                                        tileScreenY + tile_center_offset_y,
-                                       gElevation, true),
+                                       true),
             MarkOnlyPart::LEFT });
         tiles_to_visit.push_back({ tileFromScreenXY(
                                        tileScreenX + pixels_per_horizontal_move + tile_center_offset_x,
                                        tileScreenY + tile_center_offset_y,
-                                       gElevation, true),
+                                       true),
             MarkOnlyPart::RIGHT });
         tiles_to_visit.push_back({ tileFromScreenXY(
                                        tileScreenX + tile_center_offset_x,
                                        tileScreenY - pixels_per_vertical_move + tile_center_offset_y,
-                                       gElevation, true),
+                                       true),
             MarkOnlyPart::UP });
         tiles_to_visit.push_back({ tileFromScreenXY(
                                        tileScreenX + tile_center_offset_x,
                                        tileScreenY + pixels_per_vertical_move + tile_center_offset_y,
-                                       gElevation, true),
+                                       true),
             MarkOnlyPart::DOWN });
     }
 


### PR DESCRIPTION
### Description

Removes the unused `elevation` parameter from the `tileFromScreenXY` declaration/call sites so the interface matches the implementation again.

Updated all remaining callers, including the `ignoreBounds` cases, to use the new signature.

### Reproduction Steps and Savefile (if available)

1. Build the project.
2. Confirm the tree compiles after the `tileFromScreenXY` signature change.

Savefile: N/A.

### Screenshots

N/A.
