### PR TITLE
cmake: add COPY_TO_PATH variable 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -510,15 +510,27 @@ if(CMAKE_SYSTEM_NAME MATCHES "Emscripten")
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
 endif()
 
+# Optional path to which the built executable and PDB will be copied after build.
+# Can be set via -DCOPY_TO_PATH=/some/path or through the CMake/CLion GUI.
+set(COPY_TO_PATH "" CACHE PATH "Destination directory for copying the executable and PDB after build")
+
 if(DEFINED COPY_TO_PATH AND NOT "${COPY_TO_PATH}" STREQUAL "")
     add_custom_command(TARGET ${EXECUTABLE_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${COPY_TO_PATH}"
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
             "$<TARGET_FILE:${EXECUTABLE_NAME}>"
             "${COPY_TO_PATH}/"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            "$<TARGET_PDB_FILE:${EXECUTABLE_NAME}>"
-            "${COPY_TO_PATH}/"
-        COMMAND ${CMAKE_COMMAND} -E echo "Copied executable and PDB to ${COPY_TO_PATH}"
+        COMMAND ${CMAKE_COMMAND} -E echo "Copied executable to ${COPY_TO_PATH}"
     )
-    message(STATUS "Will copy executable and PDB to: ${COPY_TO_PATH}")
+    if(MSVC)
+        add_custom_command(TARGET ${EXECUTABLE_NAME} POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "$<TARGET_PDB_FILE:${EXECUTABLE_NAME}>"
+                "${COPY_TO_PATH}/"
+                COMMAND ${CMAKE_COMMAND} -E echo "Copied PDB to ${COPY_TO_PATH}"
+        )
+        message(STATUS "Will copy executable and PDB to: ${COPY_TO_PATH}")
+    else()
+        message(STATUS "Will copy executable to: ${COPY_TO_PATH}")
+    endif()
 endif()


### PR DESCRIPTION
- COPY_TO_PATH variable allows to easily copy built exe and pbd into a game directory for debugging (I'm setting it in CLion UI)
~~- windows-x86 preset will use the standard built tools, instead a separate windows-x86-xp preset is added for using the legacy XP toolset (it is not supported and may be buggy)~~