### PR TITLE
Fix crash/glitched map when the encounter table has no available entries

### DIFF
--- a/src/worldmap.cc
+++ b/src/worldmap.cc
@@ -3454,7 +3454,10 @@ static int wmRndEncounterOccurred()
         return 0;
     }
 
-    wmRndEncounterPick();
+    // CE: No encounter candidate.
+    if (wmRndEncounterPick() == -1) {
+        return 0;
+    }
 
     EncounterTable* encounterTable = &(wmEncounterTableList[wmGenData.encounterTableId]);
     EncounterTableEntry* encounterTableEntry = &(encounterTable->entries[wmGenData.encounterEntryId]);
@@ -3620,6 +3623,11 @@ static int wmRndEncounterPick()
             candidates[candidatesLength++] = index;
             totalChance += encounterTableEntry->chance;
         }
+    }
+
+    // CE: Fix crash/getting stuck on an empty map when the encounter table has no available entries.
+    if (candidatesLength <= 0) {
+        return -1;
     }
 
     int effectiveLuck = critterGetStat(gDude, STAT_LUCK) - 5;


### PR DESCRIPTION
### Description

In the original code, the game assumes there must be at least one available encounter in the encounter table. When the encounter table has no available entries, e.g. only one entry but the the conditions aren't met, the player would be stuck on an empty(black) map or have crashes on triggering an encounter due to invalid array index (-1) from `candidatesLength` being 0.

This PR will make the game treat such cases as if no encounter occurred (since no candidate to pick from), basically allows people to set up an empty encounter table.

### Reproduction Steps and Savefile (if available)

<!--- Provide detailed steps to reproduce the issue. Include a savefile if applicable, preferrably for Sonora --->
For testing, edit vanilla `worldmap.txt` like this:
```ini
[Encounter Table 17]
lookup_name=Den_M ; Areas around the Den
maps=Mountain Encounter 3, Mountain Encounter 4, Mountain Encounter 5, Cavern Encounter 0, Cavern Encounter 2
enc_00=Chance:100%,Enc:(4-9) DEN_Slavers AMBUSH Player, If(Player(Level) > 99) ; unachievable condition
; comment out the rest
```
Or simply comment out all entries in a table.
