### PR TITLE
Add original symbol beside all function and symbol offsets

### DIFF
--- a/src/actions.cc
+++ b/src/actions.cc
@@ -46,13 +46,13 @@ typedef enum ScienceRepairTargetType {
     SCIENCE_REPAIR_TARGET_TYPE_ANYONE,
 } ScienceRepairTargetType;
 
-// 0x5106D0
+// 0x5106D0 action_in_explode
 static bool _action_in_explode = false;
 
-// 0x5106D4
+// 0x5106D4 rotation
 int rotation;
 
-// 0x5106E0
+// 0x5106E0 death_2
 static const int gNormalDeathAnimations[DAMAGE_TYPE_COUNT] = {
     ANIM_DANCING_AUTOFIRE,
     ANIM_SLICED_IN_HALF,
@@ -63,7 +63,7 @@ static const int gNormalDeathAnimations[DAMAGE_TYPE_COUNT] = {
     ANIM_BIG_HOLE,
 };
 
-// 0x5106FC
+// 0x5106FC death_3
 static const int gMaximumBloodDeathAnimations[DAMAGE_TYPE_COUNT] = {
     ANIM_CHUNKS_OF_FLESH,
     ANIM_SLICED_IN_HALF,

--- a/src/actions.cc
+++ b/src/actions.cc
@@ -519,7 +519,7 @@ int _show_death(Object* obj, int anim)
 
 // Animates damage to extras in a given attack (secondary targets).
 //
-// 0x410FEC _show_damage_extras
+// 0x410FEC show_damage_extras
 int showDamageToExtras(Attack* attack)
 {
     for (int index = 0; index < attack->extrasLength; index++) {

--- a/src/animation.cc
+++ b/src/animation.cc
@@ -309,39 +309,39 @@ static unsigned int animationComputeTicksPerFrame(Object* object, int fid);
 
 static void reportOverloaded(Object* critter);
 
-// 0x510718
+// 0x510718 curr_sad
 static int gAnimationCurrentSad = 0;
 
-// 0x51071C
+// 0x51071C curr_anim_set
 static int gAnimationSequenceCurrentIndex = -1;
 
-// 0x510720
+// 0x510720 anim_in_init
 static bool gAnimationInInit = false;
 
-// 0x510724
+// 0x510724 anim_in_anim_stop
 static bool gAnimationInStop = false;
 
-// 0x510728
+// 0x510728 anim_in_bk
 static bool _anim_in_bk = false;
 
-// 0x530014
+// 0x530014 sad
 static AnimationSad gAnimationSads[ANIMATION_SAD_LIST_CAPACITY];
 
 #define PATH_NODE_CAPACITY 10000
 
-// 0x542FD4
+// 0x542FD4 dad
 static PathNode gClosedPathNodeList[PATH_NODE_CAPACITY];
 
-// 0x54CC14
+// 0x54CC14 anim_set
 static AnimationSequence gAnimationSequences[32];
 
-// 0x561814
+// 0x561814 seen_tile
 static unsigned char gPathfinderProcessedTiles[5000];
 
-// 0x562B9C
+// 0x562B9C child_path
 static PathNode gOpenPathNodeList[PATH_NODE_CAPACITY];
 
-// 0x56C7DC
+// 0x56C7DC curr_anim_counter
 static int gAnimationDescriptionCurrentIndex;
 
 // anim_init

--- a/src/art.cc
+++ b/src/art.cc
@@ -44,19 +44,19 @@ static int artReadHeader(Art* art, File* stream);
 static int artGetDataSize(const Art* art);
 static int paddingForSize(int size);
 
-// 0x5002D8
+// 0x5002D8 str2
 static char gDefaultJumpsuitMaleFileName[] = "hmjmps";
 
-// 0x05002E0
+// 0x05002E0 aHfjmps
 static char gDefaultJumpsuitFemaleFileName[] = "hfjmps";
 
-// 0x5002E8
+// 0x5002E8 aHmwarr
 static char gDefaultTribalMaleFileName[] = "hmwarr";
 
-// 0x5002F0
+// 0x5002F0 aHfprim
 static char gDefaultTribalFemaleFileName[] = "hfprim";
 
-// 0x510738
+// 0x510738 art
 static ArtListDescription gArtListDescriptions[OBJ_TYPE_COUNT] = {
     { 0, "items", nullptr, nullptr, 0 },
     { 0, "critters", nullptr, nullptr, 0 },
@@ -74,18 +74,18 @@ static ArtListDescription gArtListDescriptions[OBJ_TYPE_COUNT] = {
 // This flag denotes that localized arts should be looked up first. Used
 // together with [gArtLanguage].
 //
-// 0x510898
+// 0x510898 darn_foreigners
 static bool gArtLanguageInitialized = false;
 
-// 0x51089C
+// 0x51089C _head1
 static const char* _head1 = "gggnnnbbbgnb";
 
-// 0x5108A0
+// 0x5108A0 _head2
 static const char* _head2 = "vfngfbnfvppp";
 
 // Current native look base fid.
 //
-// 0x5108A4
+// 0x5108A4 art_vault_guy_num
 int _art_vault_guy_num = 0;
 
 // Base fids for unarmored dude.
@@ -99,37 +99,37 @@ int _art_vault_guy_num = 0;
 // been accessed differently in 0x49F984, which clearly uses look type as an
 // index, not gender.
 //
-// 0x5108A8
+// 0x5108A8 art_vault_person_nums
 int _art_vault_person_nums[DUDE_NATIVE_LOOK_COUNT][GENDER_COUNT];
 
 // Index of "grid001.frm" in tiles.lst.
 //
-// 0x5108B8
+// 0x5108B8 art_mapper_blank_tile
 static int _art_mapper_blank_tile = 1;
 
 // Non-english language name.
 //
 // This value is used as a directory name to display localized arts.
 //
-// 0x56C970
+// 0x56C970 darn_foreign_sub_path
 static char gArtLanguage[32];
 
-// 0x56C990
+// 0x56C990 art_cache
 Cache gArtCache;
 
-// 0x56C9E4
+// 0x56C9E4 art_name
 static char _art_name[COMPAT_MAX_PATH];
 
 // head_info
-// 0x56CAE8
+// 0x56CAE8 head_info
 static HeadDescription* gHeadDescriptions;
 
 // anon_alias
-// 0x56CAEC
+// 0x56CAEC anon_alias
 static int* _anon_alias;
 
 // artCritterFidShouldRunData
-// 0x56CAF0
+// 0x56CAF0 artCritterFidShouldRunData
 static int* gArtCritterFidShoudRunData;
 
 static std::unordered_map<std::string, std::shared_ptr<NamedCacheEntry>> gNamedArtCache;

--- a/src/art.cc
+++ b/src/art.cc
@@ -77,10 +77,10 @@ static ArtListDescription gArtListDescriptions[OBJ_TYPE_COUNT] = {
 // 0x510898 darn_foreigners
 static bool gArtLanguageInitialized = false;
 
-// 0x51089C _head1
+// 0x51089C head1
 static const char* _head1 = "gggnnnbbbgnb";
 
-// 0x5108A0 _head2
+// 0x5108A0 head2
 static const char* _head2 = "vfngfbnfvppp";
 
 // Current native look base fid.

--- a/src/audio.cc
+++ b/src/audio.cc
@@ -47,13 +47,13 @@ static int audioSoundDecoderReadHandler(void* data, void* buf, unsigned int size
 static bool audioIsWavePath(const char* filePath);
 static bool audioDecodeWave(File* stream, AudioFileInfo* info, unsigned char** dataPtr, int* sizePtr);
 
-// 0x5108BC
+// 0x5108BC _queryCompressedFunc
 static AudioQueryCompressedFunc* queryCompressedFunc = defaultCompressionFunc;
 
-// 0x56CB00
+// 0x56CB00 numAudio
 static int gAudioListLength;
 
-// 0x56CB04
+// 0x56CB04 audio
 static Audio* gAudioList;
 
 // 0x41A2B0

--- a/src/audio.cc
+++ b/src/audio.cc
@@ -47,7 +47,7 @@ static int audioSoundDecoderReadHandler(void* data, void* buf, unsigned int size
 static bool audioIsWavePath(const char* filePath);
 static bool audioDecodeWave(File* stream, AudioFileInfo* info, unsigned char** dataPtr, int* sizePtr);
 
-// 0x5108BC _queryCompressedFunc
+// 0x5108BC queryCompressedFunc
 static AudioQueryCompressedFunc* queryCompressedFunc = defaultCompressionFunc;
 
 // 0x56CB00 numAudio

--- a/src/audio_file.cc
+++ b/src/audio_file.cc
@@ -30,13 +30,13 @@ typedef struct AudioFile {
 static bool defaultCompressionFunc(char* filePath);
 static int audioFileSoundDecoderReadHandler(void* data, void* buffer, unsigned int size);
 
-// 0x5108C0
+// 0x5108C0 _queryCompressedFunc_2
 static AudioFileQueryCompressedFunc* queryCompressedFunc = defaultCompressionFunc;
 
-// 0x56CB10
+// 0x56CB10 audiof
 static AudioFile* gAudioFileList;
 
-// 0x56CB14
+// 0x56CB14 numAudiof
 static int gAudioFileListLength;
 
 // 0x41A850

--- a/src/audio_file.cc
+++ b/src/audio_file.cc
@@ -30,7 +30,7 @@ typedef struct AudioFile {
 static bool defaultCompressionFunc(char* filePath);
 static int audioFileSoundDecoderReadHandler(void* data, void* buffer, unsigned int size);
 
-// 0x5108C0 _queryCompressedFunc_2
+// 0x5108C0 queryCompressedFunc_2
 static AudioFileQueryCompressedFunc* queryCompressedFunc = defaultCompressionFunc;
 
 // 0x56CB10 audiof

--- a/src/automap.cc
+++ b/src/automap.cc
@@ -252,7 +252,7 @@ static AutomapHeader gAutomapHeader;
 static AutomapEntry gAutomapEntry;
 
 // automap_init
-// 0x41B7F4
+// 0x41B7F4 automap_init_
 int automapInit()
 {
     gAutomapFlags = 0;
@@ -260,7 +260,7 @@ int automapInit()
     return 0;
 }
 
-// 0x41B808
+// 0x41B808 automap_reset_
 int automapReset()
 {
     gAutomapFlags = 0;
@@ -268,7 +268,7 @@ int automapReset()
     return 0;
 }
 
-// 0x41B81C
+// 0x41B81C automap_exit_
 void automapExit()
 {
     char path[COMPAT_MAX_PATH];
@@ -276,25 +276,25 @@ void automapExit()
     compat_remove(path);
 }
 
-// 0x41B87C
+// 0x41B87C automap_load_
 int automapLoad(File* stream)
 {
     return fileReadInt32(stream, &gAutomapFlags);
 }
 
-// 0x41B898
+// 0x41B898 automap_save_
 int automapSave(File* stream)
 {
     return fileWriteInt32(stream, gAutomapFlags);
 }
 
-// 0x41B8B4
+// 0x41B8B4 automapDisplayMap_
 int _automapDisplayMap(int map)
 {
     return _displayMapList[map];
 }
 
-// 0x41B8BC
+// 0x41B8BC automap_
 void automapShow(bool isInGame, bool isUsingScanner)
 {
     ScopedGameMode gm(GameMode::kAutomap);
@@ -499,7 +499,7 @@ void automapShow(bool isInGame, bool isUsingScanner)
 
 // Renders automap in Map window.
 //
-// 0x41BD1C
+// 0x41BD1C draw_top_down_map_
 static void automapRenderInMapWindow(int window, int elevation, unsigned char* backgroundData, int flags)
 {
     int color;
@@ -620,7 +620,7 @@ static void automapRenderInMapWindow(int window, int elevation, unsigned char* b
 
 // Renders automap in Pipboy window.
 //
-// 0x41C004
+// 0x41C004 draw_top_down_map_pipboy_
 int automapRenderInPipboyWindow(int window, int map, int elevation)
 {
     unsigned char* windowBuffer = windowGetBuffer(window) + 640 * AUTOMAP_PIPBOY_VIEW_Y + AUTOMAP_PIPBOY_VIEW_X;
@@ -682,7 +682,7 @@ int automapRenderInPipboyWindow(int window, int map, int elevation)
 }
 
 // automap_pip_save
-// 0x41C0F0
+// 0x41C0F0 automap_pip_save_
 int automapSaveCurrent()
 {
     int map = mapGetCurrentMap();
@@ -896,7 +896,7 @@ int automapSaveCurrent()
 
 // Saves automap entry into stream.
 //
-// 0x41C844
+// 0x41C844 WriteAM_Entry_
 static int automapSaveEntry(File* stream)
 {
     unsigned char* buffer;
@@ -928,7 +928,7 @@ err:
     return -1;
 }
 
-// 0x41C8CC
+// 0x41C8CC AM_ReadEntry_
 static int automapLoadEntry(int map, int elevation)
 {
     gAutomapEntry.compressedData = nullptr;
@@ -1015,7 +1015,7 @@ out:
 
 // Saves automap.db header.
 //
-// 0x41CAD8
+// 0x41CAD8 WriteAM_Header_
 static int automapSaveHeader(File* stream)
 {
     fileRewind(stream);
@@ -1045,7 +1045,7 @@ err:
 
 // Loads automap.db header.
 //
-// 0x41CB50
+// 0x41CB50 AM_ReadMainHeader_
 static int automapLoadHeader(File* stream)
 {
 
@@ -1068,7 +1068,7 @@ static int automapLoadHeader(File* stream)
     return 0;
 }
 
-// 0x41CBA4
+// 0x41CBA4 decode_map_data_
 static void _decode_map_data(int elevation)
 {
     memset(gAutomapEntry.data, 0, SQUARE_GRID_SIZE);
@@ -1101,7 +1101,7 @@ static void _decode_map_data(int elevation)
     }
 }
 
-// 0x41CC98
+// 0x41CC98 am_pip_init_
 static int automapCreate()
 {
     gAutomapHeader.version = 1;
@@ -1128,7 +1128,7 @@ static int automapCreate()
 
 // Copy data from stream1 to stream2.
 //
-// 0x41CD6C
+// 0x41CD6C copy_file_data_
 static int _copy_file_data(File* stream1, File* stream2, int length)
 {
     void* buffer = internal_malloc(0xFFFF);
@@ -1160,7 +1160,7 @@ static int _copy_file_data(File* stream1, File* stream2, int length)
     return 0;
 }
 
-// 0x41CE74
+// 0x41CE74 ReadAMList_
 int automapGetHeader(AutomapHeader** automapHeaderPtr)
 {
     char path[COMPAT_MAX_PATH];

--- a/src/automap.cc
+++ b/src/automap.cc
@@ -62,14 +62,14 @@ typedef struct AutomapEntry {
     unsigned char* data;
 } AutomapEntry;
 
-// 0x41ADE0
+// 0x41ADE0 defam
 static const int _defam[AUTOMAP_MAP_COUNT][ELEVATION_COUNT] = {
     { -1, -1, -1 },
     { -1, -1, -1 },
     { -1, -1, -1 },
 };
 
-// 0x41B560
+// 0x41B560 displayMapList
 static int _displayMapList[AUTOMAP_MAP_COUNT] = {
     -1,
     -1,
@@ -242,17 +242,17 @@ static const int gAutomapFrmIds[AUTOMAP_FRM_COUNT] = {
     173, // autodwn.frm - switch down
 };
 
-// 0x5108C4
+// 0x5108C4 autoflags
 static int gAutomapFlags = 0;
 
-// 0x56CB18
+// 0x56CB18 amdbhead
 static AutomapHeader gAutomapHeader;
 
-// 0x56D2A0
+// 0x56D2A0 amdbsubhead
 static AutomapEntry gAutomapEntry;
 
 // automap_init
-// 0x41B7F4 automap_init_
+// 0x41B7F4 automap_init
 int automapInit()
 {
     gAutomapFlags = 0;
@@ -260,7 +260,7 @@ int automapInit()
     return 0;
 }
 
-// 0x41B808 automap_reset_
+// 0x41B808 automap_reset
 int automapReset()
 {
     gAutomapFlags = 0;
@@ -268,7 +268,7 @@ int automapReset()
     return 0;
 }
 
-// 0x41B81C automap_exit_
+// 0x41B81C automap_exit
 void automapExit()
 {
     char path[COMPAT_MAX_PATH];
@@ -276,25 +276,25 @@ void automapExit()
     compat_remove(path);
 }
 
-// 0x41B87C automap_load_
+// 0x41B87C automap_load
 int automapLoad(File* stream)
 {
     return fileReadInt32(stream, &gAutomapFlags);
 }
 
-// 0x41B898 automap_save_
+// 0x41B898 automap_save
 int automapSave(File* stream)
 {
     return fileWriteInt32(stream, gAutomapFlags);
 }
 
-// 0x41B8B4 automapDisplayMap_
+// 0x41B8B4 automapDisplayMap
 int _automapDisplayMap(int map)
 {
     return _displayMapList[map];
 }
 
-// 0x41B8BC automap_
+// 0x41B8BC automap
 void automapShow(bool isInGame, bool isUsingScanner)
 {
     ScopedGameMode gm(GameMode::kAutomap);
@@ -499,7 +499,7 @@ void automapShow(bool isInGame, bool isUsingScanner)
 
 // Renders automap in Map window.
 //
-// 0x41BD1C draw_top_down_map_
+// 0x41BD1C draw_top_down_map
 static void automapRenderInMapWindow(int window, int elevation, unsigned char* backgroundData, int flags)
 {
     int color;
@@ -620,7 +620,7 @@ static void automapRenderInMapWindow(int window, int elevation, unsigned char* b
 
 // Renders automap in Pipboy window.
 //
-// 0x41C004 draw_top_down_map_pipboy_
+// 0x41C004 draw_top_down_map_pipboy
 int automapRenderInPipboyWindow(int window, int map, int elevation)
 {
     unsigned char* windowBuffer = windowGetBuffer(window) + 640 * AUTOMAP_PIPBOY_VIEW_Y + AUTOMAP_PIPBOY_VIEW_X;
@@ -682,7 +682,7 @@ int automapRenderInPipboyWindow(int window, int map, int elevation)
 }
 
 // automap_pip_save
-// 0x41C0F0 automap_pip_save_
+// 0x41C0F0 automap_pip_save
 int automapSaveCurrent()
 {
     int map = mapGetCurrentMap();
@@ -896,7 +896,7 @@ int automapSaveCurrent()
 
 // Saves automap entry into stream.
 //
-// 0x41C844 WriteAM_Entry_
+// 0x41C844 WriteAM_Entry
 static int automapSaveEntry(File* stream)
 {
     unsigned char* buffer;
@@ -928,7 +928,7 @@ err:
     return -1;
 }
 
-// 0x41C8CC AM_ReadEntry_
+// 0x41C8CC AM_ReadEntry
 static int automapLoadEntry(int map, int elevation)
 {
     gAutomapEntry.compressedData = nullptr;
@@ -1015,7 +1015,7 @@ out:
 
 // Saves automap.db header.
 //
-// 0x41CAD8 WriteAM_Header_
+// 0x41CAD8 WriteAM_Header
 static int automapSaveHeader(File* stream)
 {
     fileRewind(stream);
@@ -1045,7 +1045,7 @@ err:
 
 // Loads automap.db header.
 //
-// 0x41CB50 AM_ReadMainHeader_
+// 0x41CB50 AM_ReadMainHeader
 static int automapLoadHeader(File* stream)
 {
 
@@ -1068,7 +1068,7 @@ static int automapLoadHeader(File* stream)
     return 0;
 }
 
-// 0x41CBA4 decode_map_data_
+// 0x41CBA4 decode_map_data
 static void _decode_map_data(int elevation)
 {
     memset(gAutomapEntry.data, 0, SQUARE_GRID_SIZE);
@@ -1101,7 +1101,7 @@ static void _decode_map_data(int elevation)
     }
 }
 
-// 0x41CC98 am_pip_init_
+// 0x41CC98 am_pip_init
 static int automapCreate()
 {
     gAutomapHeader.version = 1;
@@ -1128,7 +1128,7 @@ static int automapCreate()
 
 // Copy data from stream1 to stream2.
 //
-// 0x41CD6C copy_file_data_
+// 0x41CD6C copy_file_data
 static int _copy_file_data(File* stream1, File* stream2, int length)
 {
     void* buffer = internal_malloc(0xFFFF);
@@ -1160,7 +1160,7 @@ static int _copy_file_data(File* stream1, File* stream2, int length)
     return 0;
 }
 
-// 0x41CE74 ReadAMList_
+// 0x41CE74 ReadAMList
 int automapGetHeader(AutomapHeader** automapHeaderPtr)
 {
     char path[COMPAT_MAX_PATH];

--- a/src/autorun.cc
+++ b/src/autorun.cc
@@ -11,7 +11,7 @@ static HANDLE gInterplayGenericAutorunMutex;
 
 namespace fallout {
 
-// 0x4139C0
+// 0x4139C0 autorun_mutex_create_
 bool autorunMutexCreate()
 {
 #ifdef _WIN32
@@ -25,7 +25,7 @@ bool autorunMutexCreate()
     return true;
 }
 
-// 0x413A00
+// 0x413A00 autorun_mutex_destroy_
 void autorunMutexClose()
 {
 #ifdef _WIN32

--- a/src/autorun.cc
+++ b/src/autorun.cc
@@ -5,13 +5,13 @@
 #endif
 
 #ifdef _WIN32
-// 0x530010
+// 0x530010 autorun_mutex
 static HANDLE gInterplayGenericAutorunMutex;
 #endif
 
 namespace fallout {
 
-// 0x4139C0 autorun_mutex_create_
+// 0x4139C0 autorun_mutex_create
 bool autorunMutexCreate()
 {
 #ifdef _WIN32
@@ -25,7 +25,7 @@ bool autorunMutexCreate()
     return true;
 }
 
-// 0x413A00 autorun_mutex_destroy_
+// 0x413A00 autorun_mutex_destroy
 void autorunMutexClose()
 {
 #ifdef _WIN32

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -34,7 +34,7 @@ static int cacheEntriesCompareByMostRecentHit(const void* a1, const void* a2);
 static int _lock_sound_ticker = 0;
 
 // cache_init
-// 0x41FCC0
+// 0x41FCC0 cache_init_
 bool cacheInit(Cache* cache, CacheSizeProc* sizeProc, CacheReadProc* readProc, CacheFreeProc* freeProc, int maxSize)
 {
     if (!heapInit(&(cache->heap), maxSize)) {
@@ -61,7 +61,7 @@ bool cacheInit(Cache* cache, CacheSizeProc* sizeProc, CacheReadProc* readProc, C
 }
 
 // cache_exit
-// 0x41FD50
+// 0x41FD50 cache_exit_
 bool cacheFree(Cache* cache)
 {
     if (cache == nullptr) {
@@ -90,7 +90,7 @@ bool cacheFree(Cache* cache)
     return true;
 }
 
-// 0x41FDE8
+// 0x41FDE8 cache_lock_
 bool cacheLock(Cache* cache, int key, void** data, CacheEntry** cacheEntryPtr)
 {
     if (cache == nullptr || data == nullptr || cacheEntryPtr == nullptr) {
@@ -145,7 +145,7 @@ bool cacheLock(Cache* cache, int key, void** data, CacheEntry** cacheEntryPtr)
     return true;
 }
 
-// 0x4200B8
+// 0x4200B8 cache_unlock_
 bool cacheUnlock(Cache* cache, CacheEntry* cacheEntry)
 {
     if (cache == nullptr || cacheEntry == nullptr) {
@@ -166,7 +166,7 @@ bool cacheUnlock(Cache* cache, CacheEntry* cacheEntry)
 }
 
 // cache_flush
-// 0x42012C
+// 0x42012C cache_flush_
 bool cacheFlush(Cache* cache)
 {
     if (cache == nullptr) {
@@ -193,7 +193,7 @@ bool cacheFlush(Cache* cache)
     return true;
 }
 
-// 0x42019C
+// 0x42019C cache_stats_
 bool cachePrintStats(Cache* cache, char* dest, size_t size)
 {
     if (cache == nullptr || dest == nullptr) {
@@ -207,7 +207,7 @@ bool cachePrintStats(Cache* cache, char* dest, size_t size)
 
 // Fetches entry for the specified key into the cache.
 //
-// 0x4203AC
+// 0x4203AC cache_add_
 static bool cacheFetchEntryForKey(Cache* cache, int key, int* indexPtr)
 {
     CacheEntry* cacheEntry = (CacheEntry*)internal_malloc(sizeof(*cacheEntry));
@@ -307,7 +307,7 @@ static bool cacheFetchEntryForKey(Cache* cache, int key, int* indexPtr)
     return false;
 }
 
-// 0x4205E8
+// 0x4205E8 cache_insert_
 static bool cacheInsertEntryAtIndex(Cache* cache, CacheEntry* cacheEntry, int index)
 {
     // Ensure cache have enough space for new entry.
@@ -332,7 +332,7 @@ static bool cacheInsertEntryAtIndex(Cache* cache, CacheEntry* cacheEntry, int in
 // Returns 2 if entry already exists in cache, or 3 if entry does not exist. In
 // this case indexPtr represents insertion point.
 //
-// 0x420654
+// 0x420654 cache_find_
 static int cacheFindIndexForKey(Cache* cache, int key, int* indexPtr)
 {
     int length = cache->entriesLength;
@@ -371,7 +371,7 @@ static int cacheFindIndexForKey(Cache* cache, int key, int* indexPtr)
     return 3;
 }
 
-// 0x420708
+// 0x420708 cache_init_item_
 static bool cacheEntryInit(CacheEntry* cacheEntry)
 {
     cacheEntry->key = 0;
@@ -386,7 +386,7 @@ static bool cacheEntryInit(CacheEntry* cacheEntry)
 
 // NOTE: Inlined.
 //
-// 0x420740
+// 0x420740 cache_destroy_item_
 static bool cacheEntryFree(Cache* cache, CacheEntry* cacheEntry)
 {
     if (cacheEntry->data != nullptr) {
@@ -398,7 +398,7 @@ static bool cacheEntryFree(Cache* cache, CacheEntry* cacheEntry)
     return true;
 }
 
-// 0x420764
+// 0x420764 cache_unlock_all_
 static bool cacheClean(Cache* cache)
 {
     Heap* heap = &(cache->heap);
@@ -417,7 +417,7 @@ static bool cacheClean(Cache* cache)
     return true;
 }
 
-// 0x4207D4
+// 0x4207D4 cache_reset_counter_
 static bool cacheResetStatistics(Cache* cache)
 {
     if (cache == nullptr) {
@@ -447,7 +447,7 @@ static bool cacheResetStatistics(Cache* cache)
 
 // Prepare cache for storing new entry with the specified size.
 //
-// 0x42084C
+// 0x42084C cache_make_room_
 static bool cacheEnsureSize(Cache* cache, int size)
 {
     if (size > cache->maxSize) {
@@ -523,7 +523,7 @@ static bool cacheEnsureSize(Cache* cache, int size)
     return false;
 }
 
-// 0x42099C
+// 0x42099C cache_purge_
 static bool cacheSweep(Cache* cache)
 {
     for (int index = 0; index < cache->entriesLength; index++) {
@@ -554,7 +554,7 @@ static bool cacheSweep(Cache* cache)
     return true;
 }
 
-// 0x420A40
+// 0x420A40 cache_resize_array_
 static bool cacheSetCapacity(Cache* cache, int newCapacity)
 {
     if (newCapacity < cache->entriesLength) {
@@ -572,7 +572,7 @@ static bool cacheSetCapacity(Cache* cache, int newCapacity)
     return true;
 }
 
-// 0x420A74
+// 0x420A74 cache_compare_make_room_
 static int cacheEntriesCompareByUsage(const void* a1, const void* a2)
 {
     CacheEntry* lhs = *(CacheEntry**)a1;
@@ -601,7 +601,7 @@ static int cacheEntriesCompareByUsage(const void* a1, const void* a2)
     return 0;
 }
 
-// 0x420AE8
+// 0x420AE8 cache_compare_reset_counter_
 static int cacheEntriesCompareByMostRecentHit(const void* a1, const void* a2)
 {
     CacheEntry* lhs = *(CacheEntry**)a1;

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -30,11 +30,11 @@ static bool cacheSetCapacity(Cache* cache, int newCapacity);
 static int cacheEntriesCompareByUsage(const void* a1, const void* a2);
 static int cacheEntriesCompareByMostRecentHit(const void* a1, const void* a2);
 
-// 0x510938
+// 0x510938 lock_sound_ticker
 static int _lock_sound_ticker = 0;
 
 // cache_init
-// 0x41FCC0 cache_init_
+// 0x41FCC0 cache_init
 bool cacheInit(Cache* cache, CacheSizeProc* sizeProc, CacheReadProc* readProc, CacheFreeProc* freeProc, int maxSize)
 {
     if (!heapInit(&(cache->heap), maxSize)) {
@@ -61,7 +61,7 @@ bool cacheInit(Cache* cache, CacheSizeProc* sizeProc, CacheReadProc* readProc, C
 }
 
 // cache_exit
-// 0x41FD50 cache_exit_
+// 0x41FD50 cache_exit
 bool cacheFree(Cache* cache)
 {
     if (cache == nullptr) {
@@ -90,7 +90,7 @@ bool cacheFree(Cache* cache)
     return true;
 }
 
-// 0x41FDE8 cache_lock_
+// 0x41FDE8 cache_lock
 bool cacheLock(Cache* cache, int key, void** data, CacheEntry** cacheEntryPtr)
 {
     if (cache == nullptr || data == nullptr || cacheEntryPtr == nullptr) {
@@ -145,7 +145,7 @@ bool cacheLock(Cache* cache, int key, void** data, CacheEntry** cacheEntryPtr)
     return true;
 }
 
-// 0x4200B8 cache_unlock_
+// 0x4200B8 cache_unlock
 bool cacheUnlock(Cache* cache, CacheEntry* cacheEntry)
 {
     if (cache == nullptr || cacheEntry == nullptr) {
@@ -166,7 +166,7 @@ bool cacheUnlock(Cache* cache, CacheEntry* cacheEntry)
 }
 
 // cache_flush
-// 0x42012C cache_flush_
+// 0x42012C cache_flush
 bool cacheFlush(Cache* cache)
 {
     if (cache == nullptr) {
@@ -193,7 +193,7 @@ bool cacheFlush(Cache* cache)
     return true;
 }
 
-// 0x42019C cache_stats_
+// 0x42019C cache_stats
 bool cachePrintStats(Cache* cache, char* dest, size_t size)
 {
     if (cache == nullptr || dest == nullptr) {
@@ -207,7 +207,7 @@ bool cachePrintStats(Cache* cache, char* dest, size_t size)
 
 // Fetches entry for the specified key into the cache.
 //
-// 0x4203AC cache_add_
+// 0x4203AC cache_add
 static bool cacheFetchEntryForKey(Cache* cache, int key, int* indexPtr)
 {
     CacheEntry* cacheEntry = (CacheEntry*)internal_malloc(sizeof(*cacheEntry));
@@ -307,7 +307,7 @@ static bool cacheFetchEntryForKey(Cache* cache, int key, int* indexPtr)
     return false;
 }
 
-// 0x4205E8 cache_insert_
+// 0x4205E8 cache_insert
 static bool cacheInsertEntryAtIndex(Cache* cache, CacheEntry* cacheEntry, int index)
 {
     // Ensure cache have enough space for new entry.
@@ -332,7 +332,7 @@ static bool cacheInsertEntryAtIndex(Cache* cache, CacheEntry* cacheEntry, int in
 // Returns 2 if entry already exists in cache, or 3 if entry does not exist. In
 // this case indexPtr represents insertion point.
 //
-// 0x420654 cache_find_
+// 0x420654 cache_find
 static int cacheFindIndexForKey(Cache* cache, int key, int* indexPtr)
 {
     int length = cache->entriesLength;
@@ -371,7 +371,7 @@ static int cacheFindIndexForKey(Cache* cache, int key, int* indexPtr)
     return 3;
 }
 
-// 0x420708 cache_init_item_
+// 0x420708 cache_init_item
 static bool cacheEntryInit(CacheEntry* cacheEntry)
 {
     cacheEntry->key = 0;
@@ -386,7 +386,7 @@ static bool cacheEntryInit(CacheEntry* cacheEntry)
 
 // NOTE: Inlined.
 //
-// 0x420740 cache_destroy_item_
+// 0x420740 cache_destroy_item
 static bool cacheEntryFree(Cache* cache, CacheEntry* cacheEntry)
 {
     if (cacheEntry->data != nullptr) {
@@ -398,7 +398,7 @@ static bool cacheEntryFree(Cache* cache, CacheEntry* cacheEntry)
     return true;
 }
 
-// 0x420764 cache_unlock_all_
+// 0x420764 cache_unlock_all
 static bool cacheClean(Cache* cache)
 {
     Heap* heap = &(cache->heap);
@@ -417,7 +417,7 @@ static bool cacheClean(Cache* cache)
     return true;
 }
 
-// 0x4207D4 cache_reset_counter_
+// 0x4207D4 cache_reset_counter
 static bool cacheResetStatistics(Cache* cache)
 {
     if (cache == nullptr) {
@@ -447,7 +447,7 @@ static bool cacheResetStatistics(Cache* cache)
 
 // Prepare cache for storing new entry with the specified size.
 //
-// 0x42084C cache_make_room_
+// 0x42084C cache_make_room
 static bool cacheEnsureSize(Cache* cache, int size)
 {
     if (size > cache->maxSize) {
@@ -523,7 +523,7 @@ static bool cacheEnsureSize(Cache* cache, int size)
     return false;
 }
 
-// 0x42099C cache_purge_
+// 0x42099C cache_purge
 static bool cacheSweep(Cache* cache)
 {
     for (int index = 0; index < cache->entriesLength; index++) {
@@ -554,7 +554,7 @@ static bool cacheSweep(Cache* cache)
     return true;
 }
 
-// 0x420A40 cache_resize_array_
+// 0x420A40 cache_resize_array
 static bool cacheSetCapacity(Cache* cache, int newCapacity)
 {
     if (newCapacity < cache->entriesLength) {
@@ -572,7 +572,7 @@ static bool cacheSetCapacity(Cache* cache, int newCapacity)
     return true;
 }
 
-// 0x420A74 cache_compare_make_room_
+// 0x420A74 cache_compare_make_room
 static int cacheEntriesCompareByUsage(const void* a1, const void* a2)
 {
     CacheEntry* lhs = *(CacheEntry**)a1;
@@ -601,7 +601,7 @@ static int cacheEntriesCompareByUsage(const void* a1, const void* a2)
     return 0;
 }
 
-// 0x420AE8 cache_compare_reset_counter_
+// 0x420AE8 cache_compare_reset_counter
 static int cacheEntriesCompareByMostRecentHit(const void* a1, const void* a2)
 {
     CacheEntry* lhs = *(CacheEntry**)a1;

--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -502,13 +502,13 @@ static int gCharacterEditorSkillValueAdjustmentSliderY = 27;
 // 0x518538 character_points
 int gCharacterEditorRemainingCharacterPoints = 0;
 
-// 0x51853C _karma_vars
+// 0x51853C karma_vars
 static KarmaEntry* gKarmaEntries = nullptr;
 
 // 0x518540 karma_vars_count
 static int gKarmaEntriesLength = 0;
 
-// 0x518544 _general_reps
+// 0x518544 general_reps
 static GenericReputationEntry* gGenericReputationEntries = nullptr;
 
 // 0x518548 general_reps_count
@@ -618,10 +618,10 @@ static int gCharacterEditorFolderCardFrmId;
 // 0x5705B4 folder_top_line
 static int gCharacterEditorFolderViewTopLine;
 
-// 0x5705B8 _folder_card_title
+// 0x5705B8 folder_card_title
 static char* gCharacterEditorFolderCardTitle;
 
-// 0x5705BC _folder_card_title2
+// 0x5705BC folder_card_title2
 static char* gCharacterEditorFolderCardSubtitle;
 
 // 0x5705C0 folder_yoffset
@@ -633,7 +633,7 @@ static int gCharacterEditorKarmaFolderTopLine;
 // 0x5705C8 folder_highlight_line
 static int gCharacterEditorFolderViewHighlightedLine;
 
-// 0x5705CC _folder_card_desc
+// 0x5705CC folder_card_desc
 static char* gCharacterEditorFolderCardDescription;
 
 // 0x5705D0 folder_ypos

--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -304,7 +304,7 @@ static int customKarmaFolderGetFrmId();
 static void customTownReputationInit();
 static void customTownReputationFree();
 
-// 0x431C40
+// 0x431C40 grph_id
 static int gCharacterEditorFrmIds[EDITOR_GRAPHIC_COUNT] = {
     170,
     175,
@@ -360,7 +360,7 @@ static int gCharacterEditorFrmIds[EDITOR_GRAPHIC_COUNT] = {
 
 // flags to preload fid
 //
-// 0x431D08
+// 0x431D08 copyflag
 static const unsigned char gCharacterEditorFrmShouldCopy[EDITOR_GRAPHIC_COUNT] = {
     0,
     0,
@@ -417,7 +417,7 @@ static const unsigned char gCharacterEditorFrmShouldCopy[EDITOR_GRAPHIC_COUNT] =
 // graphic ids for derived stats panel
 // NOTE: the type originally short
 //
-// 0x431D3A
+// 0x431D3A ndrvd
 static const int gCharacterEditorDerivedStatFrmIds[EDITOR_DERIVED_STAT_COUNT] = {
     18,
     19,
@@ -433,7 +433,7 @@ static const int gCharacterEditorDerivedStatFrmIds[EDITOR_DERIVED_STAT_COUNT] = 
 
 // y offsets for stats +/- buttons
 //
-// 0x431D50
+// 0x431D50 StatYpos
 static const int gCharacterEditorPrimaryStatY[7] = {
     37,
     70,
@@ -490,31 +490,31 @@ static const double dbl_5018F0 = 19.2;
 // 0x5019BE
 static const double dbl_5019BE = 14.4;
 
-// 0x518528
+// 0x518528 bk_enable_0
 static bool gCharacterEditorIsoWasEnabled = false;
 
-// 0x51852C
+// 0x51852C skill_cursor
 static int gCharacterEditorCurrentSkill = 0;
 
-// 0x518534
+// 0x518534 slider_y
 static int gCharacterEditorSkillValueAdjustmentSliderY = 27;
 
-// 0x518538
+// 0x518538 character_points
 int gCharacterEditorRemainingCharacterPoints = 0;
 
-// 0x51853C
+// 0x51853C _karma_vars
 static KarmaEntry* gKarmaEntries = nullptr;
 
-// 0x518540
+// 0x518540 karma_vars_count
 static int gKarmaEntriesLength = 0;
 
-// 0x518544
+// 0x518544 _general_reps
 static GenericReputationEntry* gGenericReputationEntries = nullptr;
 
-// 0x518548
+// 0x518548 general_reps_count
 static int gGenericReputationEntriesLength = 0;
 
-// 0x51854C
+// 0x51854C town_rep_info
 static const TownReputationEntry gTownReputationEntries[TOWN_REPUTATION_COUNT] = {
     { GVAR_TOWN_REP_ARROYO, CITY_ARROYO },
     { GVAR_TOWN_REP_KLAMATH, CITY_KLAMATH },
@@ -537,7 +537,7 @@ static const TownReputationEntry gTownReputationEntries[TOWN_REPUTATION_COUNT] =
     { GVAR_TOWN_REP_GHOST_FARM, CITY_MODOC_GHOST_TOWN },
 };
 
-// 0x5185E4
+// 0x5185E4 addiction_vars
 static const int gAddictionReputationVars[ADDICTION_REPUTATION_COUNT] = {
     GVAR_NUKA_COLA_ADDICT,
     GVAR_BUFF_OUT_ADDICT,
@@ -549,7 +549,7 @@ static const int gAddictionReputationVars[ADDICTION_REPUTATION_COUNT] = {
     GVAR_ADDICT_TRAGIC,
 };
 
-// 0x518604
+// 0x518604 addiction_pics
 static const int gAddictionReputationFrmIds[ADDICTION_REPUTATION_COUNT] = {
     142,
     126,
@@ -561,221 +561,221 @@ static const int gAddictionReputationFrmIds[ADDICTION_REPUTATION_COUNT] = {
     149,
 };
 
-// 0x518624
+// 0x518624 folder_up_button
 static int gCharacterEditorFolderViewScrollUpBtn = -1;
 
-// 0x518628
+// 0x518628 folder_down_button
 static int gCharacterEditorFolderViewScrollDownBtn = -1;
 
-// 0x56FB60
+// 0x56FB60 folder_card_string
 static char gCharacterEditorFolderCardString[256];
 
-// 0x56FC60
+// 0x56FC60 skillsav
 static int gCharacterEditorSkillsBackup[SKILL_COUNT];
 
-// 0x56FCA8
+// 0x56FCA8 editor_message_file
 static MessageList gCharacterEditorMessageList;
 
-// 0x56FCB0
+// 0x56FCB0 name_sort_list
 static PerkDialogOption gPerkDialogOptionList[DIALOG_PICKER_NUM_OPTIONS];
 
 // buttons for selecting traits
 //
-// 0x5700A8
+// 0x5700A8 trait_bids
 static int gCharacterEditorOptionalTraitBtns[TRAIT_COUNT];
 
-// 0x5700E8
+// 0x5700E8 mesg
 static MessageListItem gCharacterEditorMessageListItem;
 
-// 0x5700F8
+// 0x5700F8 old_str1
 static char gCharacterEditorCardTitle[48];
 
-// 0x570128
+// 0x570128 old_str2
 static char gPerkDialogCardTitle[48];
 
 // buttons for tagging skills
 //
-// 0x570158
+// 0x570158 tag_bids
 static int gCharacterEditorTagSkillBtns[SKILL_COUNT];
 
 // pc name
 //
-// 0x5701A0
+// 0x5701A0 name_save
 static char gCharacterEditorNameBackup[32];
 
-// 0x570418
+// 0x570418 grphcpy
 static unsigned char* gCharacterEditorFrmCopy[EDITOR_GRAPHIC_COUNT];
 
-// 0x5705A8
+// 0x5705A8 folder_max_lines
 static int gCharacterEditorFolderViewMaxLines;
 
-// 0x5705AC
+// 0x5705AC folder_line
 static int gCharacterEditorFolderViewCurrentLine;
 
-// 0x5705B0
+// 0x5705B0 folder_card_fid
 static int gCharacterEditorFolderCardFrmId;
 
-// 0x5705B4
+// 0x5705B4 folder_top_line
 static int gCharacterEditorFolderViewTopLine;
 
-// 0x5705B8
+// 0x5705B8 _folder_card_title
 static char* gCharacterEditorFolderCardTitle;
 
-// 0x5705BC
+// 0x5705BC _folder_card_title2
 static char* gCharacterEditorFolderCardSubtitle;
 
-// 0x5705C0
+// 0x5705C0 folder_yoffset
 static int gCharacterEditorFolderViewOffsetY;
 
-// 0x5705C4
+// 0x5705C4 folder_karma_top_line
 static int gCharacterEditorKarmaFolderTopLine;
 
-// 0x5705C8
+// 0x5705C8 folder_highlight_line
 static int gCharacterEditorFolderViewHighlightedLine;
 
-// 0x5705CC
+// 0x5705CC _folder_card_desc
 static char* gCharacterEditorFolderCardDescription;
 
-// 0x5705D0
+// 0x5705D0 folder_ypos
 static int gCharacterEditorFolderViewNextY;
 
-// 0x5705D4
+// 0x5705D4 folder_kills_top_line
 static int gCharacterEditorKillsFolderTopLine;
 
-// 0x5705D8
+// 0x5705D8 folder_perk_top_line
 static int gCharacterEditorPerkFolderTopLine;
 
-// 0x5705E0
+// 0x5705E0 pwin
 static int gPerkDialogWindow;
 
-// 0x5705E4
+// 0x5705E4 SliderPlusID
 static int gCharacterEditorSliderPlusBtn;
 
-// 0x5705E8
+// 0x5705E8 SliderNegID
 static int gCharacterEditorSliderMinusBtn;
 
 // - stats buttons
 //
-// 0x5705EC
+// 0x5705EC stat_bids_minus
 static int gCharacterEditorPrimaryStatMinusBtns[7];
 
-// 0x570608
+// 0x570608 win_buf
 static unsigned char* gCharacterEditorWindowBuffer;
 
-// 0x57060C
+// 0x57060C edit_win
 static int gCharacterEditorWindow;
 
 // + stats buttons
 //
-// 0x570610
+// 0x570610 stat_bids_plus
 static int gCharacterEditorPrimaryStatPlusBtns[7];
 
-// 0x57062C
+// 0x57062C pwin_buf
 static unsigned char* gPerkDialogWindowBuffer;
 
-// 0x570630
+// 0x570630 dude_data
 static CritterProtoData gCharacterEditorDudeDataBackup;
 
-// 0x5707A8
+// 0x5707A8 cline
 static int gPerkDialogCurrentLine;
 
-// 0x5707AC
+// 0x5707AC oldsline
 static int gPerkDialogPreviousCurrentLine;
 
 // unspent skill points
 //
-// 0x5707B0
+// 0x5707B0 upsent_points_back
 static int gCharacterEditorUnspentSkillPointsBackup;
 
-// 0x5707B4
+// 0x5707B4 last_level
 static int gCharacterEditorLastLevel;
 
-// 0x5707B8
+// 0x5707B8 fontsave_1
 static int gCharacterEditorOldFont;
 
-// 0x5707BC
+// 0x5707BC kills_count
 static int gCharacterEditorKillsCount;
 
 // current hit points
 //
-// 0x5707C4
+// 0x5707C4 hp_back
 static int gCharacterEditorHitPointsBackup;
 
-// 0x5707C8
+// 0x5707C8 mouse_ypos
 static int gCharacterEditorMouseY; // mouse y
 
-// 0x5707CC
+// 0x5707CC mouse_xpos
 static int gCharacterEditorMouseX; // mouse x
 
-// 0x5707D0
+// 0x5707D0 info_line
 static int characterEditorSelectedItem;
 
-// 0x5707D4
+// 0x5707D4 folder
 static int characterEditorWindowSelectedFolder;
 
-// 0x5707D8
+// 0x5707D8 frstc_draw1
 static bool gCharacterEditorCardDrawn;
 
-// 0x5707DC
+// 0x5707DC crow
 static int gPerkDialogTopLine;
 
-// 0x5707E0
+// 0x5707E0 frstc_draw2
 static bool gPerkDialogCardDrawn;
 
-// 0x5707E4
+// 0x5707E4 perk_back
 static int gCharacterEditorPerksBackup[PERK_COUNT];
 
-// 0x5709C0
+// 0x5709C0 repFtime
 static unsigned int _repFtime;
 
-// 0x5709C4
+// 0x5709C4 frame_time
 static unsigned int _frame_time;
 
-// 0x5709C8
+// 0x5709C8 old_tags
 static int gCharacterEditorOldTaggedSkillCount;
 
-// 0x5709CC
+// 0x5709CC last_level_back
 static int gCharacterEditorLastLevelBackup;
 
-// 0x5709E8
+// 0x5709E8 old_fid2
 static int gPerkDialogCardFrmId;
 
-// 0x5709EC
+// 0x5709EC old_fid1
 static int gCharacterEditorCardFrmId;
 
-// 0x5709D0
+// 0x5709D0 glblmode
 static bool gCharacterEditorIsCreationMode;
 
-// 0x5709D4
+// 0x5709D4 tag_skill_back
 static int gCharacterEditorTaggedSkillsBackup[NUM_TAGGED_SKILLS];
 
-// 0x5709F0
+// 0x5709F0 trait_back
 static int gCharacterEditorOptionalTraitsBackup[3];
 
 // current index for selecting new trait
 //
-// 0x5709FC
+// 0x5709FC trait_count
 static int gCharacterEditorTempTraitCount;
 
-// 0x570A00
+// 0x570A00 optrt_count
 static int gPerkDialogOptionCount;
 
-// 0x570A04
+// 0x570A04 temp_trait
 static int gCharacterEditorTempTraits[3];
 
-// 0x570A10
+// 0x570A10 tagskill_count
 static int gCharacterEditorTaggedSkillCount;
 
-// 0x570A14
+// 0x570A14 temp_tag_skill
 static int gCharacterEditorTempTaggedSkills[NUM_TAGGED_SKILLS];
 
-// 0x570A28
+// 0x570A28 free_perk_back
 static char gCharacterEditorHasFreePerkBackup;
 
-// 0x570A29
+// 0x570A29 free_perk
 static unsigned char gCharacterEditorHasFreePerk;
 
-// 0x570A2A
+// 0x570A2A first_skill_list
 static unsigned char gCharacterEditorIsSkillsFirstDraw;
 
 static FrmImage _editorBackgroundFrmImage;
@@ -790,7 +790,7 @@ struct CustomKarmaFolderDescription {
 static std::vector<CustomKarmaFolderDescription> gCustomKarmaFolderDescriptions;
 static std::vector<TownReputationEntry> gCustomTownReputationEntries;
 
-// 0x431DF8 editor_design_
+// 0x431DF8 editor_design
 int characterEditorShow(bool isCreationMode)
 {
     ScopedGameMode gm(!isCreationMode ? GameMode::kEditor : 0);
@@ -1204,7 +1204,7 @@ int characterEditorShow(bool isCreationMode)
     return rc;
 }
 
-// 0x4329EC CharEditStart_
+// 0x4329EC CharEditStart
 static int characterEditorWindowInit()
 {
     int i;
@@ -1832,7 +1832,7 @@ static int characterEditorWindowInit()
     return 0;
 }
 
-// 0x433AA8 CharEditEnd_
+// 0x433AA8 CharEditEnd
 static void characterEditorWindowFree()
 {
     if (gCharacterEditorFolderViewScrollDownBtn != -1) {
@@ -1893,7 +1893,7 @@ static void characterEditorWindowFree()
 }
 
 // CharEditInit
-// 0x433C0C CharEditInit_
+// 0x433C0C CharEditInit
 void characterEditorInit()
 {
     int i;
@@ -2013,7 +2013,7 @@ static int _get_input_str(int win, int cancelKeyCode, char* text, int maxLength,
     return rc;
 }
 
-// 0x434060 isdoschar_
+// 0x434060 isdoschar
 bool _isdoschar(int ch)
 {
     const char* punctuations = "#@!$`'~^&()-_=[]{}";
@@ -2034,7 +2034,7 @@ bool _isdoschar(int ch)
 
 // copy filename replacing extension
 //
-// 0x4340D0 strmfe_
+// 0x4340D0 strmfe
 char* _strmfe(char* dest, const char* name, const char* ext)
 {
     char* save = dest;
@@ -2050,7 +2050,7 @@ char* _strmfe(char* dest, const char* name, const char* ext)
     return save;
 }
 
-// 0x43410C DrawFolder_
+// 0x43410C DrawFolder
 static void characterEditorDrawFolders()
 {
     if (gCharacterEditorIsCreationMode) {
@@ -2095,7 +2095,7 @@ static void characterEditorDrawFolders()
     }
 }
 
-// 0x434238 list_perks_
+// 0x434238 list_perks
 static void characterEditorDrawPerksFolder()
 {
     const char* string;
@@ -2185,7 +2185,7 @@ static void characterEditorDrawPerksFolder()
     }
 }
 
-// 0x434498 kills_list_comp_
+// 0x434498 kills_list_comp
 static int characterEditorKillsCompare(const void* a1, const void* a2)
 {
     const KillInfo* v1 = (const KillInfo*)a1;
@@ -2193,7 +2193,7 @@ static int characterEditorKillsCompare(const void* a1, const void* a2)
     return compat_stricmp(v1->name, v2->name);
 }
 
-// 0x4344A4 ListKills_
+// 0x4344A4 ListKills
 static int characterEditorDrawKillsFolder()
 {
     int i;
@@ -2241,7 +2241,7 @@ static int characterEditorDrawKillsFolder()
     return usedKills;
 }
 
-// 0x4345DC PrintBigNum_
+// 0x4345DC PrintBigNum
 static void characterEditorDrawBigNumber(int x, int y, int flags, int value, int previousValue, int windowHandle)
 {
     Rect rect;
@@ -2351,7 +2351,7 @@ static void characterEditorDrawBigNumber(int x, int y, int flags, int value, int
     }
 }
 
-// 0x434920 PrintLevelWin_
+// 0x434920 PrintLevelWin
 static void characterEditorDrawPcStats()
 {
     int color;
@@ -2434,7 +2434,7 @@ static void characterEditorDrawPcStats()
     fontDrawText(gCharacterEditorWindowBuffer + 640 * y + 32, stringBuffer, 640, 640, color);
 }
 
-// 0x434B38 PrintBasicStat_
+// 0x434B38 PrintBasicStat
 static void characterEditorDrawPrimaryStat(int stat, bool animate, int previousValue)
 {
     int off;
@@ -2503,7 +2503,7 @@ static void characterEditorDrawPrimaryStat(int stat, bool animate, int previousV
     }
 }
 
-// 0x434F18 PrintGender_
+// 0x434F18 PrintGender
 static void characterEditorDrawGender()
 {
     int gender;
@@ -2533,7 +2533,7 @@ static void characterEditorDrawGender()
     fontDrawText(gCharacterEditorFrmCopy[EDITOR_GRAPHIC_SEX_OFF] + x, text, width, width, _colorTable[18979]);
 }
 
-// 0x43501C PrintAgeBig_
+// 0x43501C PrintAgeBig
 static void characterEditorDrawAge()
 {
     int age;
@@ -2563,7 +2563,7 @@ static void characterEditorDrawAge()
     fontDrawText(gCharacterEditorFrmCopy[EDITOR_GRAPHIC_AGE_OFF] + x, text, width, width, _colorTable[18979]);
 }
 
-// 0x435118 PrintBigname_
+// 0x435118 PrintBigname
 static void characterEditorDrawName()
 {
     char* str;
@@ -2619,7 +2619,7 @@ static void characterEditorDrawName()
     fontDrawText(gCharacterEditorFrmCopy[EDITOR_GRAPHIC_NAME_OFF] + x, text, width, width, _colorTable[18979]);
 }
 
-// 0x43527C ListDrvdStats_
+// 0x43527C ListDrvdStats
 static void characterEditorDrawDerivedStats()
 {
     int conditions;
@@ -2920,7 +2920,7 @@ static void characterEditorDrawDerivedStats()
     fontDrawText(gCharacterEditorWindowBuffer + 640 * y + 288, t, 640, 640, color);
 }
 
-// 0x436154 ListSkills_
+// 0x436154 ListSkills
 static void characterEditorDrawSkills(int a1)
 {
     int selectedSkill = -1;
@@ -3053,7 +3053,7 @@ static void characterEditorDrawSkills(int a1)
     }
 }
 
-// 0x4365AC DrawInfoWin_
+// 0x4365AC DrawInfoWin
 static void characterEditorDrawCard()
 {
     int graphicId;
@@ -3198,7 +3198,7 @@ static void characterEditorDrawCard()
     }
 }
 
-// 0x436C4C NameWindow_
+// 0x436C4C NameWindow
 static int characterEditorEditName()
 {
     char* text;
@@ -3298,7 +3298,7 @@ static int characterEditorEditName()
     return 0;
 }
 
-// 0x436F70 PrintName_
+// 0x436F70 PrintName
 static void _PrintName(unsigned char* buf, int pitch)
 {
     char str[64];
@@ -3316,7 +3316,7 @@ static void _PrintName(unsigned char* buf, int pitch)
     fontDrawText(buf + 19 * pitch + 21, str, pitch, pitch, _colorTable[992]);
 }
 
-// 0x436FEC AgeWindow_
+// 0x436FEC AgeWindow
 static int characterEditorEditAge()
 {
     int win;
@@ -3567,7 +3567,7 @@ static int characterEditorEditAge()
     return 0;
 }
 
-// 0x437664 SexWindow_
+// 0x437664 SexWindow
 static void characterEditorEditGender()
 {
     char* text;
@@ -3710,7 +3710,7 @@ static void characterEditorEditGender()
     windowDestroy(win);
 }
 
-// 0x4379BC StatButton_
+// 0x4379BC StatButton
 static void characterEditorAdjustPrimaryStat(int eventCode)
 {
     _repFtime = 4;
@@ -3792,7 +3792,7 @@ static void characterEditorAdjustPrimaryStat(int eventCode)
 
 // handle options dialog
 //
-// 0x437C08 OptionWindow_
+// 0x437C08 OptionWindow
 static int characterEditorShowOptions()
 {
     int width = _editorFrmImages[43].getWidth();
@@ -4267,7 +4267,7 @@ static int characterEditorShowOptions()
     return 0;
 }
 
-// 0x4390B4 db_access_
+// 0x4390B4 db_access
 static bool characterFileExists(const char* fname)
 {
     File* stream = fileOpen(fname, "rb");
@@ -4279,7 +4279,7 @@ static bool characterFileExists(const char* fname)
     return true;
 }
 
-// 0x4390D0 Save_as_ASCII_
+// 0x4390D0 Save_as_ASCII
 static int characterPrintToFile(const char* fileName)
 {
     File* stream = fileOpen(fileName, "wt");
@@ -4730,7 +4730,7 @@ static int characterPrintToFile(const char* fileName)
     return 0;
 }
 
-// 0x43A55C AddSpaces_
+// 0x43A55C AddSpaces
 static char* _AddSpaces(char* string, int length)
 {
     char* pch = string + strlen(string);
@@ -4746,7 +4746,7 @@ static char* _AddSpaces(char* string, int length)
 
 // NOTE: Inlined.
 //
-// 0x43A58C AddDots_
+// 0x43A58C AddDots
 static char* _AddDots(char* string, int length)
 {
     char* pch = string + strlen(string);
@@ -4760,7 +4760,7 @@ static char* _AddDots(char* string, int length)
     return string;
 }
 
-// 0x43A4BC ResetScreen_
+// 0x43A4BC ResetScreen
 static void characterEditorResetScreen()
 {
     characterEditorSelectedItem = 0;
@@ -4786,7 +4786,7 @@ static void characterEditorResetScreen()
     windowRefresh(gCharacterEditorWindow);
 }
 
-// 0x43A5BC RegInfoAreas_
+// 0x43A5BC RegInfoAreas
 static void characterEditorRegisterInfoAreas()
 {
     buttonCreate(gCharacterEditorWindow, 19, 38, 125, 227, -1, -1, 525, -1, nullptr, nullptr, nullptr, 0);
@@ -4808,7 +4808,7 @@ static void characterEditorRegisterInfoAreas()
 
 // copy character to editor
 //
-// 0x43A7DC SavePlayer_
+// 0x43A7DC SavePlayer
 static void characterEditorSavePlayer()
 {
     Proto* proto;
@@ -4839,7 +4839,7 @@ static void characterEditorSavePlayer()
 
 // copy editor to character
 //
-// 0x43A8BC RestorePlayer_
+// 0x43A8BC RestorePlayer
 static void characterEditorRestorePlayer()
 {
     Proto* proto;
@@ -4897,7 +4897,7 @@ static void characterEditorRestorePlayer()
     critterAdjustHitPoints(gDude, gCharacterEditorHitPointsBackup - cur_hp);
 }
 
-// 0x43A9CC itostndn_
+// 0x43A9CC itostndn
 static char* _itostndn(int value, char* dest)
 {
     int v16[7];
@@ -4932,7 +4932,7 @@ static char* _itostndn(int value, char* dest)
     return savedDest;
 }
 
-// 0x43AAEC DrawCard_
+// 0x43AAEC DrawCard
 static int characterEditorDrawCardWithOptions(int graphicId, const char* name, const char* attributes, char* description)
 {
     FrmImage frmImage;
@@ -5035,7 +5035,7 @@ static void characterEditorHandleFolderButtonPressed()
     characterEditorDrawCard();
 }
 
-// 0x43AF40 InfoButton_
+// 0x43AF40 InfoButton
 static void characterEditorHandleInfoButtonPressed(int eventCode)
 {
     mouseGetPositionInWindow(gCharacterEditorWindow, &gCharacterEditorMouseX, &gCharacterEditorMouseY);
@@ -5159,7 +5159,7 @@ static void characterEditorHandleInfoButtonPressed(int eventCode)
     characterEditorDrawCard();
 }
 
-// 0x43B230 SliderBtn_
+// 0x43B230 SliderBtn
 static void characterEditorHandleAdjustSkillButtonPressed(int keyCode)
 {
     if (gCharacterEditorIsCreationMode) {
@@ -5292,7 +5292,7 @@ static void characterEditorHandleAdjustSkillButtonPressed(int keyCode)
     }
 }
 
-// 0x43B67C TagSkillSelect_
+// 0x43B67C TagSkillSelect
 static void characterEditorToggleTaggedSkill(int skill)
 {
     int insertionIndex;
@@ -5368,7 +5368,7 @@ static void characterEditorToggleTaggedSkill(int skill)
     windowRefresh(gCharacterEditorWindow);
 }
 
-// 0x43B8A8 ListTraits_
+// 0x43B8A8 ListTraits
 static void characterEditorDrawOptionalTraits()
 {
     int v0 = -1;
@@ -5446,7 +5446,7 @@ static void characterEditorDrawOptionalTraits()
     }
 }
 
-// 0x43BB0C TraitSelect_
+// 0x43BB0C TraitSelect
 static void characterEditorToggleOptionalTrait(int trait)
 {
     if (trait == gCharacterEditorTempTraits[0] || trait == gCharacterEditorTempTraits[1]) {
@@ -5498,7 +5498,7 @@ static void characterEditorToggleOptionalTrait(int trait)
     windowRefresh(gCharacterEditorWindow);
 }
 
-// 0x43BCE0 list_karma_
+// 0x43BCE0 list_karma
 static void characterEditorDrawKarmaFolder()
 {
     char* msg;
@@ -5651,7 +5651,7 @@ static void characterEditorDrawKarmaFolder()
     }
 }
 
-// 0x43C1B0 editor_save_
+// 0x43C1B0 editor_save
 int characterEditorSave(File* stream)
 {
     if (fileWriteInt32(stream, gCharacterEditorLastLevel) == -1)
@@ -5662,7 +5662,7 @@ int characterEditorSave(File* stream)
     return 0;
 }
 
-// 0x43C1E0 editor_load_
+// 0x43C1E0 editor_load
 int characterEditorLoad(File* stream)
 {
     if (fileReadInt32(stream, &gCharacterEditorLastLevel) == -1)
@@ -5673,7 +5673,7 @@ int characterEditorLoad(File* stream)
     return 0;
 }
 
-// 0x43C20C editor_reset_
+// 0x43C20C editor_reset
 void characterEditorReset()
 {
     gCharacterEditorRemainingCharacterPoints = 5;
@@ -5682,7 +5682,7 @@ void characterEditorReset()
 
 // level up if needed
 //
-// 0x43C228 UpdateLevel_
+// 0x43C228 UpdateLevel
 static int characterEditorUpdateLevel()
 {
     int level = pcGetStat(PC_STAT_LEVEL);
@@ -5750,7 +5750,7 @@ static int characterEditorUpdateLevel()
     return 1;
 }
 
-// 0x43C398 RedrwDPrks_
+// 0x43C398 RedrwDPrks
 static void perkDialogRefreshPerks()
 {
     blitBufferToBuffer(
@@ -5782,7 +5782,7 @@ static void perkDialogRefreshPerks()
     windowRefresh(gPerkDialogWindow);
 }
 
-// 0x43C4F0 perks_dialog_
+// 0x43C4F0 perks_dialog
 static int perkDialogShow()
 {
     gPerkDialogTopLine = 0;
@@ -5978,7 +5978,7 @@ static int perkDialogShow()
     return rc;
 }
 
-// 0x43CACC InputPDLoop_
+// 0x43CACC
 static int perkDialogHandleInput(int count, void (*refreshProc)())
 {
     fontSetCurrent(101);
@@ -6257,7 +6257,7 @@ static int perkDialogHandleInput(int count, void (*refreshProc)())
     return rc;
 }
 
-// 0x43D0BC ListDPerks_
+// 0x43D0BC ListDPerks
 static int perkDialogDrawPerks()
 {
     blitBufferToBuffer(
@@ -6319,7 +6319,7 @@ static int perkDialogDrawPerks()
     return count;
 }
 
-// 0x43D2F8 RedrwDMPrk_
+// 0x43D2F8 RedrwDMPrk
 static void perkDialogRefreshTraits()
 {
     blitBufferToBuffer(_perkDialogBackgroundFrmImage.getData() + 280,
@@ -6339,7 +6339,7 @@ static void perkDialogRefreshTraits()
     windowRefresh(gPerkDialogWindow);
 }
 
-// 0x43D38C GetMutateTrait_
+// 0x43D38C GetMutateTrait
 static bool perkDialogHandleMutatePerk()
 {
     gPerkDialogCardFrmId = -1;
@@ -6452,7 +6452,7 @@ static bool perkDialogHandleMutatePerk()
     return result;
 }
 
-// 0x43D668 RedrwDMTagSkl_
+// 0x43D668 RedrwDMTagSkl
 static void perkDialogRefreshSkills()
 {
     blitBufferToBuffer(_perkDialogBackgroundFrmImage.getData() + 280,
@@ -6472,7 +6472,7 @@ static void perkDialogRefreshSkills()
     windowRefresh(gPerkDialogWindow);
 }
 
-// 0x43D6F8 Add4thTagSkill_
+// 0x43D6F8 Add4thTagSkill
 static bool perkDialogHandleTagPerk()
 {
     fontSetCurrent(103);
@@ -6508,7 +6508,7 @@ static bool perkDialogHandleTagPerk()
     return true;
 }
 
-// 0x43D81C ListNewTagSkills_
+// 0x43D81C ListNewTagSkills
 static void perkDialogDrawSkills()
 {
     blitBufferToBuffer(_perkDialogBackgroundFrmImage.getData() + PERK_WINDOW_WIDTH * 43 + 45,
@@ -6548,7 +6548,7 @@ static void perkDialogDrawSkills()
     }
 }
 
-// 0x43D960 ListMyTraits_
+// 0x43D960 ListMyTraits
 static int perkDialogDrawTraits(int a1)
 {
     blitBufferToBuffer(_perkDialogBackgroundFrmImage.getData() + PERK_WINDOW_WIDTH * 43 + 45,
@@ -6612,7 +6612,7 @@ static int perkDialogDrawTraits(int a1)
     return 0;
 }
 
-// 0x43DB48 name_sort_comp_
+// 0x43DB48 name_sort_comp
 static int perkDialogOptionCompare(const void* a1, const void* a2)
 {
     PerkDialogOption* v1 = (PerkDialogOption*)a1;
@@ -6620,7 +6620,7 @@ static int perkDialogOptionCompare(const void* a1, const void* a2)
     return strcmp(v1->name, v2->name);
 }
 
-// 0x43DB54 DrawCard2_
+// 0x43DB54 DrawCard2
 static int perkDialogDrawCard(int frmId, const char* name, const char* rank, char* description)
 {
     FrmImage frmImage;
@@ -6714,7 +6714,7 @@ static int perkDialogDrawCard(int frmId, const char* name, const char* rank, cha
 
 // copy editor perks to character
 //
-// 0x43DEBC pop_perks_
+// 0x43DEBC pop_perks
 static void _pop_perks()
 {
     for (int perk = 0; perk < PERK_COUNT; perk++) {
@@ -6742,7 +6742,7 @@ static void _pop_perks()
 
 // validate SPECIAL stats are <= 10
 //
-// 0x43DF50 is_supper_bonus_
+// 0x43DF50 is_supper_bonus
 static int _is_supper_bonus()
 {
     for (int stat = 0; stat < 7; stat++) {
@@ -6756,7 +6756,7 @@ static int _is_supper_bonus()
     return 0;
 }
 
-// 0x43DF8C folder_init_
+// 0x43DF8C folder_init
 static int characterEditorFolderViewInit()
 {
     gCharacterEditorKarmaFolderTopLine = 0;
@@ -6797,7 +6797,7 @@ static int characterEditorFolderViewInit()
     return 0;
 }
 
-// 0x43E0D4 folder_scroll_
+// 0x43E0D4 folder_scroll
 static void characterEditorFolderViewScroll(int direction)
 {
     int* v1;
@@ -6847,7 +6847,7 @@ static void characterEditorFolderViewScroll(int direction)
     }
 }
 
-// 0x43E200 folder_clear_
+// 0x43E200 folder_clear
 static void characterEditorFolderViewClear()
 {
     int v0;
@@ -6879,7 +6879,7 @@ static void characterEditorFolderViewClear()
 
 // render heading string with line
 //
-// 0x43E28C folder_print_seperator_
+// 0x43E28C folder_print_seperator
 static int characterEditorFolderViewDrawHeading(const char* string)
 {
     int lineHeight;
@@ -6915,7 +6915,7 @@ static int characterEditorFolderViewDrawHeading(const char* string)
     }
 }
 
-// 0x43E3D8 folder_print_line_
+// 0x43E3D8 folder_print_line
 static bool characterEditorFolderViewDrawString(const char* string)
 {
     bool success = false;
@@ -6940,7 +6940,7 @@ static bool characterEditorFolderViewDrawString(const char* string)
     return success;
 }
 
-// 0x43E470 folder_print_kill_
+// 0x43E470 folder_print_kill
 static bool characterEditorFolderViewDrawKillsEntry(const char* name, int kills)
 {
     char killsString[8];
@@ -6979,7 +6979,7 @@ static bool characterEditorFolderViewDrawKillsEntry(const char* name, int kills)
     return success;
 }
 
-// 0x43E5C4 karma_vars_init_
+// 0x43E5C4 karma_vars_init
 static int karmaInit()
 {
     const char* delim = " \t,";
@@ -7059,7 +7059,7 @@ static int karmaInit()
 
 // NOTE: Inlined.
 //
-// 0x43E764 karma_vars_exit_
+// 0x43E764 karma_vars_exit
 static void karmaFree()
 {
     if (gKarmaEntries != nullptr) {
@@ -7070,7 +7070,7 @@ static void karmaFree()
     gKarmaEntriesLength = 0;
 }
 
-// 0x43E78C karma_vars_qsort_compare_
+// 0x43E78C karma_vars_qsort_compare
 static int karmaEntryCompare(const void* a1, const void* a2)
 {
     KarmaEntry* v1 = (KarmaEntry*)a1;
@@ -7078,7 +7078,7 @@ static int karmaEntryCompare(const void* a1, const void* a2)
     return v1->gvar - v2->gvar;
 }
 
-// 0x43E798 general_reps_init_
+// 0x43E798 general_reps_init
 static int genericReputationInit()
 {
     const char* delim = " \t,";
@@ -7144,7 +7144,7 @@ static int genericReputationInit()
 
 // NOTE: Inlined.
 //
-// 0x43E914 general_reps_exit_
+// 0x43E914 general_reps_exit
 static void genericReputationFree()
 {
     if (gGenericReputationEntries != nullptr) {
@@ -7155,7 +7155,7 @@ static void genericReputationFree()
     gGenericReputationEntriesLength = 0;
 }
 
-// 0x43E93C general_reps_qsort_compare_
+// 0x43E93C general_reps_qsort_compare
 static int genericReputationCompare(const void* a1, const void* a2)
 {
     GenericReputationEntry* v1 = (GenericReputationEntry*)a1;

--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -790,7 +790,7 @@ struct CustomKarmaFolderDescription {
 static std::vector<CustomKarmaFolderDescription> gCustomKarmaFolderDescriptions;
 static std::vector<TownReputationEntry> gCustomTownReputationEntries;
 
-// 0x431DF8
+// 0x431DF8 editor_design_
 int characterEditorShow(bool isCreationMode)
 {
     ScopedGameMode gm(!isCreationMode ? GameMode::kEditor : 0);
@@ -1204,7 +1204,7 @@ int characterEditorShow(bool isCreationMode)
     return rc;
 }
 
-// 0x4329EC
+// 0x4329EC CharEditStart_
 static int characterEditorWindowInit()
 {
     int i;
@@ -1832,7 +1832,7 @@ static int characterEditorWindowInit()
     return 0;
 }
 
-// 0x433AA8
+// 0x433AA8 CharEditEnd_
 static void characterEditorWindowFree()
 {
     if (gCharacterEditorFolderViewScrollDownBtn != -1) {
@@ -1893,7 +1893,7 @@ static void characterEditorWindowFree()
 }
 
 // CharEditInit
-// 0x433C0C
+// 0x433C0C CharEditInit_
 void characterEditorInit()
 {
     int i;
@@ -2013,7 +2013,7 @@ static int _get_input_str(int win, int cancelKeyCode, char* text, int maxLength,
     return rc;
 }
 
-// 0x434060
+// 0x434060 isdoschar_
 bool _isdoschar(int ch)
 {
     const char* punctuations = "#@!$`'~^&()-_=[]{}";
@@ -2034,7 +2034,7 @@ bool _isdoschar(int ch)
 
 // copy filename replacing extension
 //
-// 0x4340D0
+// 0x4340D0 strmfe_
 char* _strmfe(char* dest, const char* name, const char* ext)
 {
     char* save = dest;
@@ -2050,7 +2050,7 @@ char* _strmfe(char* dest, const char* name, const char* ext)
     return save;
 }
 
-// 0x43410C
+// 0x43410C DrawFolder_
 static void characterEditorDrawFolders()
 {
     if (gCharacterEditorIsCreationMode) {
@@ -2095,7 +2095,7 @@ static void characterEditorDrawFolders()
     }
 }
 
-// 0x434238
+// 0x434238 list_perks_
 static void characterEditorDrawPerksFolder()
 {
     const char* string;
@@ -2185,7 +2185,7 @@ static void characterEditorDrawPerksFolder()
     }
 }
 
-// 0x434498
+// 0x434498 kills_list_comp_
 static int characterEditorKillsCompare(const void* a1, const void* a2)
 {
     const KillInfo* v1 = (const KillInfo*)a1;
@@ -2193,7 +2193,7 @@ static int characterEditorKillsCompare(const void* a1, const void* a2)
     return compat_stricmp(v1->name, v2->name);
 }
 
-// 0x4344A4
+// 0x4344A4 ListKills_
 static int characterEditorDrawKillsFolder()
 {
     int i;
@@ -2241,7 +2241,7 @@ static int characterEditorDrawKillsFolder()
     return usedKills;
 }
 
-// 0x4345DC
+// 0x4345DC PrintBigNum_
 static void characterEditorDrawBigNumber(int x, int y, int flags, int value, int previousValue, int windowHandle)
 {
     Rect rect;
@@ -2351,7 +2351,7 @@ static void characterEditorDrawBigNumber(int x, int y, int flags, int value, int
     }
 }
 
-// 0x434920
+// 0x434920 PrintLevelWin_
 static void characterEditorDrawPcStats()
 {
     int color;
@@ -2434,7 +2434,7 @@ static void characterEditorDrawPcStats()
     fontDrawText(gCharacterEditorWindowBuffer + 640 * y + 32, stringBuffer, 640, 640, color);
 }
 
-// 0x434B38
+// 0x434B38 PrintBasicStat_
 static void characterEditorDrawPrimaryStat(int stat, bool animate, int previousValue)
 {
     int off;
@@ -2503,7 +2503,7 @@ static void characterEditorDrawPrimaryStat(int stat, bool animate, int previousV
     }
 }
 
-// 0x434F18
+// 0x434F18 PrintGender_
 static void characterEditorDrawGender()
 {
     int gender;
@@ -2533,7 +2533,7 @@ static void characterEditorDrawGender()
     fontDrawText(gCharacterEditorFrmCopy[EDITOR_GRAPHIC_SEX_OFF] + x, text, width, width, _colorTable[18979]);
 }
 
-// 0x43501C
+// 0x43501C PrintAgeBig_
 static void characterEditorDrawAge()
 {
     int age;
@@ -2563,7 +2563,7 @@ static void characterEditorDrawAge()
     fontDrawText(gCharacterEditorFrmCopy[EDITOR_GRAPHIC_AGE_OFF] + x, text, width, width, _colorTable[18979]);
 }
 
-// 0x435118
+// 0x435118 PrintBigname_
 static void characterEditorDrawName()
 {
     char* str;
@@ -2619,7 +2619,7 @@ static void characterEditorDrawName()
     fontDrawText(gCharacterEditorFrmCopy[EDITOR_GRAPHIC_NAME_OFF] + x, text, width, width, _colorTable[18979]);
 }
 
-// 0x43527C
+// 0x43527C ListDrvdStats_
 static void characterEditorDrawDerivedStats()
 {
     int conditions;
@@ -2920,7 +2920,7 @@ static void characterEditorDrawDerivedStats()
     fontDrawText(gCharacterEditorWindowBuffer + 640 * y + 288, t, 640, 640, color);
 }
 
-// 0x436154
+// 0x436154 ListSkills_
 static void characterEditorDrawSkills(int a1)
 {
     int selectedSkill = -1;
@@ -3053,7 +3053,7 @@ static void characterEditorDrawSkills(int a1)
     }
 }
 
-// 0x4365AC
+// 0x4365AC DrawInfoWin_
 static void characterEditorDrawCard()
 {
     int graphicId;
@@ -3198,7 +3198,7 @@ static void characterEditorDrawCard()
     }
 }
 
-// 0x436C4C
+// 0x436C4C NameWindow_
 static int characterEditorEditName()
 {
     char* text;
@@ -3298,7 +3298,7 @@ static int characterEditorEditName()
     return 0;
 }
 
-// 0x436F70
+// 0x436F70 PrintName_
 static void _PrintName(unsigned char* buf, int pitch)
 {
     char str[64];
@@ -3316,7 +3316,7 @@ static void _PrintName(unsigned char* buf, int pitch)
     fontDrawText(buf + 19 * pitch + 21, str, pitch, pitch, _colorTable[992]);
 }
 
-// 0x436FEC
+// 0x436FEC AgeWindow_
 static int characterEditorEditAge()
 {
     int win;
@@ -3567,7 +3567,7 @@ static int characterEditorEditAge()
     return 0;
 }
 
-// 0x437664
+// 0x437664 SexWindow_
 static void characterEditorEditGender()
 {
     char* text;
@@ -3710,7 +3710,7 @@ static void characterEditorEditGender()
     windowDestroy(win);
 }
 
-// 0x4379BC
+// 0x4379BC StatButton_
 static void characterEditorAdjustPrimaryStat(int eventCode)
 {
     _repFtime = 4;
@@ -3792,7 +3792,7 @@ static void characterEditorAdjustPrimaryStat(int eventCode)
 
 // handle options dialog
 //
-// 0x437C08
+// 0x437C08 OptionWindow_
 static int characterEditorShowOptions()
 {
     int width = _editorFrmImages[43].getWidth();
@@ -4267,7 +4267,7 @@ static int characterEditorShowOptions()
     return 0;
 }
 
-// 0x4390B4
+// 0x4390B4 db_access_
 static bool characterFileExists(const char* fname)
 {
     File* stream = fileOpen(fname, "rb");
@@ -4279,7 +4279,7 @@ static bool characterFileExists(const char* fname)
     return true;
 }
 
-// 0x4390D0
+// 0x4390D0 Save_as_ASCII_
 static int characterPrintToFile(const char* fileName)
 {
     File* stream = fileOpen(fileName, "wt");
@@ -4730,7 +4730,7 @@ static int characterPrintToFile(const char* fileName)
     return 0;
 }
 
-// 0x43A55C
+// 0x43A55C AddSpaces_
 static char* _AddSpaces(char* string, int length)
 {
     char* pch = string + strlen(string);
@@ -4746,7 +4746,7 @@ static char* _AddSpaces(char* string, int length)
 
 // NOTE: Inlined.
 //
-// 0x43A58C
+// 0x43A58C AddDots_
 static char* _AddDots(char* string, int length)
 {
     char* pch = string + strlen(string);
@@ -4760,7 +4760,7 @@ static char* _AddDots(char* string, int length)
     return string;
 }
 
-// 0x43A4BC
+// 0x43A4BC ResetScreen_
 static void characterEditorResetScreen()
 {
     characterEditorSelectedItem = 0;
@@ -4786,7 +4786,7 @@ static void characterEditorResetScreen()
     windowRefresh(gCharacterEditorWindow);
 }
 
-// 0x43A5BC
+// 0x43A5BC RegInfoAreas_
 static void characterEditorRegisterInfoAreas()
 {
     buttonCreate(gCharacterEditorWindow, 19, 38, 125, 227, -1, -1, 525, -1, nullptr, nullptr, nullptr, 0);
@@ -4808,7 +4808,7 @@ static void characterEditorRegisterInfoAreas()
 
 // copy character to editor
 //
-// 0x43A7DC
+// 0x43A7DC SavePlayer_
 static void characterEditorSavePlayer()
 {
     Proto* proto;
@@ -4839,7 +4839,7 @@ static void characterEditorSavePlayer()
 
 // copy editor to character
 //
-// 0x43A8BC
+// 0x43A8BC RestorePlayer_
 static void characterEditorRestorePlayer()
 {
     Proto* proto;
@@ -4897,7 +4897,7 @@ static void characterEditorRestorePlayer()
     critterAdjustHitPoints(gDude, gCharacterEditorHitPointsBackup - cur_hp);
 }
 
-// 0x43A9CC
+// 0x43A9CC itostndn_
 static char* _itostndn(int value, char* dest)
 {
     int v16[7];
@@ -4932,7 +4932,7 @@ static char* _itostndn(int value, char* dest)
     return savedDest;
 }
 
-// 0x43AAEC
+// 0x43AAEC DrawCard_
 static int characterEditorDrawCardWithOptions(int graphicId, const char* name, const char* attributes, char* description)
 {
     FrmImage frmImage;
@@ -5035,7 +5035,7 @@ static void characterEditorHandleFolderButtonPressed()
     characterEditorDrawCard();
 }
 
-// 0x43AF40
+// 0x43AF40 InfoButton_
 static void characterEditorHandleInfoButtonPressed(int eventCode)
 {
     mouseGetPositionInWindow(gCharacterEditorWindow, &gCharacterEditorMouseX, &gCharacterEditorMouseY);
@@ -5159,7 +5159,7 @@ static void characterEditorHandleInfoButtonPressed(int eventCode)
     characterEditorDrawCard();
 }
 
-// 0x43B230
+// 0x43B230 SliderBtn_
 static void characterEditorHandleAdjustSkillButtonPressed(int keyCode)
 {
     if (gCharacterEditorIsCreationMode) {
@@ -5292,7 +5292,7 @@ static void characterEditorHandleAdjustSkillButtonPressed(int keyCode)
     }
 }
 
-// 0x43B67C
+// 0x43B67C TagSkillSelect_
 static void characterEditorToggleTaggedSkill(int skill)
 {
     int insertionIndex;
@@ -5368,7 +5368,7 @@ static void characterEditorToggleTaggedSkill(int skill)
     windowRefresh(gCharacterEditorWindow);
 }
 
-// 0x43B8A8
+// 0x43B8A8 ListTraits_
 static void characterEditorDrawOptionalTraits()
 {
     int v0 = -1;
@@ -5446,7 +5446,7 @@ static void characterEditorDrawOptionalTraits()
     }
 }
 
-// 0x43BB0C
+// 0x43BB0C TraitSelect_
 static void characterEditorToggleOptionalTrait(int trait)
 {
     if (trait == gCharacterEditorTempTraits[0] || trait == gCharacterEditorTempTraits[1]) {
@@ -5498,7 +5498,7 @@ static void characterEditorToggleOptionalTrait(int trait)
     windowRefresh(gCharacterEditorWindow);
 }
 
-// 0x43BCE0
+// 0x43BCE0 list_karma_
 static void characterEditorDrawKarmaFolder()
 {
     char* msg;
@@ -5651,7 +5651,7 @@ static void characterEditorDrawKarmaFolder()
     }
 }
 
-// 0x43C1B0
+// 0x43C1B0 editor_save_
 int characterEditorSave(File* stream)
 {
     if (fileWriteInt32(stream, gCharacterEditorLastLevel) == -1)
@@ -5662,7 +5662,7 @@ int characterEditorSave(File* stream)
     return 0;
 }
 
-// 0x43C1E0
+// 0x43C1E0 editor_load_
 int characterEditorLoad(File* stream)
 {
     if (fileReadInt32(stream, &gCharacterEditorLastLevel) == -1)
@@ -5673,7 +5673,7 @@ int characterEditorLoad(File* stream)
     return 0;
 }
 
-// 0x43C20C
+// 0x43C20C editor_reset_
 void characterEditorReset()
 {
     gCharacterEditorRemainingCharacterPoints = 5;
@@ -5682,7 +5682,7 @@ void characterEditorReset()
 
 // level up if needed
 //
-// 0x43C228
+// 0x43C228 UpdateLevel_
 static int characterEditorUpdateLevel()
 {
     int level = pcGetStat(PC_STAT_LEVEL);
@@ -5750,7 +5750,7 @@ static int characterEditorUpdateLevel()
     return 1;
 }
 
-// 0x43C398
+// 0x43C398 RedrwDPrks_
 static void perkDialogRefreshPerks()
 {
     blitBufferToBuffer(
@@ -5782,7 +5782,7 @@ static void perkDialogRefreshPerks()
     windowRefresh(gPerkDialogWindow);
 }
 
-// 0x43C4F0
+// 0x43C4F0 perks_dialog_
 static int perkDialogShow()
 {
     gPerkDialogTopLine = 0;
@@ -5978,7 +5978,7 @@ static int perkDialogShow()
     return rc;
 }
 
-// 0x43CACC
+// 0x43CACC InputPDLoop_
 static int perkDialogHandleInput(int count, void (*refreshProc)())
 {
     fontSetCurrent(101);
@@ -6257,7 +6257,7 @@ static int perkDialogHandleInput(int count, void (*refreshProc)())
     return rc;
 }
 
-// 0x43D0BC
+// 0x43D0BC ListDPerks_
 static int perkDialogDrawPerks()
 {
     blitBufferToBuffer(
@@ -6319,7 +6319,7 @@ static int perkDialogDrawPerks()
     return count;
 }
 
-// 0x43D2F8
+// 0x43D2F8 RedrwDMPrk_
 static void perkDialogRefreshTraits()
 {
     blitBufferToBuffer(_perkDialogBackgroundFrmImage.getData() + 280,
@@ -6339,7 +6339,7 @@ static void perkDialogRefreshTraits()
     windowRefresh(gPerkDialogWindow);
 }
 
-// 0x43D38C
+// 0x43D38C GetMutateTrait_
 static bool perkDialogHandleMutatePerk()
 {
     gPerkDialogCardFrmId = -1;
@@ -6452,7 +6452,7 @@ static bool perkDialogHandleMutatePerk()
     return result;
 }
 
-// 0x43D668
+// 0x43D668 RedrwDMTagSkl_
 static void perkDialogRefreshSkills()
 {
     blitBufferToBuffer(_perkDialogBackgroundFrmImage.getData() + 280,
@@ -6472,7 +6472,7 @@ static void perkDialogRefreshSkills()
     windowRefresh(gPerkDialogWindow);
 }
 
-// 0x43D6F8
+// 0x43D6F8 Add4thTagSkill_
 static bool perkDialogHandleTagPerk()
 {
     fontSetCurrent(103);
@@ -6508,7 +6508,7 @@ static bool perkDialogHandleTagPerk()
     return true;
 }
 
-// 0x43D81C
+// 0x43D81C ListNewTagSkills_
 static void perkDialogDrawSkills()
 {
     blitBufferToBuffer(_perkDialogBackgroundFrmImage.getData() + PERK_WINDOW_WIDTH * 43 + 45,
@@ -6548,7 +6548,7 @@ static void perkDialogDrawSkills()
     }
 }
 
-// 0x43D960
+// 0x43D960 ListMyTraits_
 static int perkDialogDrawTraits(int a1)
 {
     blitBufferToBuffer(_perkDialogBackgroundFrmImage.getData() + PERK_WINDOW_WIDTH * 43 + 45,
@@ -6612,7 +6612,7 @@ static int perkDialogDrawTraits(int a1)
     return 0;
 }
 
-// 0x43DB48
+// 0x43DB48 name_sort_comp_
 static int perkDialogOptionCompare(const void* a1, const void* a2)
 {
     PerkDialogOption* v1 = (PerkDialogOption*)a1;
@@ -6620,7 +6620,7 @@ static int perkDialogOptionCompare(const void* a1, const void* a2)
     return strcmp(v1->name, v2->name);
 }
 
-// 0x43DB54
+// 0x43DB54 DrawCard2_
 static int perkDialogDrawCard(int frmId, const char* name, const char* rank, char* description)
 {
     FrmImage frmImage;
@@ -6714,7 +6714,7 @@ static int perkDialogDrawCard(int frmId, const char* name, const char* rank, cha
 
 // copy editor perks to character
 //
-// 0x43DEBC
+// 0x43DEBC pop_perks_
 static void _pop_perks()
 {
     for (int perk = 0; perk < PERK_COUNT; perk++) {
@@ -6742,7 +6742,7 @@ static void _pop_perks()
 
 // validate SPECIAL stats are <= 10
 //
-// 0x43DF50
+// 0x43DF50 is_supper_bonus_
 static int _is_supper_bonus()
 {
     for (int stat = 0; stat < 7; stat++) {
@@ -6756,7 +6756,7 @@ static int _is_supper_bonus()
     return 0;
 }
 
-// 0x43DF8C
+// 0x43DF8C folder_init_
 static int characterEditorFolderViewInit()
 {
     gCharacterEditorKarmaFolderTopLine = 0;
@@ -6797,7 +6797,7 @@ static int characterEditorFolderViewInit()
     return 0;
 }
 
-// 0x43E0D4
+// 0x43E0D4 folder_scroll_
 static void characterEditorFolderViewScroll(int direction)
 {
     int* v1;
@@ -6847,7 +6847,7 @@ static void characterEditorFolderViewScroll(int direction)
     }
 }
 
-// 0x43E200
+// 0x43E200 folder_clear_
 static void characterEditorFolderViewClear()
 {
     int v0;
@@ -6879,7 +6879,7 @@ static void characterEditorFolderViewClear()
 
 // render heading string with line
 //
-// 0x43E28C
+// 0x43E28C folder_print_seperator_
 static int characterEditorFolderViewDrawHeading(const char* string)
 {
     int lineHeight;
@@ -6915,7 +6915,7 @@ static int characterEditorFolderViewDrawHeading(const char* string)
     }
 }
 
-// 0x43E3D8
+// 0x43E3D8 folder_print_line_
 static bool characterEditorFolderViewDrawString(const char* string)
 {
     bool success = false;
@@ -6940,7 +6940,7 @@ static bool characterEditorFolderViewDrawString(const char* string)
     return success;
 }
 
-// 0x43E470
+// 0x43E470 folder_print_kill_
 static bool characterEditorFolderViewDrawKillsEntry(const char* name, int kills)
 {
     char killsString[8];
@@ -6979,7 +6979,7 @@ static bool characterEditorFolderViewDrawKillsEntry(const char* name, int kills)
     return success;
 }
 
-// 0x43E5C4
+// 0x43E5C4 karma_vars_init_
 static int karmaInit()
 {
     const char* delim = " \t,";
@@ -7059,7 +7059,7 @@ static int karmaInit()
 
 // NOTE: Inlined.
 //
-// 0x43E764
+// 0x43E764 karma_vars_exit_
 static void karmaFree()
 {
     if (gKarmaEntries != nullptr) {
@@ -7070,7 +7070,7 @@ static void karmaFree()
     gKarmaEntriesLength = 0;
 }
 
-// 0x43E78C
+// 0x43E78C karma_vars_qsort_compare_
 static int karmaEntryCompare(const void* a1, const void* a2)
 {
     KarmaEntry* v1 = (KarmaEntry*)a1;
@@ -7078,7 +7078,7 @@ static int karmaEntryCompare(const void* a1, const void* a2)
     return v1->gvar - v2->gvar;
 }
 
-// 0x43E798
+// 0x43E798 general_reps_init_
 static int genericReputationInit()
 {
     const char* delim = " \t,";
@@ -7144,7 +7144,7 @@ static int genericReputationInit()
 
 // NOTE: Inlined.
 //
-// 0x43E914
+// 0x43E914 general_reps_exit_
 static void genericReputationFree()
 {
     if (gGenericReputationEntries != nullptr) {
@@ -7155,7 +7155,7 @@ static void genericReputationFree()
     gGenericReputationEntriesLength = 0;
 }
 
-// 0x43E93C
+// 0x43E93C general_reps_qsort_compare_
 static int genericReputationCompare(const void* a1, const void* a2)
 {
     GenericReputationEntry* v1 = (GenericReputationEntry*)a1;

--- a/src/character_selector.cc
+++ b/src/character_selector.cc
@@ -106,10 +106,10 @@ static int gPremadeCharacterCount = PREMADE_CHARACTER_COUNT;
 // 0x51C7F8 select_window_id
 static int gCharacterSelectorWindow = -1;
 
-// 0x51C7FC _select_window_buffer
+// 0x51C7FC select_window_buffer
 static unsigned char* gCharacterSelectorWindowBuffer = nullptr;
 
-// 0x51C800 _monitor
+// 0x51C800 monitor
 static unsigned char* gCharacterSelectorBackground = nullptr;
 
 // 0x51C804 previous_button

--- a/src/character_selector.cc
+++ b/src/character_selector.cc
@@ -90,44 +90,44 @@ static bool characterSelectorWindowFatalError(bool result);
 
 static void premadeCharactersLocalizePath(char* path);
 
-// 0x51C84C
+// 0x51C84C premade_index
 static int gCurrentPremadeCharacter = PREMADE_CHARACTER_NARG;
 
-// 0x51C850
+// 0x51C850 premade_characters
 static PremadeCharacterDescription gPremadeCharacterDescriptions[PREMADE_CHARACTER_COUNT] = {
     { "premade\\combat", 201, "VID 208-197-88-125" },
     { "premade\\stealth", 202, "VID 208-206-49-229" },
     { "premade\\diplomat", 203, "VID 208-206-49-227" },
 };
 
-// 0x51C8D4
+// 0x51C8D4 premade_total
 static int gPremadeCharacterCount = PREMADE_CHARACTER_COUNT;
 
-// 0x51C7F8
+// 0x51C7F8 select_window_id
 static int gCharacterSelectorWindow = -1;
 
-// 0x51C7FC
+// 0x51C7FC _select_window_buffer
 static unsigned char* gCharacterSelectorWindowBuffer = nullptr;
 
-// 0x51C800
+// 0x51C800 _monitor
 static unsigned char* gCharacterSelectorBackground = nullptr;
 
-// 0x51C804
+// 0x51C804 previous_button
 static int gCharacterSelectorWindowPreviousButton = -1;
 
-// 0x51C810
+// 0x51C810 next_button
 static int gCharacterSelectorWindowNextButton = -1;
 
-// 0x51C81C
+// 0x51C81C take_button
 static int gCharacterSelectorWindowTakeButton = -1;
 
-// 0x51C828
+// 0x51C828 modify_button
 static int gCharacterSelectorWindowModifyButton = -1;
 
-// 0x51C834
+// 0x51C834 create_button
 static int gCharacterSelectorWindowCreateButton = -1;
 
-// 0x51C840
+// 0x51C840 back_button
 static int gCharacterSelectorWindowBackButton = -1;
 
 static FrmImage _takeButtonNormalFrmImage;
@@ -145,7 +145,7 @@ static FrmImage _previousButtonPressedFrmImage;
 
 static std::vector<PremadeCharacterDescription> gCustomPremadeCharacterDescriptions;
 
-// 0x4A71D0 select_character_
+// 0x4A71D0 select_character
 int characterSelectorOpen()
 {
 #if __APPLE__ && TARGET_OS_IOS
@@ -260,7 +260,7 @@ int characterSelectorOpen()
     return rc;
 }
 
-// 0x4A7468 select_init_
+// 0x4A7468 select_init
 static bool characterSelectorWindowInit()
 {
     if (gCharacterSelectorWindow != -1) {
@@ -497,7 +497,7 @@ static bool characterSelectorWindowInit()
     return true;
 }
 
-// 0x4A7AD4 select_exit_
+// 0x4A7AD4 select_exit
 static void characterSelectorWindowFree()
 {
     if (gCharacterSelectorWindow == -1) {
@@ -561,7 +561,7 @@ static void characterSelectorWindowFree()
     gCharacterSelectorWindow = -1;
 }
 
-// 0x4A7D58 select_update_display_
+// 0x4A7D58 select_update_display
 static bool characterSelectorWindowRefresh()
 {
     char path[COMPAT_MAX_PATH];
@@ -592,7 +592,7 @@ static bool characterSelectorWindowRefresh()
     return success;
 }
 
-// 0x4A7E08 select_display_portrait_
+// 0x4A7E08 select_display_portrait
 static bool characterSelectorWindowRenderFace()
 {
     bool success = false;
@@ -613,7 +613,7 @@ static bool characterSelectorWindowRenderFace()
     return success;
 }
 
-// 0x4A7EA8 select_display_stats_
+// 0x4A7EA8 select_display_stats
 static bool characterSelectorWindowRenderStats()
 {
     char* str;
@@ -865,7 +865,7 @@ static bool characterSelectorWindowRenderStats()
     return true;
 }
 
-// 0x4A8AE4 select_display_bio_
+// 0x4A8AE4 select_display_bio
 static bool characterSelectorWindowRenderBio()
 {
     int oldFont = fontGetCurrent();
@@ -896,7 +896,7 @@ static bool characterSelectorWindowRenderBio()
 
 // NOTE: Inlined.
 //
-// 0x4A8BD0 select_fatal_error_
+// 0x4A8BD0 select_fatal_error
 static bool characterSelectorWindowFatalError(bool result)
 {
     characterSelectorWindowFree();

--- a/src/character_selector.cc
+++ b/src/character_selector.cc
@@ -145,7 +145,7 @@ static FrmImage _previousButtonPressedFrmImage;
 
 static std::vector<PremadeCharacterDescription> gCustomPremadeCharacterDescriptions;
 
-// 0x4A71D0
+// 0x4A71D0 select_character_
 int characterSelectorOpen()
 {
 #if __APPLE__ && TARGET_OS_IOS
@@ -260,7 +260,7 @@ int characterSelectorOpen()
     return rc;
 }
 
-// 0x4A7468
+// 0x4A7468 select_init_
 static bool characterSelectorWindowInit()
 {
     if (gCharacterSelectorWindow != -1) {
@@ -497,7 +497,7 @@ static bool characterSelectorWindowInit()
     return true;
 }
 
-// 0x4A7AD4
+// 0x4A7AD4 select_exit_
 static void characterSelectorWindowFree()
 {
     if (gCharacterSelectorWindow == -1) {
@@ -561,7 +561,7 @@ static void characterSelectorWindowFree()
     gCharacterSelectorWindow = -1;
 }
 
-// 0x4A7D58
+// 0x4A7D58 select_update_display_
 static bool characterSelectorWindowRefresh()
 {
     char path[COMPAT_MAX_PATH];
@@ -592,7 +592,7 @@ static bool characterSelectorWindowRefresh()
     return success;
 }
 
-// 0x4A7E08
+// 0x4A7E08 select_display_portrait_
 static bool characterSelectorWindowRenderFace()
 {
     bool success = false;
@@ -613,7 +613,7 @@ static bool characterSelectorWindowRenderFace()
     return success;
 }
 
-// 0x4A7EA8
+// 0x4A7EA8 select_display_stats_
 static bool characterSelectorWindowRenderStats()
 {
     char* str;
@@ -865,7 +865,7 @@ static bool characterSelectorWindowRenderStats()
     return true;
 }
 
-// 0x4A8AE4
+// 0x4A8AE4 select_display_bio_
 static bool characterSelectorWindowRenderBio()
 {
     int oldFont = fontGetCurrent();
@@ -896,7 +896,7 @@ static bool characterSelectorWindowRenderBio()
 
 // NOTE: Inlined.
 //
-// 0x4A8BD0
+// 0x4A8BD0 select_fatal_error_
 static bool characterSelectorWindowFatalError(bool result)
 {
     characterSelectorWindowFree();

--- a/src/color.cc
+++ b/src/color.cc
@@ -73,7 +73,7 @@ Color colorMixMulTable[256][256];
 // 0x6A38D0
 unsigned char _colorTable[32768];
 
-// 0x4C72B4
+// 0x4C72B4 calculateColor_
 int _calculateColor(int intensity, Color color)
 {
     return intensityColorTable[color][intensity / 512];
@@ -91,7 +91,7 @@ int Color2RGB(Color c)
 
 // Performs animated palette transition.
 //
-// 0x4C7320
+// 0x4C7320 fadeSystemPalette_
 void colorPaletteFadeBetween(unsigned char* oldPalette, unsigned char* newPalette, int steps)
 {
     for (int step = 0; step < steps; step++) {
@@ -120,13 +120,13 @@ void colorPaletteFadeBetween(unsigned char* oldPalette, unsigned char* newPalett
     sharedFpsLimiter.throttle();
 }
 
-// 0x4C73D4
+// 0x4C73D4 colorSetFadeBkFunc_
 void colorPaletteSetTransitionCallback(ColorTransitionCallback* callback)
 {
     gColorPaletteTransitionCallback = callback;
 }
 
-// 0x4C73E4
+// 0x4C73E4 setSystemPalette_
 void _setSystemPalette(unsigned char* palette)
 {
     unsigned char newPalette[768];
@@ -139,13 +139,13 @@ void _setSystemPalette(unsigned char* palette)
     directDrawSetPalette(newPalette);
 }
 
-// 0x4C7420
+// 0x4C7420 getSystemPalette_
 unsigned char* _getSystemPalette()
 {
     return _systemCmap;
 }
 
-// 0x4C7428
+// 0x4C7428 setSystemPaletteEntries_
 void _setSystemPaletteEntries(unsigned char* palette, int start, int end)
 {
     unsigned char newPalette[768];
@@ -164,7 +164,7 @@ void _setSystemPaletteEntries(unsigned char* palette, int start, int end)
     directDrawSetPaletteInRange(newPalette, start, end - start + 1);
 }
 
-// 0x4C7550
+// 0x4C7550 setIntensityTableColor_
 static void _setIntensityTableColor(int cc)
 {
     int shift = 0;
@@ -190,7 +190,7 @@ static void _setIntensityTableColor(int cc)
     }
 }
 
-// 0x4C7658
+// 0x4C7658 setIntensityTables_
 static void _setIntensityTables()
 {
     for (int index = 0; index < 256; index++) {
@@ -202,7 +202,7 @@ static void _setIntensityTables()
     }
 }
 
-// 0x4C769C
+// 0x4C769C setMixTableColor_
 static void _setMixTableColor(int color)
 {
     for (int otherColor = 0; otherColor < 256; otherColor++) {
@@ -278,7 +278,7 @@ static void _setMixTableColor(int color)
     }
 }
 
-// 0x4C78E4
+// 0x4C78E4 loadColorTable_
 bool colorPaletteLoad(const char* path)
 {
     if (gColorFileNameMangler != nullptr) {
@@ -353,13 +353,13 @@ bool colorPaletteLoad(const char* path)
     return true;
 }
 
-// 0x4C7AB4
+// 0x4C7AB4 colorError_
 char* _colorError()
 {
     return _errorStr;
 }
 
-// 0x4C7B44
+// 0x4C7B44 buildBlendTable_
 static void _buildBlendTable(unsigned char* ptr, unsigned char ch)
 {
     int r, g, b;
@@ -419,7 +419,7 @@ static void _buildBlendTable(unsigned char* ptr, unsigned char ch)
     }
 }
 
-// 0x4C7D90
+// 0x4C7D90 rebuildColorBlendTables_
 static void _rebuildColorBlendTables()
 {
     int i;
@@ -431,7 +431,7 @@ static void _rebuildColorBlendTables()
     }
 }
 
-// 0x4C7DC0
+// 0x4C7DC0 getColorBlendTable_
 unsigned char* _getColorBlendTable(int ch)
 {
     unsigned char* ptr;
@@ -449,7 +449,7 @@ unsigned char* _getColorBlendTable(int ch)
     return ptr;
 }
 
-// 0x4C7E20
+// 0x4C7E20 freeColorBlendTable_
 void _freeColorBlendTable(int color)
 {
     unsigned char* blendTable = _blendTable[color];
@@ -463,7 +463,7 @@ void _freeColorBlendTable(int color)
     }
 }
 
-// 0x4C7E6C
+// 0x4C7E6C colorGamma_
 void colorSetBrightness(double value)
 {
     gBrightness = value;
@@ -476,7 +476,7 @@ void colorSetBrightness(double value)
     _setSystemPalette(_systemCmap);
 }
 
-// 0x4C89CC
+// 0x4C89CC initColors_
 bool _initColors()
 {
     if (_colorsInited) {
@@ -496,7 +496,7 @@ bool _initColors()
     return true;
 }
 
-// 0x4C8A18
+// 0x4C8A18 colorsClose_
 void _colorsClose()
 {
     for (int index = 0; index < 256; index++) {

--- a/src/color.cc
+++ b/src/color.cc
@@ -29,7 +29,7 @@ static char _aColor_cColorpa[] = "color.c: colorpalettestack overflow";
 // 0x50F9AC aColor_cColor_0
 static char aColor_cColor_0[] = "color.c: colorpalettestack underflow";
 
-// 0x51DF10 _errorStr
+// 0x51DF10 errorStr
 static char* _errorStr = _aColor_cNoError;
 
 // 0x51DF14 colorsInited

--- a/src/color.cc
+++ b/src/color.cc
@@ -17,63 +17,63 @@ static void _setMixTableColor(int color);
 static void _buildBlendTable(unsigned char* ptr, unsigned char ch);
 static void _rebuildColorBlendTables();
 
-// 0x50F930
+// 0x50F930 aColor_cNoError
 static char _aColor_cNoError[] = "color.c: No errors\n";
 
-// 0x50F95C
+// 0x50F95C aColor_cColorTa
 static char _aColor_cColorTa[] = "color.c: color table not found\n";
 
-// 0x50F984
+// 0x50F984 aColor_cColorpa
 static char _aColor_cColorpa[] = "color.c: colorpalettestack overflow";
 
-// 0x50F9AC
+// 0x50F9AC aColor_cColor_0
 static char aColor_cColor_0[] = "color.c: colorpalettestack underflow";
 
-// 0x51DF10
+// 0x51DF10 _errorStr
 static char* _errorStr = _aColor_cNoError;
 
-// 0x51DF14
+// 0x51DF14 colorsInited
 static bool _colorsInited = false;
 
-// 0x51DF18
+// 0x51DF18 currentGamma
 static double gBrightness = 1.0;
 
-// 0x51DF20
+// 0x51DF20 colorFadeBkFuncP
 static ColorTransitionCallback* gColorPaletteTransitionCallback = nullptr;
 
-// 0x51DF30
+// 0x51DF30 colorNameMangler
 static ColorFileNameManger* gColorFileNameMangler = nullptr;
 
-// 0x51DF34
+// 0x51DF34 cmap
 unsigned char _cmap[768] = {
     0x3F, 0x3F, 0x3F
 };
 
-// 0x673090
+// 0x673090 systemCmap1
 unsigned char _systemCmap[256 * 3];
 
-// 0x673390
+// 0x673390 currentGammaTable
 unsigned char _currentGammaTable[64];
 
-// 0x6733D0
+// 0x6733D0 blendTable
 unsigned char* _blendTable[256];
 
-// 0x6737D0
+// 0x6737D0 mappedColor
 unsigned char _mappedColor[256];
 
-// 0x6738D0
+// 0x6738D0 colorMixAddTable
 Color colorMixAddTable[256][256];
 
-// 0x6838D0
+// 0x6838D0 intensityColorTable
 Color intensityColorTable[256][256];
 
-// 0x6938D0
+// 0x6938D0 colorMixMulTable
 Color colorMixMulTable[256][256];
 
-// 0x6A38D0
+// 0x6A38D0 colorTable
 unsigned char _colorTable[32768];
 
-// 0x4C72B4 calculateColor_
+// 0x4C72B4 calculateColor
 int _calculateColor(int intensity, Color color)
 {
     return intensityColorTable[color][intensity / 512];
@@ -91,7 +91,7 @@ int Color2RGB(Color c)
 
 // Performs animated palette transition.
 //
-// 0x4C7320 fadeSystemPalette_
+// 0x4C7320 fadeSystemPalette
 void colorPaletteFadeBetween(unsigned char* oldPalette, unsigned char* newPalette, int steps)
 {
     for (int step = 0; step < steps; step++) {
@@ -120,13 +120,13 @@ void colorPaletteFadeBetween(unsigned char* oldPalette, unsigned char* newPalett
     sharedFpsLimiter.throttle();
 }
 
-// 0x4C73D4 colorSetFadeBkFunc_
+// 0x4C73D4 colorSetFadeBkFunc
 void colorPaletteSetTransitionCallback(ColorTransitionCallback* callback)
 {
     gColorPaletteTransitionCallback = callback;
 }
 
-// 0x4C73E4 setSystemPalette_
+// 0x4C73E4 setSystemPalette
 void _setSystemPalette(unsigned char* palette)
 {
     unsigned char newPalette[768];
@@ -139,13 +139,13 @@ void _setSystemPalette(unsigned char* palette)
     directDrawSetPalette(newPalette);
 }
 
-// 0x4C7420 getSystemPalette_
+// 0x4C7420 getSystemPalette
 unsigned char* _getSystemPalette()
 {
     return _systemCmap;
 }
 
-// 0x4C7428 setSystemPaletteEntries_
+// 0x4C7428 setSystemPaletteEntries
 void _setSystemPaletteEntries(unsigned char* palette, int start, int end)
 {
     unsigned char newPalette[768];
@@ -164,7 +164,7 @@ void _setSystemPaletteEntries(unsigned char* palette, int start, int end)
     directDrawSetPaletteInRange(newPalette, start, end - start + 1);
 }
 
-// 0x4C7550 setIntensityTableColor_
+// 0x4C7550 setIntensityTableColor
 static void _setIntensityTableColor(int cc)
 {
     int shift = 0;
@@ -190,7 +190,7 @@ static void _setIntensityTableColor(int cc)
     }
 }
 
-// 0x4C7658 setIntensityTables_
+// 0x4C7658 setIntensityTables
 static void _setIntensityTables()
 {
     for (int index = 0; index < 256; index++) {
@@ -202,7 +202,7 @@ static void _setIntensityTables()
     }
 }
 
-// 0x4C769C setMixTableColor_
+// 0x4C769C setMixTableColor
 static void _setMixTableColor(int color)
 {
     for (int otherColor = 0; otherColor < 256; otherColor++) {
@@ -278,7 +278,7 @@ static void _setMixTableColor(int color)
     }
 }
 
-// 0x4C78E4 loadColorTable_
+// 0x4C78E4 loadColorTable
 bool colorPaletteLoad(const char* path)
 {
     if (gColorFileNameMangler != nullptr) {
@@ -353,13 +353,13 @@ bool colorPaletteLoad(const char* path)
     return true;
 }
 
-// 0x4C7AB4 colorError_
+// 0x4C7AB4 colorError
 char* _colorError()
 {
     return _errorStr;
 }
 
-// 0x4C7B44 buildBlendTable_
+// 0x4C7B44 buildBlendTable
 static void _buildBlendTable(unsigned char* ptr, unsigned char ch)
 {
     int r, g, b;
@@ -419,7 +419,7 @@ static void _buildBlendTable(unsigned char* ptr, unsigned char ch)
     }
 }
 
-// 0x4C7D90 rebuildColorBlendTables_
+// 0x4C7D90 rebuildColorBlendTables
 static void _rebuildColorBlendTables()
 {
     int i;
@@ -431,7 +431,7 @@ static void _rebuildColorBlendTables()
     }
 }
 
-// 0x4C7DC0 getColorBlendTable_
+// 0x4C7DC0 getColorBlendTable
 unsigned char* _getColorBlendTable(int ch)
 {
     unsigned char* ptr;
@@ -449,7 +449,7 @@ unsigned char* _getColorBlendTable(int ch)
     return ptr;
 }
 
-// 0x4C7E20 freeColorBlendTable_
+// 0x4C7E20 freeColorBlendTable
 void _freeColorBlendTable(int color)
 {
     unsigned char* blendTable = _blendTable[color];
@@ -463,7 +463,7 @@ void _freeColorBlendTable(int color)
     }
 }
 
-// 0x4C7E6C colorGamma_
+// 0x4C7E6C colorGamma
 void colorSetBrightness(double value)
 {
     gBrightness = value;
@@ -476,7 +476,7 @@ void colorSetBrightness(double value)
     _setSystemPalette(_systemCmap);
 }
 
-// 0x4C89CC initColors_
+// 0x4C89CC initColors
 bool _initColors()
 {
     if (_colorsInited) {
@@ -496,7 +496,7 @@ bool _initColors()
     return true;
 }
 
-// 0x4C8A18 colorsClose_
+// 0x4C8A18 colorsClose
 void _colorsClose()
 {
     for (int index = 0; index < 256; index++) {

--- a/src/combat.cc
+++ b/src/combat.cc
@@ -163,10 +163,10 @@ static int combatTurnHookResult = 0;
 // 0x510944 combat_state
 unsigned int gCombatState = COMBAT_STATE_0x02;
 
-// 0x510948 _aiInfoList
+// 0x510948 aiInfoList
 static CombatAiInfo* _aiInfoList = nullptr;
 
-// 0x51094C _gcsd
+// 0x51094C gcsd
 static CombatStartData* _gcsd = nullptr;
 
 // 0x510950 combat_call_display
@@ -1948,7 +1948,7 @@ static Object* _combat_turn_obj;
 // 0x56D38C combat_highlight
 static int _combat_highlight;
 
-// 0x56D390 _combat_list
+// 0x56D390 combat_list
 static Object** _combat_list;
 
 // 0x56D394 list_com

--- a/src/combat.cc
+++ b/src/combat.cc
@@ -149,32 +149,32 @@ static void damageModCalculateGlovz(DamageCalculationContext* context);
 static int damageModGlovzDivRound(int dividend, int divisor);
 static void damageModCalculateYaam(DamageCalculationContext* context);
 
-// 0x500B50
+// 0x500B50 a_1
 static char _a_1[] = ".";
 
-// 0x51093C
+// 0x51093C combat_turn_running
 static int _combat_turn_running = 0;
 
-// 0x510940
+// 0x510940 combatNumTurns
 int _combatNumTurns = 0;
 
 static int combatTurnHookResult = 0;
 
-// 0x510944
+// 0x510944 combat_state
 unsigned int gCombatState = COMBAT_STATE_0x02;
 
-// 0x510948
+// 0x510948 _aiInfoList
 static CombatAiInfo* _aiInfoList = nullptr;
 
-// 0x51094C
+// 0x51094C _gcsd
 static CombatStartData* _gcsd = nullptr;
 
-// 0x510950
+// 0x510950 combat_call_display
 static bool _combat_call_display = false;
 
 // Accuracy modifiers for hit locations.
 //
-// 0x510954
+// 0x510954 hit_location_penalty
 static int hit_location_penalty_default[HIT_LOCATION_COUNT] = {
     -40,
     -30,
@@ -191,7 +191,7 @@ static int hit_location_penalty[HIT_LOCATION_COUNT];
 
 // Critical hit tables for every kill type.
 //
-// 0x510978
+// 0x510978 crit_succ_eff
 static CriticalHitDescription gCriticalHitTables[SFALL_KILL_TYPE_COUNT][HIT_LOCATION_COUNT][CRTICIAL_EFFECT_COUNT] = {
     // KILL_TYPE_MAN
     {
@@ -1793,7 +1793,7 @@ static CriticalHitDescription gCriticalHitTables[SFALL_KILL_TYPE_COUNT][HIT_LOCA
 
 // Player's criticals effects.
 //
-// 0x5179B0
+// 0x5179B0 pc_crit_succ_eff
 static CriticalHitDescription gPlayerCriticalHitTable[HIT_LOCATION_COUNT][CRTICIAL_EFFECT_COUNT] = {
     {
         { 3, 0, -1, 0, 0, 6500, 5000 },
@@ -1869,15 +1869,15 @@ static CriticalHitDescription gPlayerCriticalHitTable[HIT_LOCATION_COUNT][CRTICI
     },
 };
 
-// 0x517F98
+// 0x517F98 combat_end_due_to_load
 static int _combat_end_due_to_load = 0;
 
-// 0x517F9C
+// 0x517F9C combat_cleanup_enabled
 static bool _combat_cleanup_enabled = false;
 
 // Provides effects caused by failing weapons.
 //
-// 0x517FA0
+// 0x517FA0 cf_table
 static const int _cf_table[WEAPON_CRITICAL_FAILURE_TYPE_COUNT][WEAPON_CRITICAL_FAILURE_EFFECT_COUNT] = {
     { 0, DAM_LOSE_TURN, DAM_LOSE_TURN, DAM_HURT_SELF | DAM_KNOCKED_DOWN, DAM_CRIP_RANDOM },
     { 0, DAM_LOSE_TURN, DAM_DROP, DAM_RANDOM_HIT, DAM_HIT_SELF },
@@ -1888,7 +1888,7 @@ static const int _cf_table[WEAPON_CRITICAL_FAILURE_TYPE_COUNT][WEAPON_CRITICAL_F
     { 0, DAM_LOSE_TURN, DAM_RANDOM_HIT, DAM_DESTROY, DAM_EXPLODE | DAM_LOSE_TURN | DAM_ON_FIRE },
 };
 
-// 0x51802C
+// 0x51802C call_ty
 static const int _call_ty[4] = {
     122,
     188,
@@ -1896,7 +1896,7 @@ static const int _call_ty[4] = {
     316,
 };
 
-// 0x51803C
+// 0x51803C hit_loc_left
 static const int _hit_loc_left[4] = {
     HIT_LOCATION_HEAD,
     HIT_LOCATION_EYES,
@@ -1904,7 +1904,7 @@ static const int _hit_loc_left[4] = {
     HIT_LOCATION_RIGHT_LEG,
 };
 
-// 0x51804C
+// 0x51804C hit_loc_right
 static const int _hit_loc_right[4] = {
     HIT_LOCATION_TORSO,
     HIT_LOCATION_GROIN,
@@ -1912,62 +1912,62 @@ static const int _hit_loc_right[4] = {
     HIT_LOCATION_LEFT_LEG,
 };
 
-// 0x56D2B0
+// 0x56D2B0 main_ctd
 static Attack _main_ctd;
 
 // combat.msg
 //
-// 0x56D368
+// 0x56D368 combat_message_file
 static MessageList gCombatMessageList;
 
-// 0x56D370
+// 0x56D370 call_target
 static Object* gCalledShotCritter;
 
-// 0x56D374
+// 0x56D374 call_win
 static int gCalledShotWindow;
 
-// 0x56D378
+// 0x56D378 combat_elev
 static int _combat_elev;
 
-// 0x56D37C
+// 0x56D37C list_total
 static int _list_total;
 
 // Probably last who_hit_me of obj_dude
 //
-// 0x56D380
+// 0x56D380 combat_ending_guy
 static Object* _combat_ending_guy;
 
-// 0x56D384
+// 0x56D384 list_noncom
 static int _list_noncom;
 
-// 0x56D388
+// 0x56D388 combat_turn_obj
 static Object* _combat_turn_obj;
 
 // target_highlight
 //
-// 0x56D38C
+// 0x56D38C combat_highlight
 static int _combat_highlight;
 
-// 0x56D390
+// 0x56D390 _combat_list
 static Object** _combat_list;
 
-// 0x56D394
+// 0x56D394 list_com
 static int _list_com;
 
 // Experience received for killing critters during current combat.
 //
-// 0x56D398
+// 0x56D398 combat_exps
 static int _combat_exps;
 
 // bonus action points from BONUS_MOVE perk.
 //
-// 0x56D39C
+// 0x56D39C combat_free_move
 int _combat_free_move;
 
-// 0x56D3A0
+// 0x56D3A0 shoot_ctd
 static Attack _shoot_ctd;
 
-// 0x56D458
+// 0x56D458 explosion_ctd
 static Attack _explosion_ctd;
 
 static CriticalHitDescription gBaseCriticalHitTables[SFALL_KILL_TYPE_COUNT][HIT_LOCATION_COUNT][CRTICIAL_EFFECT_COUNT];

--- a/src/combat_ai.cc
+++ b/src/combat_ai.cc
@@ -147,19 +147,19 @@ static int _combatai_rating(Object* obj);
 static int aiMessageListInit();
 static int aiMessageListFree();
 
-// 0x51805C
+// 0x51805C _combat_obj
 static Object* _combat_obj = nullptr;
 
-// 0x518060
+// 0x518060 num_caps
 static int gAiPacketsLength = 0;
 
-// 0x518064
+// 0x518064 _cap
 static AiPacket* gAiPackets = nullptr;
 
-// 0x518068
+// 0x518068 combatai_is_initialized
 static bool gAiInitialized = false;
 
-// 0x51806C
+// 0x51806C area_attack_mode_strs
 const char* gAreaAttackModeKeys[AREA_ATTACK_MODE_COUNT] = {
     "always",
     "sometimes",
@@ -168,7 +168,7 @@ const char* gAreaAttackModeKeys[AREA_ATTACK_MODE_COUNT] = {
     "be_absolutely_sure",
 };
 
-// 0x5180D0
+// 0x5180D0 attack_who_mode_strs
 const char* gAttackWhoKeys[ATTACK_WHO_COUNT] = {
     "whomever_attacking_me",
     "strongest",
@@ -177,7 +177,7 @@ const char* gAttackWhoKeys[ATTACK_WHO_COUNT] = {
     "closest",
 };
 
-// 0x51809C
+// 0x51809C weapon_pref_strs
 const char* gBestWeaponKeys[BEST_WEAPON_COUNT] = {
     "no_pref",
     "melee",
@@ -189,7 +189,7 @@ const char* gBestWeaponKeys[BEST_WEAPON_COUNT] = {
     "random",
 };
 
-// 0x5180E4
+// 0x5180E4 chem_use_mode_strs
 const char* gChemUseKeys[CHEM_USE_COUNT] = {
     "clean",
     "stims_when_hurt_little",
@@ -199,7 +199,7 @@ const char* gChemUseKeys[CHEM_USE_COUNT] = {
     "always",
 };
 
-// 0x5180BC
+// 0x5180BC distance_pref_strs
 const char* gDistanceModeKeys[DISTANCE_COUNT] = {
     "stay_close",
     "charge",
@@ -208,7 +208,7 @@ const char* gDistanceModeKeys[DISTANCE_COUNT] = {
     "stay",
 };
 
-// 0x518080
+// 0x518080 run_away_mode_strs
 const char* gRunAwayModeKeys[RUN_AWAY_MODE_COUNT] = {
     "none",
     "coward",
@@ -219,7 +219,7 @@ const char* gRunAwayModeKeys[RUN_AWAY_MODE_COUNT] = {
     "never",
 };
 
-// 0x5180FC
+// 0x5180FC disposition_strs
 const char* gDispositionKeys[DISPOSITION_COUNT] = {
     "none",
     "custom",
@@ -229,7 +229,7 @@ const char* gDispositionKeys[DISPOSITION_COUNT] = {
     "berserk",
 };
 
-// 0x518114
+// 0x518114 _matchHurtStrs
 const char* gHurtTooMuchKeys[HURT_COUNT] = {
     "blind",
     "crippled",
@@ -239,7 +239,7 @@ const char* gHurtTooMuchKeys[HURT_COUNT] = {
 
 // hurt_too_much
 //
-// 0x518124
+// 0x518124 rmatchHurtVals
 static const int _rmatchHurtVals[5] = {
     DAM_BLIND,
     DAM_CRIP_LEG_LEFT | DAM_CRIP_LEG_RIGHT | DAM_CRIP_ARM_LEFT | DAM_CRIP_ARM_RIGHT,
@@ -250,7 +250,7 @@ static const int _rmatchHurtVals[5] = {
 
 // Hit points in percent to choose run away mode.
 //
-// 0x518138
+// 0x518138 hp_run_away_value
 static const int _hp_run_away_value[6] = {
     0,
     25,
@@ -260,13 +260,13 @@ static const int _hp_run_away_value[6] = {
     100,
 };
 
-// 0x518150
+// 0x518150 _attackerTeamObj
 static Object* _attackerTeamObj = nullptr;
 
-// 0x518154
+// 0x518154 _targetTeamObj
 static Object* _targetTeamObj = nullptr;
 
-// 0x518158
+// 0x518158 weapPrefOrderings
 static const int _weapPrefOrderings[BEST_WEAPON_COUNT + 1][ATTACK_TYPE_COUNT] = {
     { ATTACK_TYPE_RANGED, ATTACK_TYPE_THROW, ATTACK_TYPE_MELEE, ATTACK_TYPE_UNARMED, 0 },
     { ATTACK_TYPE_RANGED, ATTACK_TYPE_THROW, ATTACK_TYPE_MELEE, ATTACK_TYPE_UNARMED, 0 }, // BEST_WEAPON_NO_PREF
@@ -279,24 +279,24 @@ static const int _weapPrefOrderings[BEST_WEAPON_COUNT + 1][ATTACK_TYPE_COUNT] = 
     { 0, 0, 0, 0, 0 }, // BEST_WEAPON_RANDOM
 };
 
-// 0x518220
+// 0x518220 _old_state
 static int gLanguageFilter = -1;
 
 // ai.msg
 //
-// 0x56D510
+// 0x56D510 ai_message_file
 static MessageList gCombatAiMessageList;
 
-// 0x56D518
+// 0x56D518 target_str
 static char _target_str[AI_MESSAGE_SIZE];
 
-// 0x56D61C
+// 0x56D61C curr_crit_num
 static int _curr_crit_num;
 
-// 0x56D620
+// 0x56D620 _curr_crit_list
 static Object** _curr_crit_list;
 
-// 0x56D624
+// 0x56D624 attack_str
 static char _attack_str[AI_MESSAGE_SIZE];
 
 // parse hurt_too_much

--- a/src/combat_ai.cc
+++ b/src/combat_ai.cc
@@ -147,13 +147,13 @@ static int _combatai_rating(Object* obj);
 static int aiMessageListInit();
 static int aiMessageListFree();
 
-// 0x51805C _combat_obj
+// 0x51805C combat_obj
 static Object* _combat_obj = nullptr;
 
 // 0x518060 num_caps
 static int gAiPacketsLength = 0;
 
-// 0x518064 _cap
+// 0x518064 cap
 static AiPacket* gAiPackets = nullptr;
 
 // 0x518068 combatai_is_initialized
@@ -229,7 +229,7 @@ const char* gDispositionKeys[DISPOSITION_COUNT] = {
     "berserk",
 };
 
-// 0x518114 _matchHurtStrs
+// 0x518114 matchHurtStrs
 const char* gHurtTooMuchKeys[HURT_COUNT] = {
     "blind",
     "crippled",
@@ -260,10 +260,10 @@ static const int _hp_run_away_value[6] = {
     100,
 };
 
-// 0x518150 _attackerTeamObj
+// 0x518150 attackerTeamObj
 static Object* _attackerTeamObj = nullptr;
 
-// 0x518154 _targetTeamObj
+// 0x518154 targetTeamObj
 static Object* _targetTeamObj = nullptr;
 
 // 0x518158 weapPrefOrderings
@@ -279,7 +279,7 @@ static const int _weapPrefOrderings[BEST_WEAPON_COUNT + 1][ATTACK_TYPE_COUNT] = 
     { 0, 0, 0, 0, 0 }, // BEST_WEAPON_RANDOM
 };
 
-// 0x518220 _old_state
+// 0x518220 old_state
 static int gLanguageFilter = -1;
 
 // ai.msg
@@ -293,7 +293,7 @@ static char _target_str[AI_MESSAGE_SIZE];
 // 0x56D61C curr_crit_num
 static int _curr_crit_num;
 
-// 0x56D620 _curr_crit_list
+// 0x56D620 curr_crit_list
 static Object** _curr_crit_list;
 
 // 0x56D624 attack_str

--- a/src/config.cc
+++ b/src/config.cc
@@ -43,7 +43,7 @@ static void configWriteSection(FILE* stream, const char* sectionName, ConfigSect
 
 // Last section key read from .INI file.
 //
-// 0x518224
+// 0x518224 aUnknown_0
 static char gConfigLastSectionKey[CONFIG_FILE_MAX_LINE_LENGTH] = "unknown";
 
 // 0x42BD90

--- a/src/config.cc
+++ b/src/config.cc
@@ -43,7 +43,7 @@ static void configWriteSection(FILE* stream, const char* sectionName, ConfigSect
 
 // Last section key read from .INI file.
 //
-// 0x518224 aUnknown_0
+// 0x518224
 static char gConfigLastSectionKey[CONFIG_FILE_MAX_LINE_LENGTH] = "unknown";
 
 // 0x42BD90

--- a/src/credits.cc
+++ b/src/credits.cc
@@ -44,7 +44,7 @@ static int gCreditsWindowNameFont;
 // 0x56D750
 static int gCreditsWindowTitleColor;
 
-// 0x42C860
+// 0x42C860 credits_
 void creditsOpen(const char* filePath, int backgroundFid, bool useReversedStyle)
 {
     int oldFont = fontGetCurrent();
@@ -253,7 +253,7 @@ void creditsOpen(const char* filePath, int backgroundFid, bool useReversedStyle)
     fontSetCurrent(oldFont);
 }
 
-// 0x42CE6C
+// 0x42CE6C credits_get_next_line_
 static bool creditsFileParseNextLine(char* dest, int* font, int* color)
 {
     char string[256];

--- a/src/credits.cc
+++ b/src/credits.cc
@@ -29,22 +29,22 @@ namespace fallout {
 
 static bool creditsFileParseNextLine(char* dest, int* font, int* color);
 
-// 0x56D740
+// 0x56D740 _credits_file
 static File* gCreditsFile;
 
-// 0x56D744
+// 0x56D744 name_color
 static int gCreditsWindowNameColor;
 
-// 0x56D748
+// 0x56D748 title_font
 static int gCreditsWindowTitleFont;
 
-// 0x56D74C
+// 0x56D74C name_font
 static int gCreditsWindowNameFont;
 
-// 0x56D750
+// 0x56D750 title_color
 static int gCreditsWindowTitleColor;
 
-// 0x42C860 credits_
+// 0x42C860 credits
 void creditsOpen(const char* filePath, int backgroundFid, bool useReversedStyle)
 {
     int oldFont = fontGetCurrent();
@@ -253,7 +253,7 @@ void creditsOpen(const char* filePath, int backgroundFid, bool useReversedStyle)
     fontSetCurrent(oldFont);
 }
 
-// 0x42CE6C credits_get_next_line_
+// 0x42CE6C credits_get_next_line
 static bool creditsFileParseNextLine(char* dest, int* font, int* color)
 {
     char string[256];

--- a/src/credits.cc
+++ b/src/credits.cc
@@ -29,7 +29,7 @@ namespace fallout {
 
 static bool creditsFileParseNextLine(char* dest, int* font, int* color);
 
-// 0x56D740 _credits_file
+// 0x56D740 credits_file
 static File* gCreditsFile;
 
 // 0x56D744 name_color

--- a/src/critter.cc
+++ b/src/critter.cc
@@ -74,18 +74,18 @@ static int _get_rad_damage_level(Object* obj, void* data);
 static int critter_kill_count_clear();
 static int _critterClearObjDrugs(Object* obj, void* data);
 
-// 0x50141C
+// 0x50141C aCorpse
 static char _aCorpse[] = "corpse";
 
 // 0x501494
 static char byte_501494[] = "";
 
-// 0x51833C
+// 0x51833C _name_critter
 static char* _name_critter = _aCorpse;
 
 // Modifiers to endurance for performing radiation damage check.
 //
-// 0x518340
+// 0x518340 bonus
 static const int gRadiationEnduranceModifiers[RADIATION_LEVEL_COUNT] = {
     2,
     0,
@@ -104,7 +104,7 @@ static const int gRadiationEnduranceModifiers[RADIATION_LEVEL_COUNT] = {
 // The order of stats is important - primary stats must be at the top. See
 // [RADIATION_EFFECT_PRIMARY_STAT_COUNT] for more info.
 //
-// 0x518358
+// 0x518358 rad_stat
 static const int gRadiationEffectStats[RADIATION_EFFECT_COUNT] = {
     STAT_STRENGTH,
     STAT_PERCEPTION,
@@ -123,7 +123,7 @@ static const int gRadiationEffectStats[RADIATION_EFFECT_COUNT] = {
 
 // List of stat modifiers caused by radiation at different radiation levels.
 //
-// 0x518378
+// 0x518378 rad_bonus
 static const int gRadiationEffectPenalties[RADIATION_LEVEL_COUNT][RADIATION_EFFECT_COUNT] = {
     // clang-format off
     {   0,   0,   0,   0,   0,   0,   0,   0 },
@@ -135,30 +135,30 @@ static const int gRadiationEffectPenalties[RADIATION_LEVEL_COUNT][RADIATION_EFFE
     // clang-format on
 };
 
-// 0x518438
+// 0x518438 critterClearObj
 static Object* _critterClearObj = nullptr;
 
 // scrname.msg
 //
-// 0x56D754
+// 0x56D754 critter_scrmsg_file
 static MessageList gCritterMessageList;
 
-// 0x56D75C
+// 0x56D75C pc_name
 static char gDudeName[DUDE_NAME_MAX_LENGTH];
 
-// 0x56D77C
+// 0x56D77C sneak_working
 static int _sneak_working;
 
-// 0x56D780
+// 0x56D780 pc_kill_counts
 static int gKillsByType[KILL_TYPE_COUNT];
 
 // Something with radiation.
 //
-// 0x56D7CC
+// 0x56D7CC old_rad_level
 static int oldRadLevel;
 
 // scrname_init
-// 0x42CF50 critter_init_
+// 0x42CF50 critter_init
 int critterInit()
 {
     dudeResetName();
@@ -184,7 +184,7 @@ int critterInit()
     return 0;
 }
 
-// 0x42CFE4 critter_reset_
+// 0x42CFE4 critter_reset
 void critterReset()
 {
     dudeResetName();
@@ -193,14 +193,14 @@ void critterReset()
     critter_kill_count_clear();
 }
 
-// 0x42D004 critter_exit_
+// 0x42D004 critter_exit
 void critterExit()
 {
     messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_SCRNAME, nullptr);
     messageListFree(&gCritterMessageList);
 }
 
-// 0x42D01C critter_load_
+// 0x42D01C critter_load
 int critterLoad(File* stream)
 {
     if (fileReadInt32(stream, &_sneak_working) == -1) {
@@ -213,7 +213,7 @@ int critterLoad(File* stream)
     return protoCritterDataRead(stream, &(proto->critter.data));
 }
 
-// 0x42D058 critter_save_
+// 0x42D058 critter_save
 int critterSave(File* stream)
 {
     if (fileWriteInt32(stream, _sneak_working) == -1) {
@@ -226,13 +226,13 @@ int critterSave(File* stream)
     return protoCritterDataWrite(stream, &(proto->critter.data));
 }
 
-// 0x42D094 critter_copy_
+// 0x42D094 critter_copy
 void critterProtoDataCopy(CritterProtoData* dest, CritterProtoData* src)
 {
     memcpy(dest, src, sizeof(CritterProtoData));
 }
 
-// 0x42D0A8 critter_name_
+// 0x42D0A8 critter_name
 char* critterGetName(Object* obj)
 {
     if (obj == gDude) {
@@ -266,7 +266,7 @@ char* critterGetName(Object* obj)
     return name;
 }
 
-// 0x42D138 critter_pc_set_name_
+// 0x42D138 critter_pc_set_name
 int dudeSetName(const char* name)
 {
     if (strlen(name) <= DUDE_NAME_MAX_LENGTH) {
@@ -277,19 +277,19 @@ int dudeSetName(const char* name)
     return -1;
 }
 
-// 0x42D170 critter_pc_reset_name_
+// 0x42D170 critter_pc_reset_name
 void dudeResetName()
 {
     strncpy(gDudeName, "None", DUDE_NAME_MAX_LENGTH);
 }
 
-// 0x42D18C critter_get_hits_
+// 0x42D18C critter_get_hits
 int critterGetHitPoints(Object* critter)
 {
     return PID_TYPE(critter->pid) == OBJ_TYPE_CRITTER ? critter->data.critter.hp : 0;
 }
 
-// 0x42D1A4 critter_adjust_hits_
+// 0x42D1A4 critter_adjust_hits
 int critterAdjustHitPoints(Object* critter, int hp)
 {
     if (PID_TYPE(critter->pid) != OBJ_TYPE_CRITTER) {
@@ -311,7 +311,7 @@ int critterAdjustHitPoints(Object* critter, int hp)
     return 0;
 }
 
-// 0x42D1F8 critter_get_poison_
+// 0x42D1F8 critter_get_poison
 int critterGetPoison(Object* critter)
 {
     return PID_TYPE(critter->pid) == OBJ_TYPE_CRITTER ? critter->data.critter.poison : 0;
@@ -324,7 +324,7 @@ int critterGetPoison(Object* critter)
 // The [amount] can either be positive (adds poison) or negative (removes
 // poison).
 //
-// 0x42D210 critter_adjust_poison_
+// 0x42D210 critter_adjust_poison
 int critterAdjustPoison(Object* critter, int amount)
 {
     MessageListItem messageListItem;
@@ -375,7 +375,7 @@ int critterAdjustPoison(Object* critter, int amount)
     return 0;
 }
 
-// 0x42D318 critter_check_poison_
+// 0x42D318 critter_check_poison
 int poisonEventProcess(Object* obj, void* data)
 {
     if (obj != gDude) {
@@ -403,13 +403,13 @@ int poisonEventProcess(Object* obj, void* data)
     return 1;
 }
 
-// 0x42D38C critter_get_rads_
+// 0x42D38C critter_get_rads
 int critterGetRadiation(Object* obj)
 {
     return PID_TYPE(obj->pid) == OBJ_TYPE_CRITTER ? obj->data.critter.radiation : 0;
 }
 
-// 0x42D3A4 critter_adjust_rads_
+// 0x42D3A4 critter_adjust_rads
 int critterAdjustRadiation(Object* obj, int amount)
 {
     MessageListItem messageListItem;
@@ -484,7 +484,7 @@ int critterAdjustRadiation(Object* obj, int amount)
     return 0;
 }
 
-// 0x42D4F4 critter_check_rads_
+// 0x42D4F4 critter_check_rads
 // note: original ASM always returned 0
 int critterCheckRadiationEvent(Object* obj)
 {
@@ -540,7 +540,7 @@ int critterCheckRadiationEvent(Object* obj)
     return 0;
 }
 
-// 0x42D618 get_rad_damage_level_
+// 0x42D618 get_rad_damage_level
 static int _get_rad_damage_level(Object* obj, void* data)
 {
     RadiationEvent* radiationEvent = (RadiationEvent*)data;
@@ -550,7 +550,7 @@ static int _get_rad_damage_level(Object* obj, void* data)
     return 0;
 }
 
-// 0x42D624 clear_rad_damage_
+// 0x42D624 clear_rad_damage
 int radiationClearDamage(Object* obj, void* data)
 {
     RadiationEvent* radiationEvent = (RadiationEvent*)data;
@@ -564,7 +564,7 @@ int radiationClearDamage(Object* obj, void* data)
 
 // Applies radiation.
 //
-// 0x42D63C process_rads_
+// 0x42D63C process_rads
 void radiationProcess(Object* obj, int radiationLevel, bool isHealing)
 {
     MessageListItem messageListItem;
@@ -625,7 +625,7 @@ void radiationProcess(Object* obj, int radiationLevel, bool isHealing)
     }
 }
 
-// 0x42D740 critter_process_rads_
+// 0x42D740 critter_process_rads
 int radiationEventProcess(Object* obj, void* data)
 {
     RadiationEvent* radiationEvent = (RadiationEvent*)data;
@@ -645,7 +645,7 @@ int radiationEventProcess(Object* obj, void* data)
     return 1;
 }
 
-// 0x42D7A0 critter_load_rads_
+// 0x42D7A0 critter_load_rads
 int radiationEventRead(File* stream, void** dataPtr)
 {
     RadiationEvent* radiationEvent = (RadiationEvent*)internal_malloc(sizeof(*radiationEvent));
@@ -665,7 +665,7 @@ err:
     return -1;
 }
 
-// 0x42D7FC critter_save_rads_
+// 0x42D7FC critter_save_rads
 int radiationEventWrite(File* stream, void* data)
 {
     RadiationEvent* radiationEvent = (RadiationEvent*)data;
@@ -676,7 +676,7 @@ int radiationEventWrite(File* stream, void* data)
     return 0;
 }
 
-// 0x42D82C critter_get_base_damage_type_
+// 0x42D82C critter_get_base_damage_type
 int critterGetDamageType(Object* obj)
 {
     if (PID_TYPE(obj->pid) != OBJ_TYPE_CRITTER) {
@@ -693,14 +693,14 @@ int critterGetDamageType(Object* obj)
 
 // NOTE: Inlined.
 //
-// 0x42D860 critter_kill_count_clear_
+// 0x42D860 critter_kill_count_clear
 static int critter_kill_count_clear()
 {
     memset(gKillsByType, 0, sizeof(gKillsByType));
     return 0;
 }
 
-// 0x42D878 critter_kill_count_inc_
+// 0x42D878 critter_kill_count_inc
 int killsIncByType(int killType)
 {
     if (killType != -1 && killType < KILL_TYPE_COUNT) {
@@ -711,7 +711,7 @@ int killsIncByType(int killType)
     return -1;
 }
 
-// 0x42D8A8 critter_kill_count_
+// 0x42D8A8 critter_kill_count
 int killsGetByType(int killType)
 {
     if (killType != -1 && killType < KILL_TYPE_COUNT) {
@@ -721,7 +721,7 @@ int killsGetByType(int killType)
     return 0;
 }
 
-// 0x42D8C0 critter_kill_count_load_
+// 0x42D8C0 critter_kill_count_load
 int killsLoad(File* stream)
 {
     if (fileReadInt32List(stream, gKillsByType, KILL_TYPE_COUNT) == -1) {
@@ -732,7 +732,7 @@ int killsLoad(File* stream)
     return 0;
 }
 
-// 0x42D8F0 critter_kill_count_save_
+// 0x42D8F0 critter_kill_count_save
 int killsSave(File* stream)
 {
     if (fileWriteInt32List(stream, gKillsByType, KILL_TYPE_COUNT) == -1) {
@@ -743,7 +743,7 @@ int killsSave(File* stream)
     return 0;
 }
 
-// 0x42D920 critter_kill_count_type_
+// 0x42D920 critter_kill_count_type
 int critterGetKillType(Object* obj)
 {
     if (obj == gDude) {
@@ -764,7 +764,7 @@ int critterGetKillType(Object* obj)
     return proto->critter.data.killType;
 }
 
-// 0x42D974 critter_kill_name_
+// 0x42D974 critter_kill_name
 char* killTypeGetName(int killType)
 {
     if (killType != -1 && killType < KILL_TYPE_COUNT) {
@@ -779,7 +779,7 @@ char* killTypeGetName(int killType)
     }
 }
 
-// 0x42D9B4 critter_kill_info_
+// 0x42D9B4 critter_kill_info
 char* killTypeGetDescription(int killType)
 {
     if (killType != -1 && killType < KILL_TYPE_COUNT) {
@@ -794,7 +794,7 @@ char* killTypeGetDescription(int killType)
     }
 }
 
-// 0x42D9F4 critter_heal_hours_
+// 0x42D9F4 critter_heal_hours
 // heals critters based on the number of elapsed hours
 int critterHealByHours(Object* critter, int hours)
 {
@@ -811,13 +811,13 @@ int critterHealByHours(Object* critter, int hours)
     return 0;
 }
 
-// 0x42DA54 critterClearObjDrugs_
+// 0x42DA54 critterClearObjDrugs
 static int _critterClearObjDrugs(Object* obj, void* data)
 {
     return obj == _critterClearObj;
 }
 
-// 0x42DA64 critter_kill_
+// 0x42DA64 critter_kill
 void critterKill(Object* critter, int anim, bool refreshRect)
 {
     if (PID_TYPE(critter->pid) != OBJ_TYPE_CRITTER) {
@@ -920,7 +920,7 @@ void critterKill(Object* critter, int anim, bool refreshRect)
 
 // Returns experience for killing [critter].
 //
-// 0x42DCB8 critter_kill_exps_
+// 0x42DCB8 critter_kill_exps
 int critterGetExp(Object* critter)
 {
     Proto* proto;
@@ -928,7 +928,7 @@ int critterGetExp(Object* critter)
     return proto->critter.data.experience;
 }
 
-// 0x42DCDC critter_is_active_
+// 0x42DCDC critter_is_active
 bool critterIsActive(Object* critter)
 {
     if (critter == nullptr) {
@@ -950,7 +950,7 @@ bool critterIsActive(Object* critter)
     return (critter->data.critter.combat.results & DAM_DEAD) == 0;
 }
 
-// 0x42DD18 critter_is_dead_
+// 0x42DD18 critter_is_dead
 bool critterIsDead(Object* critter)
 {
     if (critter == nullptr) {
@@ -972,7 +972,7 @@ bool critterIsDead(Object* critter)
     return false;
 }
 
-// 0x42DD58 critter_is_crippled_
+// 0x42DD58 critter_is_crippled
 bool critterIsCrippled(Object* critter)
 {
     if (critter == nullptr) {
@@ -986,7 +986,7 @@ bool critterIsCrippled(Object* critter)
     return (critter->data.critter.combat.results & DAM_CRIP) != 0;
 }
 
-// 0x42DD80 critter_is_prone_
+// 0x42DD80 critter_is_prone
 bool critterIsProne(Object* critter)
 {
     if (critter == nullptr) {
@@ -1005,7 +1005,7 @@ bool critterIsProne(Object* critter)
 }
 
 // critter_body_type
-// 0x42DDC4 critter_body_type_
+// 0x42DDC4 critter_body_type
 int critterGetBodyType(Object* critter)
 {
     if (critter == nullptr) {
@@ -1022,7 +1022,7 @@ int critterGetBodyType(Object* critter)
     return proto->critter.data.bodyType;
 }
 
-// 0x42DE58 pc_load_data_
+// 0x42DE58 pc_load_data
 int gcdLoad(const char* path)
 {
     File* stream = fileOpen(path, "rb");
@@ -1064,7 +1064,7 @@ int gcdLoad(const char* path)
     return 0;
 }
 
-// 0x42DF70 critter_read_data_
+// 0x42DF70 critter_read_data
 int protoCritterDataRead(File* stream, CritterProtoData* critterData)
 {
     if (fileReadInt32(stream, &(critterData->flags)) == -1) return -1;
@@ -1094,7 +1094,7 @@ int protoCritterDataRead(File* stream, CritterProtoData* critterData)
     return 0;
 }
 
-// 0x42E08C pc_save_data_
+// 0x42E08C pc_save_data
 int gcdSave(const char* path)
 {
     File* stream = fileOpen(path, "wb");
@@ -1131,7 +1131,7 @@ int gcdSave(const char* path)
     return 0;
 }
 
-// 0x42E174 critter_write_data_
+// 0x42E174 critter_write_data
 int protoCritterDataWrite(File* stream, CritterProtoData* critterData)
 {
     if (fileWriteInt32(stream, critterData->flags) == -1) return -1;
@@ -1146,7 +1146,7 @@ int protoCritterDataWrite(File* stream, CritterProtoData* critterData)
     return 0;
 }
 
-// 0x42E220 pc_flag_off_
+// 0x42E220 pc_flag_off
 void dudeDisableState(int state)
 {
     Proto* proto;
@@ -1161,7 +1161,7 @@ void dudeDisableState(int state)
     indicatorBarRefresh();
 }
 
-// 0x42E26C pc_flag_on_
+// 0x42E26C pc_flag_on
 void dudeEnableState(int state)
 {
     Proto* proto;
@@ -1176,7 +1176,7 @@ void dudeEnableState(int state)
     indicatorBarRefresh();
 }
 
-// 0x42E2B0 pc_flag_toggle_
+// 0x42E2B0 pc_flag_toggle
 void dudeToggleState(int state)
 {
     // NOTE: Uninline.
@@ -1187,7 +1187,7 @@ void dudeToggleState(int state)
     }
 }
 
-// 0x42E2F8 is_pc_flag_
+// 0x42E2F8 is_pc_flag
 bool dudeHasState(int state)
 {
     Proto* proto;
@@ -1195,7 +1195,7 @@ bool dudeHasState(int state)
     return (proto->critter.data.flags & (1 << state)) != 0;
 }
 
-// 0x42E32C critter_sneak_check_
+// 0x42E32C critter_sneak_check
 int sneakEventProcess(Object* obj, void* data)
 {
     int time;
@@ -1227,7 +1227,7 @@ int sneakEventProcess(Object* obj, void* data)
     return 0;
 }
 
-// 0x42E3E4 critter_sneak_clear_
+// 0x42E3E4 critter_sneak_clear
 int critterDisableSneak(Object* obj, void* data)
 {
     dudeDisableState(DUDE_STATE_SNEAKING);
@@ -1236,7 +1236,7 @@ int critterDisableSneak(Object* obj, void* data)
 
 // Returns true if dude is really sneaking.
 //
-// 0x42E3F4 is_pc_sneak_working_
+// 0x42E3F4 is_pc_sneak_working
 bool dudeIsSneaking()
 {
     // NOTE: Uninline.
@@ -1247,7 +1247,7 @@ bool dudeIsSneaking()
     return false;
 }
 
-// 0x42E424 critter_wake_up_
+// 0x42E424 critter_wake_up
 int knockoutEventProcess(Object* obj, void* data)
 {
     if ((obj->data.critter.combat.results & DAM_DEAD) != 0) {
@@ -1266,7 +1266,7 @@ int knockoutEventProcess(Object* obj, void* data)
     return 0;
 }
 
-// 0x42E460 critter_wake_clear_
+// 0x42E460 critter_wake_clear
 int knockoutClear(Object* obj, void* data)
 {
     if (PID_TYPE(obj->pid) != OBJ_TYPE_CRITTER) {
@@ -1285,7 +1285,7 @@ int knockoutClear(Object* obj, void* data)
     return 0;
 }
 
-// 0x42E4C0 critter_set_who_hit_me_
+// 0x42E4C0 critter_set_who_hit_me
 // note: this is sometimes called with (attacker, defender) and sometimes with (defender, attacker).
 // `hitMe` may be nullptr
 int critterSetWhoHitMe(Object* critter, Object* hitMe)
@@ -1310,7 +1310,7 @@ int critterSetWhoHitMe(Object* critter, Object* hitMe)
     return 0;
 }
 
-// 0x42E564 critter_can_obj_dude_rest_
+// 0x42E564 critter_can_obj_dude_rest
 bool critterCanDudeRest()
 {
     bool mapDisallowsRest = false;
@@ -1351,7 +1351,7 @@ bool critterCanDudeRest()
     return result;
 }
 
-// 0x42E62C critter_compute_ap_from_distance_
+// 0x42E62C critter_compute_ap_from_distance
 int critterGetMovementPointCostAdjustedForCrippledLegs(Object* critter, int distance)
 {
     if (PID_TYPE(critter->pid) != OBJ_TYPE_CRITTER) {
@@ -1368,7 +1368,7 @@ int critterGetMovementPointCostAdjustedForCrippledLegs(Object* critter, int dist
     }
 }
 
-// 0x42E66C critterIsOverloaded_
+// 0x42E66C critterIsOverloaded
 bool critterIsEncumbered(Object* critter)
 {
     int maxWeight = critterGetStat(critter, STAT_CARRY_WEIGHT);
@@ -1376,7 +1376,7 @@ bool critterIsEncumbered(Object* critter)
     return maxWeight < currentWeight;
 }
 
-// 0x42E690 critter_is_fleeing_
+// 0x42E690 critter_is_fleeing
 bool critterIsFleeing(Object* critter)
 {
     return critter != nullptr
@@ -1386,7 +1386,7 @@ bool critterIsFleeing(Object* critter)
 
 // Checks proto critter flag.
 //
-// 0x42E6AC critter_flag_check_
+// 0x42E6AC critter_flag_check
 bool critterFlagCheck(int pid, int flag)
 {
     if (pid == -1) {
@@ -1402,7 +1402,7 @@ bool critterFlagCheck(int pid, int flag)
     return (proto->critter.data.flags & flag) != 0;
 }
 
-// 0x42E6F0 critter_flag_set_
+// 0x42E6F0 critter_flag_set
 void critterFlagSet(int pid, int flag)
 {
     Proto* proto;
@@ -1420,7 +1420,7 @@ void critterFlagSet(int pid, int flag)
     proto->critter.data.flags |= flag;
 }
 
-// 0x42E71C critter_flag_unset_
+// 0x42E71C critter_flag_unset
 void critterFlagUnset(int pid, int flag)
 {
     Proto* proto;

--- a/src/critter.cc
+++ b/src/critter.cc
@@ -80,7 +80,7 @@ static char _aCorpse[] = "corpse";
 // 0x501494
 static char byte_501494[] = "";
 
-// 0x51833C _name_critter
+// 0x51833C name_critter
 static char* _name_critter = _aCorpse;
 
 // Modifiers to endurance for performing radiation damage check.

--- a/src/critter.cc
+++ b/src/critter.cc
@@ -158,7 +158,7 @@ static int gKillsByType[KILL_TYPE_COUNT];
 static int oldRadLevel;
 
 // scrname_init
-// 0x42CF50
+// 0x42CF50 critter_init_
 int critterInit()
 {
     dudeResetName();
@@ -184,7 +184,7 @@ int critterInit()
     return 0;
 }
 
-// 0x42CFE4
+// 0x42CFE4 critter_reset_
 void critterReset()
 {
     dudeResetName();
@@ -193,14 +193,14 @@ void critterReset()
     critter_kill_count_clear();
 }
 
-// 0x42D004
+// 0x42D004 critter_exit_
 void critterExit()
 {
     messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_SCRNAME, nullptr);
     messageListFree(&gCritterMessageList);
 }
 
-// 0x42D01C
+// 0x42D01C critter_load_
 int critterLoad(File* stream)
 {
     if (fileReadInt32(stream, &_sneak_working) == -1) {
@@ -213,7 +213,7 @@ int critterLoad(File* stream)
     return protoCritterDataRead(stream, &(proto->critter.data));
 }
 
-// 0x42D058
+// 0x42D058 critter_save_
 int critterSave(File* stream)
 {
     if (fileWriteInt32(stream, _sneak_working) == -1) {
@@ -226,13 +226,13 @@ int critterSave(File* stream)
     return protoCritterDataWrite(stream, &(proto->critter.data));
 }
 
-// 0x42D094
+// 0x42D094 critter_copy_
 void critterProtoDataCopy(CritterProtoData* dest, CritterProtoData* src)
 {
     memcpy(dest, src, sizeof(CritterProtoData));
 }
 
-// 0x42D0A8
+// 0x42D0A8 critter_name_
 char* critterGetName(Object* obj)
 {
     if (obj == gDude) {
@@ -266,7 +266,7 @@ char* critterGetName(Object* obj)
     return name;
 }
 
-// 0x42D138
+// 0x42D138 critter_pc_set_name_
 int dudeSetName(const char* name)
 {
     if (strlen(name) <= DUDE_NAME_MAX_LENGTH) {
@@ -277,19 +277,19 @@ int dudeSetName(const char* name)
     return -1;
 }
 
-// 0x42D170
+// 0x42D170 critter_pc_reset_name_
 void dudeResetName()
 {
     strncpy(gDudeName, "None", DUDE_NAME_MAX_LENGTH);
 }
 
-// 0x42D18C
+// 0x42D18C critter_get_hits_
 int critterGetHitPoints(Object* critter)
 {
     return PID_TYPE(critter->pid) == OBJ_TYPE_CRITTER ? critter->data.critter.hp : 0;
 }
 
-// 0x42D1A4
+// 0x42D1A4 critter_adjust_hits_
 int critterAdjustHitPoints(Object* critter, int hp)
 {
     if (PID_TYPE(critter->pid) != OBJ_TYPE_CRITTER) {
@@ -311,7 +311,7 @@ int critterAdjustHitPoints(Object* critter, int hp)
     return 0;
 }
 
-// 0x42D1F8
+// 0x42D1F8 critter_get_poison_
 int critterGetPoison(Object* critter)
 {
     return PID_TYPE(critter->pid) == OBJ_TYPE_CRITTER ? critter->data.critter.poison : 0;
@@ -324,7 +324,7 @@ int critterGetPoison(Object* critter)
 // The [amount] can either be positive (adds poison) or negative (removes
 // poison).
 //
-// 0x42D210
+// 0x42D210 critter_adjust_poison_
 int critterAdjustPoison(Object* critter, int amount)
 {
     MessageListItem messageListItem;
@@ -375,7 +375,7 @@ int critterAdjustPoison(Object* critter, int amount)
     return 0;
 }
 
-// 0x42D318
+// 0x42D318 critter_check_poison_
 int poisonEventProcess(Object* obj, void* data)
 {
     if (obj != gDude) {
@@ -403,13 +403,13 @@ int poisonEventProcess(Object* obj, void* data)
     return 1;
 }
 
-// 0x42D38C
+// 0x42D38C critter_get_rads_
 int critterGetRadiation(Object* obj)
 {
     return PID_TYPE(obj->pid) == OBJ_TYPE_CRITTER ? obj->data.critter.radiation : 0;
 }
 
-// 0x42D3A4
+// 0x42D3A4 critter_adjust_rads_
 int critterAdjustRadiation(Object* obj, int amount)
 {
     MessageListItem messageListItem;
@@ -484,7 +484,7 @@ int critterAdjustRadiation(Object* obj, int amount)
     return 0;
 }
 
-// 0x42D4F4
+// 0x42D4F4 critter_check_rads_
 // note: original ASM always returned 0
 int critterCheckRadiationEvent(Object* obj)
 {
@@ -540,7 +540,7 @@ int critterCheckRadiationEvent(Object* obj)
     return 0;
 }
 
-// 0x42D618
+// 0x42D618 get_rad_damage_level_
 static int _get_rad_damage_level(Object* obj, void* data)
 {
     RadiationEvent* radiationEvent = (RadiationEvent*)data;
@@ -550,7 +550,7 @@ static int _get_rad_damage_level(Object* obj, void* data)
     return 0;
 }
 
-// 0x42D624
+// 0x42D624 clear_rad_damage_
 int radiationClearDamage(Object* obj, void* data)
 {
     RadiationEvent* radiationEvent = (RadiationEvent*)data;
@@ -564,7 +564,7 @@ int radiationClearDamage(Object* obj, void* data)
 
 // Applies radiation.
 //
-// 0x42D63C
+// 0x42D63C process_rads_
 void radiationProcess(Object* obj, int radiationLevel, bool isHealing)
 {
     MessageListItem messageListItem;
@@ -625,7 +625,7 @@ void radiationProcess(Object* obj, int radiationLevel, bool isHealing)
     }
 }
 
-// 0x42D740
+// 0x42D740 critter_process_rads_
 int radiationEventProcess(Object* obj, void* data)
 {
     RadiationEvent* radiationEvent = (RadiationEvent*)data;
@@ -645,7 +645,7 @@ int radiationEventProcess(Object* obj, void* data)
     return 1;
 }
 
-// 0x42D7A0
+// 0x42D7A0 critter_load_rads_
 int radiationEventRead(File* stream, void** dataPtr)
 {
     RadiationEvent* radiationEvent = (RadiationEvent*)internal_malloc(sizeof(*radiationEvent));
@@ -665,7 +665,7 @@ err:
     return -1;
 }
 
-// 0x42D7FC
+// 0x42D7FC critter_save_rads_
 int radiationEventWrite(File* stream, void* data)
 {
     RadiationEvent* radiationEvent = (RadiationEvent*)data;
@@ -676,7 +676,7 @@ int radiationEventWrite(File* stream, void* data)
     return 0;
 }
 
-// 0x42D82C
+// 0x42D82C critter_get_base_damage_type_
 int critterGetDamageType(Object* obj)
 {
     if (PID_TYPE(obj->pid) != OBJ_TYPE_CRITTER) {
@@ -693,14 +693,14 @@ int critterGetDamageType(Object* obj)
 
 // NOTE: Inlined.
 //
-// 0x42D860
+// 0x42D860 critter_kill_count_clear_
 static int critter_kill_count_clear()
 {
     memset(gKillsByType, 0, sizeof(gKillsByType));
     return 0;
 }
 
-// 0x42D878
+// 0x42D878 critter_kill_count_inc_
 int killsIncByType(int killType)
 {
     if (killType != -1 && killType < KILL_TYPE_COUNT) {
@@ -711,7 +711,7 @@ int killsIncByType(int killType)
     return -1;
 }
 
-// 0x42D8A8
+// 0x42D8A8 critter_kill_count_
 int killsGetByType(int killType)
 {
     if (killType != -1 && killType < KILL_TYPE_COUNT) {
@@ -721,7 +721,7 @@ int killsGetByType(int killType)
     return 0;
 }
 
-// 0x42D8C0
+// 0x42D8C0 critter_kill_count_load_
 int killsLoad(File* stream)
 {
     if (fileReadInt32List(stream, gKillsByType, KILL_TYPE_COUNT) == -1) {
@@ -732,7 +732,7 @@ int killsLoad(File* stream)
     return 0;
 }
 
-// 0x42D8F0
+// 0x42D8F0 critter_kill_count_save_
 int killsSave(File* stream)
 {
     if (fileWriteInt32List(stream, gKillsByType, KILL_TYPE_COUNT) == -1) {
@@ -743,7 +743,7 @@ int killsSave(File* stream)
     return 0;
 }
 
-// 0x42D920
+// 0x42D920 critter_kill_count_type_
 int critterGetKillType(Object* obj)
 {
     if (obj == gDude) {
@@ -764,7 +764,7 @@ int critterGetKillType(Object* obj)
     return proto->critter.data.killType;
 }
 
-// 0x42D974
+// 0x42D974 critter_kill_name_
 char* killTypeGetName(int killType)
 {
     if (killType != -1 && killType < KILL_TYPE_COUNT) {
@@ -779,7 +779,7 @@ char* killTypeGetName(int killType)
     }
 }
 
-// 0x42D9B4
+// 0x42D9B4 critter_kill_info_
 char* killTypeGetDescription(int killType)
 {
     if (killType != -1 && killType < KILL_TYPE_COUNT) {
@@ -794,7 +794,7 @@ char* killTypeGetDescription(int killType)
     }
 }
 
-// 0x42D9F4
+// 0x42D9F4 critter_heal_hours_
 // heals critters based on the number of elapsed hours
 int critterHealByHours(Object* critter, int hours)
 {
@@ -811,13 +811,13 @@ int critterHealByHours(Object* critter, int hours)
     return 0;
 }
 
-// 0x42DA54
+// 0x42DA54 critterClearObjDrugs_
 static int _critterClearObjDrugs(Object* obj, void* data)
 {
     return obj == _critterClearObj;
 }
 
-// 0x42DA64
+// 0x42DA64 critter_kill_
 void critterKill(Object* critter, int anim, bool refreshRect)
 {
     if (PID_TYPE(critter->pid) != OBJ_TYPE_CRITTER) {
@@ -920,7 +920,7 @@ void critterKill(Object* critter, int anim, bool refreshRect)
 
 // Returns experience for killing [critter].
 //
-// 0x42DCB8
+// 0x42DCB8 critter_kill_exps_
 int critterGetExp(Object* critter)
 {
     Proto* proto;
@@ -928,7 +928,7 @@ int critterGetExp(Object* critter)
     return proto->critter.data.experience;
 }
 
-// 0x42DCDC
+// 0x42DCDC critter_is_active_
 bool critterIsActive(Object* critter)
 {
     if (critter == nullptr) {
@@ -950,7 +950,7 @@ bool critterIsActive(Object* critter)
     return (critter->data.critter.combat.results & DAM_DEAD) == 0;
 }
 
-// 0x42DD18
+// 0x42DD18 critter_is_dead_
 bool critterIsDead(Object* critter)
 {
     if (critter == nullptr) {
@@ -972,7 +972,7 @@ bool critterIsDead(Object* critter)
     return false;
 }
 
-// 0x42DD58
+// 0x42DD58 critter_is_crippled_
 bool critterIsCrippled(Object* critter)
 {
     if (critter == nullptr) {
@@ -986,7 +986,7 @@ bool critterIsCrippled(Object* critter)
     return (critter->data.critter.combat.results & DAM_CRIP) != 0;
 }
 
-// 0x42DD80
+// 0x42DD80 critter_is_prone_
 bool critterIsProne(Object* critter)
 {
     if (critter == nullptr) {
@@ -1005,7 +1005,7 @@ bool critterIsProne(Object* critter)
 }
 
 // critter_body_type
-// 0x42DDC4
+// 0x42DDC4 critter_body_type_
 int critterGetBodyType(Object* critter)
 {
     if (critter == nullptr) {
@@ -1022,7 +1022,7 @@ int critterGetBodyType(Object* critter)
     return proto->critter.data.bodyType;
 }
 
-// 0x42DE58
+// 0x42DE58 pc_load_data_
 int gcdLoad(const char* path)
 {
     File* stream = fileOpen(path, "rb");
@@ -1064,7 +1064,7 @@ int gcdLoad(const char* path)
     return 0;
 }
 
-// 0x42DF70
+// 0x42DF70 critter_read_data_
 int protoCritterDataRead(File* stream, CritterProtoData* critterData)
 {
     if (fileReadInt32(stream, &(critterData->flags)) == -1) return -1;
@@ -1094,7 +1094,7 @@ int protoCritterDataRead(File* stream, CritterProtoData* critterData)
     return 0;
 }
 
-// 0x42E08C
+// 0x42E08C pc_save_data_
 int gcdSave(const char* path)
 {
     File* stream = fileOpen(path, "wb");
@@ -1131,7 +1131,7 @@ int gcdSave(const char* path)
     return 0;
 }
 
-// 0x42E174
+// 0x42E174 critter_write_data_
 int protoCritterDataWrite(File* stream, CritterProtoData* critterData)
 {
     if (fileWriteInt32(stream, critterData->flags) == -1) return -1;
@@ -1146,7 +1146,7 @@ int protoCritterDataWrite(File* stream, CritterProtoData* critterData)
     return 0;
 }
 
-// 0x42E220
+// 0x42E220 pc_flag_off_
 void dudeDisableState(int state)
 {
     Proto* proto;
@@ -1161,7 +1161,7 @@ void dudeDisableState(int state)
     indicatorBarRefresh();
 }
 
-// 0x42E26C
+// 0x42E26C pc_flag_on_
 void dudeEnableState(int state)
 {
     Proto* proto;
@@ -1176,7 +1176,7 @@ void dudeEnableState(int state)
     indicatorBarRefresh();
 }
 
-// 0x42E2B0
+// 0x42E2B0 pc_flag_toggle_
 void dudeToggleState(int state)
 {
     // NOTE: Uninline.
@@ -1187,7 +1187,7 @@ void dudeToggleState(int state)
     }
 }
 
-// 0x42E2F8
+// 0x42E2F8 is_pc_flag_
 bool dudeHasState(int state)
 {
     Proto* proto;
@@ -1195,7 +1195,7 @@ bool dudeHasState(int state)
     return (proto->critter.data.flags & (1 << state)) != 0;
 }
 
-// 0x42E32C
+// 0x42E32C critter_sneak_check_
 int sneakEventProcess(Object* obj, void* data)
 {
     int time;
@@ -1227,7 +1227,7 @@ int sneakEventProcess(Object* obj, void* data)
     return 0;
 }
 
-// 0x42E3E4
+// 0x42E3E4 critter_sneak_clear_
 int critterDisableSneak(Object* obj, void* data)
 {
     dudeDisableState(DUDE_STATE_SNEAKING);
@@ -1236,7 +1236,7 @@ int critterDisableSneak(Object* obj, void* data)
 
 // Returns true if dude is really sneaking.
 //
-// 0x42E3F4
+// 0x42E3F4 is_pc_sneak_working_
 bool dudeIsSneaking()
 {
     // NOTE: Uninline.
@@ -1247,7 +1247,7 @@ bool dudeIsSneaking()
     return false;
 }
 
-// 0x42E424
+// 0x42E424 critter_wake_up_
 int knockoutEventProcess(Object* obj, void* data)
 {
     if ((obj->data.critter.combat.results & DAM_DEAD) != 0) {
@@ -1266,7 +1266,7 @@ int knockoutEventProcess(Object* obj, void* data)
     return 0;
 }
 
-// 0x42E460
+// 0x42E460 critter_wake_clear_
 int knockoutClear(Object* obj, void* data)
 {
     if (PID_TYPE(obj->pid) != OBJ_TYPE_CRITTER) {
@@ -1285,7 +1285,7 @@ int knockoutClear(Object* obj, void* data)
     return 0;
 }
 
-// 0x42E4C0
+// 0x42E4C0 critter_set_who_hit_me_
 // note: this is sometimes called with (attacker, defender) and sometimes with (defender, attacker).
 // `hitMe` may be nullptr
 int critterSetWhoHitMe(Object* critter, Object* hitMe)
@@ -1310,7 +1310,7 @@ int critterSetWhoHitMe(Object* critter, Object* hitMe)
     return 0;
 }
 
-// 0x42E564
+// 0x42E564 critter_can_obj_dude_rest_
 bool critterCanDudeRest()
 {
     bool mapDisallowsRest = false;
@@ -1351,7 +1351,7 @@ bool critterCanDudeRest()
     return result;
 }
 
-// 0x42E62C
+// 0x42E62C critter_compute_ap_from_distance_
 int critterGetMovementPointCostAdjustedForCrippledLegs(Object* critter, int distance)
 {
     if (PID_TYPE(critter->pid) != OBJ_TYPE_CRITTER) {
@@ -1368,7 +1368,7 @@ int critterGetMovementPointCostAdjustedForCrippledLegs(Object* critter, int dist
     }
 }
 
-// 0x42E66C
+// 0x42E66C critterIsOverloaded_
 bool critterIsEncumbered(Object* critter)
 {
     int maxWeight = critterGetStat(critter, STAT_CARRY_WEIGHT);
@@ -1376,7 +1376,7 @@ bool critterIsEncumbered(Object* critter)
     return maxWeight < currentWeight;
 }
 
-// 0x42E690
+// 0x42E690 critter_is_fleeing_
 bool critterIsFleeing(Object* critter)
 {
     return critter != nullptr
@@ -1386,7 +1386,7 @@ bool critterIsFleeing(Object* critter)
 
 // Checks proto critter flag.
 //
-// 0x42E6AC
+// 0x42E6AC critter_flag_check_
 bool critterFlagCheck(int pid, int flag)
 {
     if (pid == -1) {
@@ -1402,7 +1402,7 @@ bool critterFlagCheck(int pid, int flag)
     return (proto->critter.data.flags & flag) != 0;
 }
 
-// 0x42E6F0
+// 0x42E6F0 critter_flag_set_
 void critterFlagSet(int pid, int flag)
 {
     Proto* proto;
@@ -1420,7 +1420,7 @@ void critterFlagSet(int pid, int flag)
     proto->critter.data.flags |= flag;
 }
 
-// 0x42E71C
+// 0x42E71C critter_flag_unset_
 void critterFlagUnset(int pid, int flag)
 {
     Proto* proto;

--- a/src/cycle.cc
+++ b/src/cycle.cc
@@ -94,7 +94,7 @@ static unsigned int last_cycle_medium;
 // 0x56D7DC
 static unsigned int last_cycle_very_fast;
 
-// 0x42E780
+// 0x42E780 cycle_init_
 void colorCycleInit()
 {
     if (gColorCycleInitialized) {
@@ -133,7 +133,7 @@ void colorCycleInit()
     cycleSetSpeedFactor(settings.system.cycle_speed_factor);
 }
 
-// 0x42E8CC
+// 0x42E8CC cycle_reset_
 void colorCycleReset()
 {
     if (gColorCycleInitialized) {
@@ -146,7 +146,7 @@ void colorCycleReset()
     }
 }
 
-// 0x42E90C
+// 0x42E90C cycle_exit_
 void colorCycleFree()
 {
     if (gColorCycleInitialized) {
@@ -156,32 +156,32 @@ void colorCycleFree()
     }
 }
 
-// 0x42E930
+// 0x42E930 cycle_disable_
 void colorCycleDisable()
 {
     gColorCycleEnabled = false;
 }
 
-// 0x42E93C
+// 0x42E93C cycle_enable_
 void colorCycleEnable()
 {
     gColorCycleEnabled = true;
 }
 
-// 0x42E948
+// 0x42E948 cycle_is_enabled_
 bool colorCycleEnabled()
 {
     return gColorCycleEnabled;
 }
 
-// 0x42E950
+// 0x42E950 change_cycle_speed_
 void cycleSetSpeedFactor(int value)
 {
     gColorCycleSpeedFactor = value;
     settings.system.cycle_speed_factor = value;
 }
 
-// 0x42E97C
+// 0x42E97C cycle_colors_
 void colorCycleTicker()
 {
     // 0x518494

--- a/src/cycle.cc
+++ b/src/cycle.cc
@@ -13,7 +13,7 @@ static constexpr unsigned int kMediumCyclePeriod = 1000 / 7;
 static constexpr unsigned int kFastCyclePeriod = 1000 / 10;
 static constexpr unsigned int kVeryFastCyclePeriod = 1000 / 30;
 
-// 0x51843C
+// 0x51843C cycle_speed_factor
 static int gColorCycleSpeedFactor = 1;
 
 // TODO: Convert colors to RGB.
@@ -21,7 +21,7 @@ static int gColorCycleSpeedFactor = 1;
 
 // Green.
 //
-// 0x518440
+// 0x518440 slime
 static unsigned char slime[12] = {
     0, 108, 0,
     11, 115, 7,
@@ -31,7 +31,7 @@ static unsigned char slime[12] = {
 
 // Light gray?
 //
-// 0x51844C
+// 0x51844C shoreline
 static unsigned char shoreline[18] = {
     83, 63, 43,
     75, 59, 43,
@@ -43,7 +43,7 @@ static unsigned char shoreline[18] = {
 
 // Orange.
 //
-// 0x51845E
+// 0x51845E fire_slow
 static unsigned char fire_slow[15] = {
     255, 0, 0,
     215, 0, 0,
@@ -54,7 +54,7 @@ static unsigned char fire_slow[15] = {
 
 // Red.
 //
-// 0x51846D
+// 0x51846D fire_fast
 static unsigned char fire_fast[15] = {
     71, 0, 0,
     123, 0, 0,
@@ -65,7 +65,7 @@ static unsigned char fire_fast[15] = {
 
 // Light blue.
 //
-// 0x51847C
+// 0x51847C monitors
 static unsigned char monitors[15] = {
     107, 107, 111,
     99, 103, 127,
@@ -76,25 +76,25 @@ static unsigned char monitors[15] = {
 
 // clang-format on
 
-// 0x51848C
+// 0x51848C cycle_initialized
 static bool gColorCycleInitialized = false;
 
-// 0x518490
+// 0x518490 cycle_enabled
 static bool gColorCycleEnabled = false;
 
-// 0x56D7D0
+// 0x56D7D0 last_cycle_fast
 static unsigned int last_cycle_fast;
 
-// 0x56D7D4
+// 0x56D7D4 last_cycle_slow
 static unsigned int last_cycle_slow;
 
-// 0x56D7D8
+// 0x56D7D8 last_cycle_medium
 static unsigned int last_cycle_medium;
 
-// 0x56D7DC
+// 0x56D7DC last_cycle_very_fast
 static unsigned int last_cycle_very_fast;
 
-// 0x42E780 cycle_init_
+// 0x42E780 cycle_init
 void colorCycleInit()
 {
     if (gColorCycleInitialized) {
@@ -133,7 +133,7 @@ void colorCycleInit()
     cycleSetSpeedFactor(settings.system.cycle_speed_factor);
 }
 
-// 0x42E8CC cycle_reset_
+// 0x42E8CC cycle_reset
 void colorCycleReset()
 {
     if (gColorCycleInitialized) {
@@ -146,7 +146,7 @@ void colorCycleReset()
     }
 }
 
-// 0x42E90C cycle_exit_
+// 0x42E90C cycle_exit
 void colorCycleFree()
 {
     if (gColorCycleInitialized) {
@@ -156,32 +156,32 @@ void colorCycleFree()
     }
 }
 
-// 0x42E930 cycle_disable_
+// 0x42E930 cycle_disable
 void colorCycleDisable()
 {
     gColorCycleEnabled = false;
 }
 
-// 0x42E93C cycle_enable_
+// 0x42E93C cycle_enable
 void colorCycleEnable()
 {
     gColorCycleEnabled = true;
 }
 
-// 0x42E948 cycle_is_enabled_
+// 0x42E948 cycle_is_enabled
 bool colorCycleEnabled()
 {
     return gColorCycleEnabled;
 }
 
-// 0x42E950 change_cycle_speed_
+// 0x42E950 change_cycle_speed
 void cycleSetSpeedFactor(int value)
 {
     gColorCycleSpeedFactor = value;
     settings.system.cycle_speed_factor = value;
 }
 
-// 0x42E97C cycle_colors_
+// 0x42E97C cycle_colors
 void colorCycleTicker()
 {
     // 0x518494

--- a/src/datafile.cc
+++ b/src/datafile.cc
@@ -11,10 +11,10 @@ namespace fallout {
 constexpr size_t DATA_FILE_PALETTE_MAX = 768;
 constexpr size_t INDEXED_PALETTE_MAX = 256;
 
-// 0x5184AC _loadFunc
+// 0x5184AC loadFunc
 DatafileLoader* gDatafileLoader = nullptr;
 
-// 0x5184B0 _mangleName
+// 0x5184B0 mangleName
 DatafileNameMangler* gDatafileNameMangler = datafileDefaultNameManglerImpl;
 
 // 0x56D7E0 pal

--- a/src/datafile.cc
+++ b/src/datafile.cc
@@ -20,7 +20,7 @@ DatafileNameMangler* gDatafileNameMangler = datafileDefaultNameManglerImpl;
 // 0x56D7E0
 uint8_t gDatafilePalette[DATA_FILE_PALETTE_MAX];
 
-// 0x42EE70
+// 0x42EE70 defaultMangleName_
 char* datafileDefaultNameManglerImpl(char* path)
 {
     return path;
@@ -28,7 +28,7 @@ char* datafileDefaultNameManglerImpl(char* path)
 
 // NOTE: Unused.
 //
-// 0x42EE74
+// 0x42EE74 datafileSetFilenameFunc_
 void datafileSetNameMangler(DatafileNameMangler* mangler)
 {
     gDatafileNameMangler = mangler;
@@ -36,13 +36,13 @@ void datafileSetNameMangler(DatafileNameMangler* mangler)
 
 // NOTE: Unused.
 //
-// 0x42EE7C
+// 0x42EE7C setBitmapLoadFunc_
 void datafileSetLoader(DatafileLoader* loader)
 {
     gDatafileLoader = loader;
 }
 
-// 0x42EE84
+// 0x42EE84 datafileConvertData_
 void datafileRemapPixelsRgb8(uint8_t* data, uint8_t* palette, int width, int height)
 {
     uint8_t indexedPalette[INDEXED_PALETTE_MAX];
@@ -65,7 +65,7 @@ void datafileRemapPixelsRgb8(uint8_t* data, uint8_t* palette, int width, int hei
 
 // NOTE: Unused.
 //
-// 0x42EEF8
+// 0x42EEF8 datafileConvertDataVGA_
 void datafileRemapPixelsRgb6(uint8_t* data, uint8_t* palette, int width, int height)
 {
     uint8_t indexedPalette[INDEXED_PALETTE_MAX];
@@ -86,7 +86,7 @@ void datafileRemapPixelsRgb6(uint8_t* data, uint8_t* palette, int width, int hei
     }
 }
 
-// 0x42EF60
+// 0x42EF60 loadRawDataFile_
 uint8_t* datafileReadRaw(char* path, int* widthPtr, int* heightPtr)
 {
     char* mangledPath = gDatafileNameMangler(path);
@@ -104,7 +104,7 @@ uint8_t* datafileReadRaw(char* path, int* widthPtr, int* heightPtr)
     return nullptr;
 }
 
-// 0x42EFCC
+// 0x42EFCC loadDataFile_
 uint8_t* datafileRead(char* path, int* widthPtr, int* heightPtr)
 {
     uint8_t* imageData = datafileReadRaw(path, widthPtr, heightPtr);
@@ -116,7 +116,7 @@ uint8_t* datafileRead(char* path, int* widthPtr, int* heightPtr)
 
 // NOTE: Unused
 //
-// 0x42EFF4
+// 0x42EFF4 load256Palette_
 uint8_t* datafileLoadPalette(char* path)
 {
     int width;
@@ -132,7 +132,7 @@ uint8_t* datafileLoadPalette(char* path)
 
 // NOTE: Unused.
 //
-// 0x42F024
+// 0x42F024 trimBuffer_
 void datafilePackUntilZero(uint8_t* data, int* widthPtr, int* heightPtr)
 {
     int width = *widthPtr;
@@ -165,7 +165,7 @@ void datafilePackUntilZero(uint8_t* data, int* widthPtr, int* heightPtr)
     internal_free_safe(compactDataWritePtr, __FILE__, __LINE__); // // "..\\int\\DATAFILE.C", 171
 }
 
-// 0x42F0E4
+// 0x42F0E4 datafileGetPalette_
 uint8_t* datafileGetPalette()
 {
     return gDatafilePalette;
@@ -173,7 +173,7 @@ uint8_t* datafileGetPalette()
 
 // NOTE: Unused.
 //
-// 0x42F0EC
+// 0x42F0EC datafileLoadBlock_
 uint8_t* datafileLoad(char* path, int* sizePtr)
 {
     const char* mangledPath = gDatafileNameMangler(path);

--- a/src/datafile.cc
+++ b/src/datafile.cc
@@ -11,16 +11,16 @@ namespace fallout {
 constexpr size_t DATA_FILE_PALETTE_MAX = 768;
 constexpr size_t INDEXED_PALETTE_MAX = 256;
 
-// 0x5184AC
+// 0x5184AC _loadFunc
 DatafileLoader* gDatafileLoader = nullptr;
 
-// 0x5184B0
+// 0x5184B0 _mangleName
 DatafileNameMangler* gDatafileNameMangler = datafileDefaultNameManglerImpl;
 
-// 0x56D7E0
+// 0x56D7E0 pal
 uint8_t gDatafilePalette[DATA_FILE_PALETTE_MAX];
 
-// 0x42EE70 defaultMangleName_
+// 0x42EE70 defaultMangleName
 char* datafileDefaultNameManglerImpl(char* path)
 {
     return path;
@@ -28,7 +28,7 @@ char* datafileDefaultNameManglerImpl(char* path)
 
 // NOTE: Unused.
 //
-// 0x42EE74 datafileSetFilenameFunc_
+// 0x42EE74 datafileSetFilenameFunc
 void datafileSetNameMangler(DatafileNameMangler* mangler)
 {
     gDatafileNameMangler = mangler;
@@ -36,13 +36,13 @@ void datafileSetNameMangler(DatafileNameMangler* mangler)
 
 // NOTE: Unused.
 //
-// 0x42EE7C setBitmapLoadFunc_
+// 0x42EE7C setBitmapLoadFunc
 void datafileSetLoader(DatafileLoader* loader)
 {
     gDatafileLoader = loader;
 }
 
-// 0x42EE84 datafileConvertData_
+// 0x42EE84 datafileConvertData
 void datafileRemapPixelsRgb8(uint8_t* data, uint8_t* palette, int width, int height)
 {
     uint8_t indexedPalette[INDEXED_PALETTE_MAX];
@@ -65,7 +65,7 @@ void datafileRemapPixelsRgb8(uint8_t* data, uint8_t* palette, int width, int hei
 
 // NOTE: Unused.
 //
-// 0x42EEF8 datafileConvertDataVGA_
+// 0x42EEF8 datafileConvertDataVGA
 void datafileRemapPixelsRgb6(uint8_t* data, uint8_t* palette, int width, int height)
 {
     uint8_t indexedPalette[INDEXED_PALETTE_MAX];
@@ -86,7 +86,7 @@ void datafileRemapPixelsRgb6(uint8_t* data, uint8_t* palette, int width, int hei
     }
 }
 
-// 0x42EF60 loadRawDataFile_
+// 0x42EF60 loadRawDataFile
 uint8_t* datafileReadRaw(char* path, int* widthPtr, int* heightPtr)
 {
     char* mangledPath = gDatafileNameMangler(path);
@@ -104,7 +104,7 @@ uint8_t* datafileReadRaw(char* path, int* widthPtr, int* heightPtr)
     return nullptr;
 }
 
-// 0x42EFCC loadDataFile_
+// 0x42EFCC loadDataFile
 uint8_t* datafileRead(char* path, int* widthPtr, int* heightPtr)
 {
     uint8_t* imageData = datafileReadRaw(path, widthPtr, heightPtr);
@@ -116,7 +116,7 @@ uint8_t* datafileRead(char* path, int* widthPtr, int* heightPtr)
 
 // NOTE: Unused
 //
-// 0x42EFF4 load256Palette_
+// 0x42EFF4 load256Palette
 uint8_t* datafileLoadPalette(char* path)
 {
     int width;
@@ -132,7 +132,7 @@ uint8_t* datafileLoadPalette(char* path)
 
 // NOTE: Unused.
 //
-// 0x42F024 trimBuffer_
+// 0x42F024 trimBuffer
 void datafilePackUntilZero(uint8_t* data, int* widthPtr, int* heightPtr)
 {
     int width = *widthPtr;
@@ -165,7 +165,7 @@ void datafilePackUntilZero(uint8_t* data, int* widthPtr, int* heightPtr)
     internal_free_safe(compactDataWritePtr, __FILE__, __LINE__); // // "..\\int\\DATAFILE.C", 171
 }
 
-// 0x42F0E4 datafileGetPalette_
+// 0x42F0E4 datafileGetPalette
 uint8_t* datafileGetPalette()
 {
     return gDatafilePalette;
@@ -173,7 +173,7 @@ uint8_t* datafileGetPalette()
 
 // NOTE: Unused.
 //
-// 0x42F0EC datafileLoadBlock_
+// 0x42F0EC datafileLoadBlock
 uint8_t* datafileLoad(char* path, int* sizePtr)
 {
     const char* mangledPath = gDatafileNameMangler(path);

--- a/src/db.cc
+++ b/src/db.cc
@@ -43,7 +43,7 @@ static FileList* gFileListHead;
 // underlying xbase implementation. Result of opening [filePath2] is ignored.
 // Returns 0 on success.
 //
-// 0x4C5D30
+// 0x4C5D30 db_init_
 int dbOpen(const char* filePath1, const char* filePath2)
 {
     if (filePath1 != nullptr) {
@@ -59,13 +59,13 @@ int dbOpen(const char* filePath1, const char* filePath2)
     return 0;
 }
 
-// 0x4C5D58
+// 0x4C5D58 db_total_
 int db_total()
 {
     return 1;
 }
 
-// 0x4C5D60
+// 0x4C5D60 db_exit_
 void dbCloseAll()
 {
     xbaseReopenAll(nullptr);
@@ -73,7 +73,7 @@ void dbCloseAll()
 
 // TODO: sizePtr should be long*.
 //
-// 0x4C5D68
+// 0x4C5D68 db_dir_entry_
 int dbGetFileSize(const char* filePath, int* sizePtr)
 {
     assert(filePath); // "filename", "db.c", 108
@@ -91,7 +91,7 @@ int dbGetFileSize(const char* filePath, int* sizePtr)
     return 0;
 }
 
-// 0x4C5DD4
+// 0x4C5DD4 db_read_to_buf_
 int dbGetFileContents(const char* filePath, void* ptr)
 {
     assert(filePath); // "filename", "db.c", 141
@@ -132,19 +132,19 @@ int dbGetFileContents(const char* filePath, void* ptr)
     return 0;
 }
 
-// 0x4C5EB4
+// 0x4C5EB4 db_fclose_
 int fileClose(File* stream)
 {
     return xfileClose(stream);
 }
 
-// 0x4C5EC8
+// 0x4C5EC8 db_fopen_
 File* fileOpen(const char* filename, const char* mode)
 {
     return xfileOpen(filename, mode);
 }
 
-// 0x4C5ED0
+// 0x4C5ED0 db_fprintf_
 int filePrintFormatted(File* stream, const char* format, ...)
 {
     assert(format); // "format", "db.c", 224
@@ -159,7 +159,7 @@ int filePrintFormatted(File* stream, const char* format, ...)
     return rc;
 }
 
-// 0x4C5F24
+// 0x4C5F24 db_fgetc_
 int fileReadChar(File* stream)
 {
     if (gFileReadProgressHandler != nullptr) {
@@ -177,7 +177,7 @@ int fileReadChar(File* stream)
     return xfileReadChar(stream);
 }
 
-// 0x4C5F70
+// 0x4C5F70 db_fgets_
 char* fileReadString(char* string, size_t size, File* stream)
 {
     if (gFileReadProgressHandler != nullptr) {
@@ -197,13 +197,13 @@ char* fileReadString(char* string, size_t size, File* stream)
     return xfileReadString(string, size, stream);
 }
 
-// 0x4C5FEC
+// 0x4C5FEC db_fputs_
 int fileWriteString(const char* string, File* stream)
 {
     return xfileWriteString(string, stream);
 }
 
-// 0x4C5FFC
+// 0x4C5FFC db_fread_
 size_t fileRead(void* ptr, size_t size, size_t count, File* stream)
 {
     if (gFileReadProgressHandler != nullptr) {
@@ -237,31 +237,31 @@ size_t fileRead(void* ptr, size_t size, size_t count, File* stream)
     return xfileRead(ptr, size, count, stream);
 }
 
-// 0x4C60B8
+// 0x4C60B8 db_fwrite_
 size_t fileWrite(const void* buf, size_t size, size_t count, File* stream)
 {
     return xfileWrite(buf, size, count, stream);
 }
 
-// 0x4C60C0
+// 0x4C60C0 db_fseek_
 int fileSeek(File* stream, long offset, int origin)
 {
     return xfileSeek(stream, offset, origin);
 }
 
-// 0x4C60C8
+// 0x4C60C8 db_ftell_
 long fileTell(File* stream)
 {
     return xfileTell(stream);
 }
 
-// 0x4C60D0
+// 0x4C60D0 db_rewind_
 void fileRewind(File* stream)
 {
     xfileRewind(stream);
 }
 
-// 0x4C60D8
+// 0x4C60D8 db_feof_
 int fileEof(File* stream)
 {
     return xfileEof(stream);
@@ -269,7 +269,7 @@ int fileEof(File* stream)
 
 // NOTE: Not sure about signness.
 //
-// 0x4C60E0
+// 0x4C60E0 db_freadByte_
 int fileReadUInt8(File* stream, unsigned char* valuePtr)
 {
     int value = fileReadChar(stream);
@@ -284,7 +284,7 @@ int fileReadUInt8(File* stream, unsigned char* valuePtr)
 
 // NOTE: Not sure about signness.
 //
-// 0x4C60F4
+// 0x4C60F4 db_freadShort_
 int fileReadInt16(File* stream, short* valuePtr)
 {
     unsigned char high;
@@ -313,7 +313,7 @@ int fileReadUInt16(File* stream, unsigned short* valuePtr)
     return fileReadInt16(stream, (short*)valuePtr);
 }
 
-// 0x4C614C
+// 0x4C614C db_freadInt_
 int fileReadInt32(File* stream, int* valuePtr)
 {
     int value;
@@ -361,13 +361,13 @@ int fileReadBool(File* stream, bool* valuePtr)
 
 // NOTE: Not sure about signness.
 //
-// 0x4C61AC
+// 0x4C61AC db_fwriteByte_
 int fileWriteUInt8(File* stream, unsigned char value)
 {
     return xfileWriteChar(value, stream);
 };
 
-// 0x4C61C8
+// 0x4C61C8 db_fwriteShort_
 int fileWriteInt16(File* stream, short value)
 {
     // NOTE: Uninline.
@@ -391,7 +391,7 @@ int fileWriteUInt16(File* stream, unsigned short value)
 
 // NOTE: Not sure about signness and int vs. long.
 //
-// 0x4C6214
+// 0x4C6214 db_fwriteInt_
 int fileWriteInt32(File* stream, int value)
 {
     // NOTE: Uninline.
@@ -401,7 +401,7 @@ int fileWriteInt32(File* stream, int value)
 // NOTE: Can either be signed vs. unsigned variant of [fileWriteInt32],
 // or int vs. long.
 //
-// 0x4C6244
+// 0x4C6244 db_fwriteLong_
 int _db_fwriteLong(File* stream, int value)
 {
     if (fileWriteInt16(stream, (value >> 16) & 0xFFFF) == -1) {
@@ -421,7 +421,7 @@ int fileWriteUInt32(File* stream, unsigned int value)
     return _db_fwriteLong(stream, (int)value);
 }
 
-// 0x4C62C4
+// 0x4C62C4 db_fwriteFloat_
 int fileWriteFloat(File* stream, float value)
 {
     // NOTE: Uninline.
@@ -433,7 +433,7 @@ int fileWriteBool(File* stream, bool value)
     return _db_fwriteLong(stream, value ? 1 : 0);
 }
 
-// 0x4C62FC
+// 0x4C62FC db_freadByteCount_
 int fileReadUInt8List(File* stream, unsigned char* arr, int count)
 {
     for (int index = 0; index < count; index++) {
@@ -458,7 +458,7 @@ int fileReadFixedLengthString(File* stream, char* string, int length)
     return fileReadUInt8List(stream, (unsigned char*)string, length);
 }
 
-// 0x4C6330
+// 0x4C6330 db_freadShortCount_
 int fileReadInt16List(File* stream, short* arr, int count)
 {
     for (int index = 0; index < count; index++) {
@@ -482,7 +482,7 @@ int fileReadUInt16List(File* stream, unsigned short* arr, int count)
 
 // NOTE: Not sure about signed/unsigned int/long.
 //
-// 0x4C63BC
+// 0x4C63BC db_freadIntCount_
 int fileReadInt32List(File* stream, int* arr, int count)
 {
     if (count == 0) {
@@ -513,7 +513,7 @@ int fileReadUInt32List(File* stream, unsigned int* arr, int count)
     return fileReadInt32List(stream, (int*)arr, count);
 }
 
-// 0x4C6464
+// 0x4C6464 db_fwriteByteCount_
 int fileWriteUInt8List(File* stream, unsigned char* arr, int count)
 {
     for (int index = 0; index < count; index++) {
@@ -532,7 +532,7 @@ int fileWriteFixedLengthString(File* stream, char* string, int length)
     return fileWriteUInt8List(stream, (unsigned char*)string, length);
 }
 
-// 0x4C6490
+// 0x4C6490 db_fwriteShortCount_
 int fileWriteInt16List(File* stream, short* arr, int count)
 {
     for (int index = 0; index < count; index++) {
@@ -553,7 +553,7 @@ int fileWriteUInt16List(File* stream, unsigned short* arr, int count)
 
 // NOTE: Can be either signed/unsigned + int/long variant.
 //
-// 0x4C64F8
+// 0x4C64F8 db_fwriteIntCount_
 int fileWriteInt32List(File* stream, int* arr, int count)
 {
     for (int index = 0; index < count; index++) {
@@ -568,7 +568,7 @@ int fileWriteInt32List(File* stream, int* arr, int count)
 
 // NOTE: Not sure about signed/unsigned int/long.
 //
-// 0x4C6550
+// 0x4C6550 db_fwriteLongCount_
 int _db_fwriteLongCount(File* stream, int* arr, int count)
 {
     for (int index = 0; index < count; index++) {
@@ -594,7 +594,7 @@ int fileWriteUInt32List(File* stream, unsigned int* arr, int count)
     return fileWriteInt32List(stream, (int*)arr, count);
 }
 
-// 0x4C6628
+// 0x4C6628 db_get_file_list_
 int fileNameListInit(const char* pattern, char*** fileNameListPtr)
 {
     FileList* fileList = (FileList*)malloc(sizeof(*fileList));
@@ -664,7 +664,7 @@ int fileNameListInit(const char* pattern, char*** fileNameListPtr)
     return length;
 }
 
-// 0x4C6868
+// 0x4C6868 db_free_file_list_
 void fileNameListFree(char*** fileNameListPtr, int unused)
 {
     (void)unused;
@@ -696,13 +696,13 @@ void fileNameListFree(char*** fileNameListPtr, int unused)
 
 // TODO: Return type should be long.
 //
-// 0x4C68BC
+// 0x4C68BC db_filelength_
 int fileGetSize(File* stream)
 {
     return xfileGetSize(stream);
 }
 
-// 0x4C68C4
+// 0x4C68C4 db_register_callback_
 void fileSetReadProgressHandler(FileReadProgressHandler* handler, int size)
 {
     if (handler != nullptr && size != 0) {
@@ -714,7 +714,7 @@ void fileSetReadProgressHandler(FileReadProgressHandler* handler, int size)
     }
 }
 
-// 0x4C68E8
+// 0x4C68E8 db_list_compare_
 int _db_list_compare(const void* p1, const void* p2)
 {
     return compat_stricmp(*(const char**)p1, *(const char**)p2);

--- a/src/db.cc
+++ b/src/db.cc
@@ -18,7 +18,7 @@ static int _db_list_compare(const void* p1, const void* p2);
 
 // Generic file progress report handler.
 //
-// 0x51DEEC _read_callback
+// 0x51DEEC read_callback
 static FileReadProgressHandler* gFileReadProgressHandler = nullptr;
 
 // Bytes read so far while tracking progress.

--- a/src/db.cc
+++ b/src/db.cc
@@ -18,7 +18,7 @@ static int _db_list_compare(const void* p1, const void* p2);
 
 // Generic file progress report handler.
 //
-// 0x51DEEC
+// 0x51DEEC _read_callback
 static FileReadProgressHandler* gFileReadProgressHandler = nullptr;
 
 // Bytes read so far while tracking progress.
@@ -26,15 +26,15 @@ static FileReadProgressHandler* gFileReadProgressHandler = nullptr;
 // Once this value reaches [gFileReadProgressChunkSize] the handler is called
 // and this value resets to zero.
 //
-// 0x51DEF0
+// 0x51DEF0 read_counter
 static int gFileReadProgressBytesRead = 0;
 
 // The number of bytes to read between calls to progress handler.
 //
-// 0x673040
+// 0x673040 read_threshold
 static int gFileReadProgressChunkSize;
 
-// 0x673044
+// 0x673044 db_file_lists
 static FileList* gFileListHead;
 
 // Opens file database.
@@ -43,7 +43,7 @@ static FileList* gFileListHead;
 // underlying xbase implementation. Result of opening [filePath2] is ignored.
 // Returns 0 on success.
 //
-// 0x4C5D30 db_init_
+// 0x4C5D30 db_init
 int dbOpen(const char* filePath1, const char* filePath2)
 {
     if (filePath1 != nullptr) {
@@ -59,13 +59,13 @@ int dbOpen(const char* filePath1, const char* filePath2)
     return 0;
 }
 
-// 0x4C5D58 db_total_
+// 0x4C5D58 db_total
 int db_total()
 {
     return 1;
 }
 
-// 0x4C5D60 db_exit_
+// 0x4C5D60 db_exit
 void dbCloseAll()
 {
     xbaseReopenAll(nullptr);
@@ -73,7 +73,7 @@ void dbCloseAll()
 
 // TODO: sizePtr should be long*.
 //
-// 0x4C5D68 db_dir_entry_
+// 0x4C5D68 db_dir_entry
 int dbGetFileSize(const char* filePath, int* sizePtr)
 {
     assert(filePath); // "filename", "db.c", 108
@@ -91,7 +91,7 @@ int dbGetFileSize(const char* filePath, int* sizePtr)
     return 0;
 }
 
-// 0x4C5DD4 db_read_to_buf_
+// 0x4C5DD4 db_read_to_buf
 int dbGetFileContents(const char* filePath, void* ptr)
 {
     assert(filePath); // "filename", "db.c", 141
@@ -132,19 +132,19 @@ int dbGetFileContents(const char* filePath, void* ptr)
     return 0;
 }
 
-// 0x4C5EB4 db_fclose_
+// 0x4C5EB4 db_fclose
 int fileClose(File* stream)
 {
     return xfileClose(stream);
 }
 
-// 0x4C5EC8 db_fopen_
+// 0x4C5EC8 db_fopen
 File* fileOpen(const char* filename, const char* mode)
 {
     return xfileOpen(filename, mode);
 }
 
-// 0x4C5ED0 db_fprintf_
+// 0x4C5ED0 db_fprintf
 int filePrintFormatted(File* stream, const char* format, ...)
 {
     assert(format); // "format", "db.c", 224
@@ -159,7 +159,7 @@ int filePrintFormatted(File* stream, const char* format, ...)
     return rc;
 }
 
-// 0x4C5F24 db_fgetc_
+// 0x4C5F24 db_fgetc
 int fileReadChar(File* stream)
 {
     if (gFileReadProgressHandler != nullptr) {
@@ -177,7 +177,7 @@ int fileReadChar(File* stream)
     return xfileReadChar(stream);
 }
 
-// 0x4C5F70 db_fgets_
+// 0x4C5F70 db_fgets
 char* fileReadString(char* string, size_t size, File* stream)
 {
     if (gFileReadProgressHandler != nullptr) {
@@ -197,13 +197,13 @@ char* fileReadString(char* string, size_t size, File* stream)
     return xfileReadString(string, size, stream);
 }
 
-// 0x4C5FEC db_fputs_
+// 0x4C5FEC db_fputs
 int fileWriteString(const char* string, File* stream)
 {
     return xfileWriteString(string, stream);
 }
 
-// 0x4C5FFC db_fread_
+// 0x4C5FFC db_fread
 size_t fileRead(void* ptr, size_t size, size_t count, File* stream)
 {
     if (gFileReadProgressHandler != nullptr) {
@@ -237,31 +237,31 @@ size_t fileRead(void* ptr, size_t size, size_t count, File* stream)
     return xfileRead(ptr, size, count, stream);
 }
 
-// 0x4C60B8 db_fwrite_
+// 0x4C60B8 db_fwrite
 size_t fileWrite(const void* buf, size_t size, size_t count, File* stream)
 {
     return xfileWrite(buf, size, count, stream);
 }
 
-// 0x4C60C0 db_fseek_
+// 0x4C60C0 db_fseek
 int fileSeek(File* stream, long offset, int origin)
 {
     return xfileSeek(stream, offset, origin);
 }
 
-// 0x4C60C8 db_ftell_
+// 0x4C60C8 db_ftell
 long fileTell(File* stream)
 {
     return xfileTell(stream);
 }
 
-// 0x4C60D0 db_rewind_
+// 0x4C60D0 db_rewind
 void fileRewind(File* stream)
 {
     xfileRewind(stream);
 }
 
-// 0x4C60D8 db_feof_
+// 0x4C60D8 db_feof
 int fileEof(File* stream)
 {
     return xfileEof(stream);
@@ -269,7 +269,7 @@ int fileEof(File* stream)
 
 // NOTE: Not sure about signness.
 //
-// 0x4C60E0 db_freadByte_
+// 0x4C60E0 db_freadByte
 int fileReadUInt8(File* stream, unsigned char* valuePtr)
 {
     int value = fileReadChar(stream);
@@ -284,7 +284,7 @@ int fileReadUInt8(File* stream, unsigned char* valuePtr)
 
 // NOTE: Not sure about signness.
 //
-// 0x4C60F4 db_freadShort_
+// 0x4C60F4 db_freadShort
 int fileReadInt16(File* stream, short* valuePtr)
 {
     unsigned char high;
@@ -313,7 +313,7 @@ int fileReadUInt16(File* stream, unsigned short* valuePtr)
     return fileReadInt16(stream, (short*)valuePtr);
 }
 
-// 0x4C614C db_freadInt_
+// 0x4C614C db_freadInt
 int fileReadInt32(File* stream, int* valuePtr)
 {
     int value;
@@ -361,13 +361,13 @@ int fileReadBool(File* stream, bool* valuePtr)
 
 // NOTE: Not sure about signness.
 //
-// 0x4C61AC db_fwriteByte_
+// 0x4C61AC db_fwriteByte
 int fileWriteUInt8(File* stream, unsigned char value)
 {
     return xfileWriteChar(value, stream);
 };
 
-// 0x4C61C8 db_fwriteShort_
+// 0x4C61C8 db_fwriteShort
 int fileWriteInt16(File* stream, short value)
 {
     // NOTE: Uninline.
@@ -391,7 +391,7 @@ int fileWriteUInt16(File* stream, unsigned short value)
 
 // NOTE: Not sure about signness and int vs. long.
 //
-// 0x4C6214 db_fwriteInt_
+// 0x4C6214 db_fwriteInt
 int fileWriteInt32(File* stream, int value)
 {
     // NOTE: Uninline.
@@ -401,7 +401,7 @@ int fileWriteInt32(File* stream, int value)
 // NOTE: Can either be signed vs. unsigned variant of [fileWriteInt32],
 // or int vs. long.
 //
-// 0x4C6244 db_fwriteLong_
+// 0x4C6244 db_fwriteLong
 int _db_fwriteLong(File* stream, int value)
 {
     if (fileWriteInt16(stream, (value >> 16) & 0xFFFF) == -1) {
@@ -421,7 +421,7 @@ int fileWriteUInt32(File* stream, unsigned int value)
     return _db_fwriteLong(stream, (int)value);
 }
 
-// 0x4C62C4 db_fwriteFloat_
+// 0x4C62C4 db_fwriteFloat
 int fileWriteFloat(File* stream, float value)
 {
     // NOTE: Uninline.
@@ -433,7 +433,7 @@ int fileWriteBool(File* stream, bool value)
     return _db_fwriteLong(stream, value ? 1 : 0);
 }
 
-// 0x4C62FC db_freadByteCount_
+// 0x4C62FC db_freadByteCount
 int fileReadUInt8List(File* stream, unsigned char* arr, int count)
 {
     for (int index = 0; index < count; index++) {
@@ -458,7 +458,7 @@ int fileReadFixedLengthString(File* stream, char* string, int length)
     return fileReadUInt8List(stream, (unsigned char*)string, length);
 }
 
-// 0x4C6330 db_freadShortCount_
+// 0x4C6330 db_freadShortCount
 int fileReadInt16List(File* stream, short* arr, int count)
 {
     for (int index = 0; index < count; index++) {
@@ -482,7 +482,7 @@ int fileReadUInt16List(File* stream, unsigned short* arr, int count)
 
 // NOTE: Not sure about signed/unsigned int/long.
 //
-// 0x4C63BC db_freadIntCount_
+// 0x4C63BC db_freadIntCount
 int fileReadInt32List(File* stream, int* arr, int count)
 {
     if (count == 0) {
@@ -513,7 +513,7 @@ int fileReadUInt32List(File* stream, unsigned int* arr, int count)
     return fileReadInt32List(stream, (int*)arr, count);
 }
 
-// 0x4C6464 db_fwriteByteCount_
+// 0x4C6464 db_fwriteByteCount
 int fileWriteUInt8List(File* stream, unsigned char* arr, int count)
 {
     for (int index = 0; index < count; index++) {
@@ -532,7 +532,7 @@ int fileWriteFixedLengthString(File* stream, char* string, int length)
     return fileWriteUInt8List(stream, (unsigned char*)string, length);
 }
 
-// 0x4C6490 db_fwriteShortCount_
+// 0x4C6490 db_fwriteShortCount
 int fileWriteInt16List(File* stream, short* arr, int count)
 {
     for (int index = 0; index < count; index++) {
@@ -553,7 +553,7 @@ int fileWriteUInt16List(File* stream, unsigned short* arr, int count)
 
 // NOTE: Can be either signed/unsigned + int/long variant.
 //
-// 0x4C64F8 db_fwriteIntCount_
+// 0x4C64F8 db_fwriteIntCount
 int fileWriteInt32List(File* stream, int* arr, int count)
 {
     for (int index = 0; index < count; index++) {
@@ -568,7 +568,7 @@ int fileWriteInt32List(File* stream, int* arr, int count)
 
 // NOTE: Not sure about signed/unsigned int/long.
 //
-// 0x4C6550 db_fwriteLongCount_
+// 0x4C6550 db_fwriteLongCount
 int _db_fwriteLongCount(File* stream, int* arr, int count)
 {
     for (int index = 0; index < count; index++) {
@@ -594,7 +594,7 @@ int fileWriteUInt32List(File* stream, unsigned int* arr, int count)
     return fileWriteInt32List(stream, (int*)arr, count);
 }
 
-// 0x4C6628 db_get_file_list_
+// 0x4C6628 db_get_file_list
 int fileNameListInit(const char* pattern, char*** fileNameListPtr)
 {
     FileList* fileList = (FileList*)malloc(sizeof(*fileList));
@@ -664,7 +664,7 @@ int fileNameListInit(const char* pattern, char*** fileNameListPtr)
     return length;
 }
 
-// 0x4C6868 db_free_file_list_
+// 0x4C6868 db_free_file_list
 void fileNameListFree(char*** fileNameListPtr, int unused)
 {
     (void)unused;
@@ -696,13 +696,13 @@ void fileNameListFree(char*** fileNameListPtr, int unused)
 
 // TODO: Return type should be long.
 //
-// 0x4C68BC db_filelength_
+// 0x4C68BC db_filelength
 int fileGetSize(File* stream)
 {
     return xfileGetSize(stream);
 }
 
-// 0x4C68C4 db_register_callback_
+// 0x4C68C4 db_register_callback
 void fileSetReadProgressHandler(FileReadProgressHandler* handler, int size)
 {
     if (handler != nullptr && size != 0) {
@@ -714,7 +714,7 @@ void fileSetReadProgressHandler(FileReadProgressHandler* handler, int size)
     }
 }
 
-// 0x4C68E8 db_list_compare_
+// 0x4C68E8 db_list_compare
 int _db_list_compare(const void* p1, const void* p2)
 {
     return compat_stricmp(*(const char**)p1, *(const char**)p2);

--- a/src/dbox.cc
+++ b/src/dbox.cc
@@ -147,7 +147,7 @@ static int gSaveFileDialogFrmIds[FILE_DIALOG_FRM_COUNT] = {
     200, // uparwon.frm - character editor
 };
 
-// 0x41CF20
+// 0x41CF20 dialog_out_
 int showDialogBox(const char* title, const char** body, int bodyLength, int x, int y, int titleColor, const char* secondaryButtonText, int bodyColor, int flags)
 {
     MessageList messageList;
@@ -565,7 +565,7 @@ int showDialogBox(const char* title, const char** body, int bodyLength, int x, i
     return rc;
 }
 
-// 0x41DE90
+// 0x41DE90 file_dialog_
 int showLoadFileDialog(char* title, char** fileList, char* dest, int fileListLength, int x, int y, int flags)
 {
     int oldFont = fontGetCurrent();
@@ -930,7 +930,7 @@ int showLoadFileDialog(char* title, char** fileList, char* dest, int fileListLen
     return rc;
 }
 
-// 0x41EA78
+// 0x41EA78 save_file_dialog_
 int showSaveFileDialog(char* title, char** fileList, char* dest, int fileListLength, int x, int y, int flags)
 {
     int oldFont = fontGetCurrent();
@@ -1402,7 +1402,7 @@ int showSaveFileDialog(char* title, char** fileList, char* dest, int fileListLen
     return rc;
 }
 
-// 0x41FBDC
+// 0x41FBDC PrntFlist_
 static void fileDialogRenderFileList(unsigned char* buffer, char** fileList, int pageOffset, int fileListLength, int selectedIndex, int pitch)
 {
     int lineHeight = fontGetLineHeight();

--- a/src/dbox.cc
+++ b/src/dbox.cc
@@ -89,43 +89,43 @@ typedef enum FileDialogScrollDirection {
 
 static void fileDialogRenderFileList(unsigned char* buffer, char** fileList, int pageOffset, int fileListLength, int selectedIndex, int pitch);
 
-// 0x5108C8
+// 0x5108C8 dbox
 static const int gDialogBoxBackgroundFrmIds[DIALOG_TYPE_COUNT] = {
     218, // MEDIALOG.FRM - Medium generic dialog box
     217, // LGDIALOG.FRM - Large generic dialog box
 };
 
-// 0x5108D0
+// 0x5108D0 ytable
 static const int _ytable[DIALOG_TYPE_COUNT] = {
     23,
     27,
 };
 
-// 0x5108D8
+// 0x5108D8 xtable
 static const int _xtable[DIALOG_TYPE_COUNT] = {
     29,
     29,
 };
 
-// 0x5108E0
+// 0x5108E0 doneY
 static const int _doneY[DIALOG_TYPE_COUNT] = {
     81,
     98,
 };
 
-// 0x5108E8
+// 0x5108E8 doneX
 static const int _doneX[DIALOG_TYPE_COUNT] = {
     51,
     37,
 };
 
-// 0x5108F0
+// 0x5108F0 dblines
 static const int _dblines[DIALOG_TYPE_COUNT] = {
     5,
     6,
 };
 
-// 0x510900
+// 0x510900 flgids
 static int gLoadFileDialogFrmIds[FILE_DIALOG_FRM_COUNT] = {
     224, // loadbox.frm - character editor
     8, // lilredup.frm - little red button up
@@ -136,7 +136,7 @@ static int gLoadFileDialogFrmIds[FILE_DIALOG_FRM_COUNT] = {
     200, // uparwon.frm - character editor
 };
 
-// 0x51091C
+// 0x51091C flgids2
 static int gSaveFileDialogFrmIds[FILE_DIALOG_FRM_COUNT] = {
     225, // savebox.frm - character editor
     8, // lilredup.frm - little red button up
@@ -147,7 +147,7 @@ static int gSaveFileDialogFrmIds[FILE_DIALOG_FRM_COUNT] = {
     200, // uparwon.frm - character editor
 };
 
-// 0x41CF20 dialog_out_
+// 0x41CF20 dialog_out
 int showDialogBox(const char* title, const char** body, int bodyLength, int x, int y, int titleColor, const char* secondaryButtonText, int bodyColor, int flags)
 {
     MessageList messageList;
@@ -565,7 +565,7 @@ int showDialogBox(const char* title, const char** body, int bodyLength, int x, i
     return rc;
 }
 
-// 0x41DE90 file_dialog_
+// 0x41DE90 file_dialog
 int showLoadFileDialog(char* title, char** fileList, char* dest, int fileListLength, int x, int y, int flags)
 {
     int oldFont = fontGetCurrent();
@@ -930,7 +930,7 @@ int showLoadFileDialog(char* title, char** fileList, char* dest, int fileListLen
     return rc;
 }
 
-// 0x41EA78 save_file_dialog_
+// 0x41EA78 save_file_dialog
 int showSaveFileDialog(char* title, char** fileList, char* dest, int fileListLength, int x, int y, int flags)
 {
     int oldFont = fontGetCurrent();
@@ -1402,7 +1402,7 @@ int showSaveFileDialog(char* title, char** fileList, char* dest, int fileListLen
     return rc;
 }
 
-// 0x41FBDC PrntFlist_
+// 0x41FBDC PrntFlist
 static void fileDialogRenderFileList(unsigned char* buffer, char** fileList, int pageOffset, int fileListLength, int selectedIndex, int pitch)
 {
     int lineHeight = fontGetLineHeight();

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -28,16 +28,16 @@ static std::string debugBuffer;
 static constexpr size_t kDebugBufferMaxSize = 64 * 1024;
 static bool debugBufferDisabled = false;
 
-// 0x51DEF8
+// 0x51DEF8 _fd
 static FILE* _fd = nullptr;
 
-// 0x51DEFC
+// 0x51DEFC _curx
 static int _curx = 0;
 
-// 0x51DF00
+// 0x51DF00 _cury
 static int _cury = 0;
 
-// 0x51DF04
+// 0x51DF04 _debug_func
 static DebugPrintProc* gDebugPrintProc = nullptr;
 
 void debugModeInit(const char* debugMode)

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -28,16 +28,16 @@ static std::string debugBuffer;
 static constexpr size_t kDebugBufferMaxSize = 64 * 1024;
 static bool debugBufferDisabled = false;
 
-// 0x51DEF8 _fd
+// 0x51DEF8 fd
 static FILE* _fd = nullptr;
 
-// 0x51DEFC _curx
+// 0x51DEFC curx
 static int _curx = 0;
 
-// 0x51DF00 _cury
+// 0x51DF00 cury
 static int _cury = 0;
 
-// 0x51DF04 _debug_func
+// 0x51DF04 debug_func
 static DebugPrintProc* gDebugPrintProc = nullptr;
 
 void debugModeInit(const char* debugMode)

--- a/src/dfile.cc
+++ b/src/dfile.cc
@@ -45,7 +45,7 @@ static void dfileUngetCompressed(DFile* stream, int ch);
 
 // Reads .DAT file contents.
 //
-// 0x4E4F58 dbase_open_
+// 0x4E4F58 dbase_open
 DBase* dbaseOpen(const char* filePath)
 {
     assert(filePath); // "filename", "dfile.c", 74
@@ -164,7 +164,7 @@ err:
 // Closes [dbase], all open file handles, frees all associated resources,
 // including the [dbase] itself.
 //
-// 0x4E5270 dbase_close_
+// 0x4E5270 dbase_close
 bool dbaseClose(DBase* dbase)
 {
     assert(dbase); // "dbase", "dfile.c", 173
@@ -198,7 +198,7 @@ bool dbaseClose(DBase* dbase)
     return true;
 }
 
-// 0x4E5308 dbase_findfirst_
+// 0x4E5308 dbase_findfirst
 bool dbaseFindFirstEntry(DBase* dbase, DFileFindData* findFileData, const char* pattern)
 {
     // .dat files always have windows style paths
@@ -215,7 +215,7 @@ bool dbaseFindFirstEntry(DBase* dbase, DFileFindData* findFileData, const char* 
     return false;
 }
 
-// 0x4E53A0 dbase_findnext_
+// 0x4E53A0 dbase_findnext
 bool dbaseFindNextEntry(DBase* dbase, DFileFindData* findFileData)
 {
     for (int index = findFileData->index + 1; index < dbase->entriesLength; index++) {
@@ -230,7 +230,7 @@ bool dbaseFindNextEntry(DBase* dbase, DFileFindData* findFileData)
     return false;
 }
 
-// 0x4E541C dbase_findclose_
+// 0x4E541C dbase_findclose
 bool dbaseFindClose(DBase* dbase, DFileFindData* findFileData)
 {
     return true;
@@ -238,7 +238,7 @@ bool dbaseFindClose(DBase* dbase, DFileFindData* findFileData)
 
 // [filelength].
 //
-// 0x4E5424 dfile_filelength_
+// 0x4E5424 dfile_filelength
 long dfileGetSize(DFile* stream)
 {
     return stream->entry->uncompressedSize;
@@ -246,7 +246,7 @@ long dfileGetSize(DFile* stream)
 
 // [fclose].
 //
-// 0x4E542C dfile_fclose_
+// 0x4E542C dfile_fclose
 int dfileClose(DFile* stream)
 {
     assert(stream); // "stream", "dfile.c", 253
@@ -303,7 +303,7 @@ int dfileClose(DFile* stream)
 
 // [fopen].
 //
-// 0x4E5504 dfile_fopen_
+// 0x4E5504 dfile_fopen
 DFile* dfileOpen(DBase* dbase, const char* filePath, const char* mode)
 {
     assert(dbase); // dfile.c, 295
@@ -315,7 +315,7 @@ DFile* dfileOpen(DBase* dbase, const char* filePath, const char* mode)
 
 // [vfprintf].
 //
-// 0x4E56C0 dfile_vfprintf_
+// 0x4E56C0 dfile_vfprintf
 int dfilePrintFormattedArgs(DFile* stream, const char* format, va_list args)
 {
     assert(stream); // "stream", "dfile.c", 368
@@ -329,7 +329,7 @@ int dfilePrintFormattedArgs(DFile* stream, const char* format, va_list args)
 // This function reports \r\n sequence as one character \n, even though it
 // consumes two characters from the underlying stream.
 //
-// 0x4E5700 dfile_fgetc_
+// 0x4E5700 dfile_fgetc
 int dfileReadChar(DFile* stream)
 {
     assert(stream); // "stream", "dfile.c", 384
@@ -356,7 +356,7 @@ int dfileReadChar(DFile* stream)
 // Both Windows (\r\n) and Unix (\n) line endings are recognized. Windows
 // line ending is reported as \n.
 //
-// 0x4E5764 dfile_fgets_
+// 0x4E5764 dfile_fgets
 char* dfileReadString(char* string, int size, DFile* stream)
 {
     assert(string); // "s", "dfile.c", 407
@@ -402,7 +402,7 @@ char* dfileReadString(char* string, int size, DFile* stream)
 
 // [fputc].
 //
-// 0x4E5830 dfile_fputc_
+// 0x4E5830 dfile_fputc
 int dfileWriteChar(int ch, DFile* stream)
 {
     assert(stream); // "stream", "dfile.c", 437
@@ -412,7 +412,7 @@ int dfileWriteChar(int ch, DFile* stream)
 
 // [fputs].
 //
-// 0x4E5854 dfile_fputs_
+// 0x4E5854 dfile_fputs
 int dfileWriteString(const char* string, DFile* stream)
 {
     assert(string); // "s", "dfile.c", 448
@@ -423,7 +423,7 @@ int dfileWriteString(const char* string, DFile* stream)
 
 // [fread].
 //
-// 0x4E58FC dfile_fread_
+// 0x4E58FC dfile_fread
 size_t dfileRead(void* ptr, size_t size, size_t count, DFile* stream)
 {
     assert(ptr); // "ptr", "dfile.c", 499
@@ -474,7 +474,7 @@ size_t dfileRead(void* ptr, size_t size, size_t count, DFile* stream)
 
 // [fwrite].
 //
-// 0x4E59F8 dfile_fwrite_
+// 0x4E59F8 dfile_fwrite
 size_t dfileWrite(const void* ptr, size_t size, size_t count, DFile* stream)
 {
     assert(ptr); // "ptr", "dfile.c", 538
@@ -485,7 +485,7 @@ size_t dfileWrite(const void* ptr, size_t size, size_t count, DFile* stream)
 
 // [fseek].
 //
-// 0x4E5A74 dfile_fseek_
+// 0x4E5A74 dfile_fseek
 int dfileSeek(DFile* stream, long offset, int origin)
 {
     assert(stream); // "stream", "dfile.c", 569
@@ -594,7 +594,7 @@ int dfileSeek(DFile* stream, long offset, int origin)
 
 // [ftell].
 //
-// 0x4E5C88 dfile_ftell_
+// 0x4E5C88 dfile_ftell
 long dfileTell(DFile* stream)
 {
     assert(stream); // "stream", "dfile.c", 654
@@ -604,7 +604,7 @@ long dfileTell(DFile* stream)
 
 // [rewind].
 //
-// 0x4E5CB0 dfile_rewind_
+// 0x4E5CB0 dfile_rewind
 void dfileRewind(DFile* stream)
 {
     assert(stream); // "stream", "dfile.c", 664
@@ -616,7 +616,7 @@ void dfileRewind(DFile* stream)
 
 // [feof].
 //
-// 0x4E5D10 dfile_feof_
+// 0x4E5D10 dfile_feof
 int dfileEof(DFile* stream)
 {
     assert(stream); // "stream", "dfile.c", 685
@@ -627,7 +627,7 @@ int dfileEof(DFile* stream)
 // The [bsearch] comparison callback, which is used to find [DBaseEntry] for
 // specified [filePath].
 //
-// 0x4E5D70 dinfo_bsearch_compare_
+// 0x4E5D70 dinfo_bsearch_compare
 static int dbaseFindEntryByFilePath(const void* file, const void* entryName)
 {
     const char* filePath = (const char*)file;
@@ -636,7 +636,7 @@ static int dbaseFindEntryByFilePath(const void* file, const void* entryName)
     return compat_stricmp(filePath, entry->path);
 }
 
-// 0x4E5D9C dfile_fopen_helper_
+// 0x4E5D9C dfile_fopen_helper
 static DFile* dfileOpenInternal(DBase* dbase, const char* filePath, const char* mode, DFile* dfile)
 {
     DBaseEntry* entry = (DBaseEntry*)bsearch(filePath, dbase->entries, dbase->entriesLength, sizeof(*dbase->entries), dbaseFindEntryByFilePath);
@@ -742,7 +742,7 @@ err:
     return nullptr;
 }
 
-// 0x4E5F9C dfile_fgetc_helper_
+// 0x4E5F9C dfile_fgetc_helper
 static int dfileReadCharInternal(DFile* stream)
 {
     if (stream->entry->compressed == 1) {
@@ -798,7 +798,7 @@ static int dfileReadCharInternal(DFile* stream)
     return ch;
 }
 
-// 0x4E6078 dfile_read_comp_bytes_
+// 0x4E6078 dfile_read_comp_bytes
 static bool dfileReadCompressed(DFile* stream, void* ptr, size_t size)
 {
     if ((stream->flags & DFILE_HAS_COMPRESSED_UNGETC) != 0) {
@@ -853,7 +853,7 @@ static bool dfileReadCompressed(DFile* stream, void* ptr, size_t size)
 
 // NOTE: Inlined.
 //
-// 0x4E613C dfile_zungetc_
+// 0x4E613C dfile_zungetc
 static void dfileUngetCompressed(DFile* stream, int ch)
 {
     stream->compressedUngotten = ch;

--- a/src/dfile.cc
+++ b/src/dfile.cc
@@ -45,7 +45,7 @@ static void dfileUngetCompressed(DFile* stream, int ch);
 
 // Reads .DAT file contents.
 //
-// 0x4E4F58
+// 0x4E4F58 dbase_open_
 DBase* dbaseOpen(const char* filePath)
 {
     assert(filePath); // "filename", "dfile.c", 74
@@ -164,7 +164,7 @@ err:
 // Closes [dbase], all open file handles, frees all associated resources,
 // including the [dbase] itself.
 //
-// 0x4E5270
+// 0x4E5270 dbase_close_
 bool dbaseClose(DBase* dbase)
 {
     assert(dbase); // "dbase", "dfile.c", 173
@@ -198,7 +198,7 @@ bool dbaseClose(DBase* dbase)
     return true;
 }
 
-// 0x4E5308
+// 0x4E5308 dbase_findfirst_
 bool dbaseFindFirstEntry(DBase* dbase, DFileFindData* findFileData, const char* pattern)
 {
     // .dat files always have windows style paths
@@ -215,7 +215,7 @@ bool dbaseFindFirstEntry(DBase* dbase, DFileFindData* findFileData, const char* 
     return false;
 }
 
-// 0x4E53A0
+// 0x4E53A0 dbase_findnext_
 bool dbaseFindNextEntry(DBase* dbase, DFileFindData* findFileData)
 {
     for (int index = findFileData->index + 1; index < dbase->entriesLength; index++) {
@@ -230,7 +230,7 @@ bool dbaseFindNextEntry(DBase* dbase, DFileFindData* findFileData)
     return false;
 }
 
-// 0x4E541C
+// 0x4E541C dbase_findclose_
 bool dbaseFindClose(DBase* dbase, DFileFindData* findFileData)
 {
     return true;
@@ -238,7 +238,7 @@ bool dbaseFindClose(DBase* dbase, DFileFindData* findFileData)
 
 // [filelength].
 //
-// 0x4E5424
+// 0x4E5424 dfile_filelength_
 long dfileGetSize(DFile* stream)
 {
     return stream->entry->uncompressedSize;
@@ -246,7 +246,7 @@ long dfileGetSize(DFile* stream)
 
 // [fclose].
 //
-// 0x4E542C
+// 0x4E542C dfile_fclose_
 int dfileClose(DFile* stream)
 {
     assert(stream); // "stream", "dfile.c", 253
@@ -303,7 +303,7 @@ int dfileClose(DFile* stream)
 
 // [fopen].
 //
-// 0x4E5504
+// 0x4E5504 dfile_fopen_
 DFile* dfileOpen(DBase* dbase, const char* filePath, const char* mode)
 {
     assert(dbase); // dfile.c, 295
@@ -315,7 +315,7 @@ DFile* dfileOpen(DBase* dbase, const char* filePath, const char* mode)
 
 // [vfprintf].
 //
-// 0x4E56C0
+// 0x4E56C0 dfile_vfprintf_
 int dfilePrintFormattedArgs(DFile* stream, const char* format, va_list args)
 {
     assert(stream); // "stream", "dfile.c", 368
@@ -329,7 +329,7 @@ int dfilePrintFormattedArgs(DFile* stream, const char* format, va_list args)
 // This function reports \r\n sequence as one character \n, even though it
 // consumes two characters from the underlying stream.
 //
-// 0x4E5700
+// 0x4E5700 dfile_fgetc_
 int dfileReadChar(DFile* stream)
 {
     assert(stream); // "stream", "dfile.c", 384
@@ -356,7 +356,7 @@ int dfileReadChar(DFile* stream)
 // Both Windows (\r\n) and Unix (\n) line endings are recognized. Windows
 // line ending is reported as \n.
 //
-// 0x4E5764
+// 0x4E5764 dfile_fgets_
 char* dfileReadString(char* string, int size, DFile* stream)
 {
     assert(string); // "s", "dfile.c", 407
@@ -402,7 +402,7 @@ char* dfileReadString(char* string, int size, DFile* stream)
 
 // [fputc].
 //
-// 0x4E5830
+// 0x4E5830 dfile_fputc_
 int dfileWriteChar(int ch, DFile* stream)
 {
     assert(stream); // "stream", "dfile.c", 437
@@ -412,7 +412,7 @@ int dfileWriteChar(int ch, DFile* stream)
 
 // [fputs].
 //
-// 0x4E5854
+// 0x4E5854 dfile_fputs_
 int dfileWriteString(const char* string, DFile* stream)
 {
     assert(string); // "s", "dfile.c", 448
@@ -423,7 +423,7 @@ int dfileWriteString(const char* string, DFile* stream)
 
 // [fread].
 //
-// 0x4E58FC
+// 0x4E58FC dfile_fread_
 size_t dfileRead(void* ptr, size_t size, size_t count, DFile* stream)
 {
     assert(ptr); // "ptr", "dfile.c", 499
@@ -474,7 +474,7 @@ size_t dfileRead(void* ptr, size_t size, size_t count, DFile* stream)
 
 // [fwrite].
 //
-// 0x4E59F8
+// 0x4E59F8 dfile_fwrite_
 size_t dfileWrite(const void* ptr, size_t size, size_t count, DFile* stream)
 {
     assert(ptr); // "ptr", "dfile.c", 538
@@ -485,7 +485,7 @@ size_t dfileWrite(const void* ptr, size_t size, size_t count, DFile* stream)
 
 // [fseek].
 //
-// 0x4E5A74
+// 0x4E5A74 dfile_fseek_
 int dfileSeek(DFile* stream, long offset, int origin)
 {
     assert(stream); // "stream", "dfile.c", 569
@@ -594,7 +594,7 @@ int dfileSeek(DFile* stream, long offset, int origin)
 
 // [ftell].
 //
-// 0x4E5C88
+// 0x4E5C88 dfile_ftell_
 long dfileTell(DFile* stream)
 {
     assert(stream); // "stream", "dfile.c", 654
@@ -604,7 +604,7 @@ long dfileTell(DFile* stream)
 
 // [rewind].
 //
-// 0x4E5CB0
+// 0x4E5CB0 dfile_rewind_
 void dfileRewind(DFile* stream)
 {
     assert(stream); // "stream", "dfile.c", 664
@@ -616,7 +616,7 @@ void dfileRewind(DFile* stream)
 
 // [feof].
 //
-// 0x4E5D10
+// 0x4E5D10 dfile_feof_
 int dfileEof(DFile* stream)
 {
     assert(stream); // "stream", "dfile.c", 685
@@ -627,7 +627,7 @@ int dfileEof(DFile* stream)
 // The [bsearch] comparison callback, which is used to find [DBaseEntry] for
 // specified [filePath].
 //
-// 0x4E5D70
+// 0x4E5D70 dinfo_bsearch_compare_
 static int dbaseFindEntryByFilePath(const void* file, const void* entryName)
 {
     const char* filePath = (const char*)file;
@@ -636,7 +636,7 @@ static int dbaseFindEntryByFilePath(const void* file, const void* entryName)
     return compat_stricmp(filePath, entry->path);
 }
 
-// 0x4E5D9C
+// 0x4E5D9C dfile_fopen_helper_
 static DFile* dfileOpenInternal(DBase* dbase, const char* filePath, const char* mode, DFile* dfile)
 {
     DBaseEntry* entry = (DBaseEntry*)bsearch(filePath, dbase->entries, dbase->entriesLength, sizeof(*dbase->entries), dbaseFindEntryByFilePath);
@@ -742,7 +742,7 @@ err:
     return nullptr;
 }
 
-// 0x4E5F9C
+// 0x4E5F9C dfile_fgetc_helper_
 static int dfileReadCharInternal(DFile* stream)
 {
     if (stream->entry->compressed == 1) {
@@ -798,7 +798,7 @@ static int dfileReadCharInternal(DFile* stream)
     return ch;
 }
 
-// 0x4E6078
+// 0x4E6078 dfile_read_comp_bytes_
 static bool dfileReadCompressed(DFile* stream, void* ptr, size_t size)
 {
     if ((stream->flags & DFILE_HAS_COMPRESSED_UNGETC) != 0) {
@@ -853,7 +853,7 @@ static bool dfileReadCompressed(DFile* stream, void* ptr, size_t size)
 
 // NOTE: Inlined.
 //
-// 0x4E613C
+// 0x4E613C dfile_zungetc_
 static void dfileUngetCompressed(DFile* stream, int ch)
 {
     stream->compressedUngotten = ch;

--- a/src/dialog.cc
+++ b/src/dialog.cc
@@ -164,7 +164,7 @@ char* off_56DBE8;
 // 0x56DBEC
 char* off_56DBEC;
 
-// 0x42F434
+// 0x42F434 getReply_
 STRUCT_56DAE0_FIELD_4* _getReply()
 {
     STRUCT_56DAE0_FIELD_4* v0;
@@ -183,7 +183,7 @@ STRUCT_56DAE0_FIELD_4* _getReply()
     return v0;
 }
 
-// 0x42F4C0
+// 0x42F4C0 replyAddOption_
 void _replyAddOption(const char* a1, const char* a2, int a3)
 {
     STRUCT_56DAE0_FIELD_4* v18;
@@ -216,7 +216,7 @@ void _replyAddOption(const char* a1, const char* a2, int a3)
     v18->field_C[v17].field_14 = a3;
 }
 
-// 0x42F624
+// 0x42F624 replyAddOptionProc_
 void _replyAddOptionProc(const char* a1, int a2, int a3)
 {
     STRUCT_56DAE0_FIELD_4* v5;
@@ -243,7 +243,7 @@ void _replyAddOptionProc(const char* a1, int a2, int a3)
     v5->field_C[v13].field_14 = a3;
 }
 
-// 0x42F714
+// 0x42F714 optionFree_
 void _optionFree(STRUCT_56DAE0_FIELD_4_FIELD_C* a1)
 {
     if (a1->field_0 != nullptr) {
@@ -257,7 +257,7 @@ void _optionFree(STRUCT_56DAE0_FIELD_4_FIELD_C* a1)
     }
 }
 
-// 0x42F754
+// 0x42F754 replyFree_
 void _replyFree()
 {
     int i;
@@ -295,7 +295,7 @@ void _replyFree()
     }
 }
 
-// 0x42FB94
+// 0x42FB94 endDialog_
 int _endDialog()
 {
     if (_tods == -1) {
@@ -315,7 +315,7 @@ int _endDialog()
     return 0;
 }
 
-// 0x42FC70
+// 0x42FC70 printLine_
 void _printLine(int win, char** strings, int strings_num, int a4, int a5, int a6, int a7, int a8, int a9)
 {
     int i;
@@ -327,7 +327,7 @@ void _printLine(int win, char** strings, int strings_num, int a4, int a5, int a6
     }
 }
 
-// 0x42FCF0
+// 0x42FCF0 printStr_
 void _printStr(int win, char* a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9)
 {
     char** strings;
@@ -338,7 +338,7 @@ void _printStr(int win, char* a2, int a3, int a4, int a5, int a6, int a7, int a8
     windowFreeWordList(strings, strings_num);
 }
 
-// 0x430104
+// 0x430104 abortReply_
 int _abortReply(int a1)
 {
     int result;
@@ -368,7 +368,7 @@ int _abortReply(int a1)
     return result;
 }
 
-// 0x430180
+// 0x430180 endReply_
 void _endReply()
 {
     if (_replyPlaying != 2) {
@@ -384,7 +384,7 @@ void _endReply()
     }
 }
 
-// 0x4301E8
+// 0x4301E8 drawStr_
 void _drawStr(int win, char* str, int font, int width, int height, int left, int top, int a8, int a9, int a10)
 {
     int old_font;
@@ -403,7 +403,7 @@ void _drawStr(int win, char* str, int font, int width, int height, int left, int
     windowSetFont(old_font);
 }
 
-// 0x430D40
+// 0x430D40 dialogStart_
 int _dialogStart(Program* a1)
 {
     STRUCT_56DAE0* ptr;
@@ -426,7 +426,7 @@ int _dialogStart(Program* a1)
     return 0;
 }
 
-// 0x430DB8
+// 0x430DB8 dialogRestart_
 int _dialogRestart()
 {
     if (_tods == -1) {
@@ -438,7 +438,7 @@ int _dialogRestart()
     return 0;
 }
 
-// 0x430DE4
+// 0x430DE4 dialogGotoReply_
 int _dialogGotoReply(const char* a1)
 {
     STRUCT_56DAE0* ptr;
@@ -467,7 +467,7 @@ int _dialogGotoReply(const char* a1)
     return 0;
 }
 
-// 0x430E84
+// 0x430E84 dialogTitle_
 int dialogSetReplyTitle(const char* a1)
 {
     if (gDialogReplyTitle != nullptr) {
@@ -484,7 +484,7 @@ int dialogSetReplyTitle(const char* a1)
     return 0;
 }
 
-// 0x430EFC
+// 0x430EFC dialogReply_
 int _dialogReply(const char* a1, const char* a2)
 {
     // TODO: Incomplete.
@@ -492,7 +492,7 @@ int _dialogReply(const char* a1, const char* a2)
     return 0;
 }
 
-// 0x430F04
+// 0x430F04 dialogOption_
 int _dialogOption(const char* a1, const char* a2)
 {
     if (_dialog[_tods].field_C == -1) {
@@ -504,7 +504,7 @@ int _dialogOption(const char* a1, const char* a2)
     return 0;
 }
 
-// 0x430F38
+// 0x430F38 dialogOptionProc_
 int _dialogOptionProc(const char* a1, int a2)
 {
     if (_dialog[_tods].field_C == -1) {
@@ -516,27 +516,27 @@ int _dialogOptionProc(const char* a1, int a2)
     return 0;
 }
 
-// 0x430FD4
+// 0x430FD4 dialogMessage_
 int dialogMessage(const char* a1, const char* a2, int timeout)
 {
     // TODO: Incomplete.
     return -1;
 }
 
-// 0x431088
+// 0x431088 dialogGo_
 int dialogGo(int a1)
 {
     // TODO: Incomplete.
     return -1;
 }
 
-// 0x431184
+// 0x431184 dialogGetExitPoint_
 int _dialogGetExitPoint()
 {
     return _topDialogLine + (_topDialogReply << 16);
 }
 
-// 0x431198
+// 0x431198 dialogQuit_
 int _dialogQuit()
 {
     if (_inDialog) {
@@ -548,7 +548,7 @@ int _dialogQuit()
     return 0;
 }
 
-// 0x4311B8
+// 0x4311B8 dialogSetOptionWindow_
 int dialogSetOptionWindow(int a1, int a2, int a3, int a4, char* a5)
 {
     dword_56DB6C = a1;
@@ -559,7 +559,7 @@ int dialogSetOptionWindow(int a1, int a2, int a3, int a4, char* a5)
     return 0;
 }
 
-// 0x4311E0
+// 0x4311E0 dialogSetReplyWindow_
 int dialogSetReplyWindow(int a1, int a2, int a3, int a4, char* a5)
 {
     dword_56DB84 = a1;
@@ -571,7 +571,7 @@ int dialogSetReplyWindow(int a1, int a2, int a3, int a4, char* a5)
     return 0;
 }
 
-// 0x431208
+// 0x431208 dialogSetBorder_
 int dialogSetBorder(int a1, int a2)
 {
     gDialogBorderX = a1;
@@ -580,7 +580,7 @@ int dialogSetBorder(int a1, int a2)
     return 0;
 }
 
-// 0x431218
+// 0x431218 dialogSetScrollUp_
 int _dialogSetScrollUp(int a1, int a2, char* a3, char* a4, char* a5, char* a6, int a7)
 {
     _upButton = a1;
@@ -611,7 +611,7 @@ int _dialogSetScrollUp(int a1, int a2, char* a3, char* a4, char* a5, char* a6, i
     return 0;
 }
 
-// 0x4312C0
+// 0x4312C0 dialogSetScrollDown_
 int _dialogSetScrollDown(int a1, int a2, char* a3, char* a4, char* a5, char* a6, int a7)
 {
     _downButton = a1;
@@ -642,7 +642,7 @@ int _dialogSetScrollDown(int a1, int a2, char* a3, char* a4, char* a5, char* a6,
     return 0;
 }
 
-// 0x431368
+// 0x431368 dialogSetSpacing_
 int dialogSetOptionSpacing(int value)
 {
     gDialogOptionSpacing = value;
@@ -650,7 +650,7 @@ int dialogSetOptionSpacing(int value)
     return 0;
 }
 
-// 0x431370
+// 0x431370 dialogSetOptionColor_
 int dialogSetOptionColor(float a1, float a2, float a3)
 {
     gDialogOptionColorR = (int)(a1 * flt_501623);
@@ -662,7 +662,7 @@ int dialogSetOptionColor(float a1, float a2, float a3)
     return 0;
 }
 
-// 0x4313C8
+// 0x4313C8 dialogSetReplyColor_
 int dialogSetReplyColor(float a1, float a2, float a3)
 {
     gDialogReplyColorR = (int)(a1 * flt_501627);
@@ -674,7 +674,7 @@ int dialogSetReplyColor(float a1, float a2, float a3)
     return 0;
 }
 
-// 0x431420
+// 0x431420 dialogSetOptionFlags_
 int _dialogSetOptionFlags(int flags)
 {
     word_56DB60 = flags & 0xFFFF;
@@ -687,7 +687,7 @@ void dialogInit()
 {
 }
 
-// 0x431434
+// 0x431434 dialogClose_
 void _dialogClose()
 {
     if (off_56DBE0) {
@@ -723,20 +723,20 @@ void _dialogClose()
     }
 }
 
-// 0x431518
+// 0x431518 dialogGetDialogDepth_
 int _dialogGetDialogDepth()
 {
     return _tods;
 }
 
-// 0x431520
+// 0x431520 dialogRegisterWinDrawCallbacks_
 void _dialogRegisterWinDrawCallbacks(DialogFunc1* a1, DialogFunc2* a2)
 {
     _replyWinDrawCallback = a1;
     _optionsWinDrawCallback = a2;
 }
 
-// 0x431530
+// 0x431530 dialogToggleMediaFlag_
 int _dialogToggleMediaFlag(int a1)
 {
     if ((a1 & _mediaFlag) == a1) {
@@ -748,7 +748,7 @@ int _dialogToggleMediaFlag(int a1)
     return _mediaFlag;
 }
 
-// 0x431554
+// 0x431554 dialogGetMediaFlag_
 int _dialogGetMediaFlag()
 {
     return _mediaFlag;

--- a/src/dialog.cc
+++ b/src/dialog.cc
@@ -27,10 +27,10 @@ int _topDialogLine = 0;
 // 0x5184BC topDialogReply
 int _topDialogReply = 0;
 
-// 0x5184E4 _replyWinDrawCallback
+// 0x5184E4 replyWinDrawCallback
 DialogFunc1* _replyWinDrawCallback = nullptr;
 
-// 0x5184E8 _optionsWinDrawCallback
+// 0x5184E8 optionsWinDrawCallback
 DialogFunc2* _optionsWinDrawCallback = nullptr;
 
 // 0x5184EC defaultBorderX
@@ -77,7 +77,7 @@ int dword_56DB6C;
 // 0x56DB70 y_option_win
 int dword_56DB70;
 
-// 0x56DB74 _pcx_option_win
+// 0x56DB74 pcx_option_win
 char* off_56DB74;
 
 // 0x56DB7C
@@ -95,7 +95,7 @@ int dword_56DB88;
 // 0x56DB8C
 char* off_56DB8C;
 
-// 0x56DB90 _replyPlaying
+// 0x56DB90 replyPlaying
 int _replyPlaying;
 
 // 0x56DB94 replyWin
@@ -119,7 +119,7 @@ int gDialogOptionColorB;
 // 0x56DBB0 optionR
 int gDialogOptionColorR;
 
-// 0x56DBB4 _downButton
+// 0x56DBB4 downButton
 int _downButton;
 
 // 0x56DBB8
@@ -143,7 +143,7 @@ char* off_56DBCC;
 // 0x56DBD0 replyTitleDefault
 char* gDialogReplyTitle;
 
-// 0x56DBD4 _upButton
+// 0x56DBD4 upButton
 int _upButton;
 
 // 0x56DBD8

--- a/src/dialog.cc
+++ b/src/dialog.cc
@@ -18,72 +18,72 @@ const float flt_501623 = 31.0;
 // 0x501627
 const float flt_501627 = 31.0;
 
-// 0x5184B4
+// 0x5184B4 tods
 int _tods = -1;
 
-// 0x5184B8
+// 0x5184B8 topDialogLine
 int _topDialogLine = 0;
 
-// 0x5184BC
+// 0x5184BC topDialogReply
 int _topDialogReply = 0;
 
-// 0x5184E4
+// 0x5184E4 _replyWinDrawCallback
 DialogFunc1* _replyWinDrawCallback = nullptr;
 
-// 0x5184E8
+// 0x5184E8 _optionsWinDrawCallback
 DialogFunc2* _optionsWinDrawCallback = nullptr;
 
-// 0x5184EC
+// 0x5184EC defaultBorderX
 int gDialogBorderX = 7;
 
-// 0x5184F0
+// 0x5184F0 defaultBorderY
 int gDialogBorderY = 7;
 
-// 0x5184F4
+// 0x5184F4 defaultSpacing
 int gDialogOptionSpacing = 5;
 
-// 0x5184F8
+// 0x5184F8 replyRGBset
 int _replyRGBset = 0;
 
-// 0x5184FC
+// 0x5184FC optionRGBset
 int _optionRGBset = 0;
 
-// 0x518500
+// 0x518500 exitDialog
 int _exitDialog = 0;
 
-// 0x518504
+// 0x518504 inDialog
 int _inDialog = 0;
 
-// 0x518508
+// 0x518508 mediaFlag
 int _mediaFlag = 2;
 
-// 0x56DAE0
+// 0x56DAE0 dialog
 STRUCT_56DAE0 _dialog[4];
 
 // Reply flags.
 //
-// 0x56DB60
+// 0x56DB60 defaultOption
 short word_56DB60;
 
-// 0x56DB64
+// 0x56DB64 w_option_win
 int dword_56DB64;
 
-// 0x56DB68
+// 0x56DB68 h_option_win
 int dword_56DB68;
 
-// 0x56DB6C
+// 0x56DB6C x_option_win
 int dword_56DB6C;
 
-// 0x56DB70
+// 0x56DB70 y_option_win
 int dword_56DB70;
 
-// 0x56DB74
+// 0x56DB74 _pcx_option_win
 char* off_56DB74;
 
 // 0x56DB7C
 int dword_56DB7C;
 
-// 0x56DB80
+// 0x56DB80 heightFrom
 int dword_56DB80;
 
 // 0x56DB84
@@ -95,31 +95,31 @@ int dword_56DB88;
 // 0x56DB8C
 char* off_56DB8C;
 
-// 0x56DB90
+// 0x56DB90 _replyPlaying
 int _replyPlaying;
 
-// 0x56DB94
+// 0x56DB94 replyWin
 int _replyWin = -1;
 
-// 0x56DB98
+// 0x56DB98 replyG
 int gDialogReplyColorG;
 
-// 0x56DB9C
+// 0x56DB9C replyB
 int gDialogReplyColorB;
 
-// 0x56DBA4
+// 0x56DBA4 optionG
 int gDialogOptionColorG;
 
-// 0x56DBA8
+// 0x56DBA8 replyR
 int gDialogReplyColorR;
 
-// 0x56DBAC
+// 0x56DBAC optionB
 int gDialogOptionColorB;
 
-// 0x56DBB0
+// 0x56DBB0 optionR
 int gDialogOptionColorR;
 
-// 0x56DBB4
+// 0x56DBB4 _downButton
 int _downButton;
 
 // 0x56DBB8
@@ -140,10 +140,10 @@ char* off_56DBC8;
 // 0x56DBCC
 char* off_56DBCC;
 
-// 0x56DBD0
+// 0x56DBD0 replyTitleDefault
 char* gDialogReplyTitle;
 
-// 0x56DBD4
+// 0x56DBD4 _upButton
 int _upButton;
 
 // 0x56DBD8
@@ -152,7 +152,7 @@ int dword_56DBD8;
 // 0x56DBDC
 int dword_56DBDC;
 
-// 0x56DBE0
+// 0x56DBE0 mem
 char* off_56DBE0;
 
 // 0x56DBE4
@@ -164,7 +164,7 @@ char* off_56DBE8;
 // 0x56DBEC
 char* off_56DBEC;
 
-// 0x42F434 getReply_
+// 0x42F434 getReply
 STRUCT_56DAE0_FIELD_4* _getReply()
 {
     STRUCT_56DAE0_FIELD_4* v0;
@@ -183,7 +183,7 @@ STRUCT_56DAE0_FIELD_4* _getReply()
     return v0;
 }
 
-// 0x42F4C0 replyAddOption_
+// 0x42F4C0 replyAddOption
 void _replyAddOption(const char* a1, const char* a2, int a3)
 {
     STRUCT_56DAE0_FIELD_4* v18;
@@ -216,7 +216,7 @@ void _replyAddOption(const char* a1, const char* a2, int a3)
     v18->field_C[v17].field_14 = a3;
 }
 
-// 0x42F624 replyAddOptionProc_
+// 0x42F624 replyAddOptionProc
 void _replyAddOptionProc(const char* a1, int a2, int a3)
 {
     STRUCT_56DAE0_FIELD_4* v5;
@@ -243,7 +243,7 @@ void _replyAddOptionProc(const char* a1, int a2, int a3)
     v5->field_C[v13].field_14 = a3;
 }
 
-// 0x42F714 optionFree_
+// 0x42F714 optionFree
 void _optionFree(STRUCT_56DAE0_FIELD_4_FIELD_C* a1)
 {
     if (a1->field_0 != nullptr) {
@@ -257,7 +257,7 @@ void _optionFree(STRUCT_56DAE0_FIELD_4_FIELD_C* a1)
     }
 }
 
-// 0x42F754 replyFree_
+// 0x42F754 replyFree
 void _replyFree()
 {
     int i;
@@ -295,7 +295,7 @@ void _replyFree()
     }
 }
 
-// 0x42FB94 endDialog_
+// 0x42FB94 endDialog
 int _endDialog()
 {
     if (_tods == -1) {
@@ -315,7 +315,7 @@ int _endDialog()
     return 0;
 }
 
-// 0x42FC70 printLine_
+// 0x42FC70 printLine
 void _printLine(int win, char** strings, int strings_num, int a4, int a5, int a6, int a7, int a8, int a9)
 {
     int i;
@@ -327,7 +327,7 @@ void _printLine(int win, char** strings, int strings_num, int a4, int a5, int a6
     }
 }
 
-// 0x42FCF0 printStr_
+// 0x42FCF0 printStr
 void _printStr(int win, char* a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9)
 {
     char** strings;
@@ -338,7 +338,7 @@ void _printStr(int win, char* a2, int a3, int a4, int a5, int a6, int a7, int a8
     windowFreeWordList(strings, strings_num);
 }
 
-// 0x430104 abortReply_
+// 0x430104 abortReply
 int _abortReply(int a1)
 {
     int result;
@@ -368,7 +368,7 @@ int _abortReply(int a1)
     return result;
 }
 
-// 0x430180 endReply_
+// 0x430180 endReply
 void _endReply()
 {
     if (_replyPlaying != 2) {
@@ -384,7 +384,7 @@ void _endReply()
     }
 }
 
-// 0x4301E8 drawStr_
+// 0x4301E8 drawStr
 void _drawStr(int win, char* str, int font, int width, int height, int left, int top, int a8, int a9, int a10)
 {
     int old_font;
@@ -403,7 +403,7 @@ void _drawStr(int win, char* str, int font, int width, int height, int left, int
     windowSetFont(old_font);
 }
 
-// 0x430D40 dialogStart_
+// 0x430D40 dialogStart
 int _dialogStart(Program* a1)
 {
     STRUCT_56DAE0* ptr;
@@ -426,7 +426,7 @@ int _dialogStart(Program* a1)
     return 0;
 }
 
-// 0x430DB8 dialogRestart_
+// 0x430DB8 dialogRestart
 int _dialogRestart()
 {
     if (_tods == -1) {
@@ -438,7 +438,7 @@ int _dialogRestart()
     return 0;
 }
 
-// 0x430DE4 dialogGotoReply_
+// 0x430DE4 dialogGotoReply
 int _dialogGotoReply(const char* a1)
 {
     STRUCT_56DAE0* ptr;
@@ -467,7 +467,7 @@ int _dialogGotoReply(const char* a1)
     return 0;
 }
 
-// 0x430E84 dialogTitle_
+// 0x430E84 dialogTitle
 int dialogSetReplyTitle(const char* a1)
 {
     if (gDialogReplyTitle != nullptr) {
@@ -484,7 +484,7 @@ int dialogSetReplyTitle(const char* a1)
     return 0;
 }
 
-// 0x430EFC dialogReply_
+// 0x430EFC dialogReply
 int _dialogReply(const char* a1, const char* a2)
 {
     // TODO: Incomplete.
@@ -492,7 +492,7 @@ int _dialogReply(const char* a1, const char* a2)
     return 0;
 }
 
-// 0x430F04 dialogOption_
+// 0x430F04 dialogOption
 int _dialogOption(const char* a1, const char* a2)
 {
     if (_dialog[_tods].field_C == -1) {
@@ -504,7 +504,7 @@ int _dialogOption(const char* a1, const char* a2)
     return 0;
 }
 
-// 0x430F38 dialogOptionProc_
+// 0x430F38 dialogOptionProc
 int _dialogOptionProc(const char* a1, int a2)
 {
     if (_dialog[_tods].field_C == -1) {
@@ -516,27 +516,27 @@ int _dialogOptionProc(const char* a1, int a2)
     return 0;
 }
 
-// 0x430FD4 dialogMessage_
+// 0x430FD4 dialogMessage
 int dialogMessage(const char* a1, const char* a2, int timeout)
 {
     // TODO: Incomplete.
     return -1;
 }
 
-// 0x431088 dialogGo_
+// 0x431088 dialogGo
 int dialogGo(int a1)
 {
     // TODO: Incomplete.
     return -1;
 }
 
-// 0x431184 dialogGetExitPoint_
+// 0x431184 dialogGetExitPoint
 int _dialogGetExitPoint()
 {
     return _topDialogLine + (_topDialogReply << 16);
 }
 
-// 0x431198 dialogQuit_
+// 0x431198 dialogQuit
 int _dialogQuit()
 {
     if (_inDialog) {
@@ -548,7 +548,7 @@ int _dialogQuit()
     return 0;
 }
 
-// 0x4311B8 dialogSetOptionWindow_
+// 0x4311B8 dialogSetOptionWindow
 int dialogSetOptionWindow(int a1, int a2, int a3, int a4, char* a5)
 {
     dword_56DB6C = a1;
@@ -559,7 +559,7 @@ int dialogSetOptionWindow(int a1, int a2, int a3, int a4, char* a5)
     return 0;
 }
 
-// 0x4311E0 dialogSetReplyWindow_
+// 0x4311E0 dialogSetReplyWindow
 int dialogSetReplyWindow(int a1, int a2, int a3, int a4, char* a5)
 {
     dword_56DB84 = a1;
@@ -571,7 +571,7 @@ int dialogSetReplyWindow(int a1, int a2, int a3, int a4, char* a5)
     return 0;
 }
 
-// 0x431208 dialogSetBorder_
+// 0x431208 dialogSetBorder
 int dialogSetBorder(int a1, int a2)
 {
     gDialogBorderX = a1;
@@ -580,7 +580,7 @@ int dialogSetBorder(int a1, int a2)
     return 0;
 }
 
-// 0x431218 dialogSetScrollUp_
+// 0x431218 dialogSetScrollUp
 int _dialogSetScrollUp(int a1, int a2, char* a3, char* a4, char* a5, char* a6, int a7)
 {
     _upButton = a1;
@@ -611,7 +611,7 @@ int _dialogSetScrollUp(int a1, int a2, char* a3, char* a4, char* a5, char* a6, i
     return 0;
 }
 
-// 0x4312C0 dialogSetScrollDown_
+// 0x4312C0 dialogSetScrollDown
 int _dialogSetScrollDown(int a1, int a2, char* a3, char* a4, char* a5, char* a6, int a7)
 {
     _downButton = a1;
@@ -642,7 +642,7 @@ int _dialogSetScrollDown(int a1, int a2, char* a3, char* a4, char* a5, char* a6,
     return 0;
 }
 
-// 0x431368 dialogSetSpacing_
+// 0x431368 dialogSetSpacing
 int dialogSetOptionSpacing(int value)
 {
     gDialogOptionSpacing = value;
@@ -650,7 +650,7 @@ int dialogSetOptionSpacing(int value)
     return 0;
 }
 
-// 0x431370 dialogSetOptionColor_
+// 0x431370 dialogSetOptionColor
 int dialogSetOptionColor(float a1, float a2, float a3)
 {
     gDialogOptionColorR = (int)(a1 * flt_501623);
@@ -662,7 +662,7 @@ int dialogSetOptionColor(float a1, float a2, float a3)
     return 0;
 }
 
-// 0x4313C8 dialogSetReplyColor_
+// 0x4313C8 dialogSetReplyColor
 int dialogSetReplyColor(float a1, float a2, float a3)
 {
     gDialogReplyColorR = (int)(a1 * flt_501627);
@@ -674,7 +674,7 @@ int dialogSetReplyColor(float a1, float a2, float a3)
     return 0;
 }
 
-// 0x431420 dialogSetOptionFlags_
+// 0x431420 dialogSetOptionFlags
 int _dialogSetOptionFlags(int flags)
 {
     word_56DB60 = flags & 0xFFFF;
@@ -687,7 +687,7 @@ void dialogInit()
 {
 }
 
-// 0x431434 dialogClose_
+// 0x431434 dialogClose
 void _dialogClose()
 {
     if (off_56DBE0) {
@@ -723,20 +723,20 @@ void _dialogClose()
     }
 }
 
-// 0x431518 dialogGetDialogDepth_
+// 0x431518 dialogGetDialogDepth
 int _dialogGetDialogDepth()
 {
     return _tods;
 }
 
-// 0x431520 dialogRegisterWinDrawCallbacks_
+// 0x431520 dialogRegisterWinDrawCallbacks
 void _dialogRegisterWinDrawCallbacks(DialogFunc1* a1, DialogFunc2* a2)
 {
     _replyWinDrawCallback = a1;
     _optionsWinDrawCallback = a2;
 }
 
-// 0x431530 dialogToggleMediaFlag_
+// 0x431530 dialogToggleMediaFlag
 int _dialogToggleMediaFlag(int a1)
 {
     if ((a1 & _mediaFlag) == a1) {
@@ -748,7 +748,7 @@ int _dialogToggleMediaFlag(int a1)
     return _mediaFlag;
 }
 
-// 0x431554 dialogGetMediaFlag_
+// 0x431554 dialogGetMediaFlag
 int _dialogGetMediaFlag()
 {
     return _mediaFlag;

--- a/src/dictionary.cc
+++ b/src/dictionary.cc
@@ -21,7 +21,7 @@ bool Dictionary::isInitialized() const
 
 static int dictionaryFindIndexForKey(Dictionary* dictionary, const char* key, int* index);
 
-// 0x4D9BA8
+// 0x4D9BA8 assoc_init_
 int dictionaryInit(Dictionary* dictionary, int initialCapacity, size_t valueSize, DictionaryIO* io)
 {
     dictionary->entriesCapacity = initialCapacity;
@@ -53,7 +53,7 @@ int dictionaryInit(Dictionary* dictionary, int initialCapacity, size_t valueSize
     return rc;
 }
 
-// 0x4D9C0C
+// 0x4D9C0C assoc_resize_
 int dictionarySetCapacity(Dictionary* dictionary, int newCapacity)
 {
     if (dictionary->marker != DICTIONARY_MARKER) {
@@ -75,7 +75,7 @@ int dictionarySetCapacity(Dictionary* dictionary, int newCapacity)
     return 0;
 }
 
-// 0x4D9C48
+// 0x4D9C48 assoc_free_
 int dictionaryFree(Dictionary* dictionary)
 {
     if (dictionary->marker != DICTIONARY_MARKER) {
@@ -107,7 +107,7 @@ int dictionaryFree(Dictionary* dictionary)
 // Returns 0 if key is found. Otherwise returns -1, in this case [indexPtr]
 // specifies an insertion point for given key.
 //
-// 0x4D9CC4
+// 0x4D9CC4 assoc_find_
 static int dictionaryFindIndexForKey(Dictionary* dictionary, const char* key, int* indexPtr)
 {
     if (dictionary->marker != DICTIONARY_MARKER) {
@@ -155,7 +155,7 @@ static int dictionaryFindIndexForKey(Dictionary* dictionary, const char* key, in
 // Returns the index of the entry for the specified key, or -1 if it's not
 // present in the dictionary.
 //
-// 0x4D9D5C
+// 0x4D9D5C assoc_search_
 int dictionaryGetIndexByKey(Dictionary* dictionary, const char* key)
 {
     if (dictionary->marker != DICTIONARY_MARKER) {
@@ -176,7 +176,7 @@ int dictionaryGetIndexByKey(Dictionary* dictionary, const char* key)
 // Returns 0 on success, or -1 on any error (including key already exists
 // error).
 //
-// 0x4D9D88
+// 0x4D9D88 assoc_insert_
 int dictionaryAddValue(Dictionary* dictionary, const char* key, const void* value)
 {
     if (dictionary->marker != DICTIONARY_MARKER) {
@@ -240,7 +240,7 @@ int dictionaryAddValue(Dictionary* dictionary, const char* key, const void* valu
 //
 // Returns 0 on success, -1 on any error (including key not present error).
 //
-// 0x4D9EE8
+// 0x4D9EE8 assoc_delete_
 int dictionaryRemoveValue(Dictionary* dictionary, const char* key)
 {
     if (dictionary->marker != DICTIONARY_MARKER) {
@@ -275,7 +275,7 @@ int dictionaryRemoveValue(Dictionary* dictionary, const char* key)
 
 // NOTE: Unused.
 //
-// 0x4D9F84
+// 0x4D9F84 assoc_copy_
 int dictionaryCopy(Dictionary* dest, Dictionary* src)
 {
     if (src->marker != DICTIONARY_MARKER) {
@@ -299,7 +299,7 @@ int dictionaryCopy(Dictionary* dest, Dictionary* src)
 
 // NOTE: Unused.
 //
-// 0x4DA090
+// 0x4DA090 assoc_read_long_
 int dictionaryReadInt(FILE* stream, int* valuePtr)
 {
     int ch;
@@ -340,7 +340,7 @@ int dictionaryReadInt(FILE* stream, int* valuePtr)
 
 // NOTE: Unused.
 //
-// 0x4DA0F4
+// 0x4DA0F4 assoc_read_assoc_array_
 int dictionaryReadHeader(FILE* stream, Dictionary* dictionary)
 {
     int value;
@@ -362,7 +362,7 @@ int dictionaryReadHeader(FILE* stream, Dictionary* dictionary)
 
 // NOTE: Unused.
 //
-// 0x4DA158
+// 0x4DA158 assoc_load_
 int dictionaryLoad(FILE* stream, Dictionary* dictionary, int a3)
 {
     if (dictionary->marker != DICTIONARY_MARKER) {
@@ -448,7 +448,7 @@ int dictionaryLoad(FILE* stream, Dictionary* dictionary, int a3)
 
 // NOTE: Unused.
 //
-// 0x4DA2EC
+// 0x4DA2EC assoc_write_long_
 int dictionaryWriteInt(FILE* stream, int value)
 {
     if (fputc((value >> 24) & 0xFF, stream) == -1) return -1;
@@ -461,7 +461,7 @@ int dictionaryWriteInt(FILE* stream, int value)
 
 // NOTE: Unused.
 //
-// 0x4DA360
+// 0x4DA360 assoc_write_assoc_array_
 int dictionaryWriteHeader(FILE* stream, Dictionary* dictionary)
 {
     if (dictionaryWriteInt(stream, dictionary->entriesLength) != 0) return -1;
@@ -475,7 +475,7 @@ int dictionaryWriteHeader(FILE* stream, Dictionary* dictionary)
 
 // NOTE: Unused.
 //
-// 0x4DA3A4
+// 0x4DA3A4 assoc_save_
 int dictionaryWrite(FILE* stream, Dictionary* dictionary, int a3)
 {
     if (dictionary->marker != DICTIONARY_MARKER) {

--- a/src/dictionary.cc
+++ b/src/dictionary.cc
@@ -21,7 +21,7 @@ bool Dictionary::isInitialized() const
 
 static int dictionaryFindIndexForKey(Dictionary* dictionary, const char* key, int* index);
 
-// 0x4D9BA8 assoc_init_
+// 0x4D9BA8 assoc_init
 int dictionaryInit(Dictionary* dictionary, int initialCapacity, size_t valueSize, DictionaryIO* io)
 {
     dictionary->entriesCapacity = initialCapacity;
@@ -53,7 +53,7 @@ int dictionaryInit(Dictionary* dictionary, int initialCapacity, size_t valueSize
     return rc;
 }
 
-// 0x4D9C0C assoc_resize_
+// 0x4D9C0C assoc_resize
 int dictionarySetCapacity(Dictionary* dictionary, int newCapacity)
 {
     if (dictionary->marker != DICTIONARY_MARKER) {
@@ -75,7 +75,7 @@ int dictionarySetCapacity(Dictionary* dictionary, int newCapacity)
     return 0;
 }
 
-// 0x4D9C48 assoc_free_
+// 0x4D9C48 assoc_free
 int dictionaryFree(Dictionary* dictionary)
 {
     if (dictionary->marker != DICTIONARY_MARKER) {
@@ -107,7 +107,7 @@ int dictionaryFree(Dictionary* dictionary)
 // Returns 0 if key is found. Otherwise returns -1, in this case [indexPtr]
 // specifies an insertion point for given key.
 //
-// 0x4D9CC4 assoc_find_
+// 0x4D9CC4 assoc_find
 static int dictionaryFindIndexForKey(Dictionary* dictionary, const char* key, int* indexPtr)
 {
     if (dictionary->marker != DICTIONARY_MARKER) {
@@ -155,7 +155,7 @@ static int dictionaryFindIndexForKey(Dictionary* dictionary, const char* key, in
 // Returns the index of the entry for the specified key, or -1 if it's not
 // present in the dictionary.
 //
-// 0x4D9D5C assoc_search_
+// 0x4D9D5C assoc_search
 int dictionaryGetIndexByKey(Dictionary* dictionary, const char* key)
 {
     if (dictionary->marker != DICTIONARY_MARKER) {
@@ -176,7 +176,7 @@ int dictionaryGetIndexByKey(Dictionary* dictionary, const char* key)
 // Returns 0 on success, or -1 on any error (including key already exists
 // error).
 //
-// 0x4D9D88 assoc_insert_
+// 0x4D9D88 assoc_insert
 int dictionaryAddValue(Dictionary* dictionary, const char* key, const void* value)
 {
     if (dictionary->marker != DICTIONARY_MARKER) {
@@ -240,7 +240,7 @@ int dictionaryAddValue(Dictionary* dictionary, const char* key, const void* valu
 //
 // Returns 0 on success, -1 on any error (including key not present error).
 //
-// 0x4D9EE8 assoc_delete_
+// 0x4D9EE8 assoc_delete
 int dictionaryRemoveValue(Dictionary* dictionary, const char* key)
 {
     if (dictionary->marker != DICTIONARY_MARKER) {
@@ -275,7 +275,7 @@ int dictionaryRemoveValue(Dictionary* dictionary, const char* key)
 
 // NOTE: Unused.
 //
-// 0x4D9F84 assoc_copy_
+// 0x4D9F84 assoc_copy
 int dictionaryCopy(Dictionary* dest, Dictionary* src)
 {
     if (src->marker != DICTIONARY_MARKER) {
@@ -299,7 +299,7 @@ int dictionaryCopy(Dictionary* dest, Dictionary* src)
 
 // NOTE: Unused.
 //
-// 0x4DA090 assoc_read_long_
+// 0x4DA090 assoc_read_long
 int dictionaryReadInt(FILE* stream, int* valuePtr)
 {
     int ch;
@@ -340,7 +340,7 @@ int dictionaryReadInt(FILE* stream, int* valuePtr)
 
 // NOTE: Unused.
 //
-// 0x4DA0F4 assoc_read_assoc_array_
+// 0x4DA0F4 assoc_read_assoc_array
 int dictionaryReadHeader(FILE* stream, Dictionary* dictionary)
 {
     int value;
@@ -362,7 +362,7 @@ int dictionaryReadHeader(FILE* stream, Dictionary* dictionary)
 
 // NOTE: Unused.
 //
-// 0x4DA158 assoc_load_
+// 0x4DA158 assoc_load
 int dictionaryLoad(FILE* stream, Dictionary* dictionary, int a3)
 {
     if (dictionary->marker != DICTIONARY_MARKER) {
@@ -448,7 +448,7 @@ int dictionaryLoad(FILE* stream, Dictionary* dictionary, int a3)
 
 // NOTE: Unused.
 //
-// 0x4DA2EC assoc_write_long_
+// 0x4DA2EC assoc_write_long
 int dictionaryWriteInt(FILE* stream, int value)
 {
     if (fputc((value >> 24) & 0xFF, stream) == -1) return -1;
@@ -461,7 +461,7 @@ int dictionaryWriteInt(FILE* stream, int value)
 
 // NOTE: Unused.
 //
-// 0x4DA360 assoc_write_assoc_array_
+// 0x4DA360 assoc_write_assoc_array
 int dictionaryWriteHeader(FILE* stream, Dictionary* dictionary)
 {
     if (dictionaryWriteInt(stream, dictionary->entriesLength) != 0) return -1;
@@ -475,7 +475,7 @@ int dictionaryWriteHeader(FILE* stream, Dictionary* dictionary)
 
 // NOTE: Unused.
 //
-// 0x4DA3A4 assoc_save_
+// 0x4DA3A4 assoc_save
 int dictionaryWrite(FILE* stream, Dictionary* dictionary, int a3)
 {
     if (dictionary->marker != DICTIONARY_MARKER) {

--- a/src/display_monitor.cc
+++ b/src/display_monitor.cc
@@ -98,7 +98,7 @@ static unsigned int gDisplayMonitorLastBeepTimestamp;
 static std::ofstream gConsoleFileStream;
 static int gConsoleFilePrintCount = 0;
 
-// 0x431610
+// 0x431610 display_init_
 int displayMonitorInit()
 {
     if (!gDisplayMonitorInitialized) {
@@ -205,7 +205,7 @@ int displayMonitorInit()
     return 0;
 }
 
-// 0x431800
+// 0x431800 display_reset_
 int displayMonitorReset()
 {
     // NOTE: Uninline.
@@ -217,7 +217,7 @@ int displayMonitorReset()
     return 0;
 }
 
-// 0x43184C
+// 0x43184C display_exit_
 void displayMonitorExit()
 {
     if (gDisplayMonitorInitialized) {
@@ -229,7 +229,7 @@ void displayMonitorExit()
     }
 }
 
-// 0x43186C
+// 0x43186C display_print_
 void displayMonitorAddMessage(const char* str)
 {
     if (!gDisplayMonitorInitialized || str == nullptr) {
@@ -327,7 +327,7 @@ void displayMonitorAddMessage(const char* str)
 
 // NOTE: Inlined.
 //
-// 0x431A2C
+// 0x431A2C display_clear_
 static void display_clear()
 {
     int index;
@@ -343,7 +343,7 @@ static void display_clear()
     }
 }
 
-// 0x431A78
+// 0x431A78 display_redraw_
 static void displayMonitorRefresh()
 {
     if (!gDisplayMonitorInitialized) {
@@ -382,7 +382,7 @@ static void displayMonitorRefresh()
     fontSetCurrent(oldFont);
 }
 
-// 0x431B70
+// 0x431B70 display_scroll_up_
 static void displayMonitorScrollUpOnMouseDown(int btn, int keyCode)
 {
     if ((gDisplayMonitorLinesCapacity + _disp_curr - 1) % gDisplayMonitorLinesCapacity != _disp_start) {
@@ -391,7 +391,7 @@ static void displayMonitorScrollUpOnMouseDown(int btn, int keyCode)
     }
 }
 
-// 0x431B9C
+// 0x431B9C display_scroll_down_
 static void displayMonitorScrollDownOnMouseDown(int btn, int keyCode)
 {
     if (_disp_curr != _disp_start) {
@@ -400,25 +400,25 @@ static void displayMonitorScrollDownOnMouseDown(int btn, int keyCode)
     }
 }
 
-// 0x431BC8
+// 0x431BC8 display_arrow_up_
 static void displayMonitorScrollUpOnMouseEnter(int btn, int keyCode)
 {
     gameMouseSetCursor(MOUSE_CURSOR_SMALL_ARROW_UP);
 }
 
-// 0x431BD4
+// 0x431BD4 display_arrow_down_
 static void displayMonitorScrollDownOnMouseEnter(int btn, int keyCode)
 {
     gameMouseSetCursor(MOUSE_CURSOR_SMALL_ARROW_DOWN);
 }
 
-// 0x431BE0
+// 0x431BE0 display_arrow_restore_
 static void displayMonitorOnMouseExit(int btn, int keyCode)
 {
     gameMouseSetCursor(MOUSE_CURSOR_ARROW);
 }
 
-// 0x431BEC
+// 0x431BEC display_disable_
 void displayMonitorDisable()
 {
     if (gDisplayMonitorEnabled) {
@@ -428,7 +428,7 @@ void displayMonitorDisable()
     }
 }
 
-// 0x431C14
+// 0x431C14 display_enable_
 void displayMonitorEnable()
 {
     if (!gDisplayMonitorEnabled) {

--- a/src/display_monitor.cc
+++ b/src/display_monitor.cc
@@ -71,7 +71,7 @@ static int gDisplayMonitorScrollUpButton = -1;
 // 0x56DBFC display_string_buf
 static char gDisplayMonitorLines[DISPLAY_MONITOR_LINES_CAPACITY][DISPLAY_MONITOR_LINE_LENGTH];
 
-// 0x56FB3C _disp_buf
+// 0x56FB3C disp_buf
 static unsigned char* gDisplayMonitorBackgroundFrmData;
 
 // 0x56FB40 max_disp

--- a/src/display_monitor.cc
+++ b/src/display_monitor.cc
@@ -54,51 +54,51 @@ static void consoleFileExit();
 static void consoleFileAddMessage(const char* message);
 static void consoleFileFlush();
 
-// 0x51850C
+// 0x51850C disp_init
 static bool gDisplayMonitorInitialized = false;
 
 // The rectangle that display monitor occupies in the main interface window.
 //
-// 0x518510
+// 0x518510 disp_rect
 static Rect gDisplayMonitorRect;
 
-// 0x518520
+// 0x518520 dn_bid
 static int gDisplayMonitorScrollDownButton = -1;
 
-// 0x518524
+// 0x518524 up_bid
 static int gDisplayMonitorScrollUpButton = -1;
 
-// 0x56DBFC
+// 0x56DBFC display_string_buf
 static char gDisplayMonitorLines[DISPLAY_MONITOR_LINES_CAPACITY][DISPLAY_MONITOR_LINE_LENGTH];
 
-// 0x56FB3C
+// 0x56FB3C _disp_buf
 static unsigned char* gDisplayMonitorBackgroundFrmData;
 
-// 0x56FB40
+// 0x56FB40 max_disp
 static int _max_disp;
 
-// 0x56FB44
+// 0x56FB44 display_enabled
 static bool gDisplayMonitorEnabled;
 
-// 0x56FB48
+// 0x56FB48 disp_curr
 static int _disp_curr;
 
-// 0x56FB4C
+// 0x56FB4C intface_full_width
 static int _intface_full_width;
 
-// 0x56FB50
+// 0x56FB50 max
 static int gDisplayMonitorLinesCapacity;
 
-// 0x56FB54
+// 0x56FB54 disp_start
 static int _disp_start;
 
-// 0x56FB58
+// 0x56FB58 lastTime
 static unsigned int gDisplayMonitorLastBeepTimestamp;
 
 static std::ofstream gConsoleFileStream;
 static int gConsoleFilePrintCount = 0;
 
-// 0x431610 display_init_
+// 0x431610 display_init
 int displayMonitorInit()
 {
     if (!gDisplayMonitorInitialized) {
@@ -205,7 +205,7 @@ int displayMonitorInit()
     return 0;
 }
 
-// 0x431800 display_reset_
+// 0x431800 display_reset
 int displayMonitorReset()
 {
     // NOTE: Uninline.
@@ -217,7 +217,7 @@ int displayMonitorReset()
     return 0;
 }
 
-// 0x43184C display_exit_
+// 0x43184C display_exit
 void displayMonitorExit()
 {
     if (gDisplayMonitorInitialized) {
@@ -229,7 +229,7 @@ void displayMonitorExit()
     }
 }
 
-// 0x43186C display_print_
+// 0x43186C display_print
 void displayMonitorAddMessage(const char* str)
 {
     if (!gDisplayMonitorInitialized || str == nullptr) {
@@ -327,7 +327,7 @@ void displayMonitorAddMessage(const char* str)
 
 // NOTE: Inlined.
 //
-// 0x431A2C display_clear_
+// 0x431A2C display_clear
 static void display_clear()
 {
     int index;
@@ -343,7 +343,7 @@ static void display_clear()
     }
 }
 
-// 0x431A78 display_redraw_
+// 0x431A78 display_redraw
 static void displayMonitorRefresh()
 {
     if (!gDisplayMonitorInitialized) {
@@ -382,7 +382,7 @@ static void displayMonitorRefresh()
     fontSetCurrent(oldFont);
 }
 
-// 0x431B70 display_scroll_up_
+// 0x431B70 display_scroll_up
 static void displayMonitorScrollUpOnMouseDown(int btn, int keyCode)
 {
     if ((gDisplayMonitorLinesCapacity + _disp_curr - 1) % gDisplayMonitorLinesCapacity != _disp_start) {
@@ -391,7 +391,7 @@ static void displayMonitorScrollUpOnMouseDown(int btn, int keyCode)
     }
 }
 
-// 0x431B9C display_scroll_down_
+// 0x431B9C display_scroll_down
 static void displayMonitorScrollDownOnMouseDown(int btn, int keyCode)
 {
     if (_disp_curr != _disp_start) {
@@ -400,25 +400,25 @@ static void displayMonitorScrollDownOnMouseDown(int btn, int keyCode)
     }
 }
 
-// 0x431BC8 display_arrow_up_
+// 0x431BC8 display_arrow_up
 static void displayMonitorScrollUpOnMouseEnter(int btn, int keyCode)
 {
     gameMouseSetCursor(MOUSE_CURSOR_SMALL_ARROW_UP);
 }
 
-// 0x431BD4 display_arrow_down_
+// 0x431BD4 display_arrow_down
 static void displayMonitorScrollDownOnMouseEnter(int btn, int keyCode)
 {
     gameMouseSetCursor(MOUSE_CURSOR_SMALL_ARROW_DOWN);
 }
 
-// 0x431BE0 display_arrow_restore_
+// 0x431BE0 display_arrow_restore
 static void displayMonitorOnMouseExit(int btn, int keyCode)
 {
     gameMouseSetCursor(MOUSE_CURSOR_ARROW);
 }
 
-// 0x431BEC display_disable_
+// 0x431BEC display_disable
 void displayMonitorDisable()
 {
     if (gDisplayMonitorEnabled) {
@@ -428,7 +428,7 @@ void displayMonitorDisable()
     }
 }
 
-// 0x431C14 display_enable_
+// 0x431C14 display_enable
 void displayMonitorEnable()
 {
     if (!gDisplayMonitorEnabled) {

--- a/src/elevator.cc
+++ b/src/elevator.cc
@@ -335,7 +335,7 @@ static FrmImage _elevatorPanelFrmImage;
 
 // Presents elevator dialog for player to pick a desired level.
 //
-// 0x43EF5C
+// 0x43EF5C elevator_select_
 int elevatorSelectLevel(int elevator, int* mapPtr, int* elevationPtr, int* tilePtr)
 {
     if (elevator < 0 || elevator >= ELEVATORS_MAX) {
@@ -479,7 +479,7 @@ int elevatorSelectLevel(int elevator, int* mapPtr, int* elevationPtr, int* tileP
     return 0;
 }
 
-// 0x43F324
+// 0x43F324 elevator_start_
 static int elevatorWindowInit(int elevator)
 {
     gElevatorWindowIsoWasEnabled = isoDisable();
@@ -607,7 +607,7 @@ static int elevatorWindowInit(int elevator)
     return 0;
 }
 
-// 0x43F6D0
+// 0x43F6D0 elevator_end_
 static void elevatorWindowFree()
 {
     windowDestroy(gElevatorWindow);
@@ -630,7 +630,7 @@ static void elevatorWindowFree()
     gameMouseSetCursor(MOUSE_CURSOR_ARROW);
 }
 
-// 0x43F73C
+// 0x43F73C Check4Keys_
 static int elevatorGetLevelFromKeyCode(int elevator, int keyCode)
 {
     for (int index = 0; index < ELEVATOR_LEVEL_MAX; index++) {

--- a/src/elevator.cc
+++ b/src/elevator.cc
@@ -55,14 +55,14 @@ static int elevatorWindowInit(int elevator);
 static void elevatorWindowFree();
 static int elevatorGetLevelFromKeyCode(int elevator, int keyCode);
 
-// 0x43E950
+// 0x43E950 grph_id_2
 static const int gElevatorFrmIds[ELEVATOR_FRM_COUNT] = {
     141, // ebut_in.frm - map elevator screen
     142, // ebut_out.frm - map elevator screen
     149, // gaj000.frm - map elevator screen
 };
 
-// 0x43E95C
+// 0x43E95C intotal
 static ElevatorBackground gElevatorBackgrounds[ELEVATORS_MAX] = {
     { 143, -1 },
     { 143, 150 },
@@ -92,7 +92,7 @@ static ElevatorBackground gElevatorBackgrounds[ELEVATORS_MAX] = {
 
 // Number of levels for eleveators.
 //
-// 0x43EA1C
+// 0x43EA1C btncnt
 static int gElevatorLevels[ELEVATORS_MAX] = {
     4,
     2,
@@ -120,7 +120,7 @@ static int gElevatorLevels[ELEVATORS_MAX] = {
     2,
 };
 
-// 0x43EA7C
+// 0x43EA7C retvals
 static ElevatorDescription gElevatorDescriptions[ELEVATORS_MAX][ELEVATOR_LEVEL_MAX] = {
     {
         { 14, 0, 18940 },
@@ -270,7 +270,7 @@ static ElevatorDescription gElevatorDescriptions[ELEVATORS_MAX][ELEVATOR_LEVEL_M
 
 // NOTE: These values are also used as key bindings.
 //
-// 0x43EEFC
+// 0x43EEFC keytable
 static char gElevatorLevelLabels[ELEVATORS_MAX][ELEVATOR_LEVEL_MAX] = {
     { '1', '2', '3', '4' },
     { 'G', '1', '\0', '\0' },
@@ -298,7 +298,7 @@ static char gElevatorLevelLabels[ELEVATORS_MAX][ELEVATOR_LEVEL_MAX] = {
     { '1', '2', '\0', '\0' },
 };
 
-// 0x51862C
+// 0x51862C _sfxtable
 static const char* gElevatorSoundEffects[ELEVATOR_LEVEL_MAX - 1][ELEVATOR_LEVEL_MAX] = {
     {
         "ELV1_1",
@@ -320,13 +320,13 @@ static const char* gElevatorSoundEffects[ELEVATOR_LEVEL_MAX - 1][ELEVATOR_LEVEL_
     },
 };
 
-// 0x570A54
+// 0x570A54 elev_win
 static int gElevatorWindow;
 
-// 0x570A6C
+// 0x570A6C win_buf_2
 static unsigned char* gElevatorWindowBuffer;
 
-// 0x570A70
+// 0x570A70 bk_enable_2
 static bool gElevatorWindowIsoWasEnabled;
 
 static FrmImage _elevatorFrmImages[ELEVATOR_FRM_COUNT];
@@ -335,7 +335,7 @@ static FrmImage _elevatorPanelFrmImage;
 
 // Presents elevator dialog for player to pick a desired level.
 //
-// 0x43EF5C elevator_select_
+// 0x43EF5C elevator_select
 int elevatorSelectLevel(int elevator, int* mapPtr, int* elevationPtr, int* tilePtr)
 {
     if (elevator < 0 || elevator >= ELEVATORS_MAX) {
@@ -479,7 +479,7 @@ int elevatorSelectLevel(int elevator, int* mapPtr, int* elevationPtr, int* tileP
     return 0;
 }
 
-// 0x43F324 elevator_start_
+// 0x43F324 elevator_start
 static int elevatorWindowInit(int elevator)
 {
     gElevatorWindowIsoWasEnabled = isoDisable();
@@ -607,7 +607,7 @@ static int elevatorWindowInit(int elevator)
     return 0;
 }
 
-// 0x43F6D0 elevator_end_
+// 0x43F6D0 elevator_end
 static void elevatorWindowFree()
 {
     windowDestroy(gElevatorWindow);
@@ -630,7 +630,7 @@ static void elevatorWindowFree()
     gameMouseSetCursor(MOUSE_CURSOR_ARROW);
 }
 
-// 0x43F73C Check4Keys_
+// 0x43F73C Check4Keys
 static int elevatorGetLevelFromKeyCode(int elevator, int keyCode)
 {
     for (int index = 0; index < ELEVATOR_LEVEL_MAX; index++) {

--- a/src/elevator.cc
+++ b/src/elevator.cc
@@ -298,7 +298,7 @@ static char gElevatorLevelLabels[ELEVATORS_MAX][ELEVATOR_LEVEL_MAX] = {
     { '1', '2', '\0', '\0' },
 };
 
-// 0x51862C _sfxtable
+// 0x51862C sfxtable
 static const char* gElevatorSoundEffects[ELEVATOR_LEVEL_MAX - 1][ELEVATOR_LEVEL_MAX] = {
     {
         "ELV1_1",

--- a/src/endgame.cc
+++ b/src/endgame.cc
@@ -207,7 +207,7 @@ static int gEndgameEndingSlideshowWindow;
 
 static int gEndgameEndingOverlay;
 
-// 0x43F788
+// 0x43F788 endgame_slideshow_
 void endgamePlaySlideshow()
 {
     if (endgameEndingSlideshowWindowInit() == -1) {
@@ -230,7 +230,7 @@ void endgamePlaySlideshow()
     endgameEndingSlideshowWindowFree();
 }
 
-// 0x43F810
+// 0x43F810 endgame_movie_
 void endgamePlayMovie()
 {
     backgroundSoundDelete();
@@ -257,7 +257,7 @@ void endgamePlayMovie()
     endgameEndingHandleContinuePlaying();
 }
 
-// 0x43F8C4
+// 0x43F8C4 gameOverConfim_
 static int endgameEndingHandleContinuePlaying()
 {
     bool isoWasEnabled = isoDisable();
@@ -310,7 +310,7 @@ static int endgameEndingHandleContinuePlaying()
     return rc;
 }
 
-// 0x43FBDC
+// 0x43FBDC endgame_pan_desert_
 static void endgameEndingRenderPanningScene(int direction, const char* narratorFileName)
 {
     int fid = buildFid(OBJ_TYPE_INTERFACE, 327, 0, 0, 0);
@@ -449,7 +449,7 @@ static void endgameEndingRenderPanningScene(int direction, const char* narratorF
     }
 }
 
-// 0x440004
+// 0x440004 endgame_display_image_
 static void endgameEndingRenderStaticScene(int fid, const char* narratorFileName)
 {
     CacheEntry* backgroundHandle;
@@ -543,7 +543,7 @@ static void endgameEndingRenderStaticScene(int fid, const char* narratorFileName
     artUnlock(backgroundHandle);
 }
 
-// 0x43F99C
+// 0x43F99C endgame_init_
 static int endgameEndingSlideshowWindowInit()
 {
     if (endgameEndingInit() != 0) {
@@ -624,7 +624,7 @@ static int endgameEndingSlideshowWindowInit()
     return 0;
 }
 
-// 0x43FB28
+// 0x43FB28 endgame_exit_
 static void endgameEndingSlideshowWindowFree()
 {
     if (gEndgameEndingSubtitlesEnabled) {
@@ -662,7 +662,7 @@ static void endgameEndingSlideshowWindowFree()
     }
 }
 
-// 0x4401A0
+// 0x4401A0 endgame_load_voiceover_
 static void endgameEndingVoiceOverInit(const char* fileBaseName)
 {
     char path[COMPAT_MAX_PATH];
@@ -710,7 +710,7 @@ static void endgameEndingVoiceOverInit(const char* fileBaseName)
 
 // NOTE: This function was inlined at every call site.
 //
-// 0x440324
+// 0x440324 endgame_play_voiceover_
 static void endgameEndingVoiceOverReset()
 {
     gEndgameEndingSubtitlesEnded = false;
@@ -727,7 +727,7 @@ static void endgameEndingVoiceOverReset()
 
 // NOTE: This function was inlined at every call site.
 //
-// 0x44035C
+// 0x44035C endgame_stop_voiceover_
 static void endgameEndingVoiceOverFree()
 {
     speechDelete();
@@ -736,7 +736,7 @@ static void endgameEndingVoiceOverFree()
     gEndgameEndingVoiceOverSubtitlesLoaded = false;
 }
 
-// 0x440378
+// 0x440378 endgame_load_palette_
 static void endgameEndingLoadPalette(int type, int id)
 {
     char fileName[13];
@@ -757,7 +757,7 @@ static void endgameEndingLoadPalette(int type, int id)
     }
 }
 
-// 0x4403F0
+// 0x4403F0 endgame_voiceover_callback_
 static void _endgame_voiceover_callback()
 {
     gEndgameEndingSpeechEnded = true;
@@ -765,7 +765,7 @@ static void _endgame_voiceover_callback()
 
 // Loads subtitles file.
 //
-// 0x4403FC
+// 0x4403FC endgame_load_subtitles_
 static int endgameEndingSubtitlesLoad(const char* filePath)
 {
     endgameEndingSubtitlesFree();
@@ -806,7 +806,7 @@ static int endgameEndingSubtitlesLoad(const char* filePath)
 
 // Refreshes subtitles.
 //
-// 0x4404EC
+// 0x4404EC endgame_show_subtitles_
 static void endgameEndingRefreshSubtitles()
 {
     if (gEndgameEndingSubtitlesLength <= gEndgameEndingSubtitlesCurrentLine) {
@@ -857,7 +857,7 @@ static void endgameEndingRefreshSubtitles()
     }
 }
 
-// 0x4406CC
+// 0x4406CC endgame_clear_subtitles_
 static void endgameEndingSubtitlesFree()
 {
     for (int index = 0; index < gEndgameEndingSubtitlesLength; index++) {
@@ -872,13 +872,13 @@ static void endgameEndingSubtitlesFree()
     gEndgameEndingSubtitlesLength = 0;
 }
 
-// 0x440728
+// 0x440728 endgame_movie_callback_
 static void _endgame_movie_callback()
 {
     _endgame_maybe_done = 1;
 }
 
-// 0x440734
+// 0x440734 endgame_movie_bk_process_
 static void _endgame_movie_bk_process()
 {
     if (_endgame_maybe_done) {
@@ -888,7 +888,7 @@ static void _endgame_movie_bk_process()
     }
 }
 
-// 0x440770
+// 0x440770 endgame_load_slide_info_
 static int endgameEndingInit()
 {
     File* stream;
@@ -985,7 +985,7 @@ err:
 
 // NOTE: There are no references to this function. It was inlined.
 //
-// 0x44095C
+// 0x44095C endgame_unload_slide_info_
 static void endgameEndingFree()
 {
     if (gEndgameEndings != nullptr) {
@@ -997,7 +997,7 @@ static void endgameEndingFree()
 }
 
 // endgameDeathEndingInit
-// 0x440984
+// 0x440984 endgameDeathEndingInit_
 int endgameDeathEndingInit()
 {
     File* stream;
@@ -1105,7 +1105,7 @@ err:
     return -1;
 }
 
-// 0x440BA8
+// 0x440BA8 endgameDeathEndingExit_
 int endgameDeathEndingExit()
 {
     if (gEndgameDeathEndings != nullptr) {
@@ -1119,7 +1119,7 @@ int endgameDeathEndingExit()
 }
 
 // endgameSetupDeathEnding
-// 0x440BD0
+// 0x440BD0 endgameSetupDeathEnding_
 void endgameSetupDeathEnding(int reason)
 {
     if (!gEndgameDeathEndingsLength) {
@@ -1177,7 +1177,7 @@ void endgameSetupDeathEnding(int reason)
 // Upon return [percentage] is set as a sum of all valid endings' percentages.
 // Always returns 0.
 //
-// 0x440CF4
+// 0x440CF4 endgameSetupInit_
 static int endgameDeathEndingValidate(int* percentage)
 {
     *percentage = 0;
@@ -1221,7 +1221,7 @@ static int endgameDeathEndingValidate(int* percentage)
 //
 // This path does not include extension.
 //
-// 0x440D8C
+// 0x440D8C endgameGetDeathEndingFileName_
 char* endgameDeathEndingGetFileName()
 {
     if (gEndgameDeathEndingsLength == 0) {

--- a/src/endgame.cc
+++ b/src/endgame.cc
@@ -111,7 +111,7 @@ static int _endgame_maybe_done = 0;
 
 // enddeath.txt
 //
-// 0x518678 _endDeathInfoList
+// 0x518678 endDeathInfoList
 static EndgameDeathEnding* gEndgameDeathEndings = nullptr;
 
 // The number of death endings in [gEndgameDeathEndings] array.
@@ -142,7 +142,7 @@ static bool gEndgameEndingSpeechEnded;
 
 // endgame.txt
 //
-// 0x570BC4 _slides
+// 0x570BC4 slides
 static EndgameEnding* gEndgameEndings;
 
 // The array of text lines in current subtitles file.
@@ -199,7 +199,7 @@ static unsigned int* gEndgameEndingSubtitlesTimings;
 // 0x570BEC endgame_old_font
 static int gEndgameEndingSlideshowOldFont;
 
-// 0x570BF0 _endgame_window_buffer
+// 0x570BF0 endgame_window_buffer
 static unsigned char* gEndgameEndingSlideshowWindowBuffer;
 
 // 0x570BF4 endgame_window

--- a/src/endgame.cc
+++ b/src/endgame.cc
@@ -93,56 +93,56 @@ static void endgameEndingUpdateOverlay();
 //
 // This value does not exceed [ENDGAME_ENDING_SUBTITLES_CAPACITY].
 //
-// 0x518668
+// 0x518668 endgame_subtitle_count
 static int gEndgameEndingSubtitlesLength = 0;
 
 // The number of characters in current subtitles file.
 //
 // This value is used to determine
 //
-// 0x51866C
+// 0x51866C endgame_subtitle_characters
 static int gEndgameEndingSubtitlesCharactersCount = 0;
 
-// 0x518670
+// 0x518670 endgame_current_subtitle
 static int gEndgameEndingSubtitlesCurrentLine = 0;
 
-// 0x518674
+// 0x518674 endgame_maybe_done
 static int _endgame_maybe_done = 0;
 
 // enddeath.txt
 //
-// 0x518678
+// 0x518678 _endDeathInfoList
 static EndgameDeathEnding* gEndgameDeathEndings = nullptr;
 
 // The number of death endings in [gEndgameDeathEndings] array.
 //
-// 0x51867C
+// 0x51867C maxEndDeathInfo
 static int gEndgameDeathEndingsLength = 0;
 
 // Base file name for death ending.
 //
 // This value does not include extension.
 //
-// 0x570A90
+// 0x570A90 endDeathSndChoice
 static char gEndgameDeathEndingFileName[40];
 
 // This flag denotes whether speech sound was successfully loaded for
 // the current slide.
 //
-// 0x570AB8
+// 0x570AB8 endgame_voiceover_loaded
 static bool gEndgameEndingVoiceOverSpeechLoaded;
 
-// 0x570ABC
+// 0x570ABC endgame_subtitle_path
 static char gEndgameEndingSubtitlesLocalizedPath[COMPAT_MAX_PATH];
 
 // The flag used to denote voice over speech for current slide has ended.
 //
-// 0x570BC0
+// 0x570BC0 endgame_voiceover_done
 static bool gEndgameEndingSpeechEnded;
 
 // endgame.txt
 //
-// 0x570BC4
+// 0x570BC4 _slides
 static EndgameEnding* gEndgameEndings;
 
 // The array of text lines in current subtitles file.
@@ -150,32 +150,32 @@ static EndgameEnding* gEndgameEndings;
 // The length is specified in [gEndgameEndingSubtitlesLength]. It's capacity
 // is [ENDGAME_ENDING_SUBTITLES_CAPACITY].
 //
-// 0x570BC8
+// 0x570BC8 endgame_subtitle_text
 static char** gEndgameEndingSubtitles;
 
-// 0x570BCC
+// 0x570BCC endgame_do_subtitles
 static bool gEndgameEndingSubtitlesEnabled;
 
 // The flag used to denote voice over subtitles for current slide has ended.
 //
-// 0x570BD0
+// 0x570BD0 endgame_subtitle_done
 static bool gEndgameEndingSubtitlesEnded;
 
-// 0x570BD4
+// 0x570BD4 endgame_map_enabled
 static bool _endgame_map_enabled;
 
-// 0x570BD8
+// 0x570BD8 endgame_mouse_state
 static bool _endgame_mouse_state;
 
 // The number of endings in [gEndgameEndings] array.
 //
-// 0x570BDC
+// 0x570BDC num_slides
 static int gEndgameEndingsLength = 0;
 
 // This flag denotes whether subtitles was successfully loaded for
 // the current slide.
 //
-// 0x570BE0
+// 0x570BE0 endgame_subtitle_loaded
 static bool gEndgameEndingVoiceOverSubtitlesLoaded;
 
 // Reference time is a timestamp when subtitle is first displayed.
@@ -183,7 +183,7 @@ static bool gEndgameEndingVoiceOverSubtitlesLoaded;
 // This value is used together with [gEndgameEndingSubtitlesTimings] array to
 // determine when next line needs to be displayed.
 //
-// 0x570BE4
+// 0x570BE4 endgame_subtitle_start_time
 static unsigned int gEndgameEndingSubtitlesReferenceTime;
 
 // The array of timings for each line in current subtitles file.
@@ -191,23 +191,23 @@ static unsigned int gEndgameEndingSubtitlesReferenceTime;
 // The length is specified in [gEndgameEndingSubtitlesLength]. It's capacity
 // is [ENDGAME_ENDING_SUBTITLES_CAPACITY].
 //
-// 0x570BE8
+// 0x570BE8 endgame_subtitle_times
 static unsigned int* gEndgameEndingSubtitlesTimings;
 
 // Font that was current before endgame slideshow window was created.
 //
-// 0x570BEC
+// 0x570BEC endgame_old_font
 static int gEndgameEndingSlideshowOldFont;
 
-// 0x570BF0
+// 0x570BF0 _endgame_window_buffer
 static unsigned char* gEndgameEndingSlideshowWindowBuffer;
 
-// 0x570BF4
+// 0x570BF4 endgame_window
 static int gEndgameEndingSlideshowWindow;
 
 static int gEndgameEndingOverlay;
 
-// 0x43F788 endgame_slideshow_
+// 0x43F788 endgame_slideshow
 void endgamePlaySlideshow()
 {
     if (endgameEndingSlideshowWindowInit() == -1) {
@@ -230,7 +230,7 @@ void endgamePlaySlideshow()
     endgameEndingSlideshowWindowFree();
 }
 
-// 0x43F810 endgame_movie_
+// 0x43F810 endgame_movie
 void endgamePlayMovie()
 {
     backgroundSoundDelete();
@@ -257,7 +257,7 @@ void endgamePlayMovie()
     endgameEndingHandleContinuePlaying();
 }
 
-// 0x43F8C4 gameOverConfim_
+// 0x43F8C4 gameOverConfim
 static int endgameEndingHandleContinuePlaying()
 {
     bool isoWasEnabled = isoDisable();
@@ -310,7 +310,7 @@ static int endgameEndingHandleContinuePlaying()
     return rc;
 }
 
-// 0x43FBDC endgame_pan_desert_
+// 0x43FBDC endgame_pan_desert
 static void endgameEndingRenderPanningScene(int direction, const char* narratorFileName)
 {
     int fid = buildFid(OBJ_TYPE_INTERFACE, 327, 0, 0, 0);
@@ -449,7 +449,7 @@ static void endgameEndingRenderPanningScene(int direction, const char* narratorF
     }
 }
 
-// 0x440004 endgame_display_image_
+// 0x440004 endgame_display_image
 static void endgameEndingRenderStaticScene(int fid, const char* narratorFileName)
 {
     CacheEntry* backgroundHandle;
@@ -543,7 +543,7 @@ static void endgameEndingRenderStaticScene(int fid, const char* narratorFileName
     artUnlock(backgroundHandle);
 }
 
-// 0x43F99C endgame_init_
+// 0x43F99C endgame_init
 static int endgameEndingSlideshowWindowInit()
 {
     if (endgameEndingInit() != 0) {
@@ -624,7 +624,7 @@ static int endgameEndingSlideshowWindowInit()
     return 0;
 }
 
-// 0x43FB28 endgame_exit_
+// 0x43FB28 endgame_exit
 static void endgameEndingSlideshowWindowFree()
 {
     if (gEndgameEndingSubtitlesEnabled) {
@@ -662,7 +662,7 @@ static void endgameEndingSlideshowWindowFree()
     }
 }
 
-// 0x4401A0 endgame_load_voiceover_
+// 0x4401A0 endgame_load_voiceover
 static void endgameEndingVoiceOverInit(const char* fileBaseName)
 {
     char path[COMPAT_MAX_PATH];
@@ -710,7 +710,7 @@ static void endgameEndingVoiceOverInit(const char* fileBaseName)
 
 // NOTE: This function was inlined at every call site.
 //
-// 0x440324 endgame_play_voiceover_
+// 0x440324 endgame_play_voiceover
 static void endgameEndingVoiceOverReset()
 {
     gEndgameEndingSubtitlesEnded = false;
@@ -727,7 +727,7 @@ static void endgameEndingVoiceOverReset()
 
 // NOTE: This function was inlined at every call site.
 //
-// 0x44035C endgame_stop_voiceover_
+// 0x44035C endgame_stop_voiceover
 static void endgameEndingVoiceOverFree()
 {
     speechDelete();
@@ -736,7 +736,7 @@ static void endgameEndingVoiceOverFree()
     gEndgameEndingVoiceOverSubtitlesLoaded = false;
 }
 
-// 0x440378 endgame_load_palette_
+// 0x440378 endgame_load_palette
 static void endgameEndingLoadPalette(int type, int id)
 {
     char fileName[13];
@@ -757,7 +757,7 @@ static void endgameEndingLoadPalette(int type, int id)
     }
 }
 
-// 0x4403F0 endgame_voiceover_callback_
+// 0x4403F0 endgame_voiceover_callback
 static void _endgame_voiceover_callback()
 {
     gEndgameEndingSpeechEnded = true;
@@ -765,7 +765,7 @@ static void _endgame_voiceover_callback()
 
 // Loads subtitles file.
 //
-// 0x4403FC endgame_load_subtitles_
+// 0x4403FC endgame_load_subtitles
 static int endgameEndingSubtitlesLoad(const char* filePath)
 {
     endgameEndingSubtitlesFree();
@@ -806,7 +806,7 @@ static int endgameEndingSubtitlesLoad(const char* filePath)
 
 // Refreshes subtitles.
 //
-// 0x4404EC endgame_show_subtitles_
+// 0x4404EC endgame_show_subtitles
 static void endgameEndingRefreshSubtitles()
 {
     if (gEndgameEndingSubtitlesLength <= gEndgameEndingSubtitlesCurrentLine) {
@@ -857,7 +857,7 @@ static void endgameEndingRefreshSubtitles()
     }
 }
 
-// 0x4406CC endgame_clear_subtitles_
+// 0x4406CC endgame_clear_subtitles
 static void endgameEndingSubtitlesFree()
 {
     for (int index = 0; index < gEndgameEndingSubtitlesLength; index++) {
@@ -872,13 +872,13 @@ static void endgameEndingSubtitlesFree()
     gEndgameEndingSubtitlesLength = 0;
 }
 
-// 0x440728 endgame_movie_callback_
+// 0x440728 endgame_movie_callback
 static void _endgame_movie_callback()
 {
     _endgame_maybe_done = 1;
 }
 
-// 0x440734 endgame_movie_bk_process_
+// 0x440734 endgame_movie_bk_process
 static void _endgame_movie_bk_process()
 {
     if (_endgame_maybe_done) {
@@ -888,7 +888,7 @@ static void _endgame_movie_bk_process()
     }
 }
 
-// 0x440770 endgame_load_slide_info_
+// 0x440770 endgame_load_slide_info
 static int endgameEndingInit()
 {
     File* stream;
@@ -985,7 +985,7 @@ err:
 
 // NOTE: There are no references to this function. It was inlined.
 //
-// 0x44095C endgame_unload_slide_info_
+// 0x44095C endgame_unload_slide_info
 static void endgameEndingFree()
 {
     if (gEndgameEndings != nullptr) {
@@ -997,7 +997,7 @@ static void endgameEndingFree()
 }
 
 // endgameDeathEndingInit
-// 0x440984 endgameDeathEndingInit_
+// 0x440984 endgameDeathEndingInit
 int endgameDeathEndingInit()
 {
     File* stream;
@@ -1105,7 +1105,7 @@ err:
     return -1;
 }
 
-// 0x440BA8 endgameDeathEndingExit_
+// 0x440BA8 endgameDeathEndingExit
 int endgameDeathEndingExit()
 {
     if (gEndgameDeathEndings != nullptr) {
@@ -1119,7 +1119,7 @@ int endgameDeathEndingExit()
 }
 
 // endgameSetupDeathEnding
-// 0x440BD0 endgameSetupDeathEnding_
+// 0x440BD0 endgameSetupDeathEnding
 void endgameSetupDeathEnding(int reason)
 {
     if (!gEndgameDeathEndingsLength) {
@@ -1177,7 +1177,7 @@ void endgameSetupDeathEnding(int reason)
 // Upon return [percentage] is set as a sum of all valid endings' percentages.
 // Always returns 0.
 //
-// 0x440CF4 endgameSetupInit_
+// 0x440CF4 endgameSetupInit
 static int endgameDeathEndingValidate(int* percentage)
 {
     *percentage = 0;
@@ -1221,7 +1221,7 @@ static int endgameDeathEndingValidate(int* percentage)
 //
 // This path does not include extension.
 //
-// 0x440D8C endgameGetDeathEndingFileName_
+// 0x440D8C endgameGetDeathEndingFileName
 char* endgameDeathEndingGetFileName()
 {
     if (gEndgameDeathEndingsLength == 0) {

--- a/src/export.cc
+++ b/src/export.cc
@@ -38,7 +38,7 @@ static ExternalVariable gExternalVariables[1013];
 
 // NOTE: Inlined.
 //
-// 0x440F10
+// 0x440F10 hashName_
 static unsigned int _hashName(const char* identifier)
 {
     unsigned int h = 0;
@@ -53,7 +53,7 @@ static unsigned int _hashName(const char* identifier)
     return h;
 }
 
-// 0x440F58
+// 0x440F58 findProc_
 static ExternalProcedure* externalProcedureFind(const char* identifier)
 {
     // NOTE: Uninline.
@@ -84,7 +84,7 @@ static ExternalProcedure* externalProcedureFind(const char* identifier)
     return nullptr;
 }
 
-// 0x441018
+// 0x441018 findEmptyProc_
 static ExternalProcedure* externalProcedureAdd(const char* identifier)
 {
     // NOTE: Uninline.
@@ -111,7 +111,7 @@ static ExternalProcedure* externalProcedureAdd(const char* identifier)
     return nullptr;
 }
 
-// 0x4410AC
+// 0x4410AC findVar_
 static ExternalVariable* externalVariableFind(const char* identifier)
 {
     // NOTE: Uninline.
@@ -143,7 +143,7 @@ static ExternalVariable* externalVariableFind(const char* identifier)
     return nullptr;
 }
 
-// 0x44118C
+// 0x44118C findEmptyVar_
 static ExternalVariable* externalVariableAdd(const char* identifier)
 {
     // NOTE: Uninline.
@@ -170,7 +170,7 @@ static ExternalVariable* externalVariableAdd(const char* identifier)
     return nullptr;
 }
 
-// 0x44127C
+// 0x44127C exportStoreVariable_
 int externalVariableSetValue(Program* program, const char* name, ProgramValue& programValue)
 {
     ExternalVariable* exportedVariable = externalVariableFind(name);
@@ -197,7 +197,7 @@ int externalVariableSetValue(Program* program, const char* name, ProgramValue& p
     return 0;
 }
 
-// 0x4413D4
+// 0x4413D4 exportFetchVariable_
 int externalVariableGetValue(Program* program, const char* name, ProgramValue& value)
 {
     ExternalVariable* exportedVariable = externalVariableFind(name);
@@ -215,7 +215,7 @@ int externalVariableGetValue(Program* program, const char* name, ProgramValue& v
     return 0;
 }
 
-// 0x4414B8
+// 0x4414B8 exportExportVariable_
 int externalVariableCreate(Program* program, const char* identifier)
 {
     const char* programName = program->name;
@@ -247,7 +247,7 @@ int externalVariableCreate(Program* program, const char* identifier)
     return 0;
 }
 
-// 0x4414FC
+// 0x4414FC removeProgramReferences_
 static void _removeProgramReferences(Program* program)
 {
     for (int index = 0; index < 1013; index++) {
@@ -259,13 +259,13 @@ static void _removeProgramReferences(Program* program)
     }
 }
 
-// 0x44152C
+// 0x44152C initExport_
 void _initExport()
 {
     intLibRegisterProgramDeleteCallback(_removeProgramReferences);
 }
 
-// 0x441538
+// 0x441538 exportClose_
 void externalVariablesClear()
 {
     for (int index = 0; index < 1013; index++) {
@@ -281,7 +281,7 @@ void externalVariablesClear()
     }
 }
 
-// 0x44158C
+// 0x44158C exportFindProcedure_
 Program* externalProcedureGetProgram(const char* identifier, int* addressPtr, int* argumentCountPtr)
 {
     ExternalProcedure* externalProcedure = externalProcedureFind(identifier);
@@ -299,7 +299,7 @@ Program* externalProcedureGetProgram(const char* identifier, int* addressPtr, in
     return externalProcedure->program;
 }
 
-// 0x4415B0
+// 0x4415B0 exportExportProcedure_
 int externalProcedureCreate(Program* program, const char* identifier, int address, int argumentCount)
 {
     ExternalProcedure* externalProcedure = externalProcedureFind(identifier);
@@ -323,7 +323,7 @@ int externalProcedureCreate(Program* program, const char* identifier, int addres
     return 0;
 }
 
-// 0x441824
+// 0x441824 exportClearAllVariables_
 void _exportClearAllVariables()
 {
     for (int index = 0; index < 1013; index++) {

--- a/src/export.cc
+++ b/src/export.cc
@@ -30,15 +30,15 @@ static ExternalVariable* externalVariableFind(const char* identifier);
 static ExternalVariable* externalVariableAdd(const char* identifier);
 static void _removeProgramReferences(Program* program);
 
-// 0x570C00
+// 0x570C00 procHashTable
 static ExternalProcedure gExternalProcedures[1013];
 
-// 0x57BA1C
+// 0x57BA1C varHashTable
 static ExternalVariable gExternalVariables[1013];
 
 // NOTE: Inlined.
 //
-// 0x440F10 hashName_
+// 0x440F10 hashName
 static unsigned int _hashName(const char* identifier)
 {
     unsigned int h = 0;
@@ -53,7 +53,7 @@ static unsigned int _hashName(const char* identifier)
     return h;
 }
 
-// 0x440F58 findProc_
+// 0x440F58 findProc
 static ExternalProcedure* externalProcedureFind(const char* identifier)
 {
     // NOTE: Uninline.
@@ -84,7 +84,7 @@ static ExternalProcedure* externalProcedureFind(const char* identifier)
     return nullptr;
 }
 
-// 0x441018 findEmptyProc_
+// 0x441018 findEmptyProc
 static ExternalProcedure* externalProcedureAdd(const char* identifier)
 {
     // NOTE: Uninline.
@@ -111,7 +111,7 @@ static ExternalProcedure* externalProcedureAdd(const char* identifier)
     return nullptr;
 }
 
-// 0x4410AC findVar_
+// 0x4410AC findVar
 static ExternalVariable* externalVariableFind(const char* identifier)
 {
     // NOTE: Uninline.
@@ -143,7 +143,7 @@ static ExternalVariable* externalVariableFind(const char* identifier)
     return nullptr;
 }
 
-// 0x44118C findEmptyVar_
+// 0x44118C findEmptyVar
 static ExternalVariable* externalVariableAdd(const char* identifier)
 {
     // NOTE: Uninline.
@@ -170,7 +170,7 @@ static ExternalVariable* externalVariableAdd(const char* identifier)
     return nullptr;
 }
 
-// 0x44127C exportStoreVariable_
+// 0x44127C exportStoreVariable
 int externalVariableSetValue(Program* program, const char* name, ProgramValue& programValue)
 {
     ExternalVariable* exportedVariable = externalVariableFind(name);
@@ -197,7 +197,7 @@ int externalVariableSetValue(Program* program, const char* name, ProgramValue& p
     return 0;
 }
 
-// 0x4413D4 exportFetchVariable_
+// 0x4413D4 exportFetchVariable
 int externalVariableGetValue(Program* program, const char* name, ProgramValue& value)
 {
     ExternalVariable* exportedVariable = externalVariableFind(name);
@@ -215,7 +215,7 @@ int externalVariableGetValue(Program* program, const char* name, ProgramValue& v
     return 0;
 }
 
-// 0x4414B8 exportExportVariable_
+// 0x4414B8 exportExportVariable
 int externalVariableCreate(Program* program, const char* identifier)
 {
     const char* programName = program->name;
@@ -247,7 +247,7 @@ int externalVariableCreate(Program* program, const char* identifier)
     return 0;
 }
 
-// 0x4414FC removeProgramReferences_
+// 0x4414FC removeProgramReferences
 static void _removeProgramReferences(Program* program)
 {
     for (int index = 0; index < 1013; index++) {
@@ -259,13 +259,13 @@ static void _removeProgramReferences(Program* program)
     }
 }
 
-// 0x44152C initExport_
+// 0x44152C initExport
 void _initExport()
 {
     intLibRegisterProgramDeleteCallback(_removeProgramReferences);
 }
 
-// 0x441538 exportClose_
+// 0x441538 exportClose
 void externalVariablesClear()
 {
     for (int index = 0; index < 1013; index++) {
@@ -281,7 +281,7 @@ void externalVariablesClear()
     }
 }
 
-// 0x44158C exportFindProcedure_
+// 0x44158C exportFindProcedure
 Program* externalProcedureGetProgram(const char* identifier, int* addressPtr, int* argumentCountPtr)
 {
     ExternalProcedure* externalProcedure = externalProcedureFind(identifier);
@@ -299,7 +299,7 @@ Program* externalProcedureGetProgram(const char* identifier, int* addressPtr, in
     return externalProcedure->program;
 }
 
-// 0x4415B0 exportExportProcedure_
+// 0x4415B0 exportExportProcedure
 int externalProcedureCreate(Program* program, const char* identifier, int address, int argumentCount)
 {
     ExternalProcedure* externalProcedure = externalProcedureFind(identifier);
@@ -323,7 +323,7 @@ int externalProcedureCreate(Program* program, const char* identifier, int addres
     return 0;
 }
 
-// 0x441824 exportClearAllVariables_
+// 0x441824 exportClearAllVariables
 void _exportClearAllVariables()
 {
     for (int index = 0; index < 1013; index++) {

--- a/src/file_find.cc
+++ b/src/file_find.cc
@@ -7,7 +7,7 @@
 
 namespace fallout {
 
-// 0x4E6380
+// 0x4E6380 xsys_findfirst_
 bool fileFindFirst(const char* path, DirectoryFileFindData* findData)
 {
 #if defined(_WIN32)
@@ -58,7 +58,7 @@ bool fileFindFirst(const char* path, DirectoryFileFindData* findData)
     return true;
 }
 
-// 0x4E63A8
+// 0x4E63A8 xsys_findnext_
 bool fileFindNext(DirectoryFileFindData* findData)
 {
 #if defined(_WIN32)
@@ -87,7 +87,7 @@ bool fileFindNext(DirectoryFileFindData* findData)
     return true;
 }
 
-// 0x4E63CC
+// 0x4E63CC xsys_findclose_
 bool findFindClose(DirectoryFileFindData* findData)
 {
 #if defined(_MSC_VER)

--- a/src/file_find.cc
+++ b/src/file_find.cc
@@ -7,7 +7,7 @@
 
 namespace fallout {
 
-// 0x4E6380 xsys_findfirst_
+// 0x4E6380 xsys_findfirst
 bool fileFindFirst(const char* path, DirectoryFileFindData* findData)
 {
 #if defined(_WIN32)
@@ -58,7 +58,7 @@ bool fileFindFirst(const char* path, DirectoryFileFindData* findData)
     return true;
 }
 
-// 0x4E63A8 xsys_findnext_
+// 0x4E63A8 xsys_findnext
 bool fileFindNext(DirectoryFileFindData* findData)
 {
 #if defined(_WIN32)
@@ -87,7 +87,7 @@ bool fileFindNext(DirectoryFileFindData* findData)
     return true;
 }
 
-// 0x4E63CC xsys_findclose_
+// 0x4E63CC xsys_findclose
 bool findFindClose(DirectoryFileFindData* findData)
 {
 #if defined(_MSC_VER)

--- a/src/file_utils.cc
+++ b/src/file_utils.cc
@@ -17,7 +17,7 @@ static void fileCopy(const char* existingFilePath, const char* newFilePath);
 static bool copyGzToFile(gzFile inStream, FILE* outStream);
 static bool copyFileToGz(FILE* inStream, gzFile outStream);
 
-// 0x452740
+// 0x452740 gzRealUncompressCopyReal_file_
 int fileCopyDecompressed(const char* existingFilePath, const char* newFilePath)
 {
     FILE* stream = compat_fopen(existingFilePath, "rb");
@@ -61,7 +61,7 @@ int fileCopyDecompressed(const char* existingFilePath, const char* newFilePath)
     return 0;
 }
 
-// 0x452804
+// 0x452804 gzcompress_file_
 int fileCopyCompressed(const char* existingFilePath, const char* newFilePath)
 {
     FILE* inStream = compat_fopen(existingFilePath, "rb");

--- a/src/file_utils.cc
+++ b/src/file_utils.cc
@@ -17,7 +17,7 @@ static void fileCopy(const char* existingFilePath, const char* newFilePath);
 static bool copyGzToFile(gzFile inStream, FILE* outStream);
 static bool copyFileToGz(FILE* inStream, gzFile outStream);
 
-// 0x452740 gzRealUncompressCopyReal_file_
+// 0x452740 gzRealUncompressCopyReal_file
 int fileCopyDecompressed(const char* existingFilePath, const char* newFilePath)
 {
     FILE* stream = compat_fopen(existingFilePath, "rb");
@@ -61,7 +61,7 @@ int fileCopyDecompressed(const char* existingFilePath, const char* newFilePath)
     return 0;
 }
 
-// 0x452804 gzcompress_file_
+// 0x452804 gzcompress_file
 int fileCopyCompressed(const char* existingFilePath, const char* newFilePath)
 {
     FILE* inStream = compat_fopen(existingFilePath, "rb");

--- a/src/font_manager.cc
+++ b/src/font_manager.cc
@@ -75,7 +75,7 @@ static int gCurrentInterfaceFont;
 // 0x58E93C
 static InterfaceFontDescriptor* gCurrentInterfaceFontDescriptor;
 
-// 0x441C80
+// 0x441C80 FMInit_
 int interfaceFontsInit()
 {
     int currentFont = -1;
@@ -104,7 +104,7 @@ int interfaceFontsInit()
     return 0;
 }
 
-// 0x441CEC
+// 0x441CEC FMExit_
 void interfaceFontsExit()
 {
     for (int font = 0; font < INTERFACE_FONT_MAX; font++) {
@@ -114,7 +114,7 @@ void interfaceFontsExit()
     }
 }
 
-// 0x441D20
+// 0x441D20 FMLoadFont_
 static int interfaceFontLoad(int font_index)
 {
     InterfaceFontDescriptor* fontDescriptor = &(gInterfaceFontDescriptors[font_index]);
@@ -219,7 +219,7 @@ static int interfaceFontLoad(int font_index)
     return 0;
 }
 
-// 0x442120
+// 0x442120 FMtext_font_
 static void interfaceFontSetCurrentImpl(int font)
 {
     if (!gInterfaceFontsInitialized) {
@@ -234,7 +234,7 @@ static void interfaceFontSetCurrentImpl(int font)
     }
 }
 
-// 0x442168
+// 0x442168 FMtext_height_
 static int interfaceFontGetLineHeightImpl()
 {
     if (!gInterfaceFontsInitialized) {
@@ -244,7 +244,7 @@ static int interfaceFontGetLineHeightImpl()
     return gCurrentInterfaceFontDescriptor->lineSpacing + gCurrentInterfaceFontDescriptor->maxHeight;
 }
 
-// 0x442188
+// 0x442188 FMtext_width_
 static int interfaceFontGetStringWidthImpl(const char* string)
 {
     if (!gInterfaceFontsInitialized) {
@@ -269,7 +269,7 @@ static int interfaceFontGetStringWidthImpl(const char* string)
     return stringWidth;
 }
 
-// 0x4421DC
+// 0x4421DC FMtext_char_width_
 static int interfaceFontGetCharacterWidthImpl(int ch)
 {
     int width;
@@ -287,7 +287,7 @@ static int interfaceFontGetCharacterWidthImpl(int ch)
     return width;
 }
 
-// 0x442210
+// 0x442210 FMtext_mono_width_
 static int interfaceFontGetMonospacedStringWidthImpl(const char* str)
 {
     if (!gInterfaceFontsInitialized) {
@@ -297,7 +297,7 @@ static int interfaceFontGetMonospacedStringWidthImpl(const char* str)
     return interfaceFontGetMonospacedCharacterWidthImpl() * strlen(str);
 }
 
-// 0x442240
+// 0x442240 FMtext_spacing_
 static int interfaceFontGetLetterSpacingImpl()
 {
     if (!gInterfaceFontsInitialized) {
@@ -307,7 +307,7 @@ static int interfaceFontGetLetterSpacingImpl()
     return gCurrentInterfaceFontDescriptor->letterSpacing;
 }
 
-// 0x442258
+// 0x442258 FMtext_size_
 static int interfaceFontGetBufferSizeImpl(const char* str)
 {
     if (!gInterfaceFontsInitialized) {
@@ -317,7 +317,7 @@ static int interfaceFontGetBufferSizeImpl(const char* str)
     return interfaceFontGetStringWidthImpl(str) * interfaceFontGetLineHeightImpl();
 }
 
-// 0x442278
+// 0x442278 FMtext_max_
 static int interfaceFontGetMonospacedCharacterWidthImpl()
 {
     if (!gInterfaceFontsInitialized) {
@@ -334,7 +334,7 @@ static int interfaceFontGetMonospacedCharacterWidthImpl()
     return spacing + gCurrentInterfaceFontDescriptor->maxHeight;
 }
 
-// 0x4422B4
+// 0x4422B4 FMtext_to_buf_
 static void interfaceFontDrawImpl(unsigned char* buf, const char* string, int length, int pitch, int color)
 {
     if (!gInterfaceFontsInitialized) {
@@ -411,7 +411,7 @@ static void interfaceFontDrawImpl(unsigned char* buf, const char* string, int le
 
 // NOTE: Inlined.
 //
-// 0x442520
+// 0x442520 Swap4_
 static void interfaceFontByteSwapUInt32(unsigned int* value)
 {
     unsigned int swapped = *value;
@@ -430,7 +430,7 @@ static void interfaceFontByteSwapInt32(int* value)
     interfaceFontByteSwapUInt32((unsigned int*)value);
 }
 
-// 0x442568
+// 0x442568 Swap2_
 static void interfaceFontByteSwapUInt16(unsigned short* value)
 {
     unsigned short swapped = *value;

--- a/src/font_manager.cc
+++ b/src/font_manager.cc
@@ -45,13 +45,13 @@ static void interfaceFontByteSwapInt32(int* value);
 static void interfaceFontByteSwapUInt16(unsigned short* value);
 static void interfaceFontByteSwapInt16(short* value);
 
-// 0x518680
+// 0x518680 gFMInit
 static bool gInterfaceFontsInitialized = false;
 
-// 0x518684
+// 0x518684 gNumFonts
 static int gInterfaceFontsLength = 0;
 
-// 0x518688
+// 0x518688 alias_mgr
 FontManager gModernFontManager = {
     100,
     110,
@@ -66,16 +66,16 @@ FontManager gModernFontManager = {
     interfaceFontGetMonospacedCharacterWidthImpl,
 };
 
-// 0x586838
+// 0x586838 gFontCache
 static InterfaceFontDescriptor gInterfaceFontDescriptors[INTERFACE_FONT_MAX];
 
-// 0x58E938
+// 0x58E938 gCurrentFontNum
 static int gCurrentInterfaceFont;
 
-// 0x58E93C
+// 0x58E93C _gCurrentFont
 static InterfaceFontDescriptor* gCurrentInterfaceFontDescriptor;
 
-// 0x441C80 FMInit_
+// 0x441C80 FMInit
 int interfaceFontsInit()
 {
     int currentFont = -1;
@@ -104,7 +104,7 @@ int interfaceFontsInit()
     return 0;
 }
 
-// 0x441CEC FMExit_
+// 0x441CEC FMExit
 void interfaceFontsExit()
 {
     for (int font = 0; font < INTERFACE_FONT_MAX; font++) {
@@ -114,7 +114,7 @@ void interfaceFontsExit()
     }
 }
 
-// 0x441D20 FMLoadFont_
+// 0x441D20 FMLoadFont
 static int interfaceFontLoad(int font_index)
 {
     InterfaceFontDescriptor* fontDescriptor = &(gInterfaceFontDescriptors[font_index]);
@@ -219,7 +219,7 @@ static int interfaceFontLoad(int font_index)
     return 0;
 }
 
-// 0x442120 FMtext_font_
+// 0x442120 FMtext_font
 static void interfaceFontSetCurrentImpl(int font)
 {
     if (!gInterfaceFontsInitialized) {
@@ -234,7 +234,7 @@ static void interfaceFontSetCurrentImpl(int font)
     }
 }
 
-// 0x442168 FMtext_height_
+// 0x442168 FMtext_height
 static int interfaceFontGetLineHeightImpl()
 {
     if (!gInterfaceFontsInitialized) {
@@ -244,7 +244,7 @@ static int interfaceFontGetLineHeightImpl()
     return gCurrentInterfaceFontDescriptor->lineSpacing + gCurrentInterfaceFontDescriptor->maxHeight;
 }
 
-// 0x442188 FMtext_width_
+// 0x442188 FMtext_width
 static int interfaceFontGetStringWidthImpl(const char* string)
 {
     if (!gInterfaceFontsInitialized) {
@@ -269,7 +269,7 @@ static int interfaceFontGetStringWidthImpl(const char* string)
     return stringWidth;
 }
 
-// 0x4421DC FMtext_char_width_
+// 0x4421DC FMtext_char_width
 static int interfaceFontGetCharacterWidthImpl(int ch)
 {
     int width;
@@ -287,7 +287,7 @@ static int interfaceFontGetCharacterWidthImpl(int ch)
     return width;
 }
 
-// 0x442210 FMtext_mono_width_
+// 0x442210 FMtext_mono_width
 static int interfaceFontGetMonospacedStringWidthImpl(const char* str)
 {
     if (!gInterfaceFontsInitialized) {
@@ -297,7 +297,7 @@ static int interfaceFontGetMonospacedStringWidthImpl(const char* str)
     return interfaceFontGetMonospacedCharacterWidthImpl() * strlen(str);
 }
 
-// 0x442240 FMtext_spacing_
+// 0x442240 FMtext_spacing
 static int interfaceFontGetLetterSpacingImpl()
 {
     if (!gInterfaceFontsInitialized) {
@@ -307,7 +307,7 @@ static int interfaceFontGetLetterSpacingImpl()
     return gCurrentInterfaceFontDescriptor->letterSpacing;
 }
 
-// 0x442258 FMtext_size_
+// 0x442258 FMtext_size
 static int interfaceFontGetBufferSizeImpl(const char* str)
 {
     if (!gInterfaceFontsInitialized) {
@@ -317,7 +317,7 @@ static int interfaceFontGetBufferSizeImpl(const char* str)
     return interfaceFontGetStringWidthImpl(str) * interfaceFontGetLineHeightImpl();
 }
 
-// 0x442278 FMtext_max_
+// 0x442278 FMtext_max
 static int interfaceFontGetMonospacedCharacterWidthImpl()
 {
     if (!gInterfaceFontsInitialized) {
@@ -334,7 +334,7 @@ static int interfaceFontGetMonospacedCharacterWidthImpl()
     return spacing + gCurrentInterfaceFontDescriptor->maxHeight;
 }
 
-// 0x4422B4 FMtext_to_buf_
+// 0x4422B4 FMtext_to_buf
 static void interfaceFontDrawImpl(unsigned char* buf, const char* string, int length, int pitch, int color)
 {
     if (!gInterfaceFontsInitialized) {
@@ -411,7 +411,7 @@ static void interfaceFontDrawImpl(unsigned char* buf, const char* string, int le
 
 // NOTE: Inlined.
 //
-// 0x442520 Swap4_
+// 0x442520 Swap4
 static void interfaceFontByteSwapUInt32(unsigned int* value)
 {
     unsigned int swapped = *value;
@@ -430,7 +430,7 @@ static void interfaceFontByteSwapInt32(int* value)
     interfaceFontByteSwapUInt32((unsigned int*)value);
 }
 
-// 0x442568 Swap2_
+// 0x442568 Swap2
 static void interfaceFontByteSwapUInt16(unsigned short* value)
 {
     unsigned short swapped = *value;

--- a/src/font_manager.cc
+++ b/src/font_manager.cc
@@ -72,7 +72,7 @@ static InterfaceFontDescriptor gInterfaceFontDescriptors[INTERFACE_FONT_MAX];
 // 0x58E938 gCurrentFontNum
 static int gCurrentInterfaceFont;
 
-// 0x58E93C _gCurrentFont
+// 0x58E93C gCurrentFont
 static InterfaceFontDescriptor* gCurrentInterfaceFontDescriptor;
 
 // 0x441C80 FMInit

--- a/src/game.cc
+++ b/src/game.cc
@@ -111,13 +111,13 @@ static int gGameState = GAME_STATE_0;
 // 0x5186BC game_in_mapper
 static bool gIsMapper = false;
 
-// 0x5186C0 _game_global_vars
+// 0x5186C0 game_global_vars
 int* gGameGlobalVars = nullptr;
 
 // 0x5186C4 num_game_global_vars
 int gGameGlobalVarsLength = 0;
 
-// 0x5186C8 _msg_path
+// 0x5186C8 msg_path
 const char* asc_5186C8 = _aGame_0;
 
 // 0x5186CC game_user_wants_to_quit

--- a/src/game.cc
+++ b/src/game.cc
@@ -95,37 +95,37 @@ static void showSplash();
 
 inline constexpr char kBaseModPath[] = "ce.dat";
 
-// 0x501C9C
+// 0x501C9C aGame_0
 static char _aGame_0[] = "game\\";
 
-// 0x5020B8
+// 0x5020B8 aDec11199816543
 static char _aBuildDate[] = _BUILD_DATE;
 static char _aBuildHash[] = _BUILD_HASH;
 
-// 0x5186B4
+// 0x5186B4 game_ui_disabled
 static bool gGameUiDisabled = false;
 
-// 0x5186B8
+// 0x5186B8 game_state_cur
 static int gGameState = GAME_STATE_0;
 
-// 0x5186BC
+// 0x5186BC game_in_mapper
 static bool gIsMapper = false;
 
-// 0x5186C0
+// 0x5186C0 _game_global_vars
 int* gGameGlobalVars = nullptr;
 
-// 0x5186C4
+// 0x5186C4 num_game_global_vars
 int gGameGlobalVarsLength = 0;
 
-// 0x5186C8
+// 0x5186C8 _msg_path
 const char* asc_5186C8 = _aGame_0;
 
-// 0x5186CC
+// 0x5186CC game_user_wants_to_quit
 GameQuitRequest _game_user_wants_to_quit = GAME_QUIT_REQUEST_NONE;
 
 // misc.msg
 //
-// 0x58E940
+// 0x58E940 misc_message_file
 MessageList gMiscMessageList;
 
 bool gGameLoaded = false;

--- a/src/game_config.cc
+++ b/src/game_config.cc
@@ -54,7 +54,7 @@ char gGameConfigFilePath[COMPAT_MAX_PATH];
 // Finally, this function merges key-value pairs from [argv] if any, see
 // [configParseCommandLineArguments] for expected format.
 //
-// 0x444570
+// 0x444570 gconfig_init_
 bool gameConfigInit(bool isMapper, int argc, char** argv)
 {
     if (gGameConfigInitialized) {
@@ -148,7 +148,7 @@ EM_ASYNC_JS(void, do_save_idbfs_gameconfig, (), {
 
 // Saves game config into `fallout2.cfg`.
 //
-// 0x444C14
+// 0x444C14 gconfig_save_
 bool gameConfigSave()
 {
     if (!gGameConfigInitialized) {
@@ -168,7 +168,7 @@ bool gameConfigSave()
 
 // Frees game config, optionally saving it.
 //
-// 0x444C3C
+// 0x444C3C gconfig_exit_
 bool gameConfigExit(bool shouldSave)
 {
     if (!gGameConfigInitialized) {

--- a/src/game_config.cc
+++ b/src/game_config.cc
@@ -23,18 +23,18 @@ constexpr char kMapperConfigFileName[] = "mapper2.cfg";
 
 // A flag indicating if [gGameConfig] was initialized.
 //
-// 0x5186D0
+// 0x5186D0 gconfig_initialized
 bool gGameConfigInitialized = false;
 
 // fallout2.cfg
 //
-// 0x58E950
+// 0x58E950 game_config
 Config gGameConfig;
 
 // NOTE: There are additional 4 bytes following this array at 0x58EA7C, which
 // probably means it's size is 264 bytes.
 //
-// 0x58E978
+// 0x58E978 gconfig_file_name
 char gGameConfigFilePath[COMPAT_MAX_PATH];
 
 // Inits main game config.
@@ -54,7 +54,7 @@ char gGameConfigFilePath[COMPAT_MAX_PATH];
 // Finally, this function merges key-value pairs from [argv] if any, see
 // [configParseCommandLineArguments] for expected format.
 //
-// 0x444570 gconfig_init_
+// 0x444570 gconfig_init
 bool gameConfigInit(bool isMapper, int argc, char** argv)
 {
     if (gGameConfigInitialized) {
@@ -148,7 +148,7 @@ EM_ASYNC_JS(void, do_save_idbfs_gameconfig, (), {
 
 // Saves game config into `fallout2.cfg`.
 //
-// 0x444C14 gconfig_save_
+// 0x444C14 gconfig_save
 bool gameConfigSave()
 {
     if (!gGameConfigInitialized) {
@@ -168,7 +168,7 @@ bool gameConfigSave()
 
 // Frees game config, optionally saving it.
 //
-// 0x444C3C gconfig_exit_
+// 0x444C3C gconfig_exit
 bool gameConfigExit(bool shouldSave)
 {
     if (!gGameConfigInitialized) {

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -172,7 +172,7 @@ typedef enum PartyMemberCustomizationOption {
     PARTY_MEMBER_CUSTOMIZATION_OPTION_COUNT,
 } PartyMemberCustomizationOption;
 
-// 0x444D10 _Dogs
+// 0x444D10 Dogs
 static int _Dogs[3] = {
     0x1000088,
     0x1000156,
@@ -188,7 +188,7 @@ static int gGameDialogOptionEntriesLength = 0;
 // 0x5186DC curReviewSlot
 static int gGameDialogReviewEntriesLength = 0;
 
-// 0x5186E0 _headWindowBuffer
+// 0x5186E0 headWindowBuffer
 static unsigned char* gGameDialogDisplayBuffer = nullptr;
 
 // 0x5186E4 gReplyWin
@@ -253,12 +253,12 @@ static bool _gdReplyTooBig = false;
 
 // A hidden object (PID -1) created during barter to serve as a container for player items offered to the NPC.
 //
-// 0x518730 _peon_table_obj
+// 0x518730 peon_table_obj
 static Object* gGameDialogPlayerTableObj = nullptr;
 
 // A hidden object (PID -1) created during barter to serve as a container for NPC items requested by player.
 //
-// 0x518734 _barterer_table_obj
+// 0x518734 barterer_table_obj
 static Object* gGameDialogBartererTableObj = nullptr;
 
 // A hidden object (PID -1) created during barter.
@@ -381,7 +381,7 @@ static int gGameDialogReviewWindowButtonFrmIds[GAME_DIALOG_REVIEW_WINDOW_BUTTON_
     92, // di_done2.frm - dialog big done button down
 };
 
-// 0x518848 _dialog_target
+// 0x518848 dialog_target
 Object* gGameDialogSpeaker = nullptr;
 
 // 0x51884C dialog_target_is_party
@@ -450,7 +450,7 @@ static int _loop_cnt = -1;
 // 0x518908 tocksWaiting
 static unsigned int _tocksWaiting = 10000;
 
-// 0x51890C _react_strs
+// 0x51890C react_strs
 static const char* _react_strs[3] = {
     "Said Good",
     "Said Neutral",
@@ -592,7 +592,7 @@ static unsigned int gGameDialogFidgetLastUpdateTimestamp;
 // 0x58F4D0 fidgetAnim
 static int gGameDialogFidgetReaction;
 
-// 0x58F4D4 _dialogBlock
+// 0x58F4D4 dialogBlock
 static Program* gDialogReplyProgram;
 
 // 0x58F4D8

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -172,59 +172,59 @@ typedef enum PartyMemberCustomizationOption {
     PARTY_MEMBER_CUSTOMIZATION_OPTION_COUNT,
 } PartyMemberCustomizationOption;
 
-// 0x444D10
+// 0x444D10 _Dogs
 static int _Dogs[3] = {
     0x1000088,
     0x1000156,
     0x1000180,
 };
 
-// 0x5186D4
+// 0x5186D4 dialog_state_fix
 static int _dialog_state_fix = 0;
 
-// 0x5186D8
+// 0x5186D8 gdNumOptions
 static int gGameDialogOptionEntriesLength = 0;
 
-// 0x5186DC
+// 0x5186DC curReviewSlot
 static int gGameDialogReviewEntriesLength = 0;
 
-// 0x5186E0
+// 0x5186E0 _headWindowBuffer
 static unsigned char* gGameDialogDisplayBuffer = nullptr;
 
-// 0x5186E4
+// 0x5186E4 gReplyWin
 static int gGameDialogReplyWindow = -1;
 
-// 0x5186E8
+// 0x5186E8 gOptionWin
 static int gGameDialogOptionsWindow = -1;
 
-// 0x5186EC
+// 0x5186EC gdialog_window_created
 static bool _gdialog_window_created = false;
 
-// 0x5186F0
+// 0x5186F0 boxesWereDisabled
 static int _boxesWereDisabled = 0;
 
-// 0x5186F4
+// 0x5186F4 fidgetFID
 static int gGameDialogFidgetFid = 0;
 
-// 0x5186F8
+// 0x5186F8 fidgetKey
 static CacheEntry* gGameDialogFidgetFrmHandle = nullptr;
 
-// 0x5186FC
+// 0x5186FC fidgetFp
 static Art* gGameDialogFidgetFrm = nullptr;
 
-// 0x518700
+// 0x518700 backgroundIndex
 static int gGameDialogBackground = 2;
 
-// 0x518704
+// 0x518704 lipsFID
 static int _lipsFID = 0;
 
-// 0x518708
+// 0x518708 lipsKey
 static CacheEntry* _lipsKey = nullptr;
 
-// 0x51870C
+// 0x51870C lipsFp
 static Art* _lipsFp = nullptr;
 
-// 0x518710
+// 0x518710 gdialog_speech_playing
 static bool gGameDialogLipSyncStarted = false;
 
 // 0x518714
@@ -239,26 +239,26 @@ static GameDialogMode dialogSwitchMode = GAME_DIALOG_MODE_NONE;
 // whether the dialog system is active or not
 static GameDialogStatus _gdialog_state = GAME_DIALOG_NONE;
 
-// 0x518720
+// 0x518720 gdDialogWentOff
 static bool _gdDialogWentOff = false;
 
-// 0x518724
+// 0x518724 gdDialogTurnMouseOff
 static bool _gdDialogTurnMouseOff = false;
 
-// 0x518728
+// 0x518728 gdReenterLevel
 static int _gdReenterLevel = 0;
 
-// 0x51872C
+// 0x51872C gdReplyTooBig
 static bool _gdReplyTooBig = false;
 
 // A hidden object (PID -1) created during barter to serve as a container for player items offered to the NPC.
 //
-// 0x518730 peon_table_obj
+// 0x518730 _peon_table_obj
 static Object* gGameDialogPlayerTableObj = nullptr;
 
 // A hidden object (PID -1) created during barter to serve as a container for NPC items requested by player.
 //
-// 0x518734 barterer_table_obj
+// 0x518734 _barterer_table_obj
 static Object* gGameDialogBartererTableObj = nullptr;
 
 // A hidden object (PID -1) created during barter.
@@ -272,16 +272,16 @@ static Object* _barterer_temp_obj = nullptr;
 static int gGameDialogBarterModifier = 0;
 
 // dialogueBackWindow
-// 0x518740
+// 0x518740 dialogueBackWindow
 static int gGameDialogBackgroundWindow = -1;
 
 // Dialog sub-window: barter, party control, customization
-// 0x518744
+// 0x518744 dialogueWindow
 static int gGameDialogWindow = -1;
 
 static bool gameDialogUseHrArt = false;
 
-// 0x518748
+// 0x518748 backgrndRects
 static Rect _backgrndRects[8] = {
     { 126, 14, 152, 40 },
     { 488, 14, 514, 40 },
@@ -324,54 +324,54 @@ static int gameDialogGetBackgroundWindowY()
     return (screenGetHeight() - GAME_DIALOG_WINDOW_HEIGHT) / 2;
 }
 
-// 0x5187C8
+// 0x5187C8 talk_need_to_center
 static bool _talk_need_to_center = true;
 
-// 0x5187CC
+// 0x5187CC can_start_new_fidget
 static bool _can_start_new_fidget = false;
 
-// 0x5187D0
+// 0x5187D0 gd_replyWin
 static int _gd_replyWin = -1;
 
-// 0x5187D4
+// 0x5187D4 gd_optionsWin
 static int _gd_optionsWin = -1;
 
-// 0x5187D8
+// 0x5187D8 gDialogMusicVol
 static int gGameDialogOldMusicVolume = -1;
 
-// 0x5187DC
+// 0x5187DC gdCenterTile
 static int gGameDialogOldCenterTile = -1;
 
-// 0x5187E0
+// 0x5187E0 gdPlayerTile
 static int gGameDialogOldDudeTile = -1;
 
-// 0x5187E4
+// 0x5187E4 light_BlendTable
 static unsigned char* _light_BlendTable = nullptr;
 
-// 0x5187E8
+// 0x5187E8 dark_BlendTable
 static unsigned char* _dark_BlendTable = nullptr;
 
-// 0x5187EC
+// 0x5187EC dialogue_just_started
 static int _dialogue_just_started = 0;
 
-// 0x5187F0
+// 0x5187F0 dialogue_seconds_since_last_input
 static int _dialogue_seconds_since_last_input = 0;
 
-// 0x518818
+// 0x518818 reviewFidWids
 static const int gGameDialogReviewWindowButtonWidths[GAME_DIALOG_REVIEW_WINDOW_BUTTON_COUNT] = {
     35,
     35,
     82,
 };
 
-// 0x518824
+// 0x518824 reviewFidLens
 static const int gGameDialogReviewWindowButtonHeights[GAME_DIALOG_REVIEW_WINDOW_BUTTON_COUNT] = {
     35,
     37,
     46,
 };
 
-// 0x518830
+// 0x518830 reviewFids
 static int gGameDialogReviewWindowButtonFrmIds[GAME_DIALOG_REVIEW_WINDOW_BUTTON_FRM_COUNT] = {
     89, // di_bgdn1.frm - dialog big down arrow
     90, // di_bgdn2.frm - dialog big down arrow
@@ -381,21 +381,21 @@ static int gGameDialogReviewWindowButtonFrmIds[GAME_DIALOG_REVIEW_WINDOW_BUTTON_
     92, // di_done2.frm - dialog big done button down
 };
 
-// 0x518848
+// 0x518848 _dialog_target
 Object* gGameDialogSpeaker = nullptr;
 
-// 0x51884C
+// 0x51884C dialog_target_is_party
 bool gGameDialogSpeakerIsPartyMember = false;
 
-// 0x518850
+// 0x518850 dialogue_head
 int gGameDialogHeadFid = 0;
 
-// 0x518854
+// 0x518854 dialogue_scr_id
 int gGameDialogSid = -1;
 
 // Maps phoneme to talking head frame.
 //
-// 0x518858
+// 0x518858 head_phoneme_lookup
 static int _head_phoneme_lookup[PHONEME_COUNT] = {
     0,
     3,
@@ -441,23 +441,23 @@ static int _head_phoneme_lookup[PHONEME_COUNT] = {
     8,
 };
 
-// 0x518900
+// 0x518900 phone_anim
 static int _phone_anim = 0;
 
-// 0x518904
+// 0x518904 loop_cnt
 static int _loop_cnt = -1;
 
-// 0x518908
+// 0x518908 tocksWaiting
 static unsigned int _tocksWaiting = 10000;
 
-// 0x51890C
+// 0x51890C _react_strs
 static const char* _react_strs[3] = {
     "Said Good",
     "Said Neutral",
     "Said Bad",
 };
 
-// 0x518918
+// 0x518918 dialogue_subwin_len
 static int _dialogue_subwin_len = 0;
 
 // Extra pixels the expanded barter frame adds below the 480-tall dialog background.
@@ -471,7 +471,7 @@ static bool gBarterWindowExpanded = false;
 // Cached FRM availability; set once per dialog session in talk_to_create_background_window.
 static bool gExpandedBarterEnabled = false;
 
-// 0x51891C
+// 0x51891C control_button_info
 static GameDialogButtonData gGameDialogDispositionButtonsData[5] = {
     { 438, 37, 397, 395, 396, nullptr, nullptr, nullptr, 2098, 4 },
     { 438, 67, 394, 392, 393, nullptr, nullptr, nullptr, 2103, 3 },
@@ -480,7 +480,7 @@ static GameDialogButtonData gGameDialogDispositionButtonsData[5] = {
     { 438, 156, 403, 401, 402, nullptr, nullptr, nullptr, 2099, 0 },
 };
 
-// 0x5189E4
+// 0x5189E4 custom_settings
 static PartyMemberOptionSetting _custom_settings[PARTY_MEMBER_CUSTOMIZATION_OPTION_COUNT][6] = {
     {
         { 100, AREA_ATTACK_MODE_ALWAYS }, // Always!
@@ -532,7 +532,7 @@ static PartyMemberOptionSetting _custom_settings[PARTY_MEMBER_CUSTOMIZATION_OPTI
     },
 };
 
-// 0x518B04
+// 0x518B04 custom_button_info
 static GameDialogButtonData _custom_button_info[PARTY_MEMBER_CUSTOMIZATION_OPTION_COUNT] = {
     { 95, 9, 410, 409, -1, nullptr, nullptr, nullptr, 0, 0 },
     { 96, 38, 416, 415, -1, nullptr, nullptr, nullptr, 1, 0 },
@@ -542,57 +542,57 @@ static GameDialogButtonData _custom_button_info[PARTY_MEMBER_CUSTOMIZATION_OPTIO
     { 96, 157, 412, 411, -1, nullptr, nullptr, nullptr, 5, 0 },
 };
 
-// 0x518BF4
+// 0x518BF4 totalHotx
 static int _totalHotx = 0;
 
-// 0x58EA80
+// 0x58EA80 custom_current_selected
 static int _custom_current_selected[PARTY_MEMBER_CUSTOMIZATION_OPTION_COUNT];
 
 // custom.msg
 //
-// 0x58EA98
+// 0x58EA98 custom_msg_file
 static MessageList gCustomMessageList;
 
-// 0x58EAA0
+// 0x58EAA0 light_GrayTable
 static unsigned char _light_GrayTable[256];
 
-// 0x58EBA0
+// 0x58EBA0 dark_GrayTable
 static unsigned char _dark_GrayTable[256];
 
-// 0x58ECA0
+// 0x58ECA0 backgrndBufs
 static unsigned char* _backgrndBufs[8];
 
-// 0x58ECC0
+// 0x58ECC0 optionRect
 static Rect _optionRect;
 
-// 0x58ECD0
+// 0x58ECD0 replyRect
 static Rect _replyRect;
 
-// 0x58ECE0
+// 0x58ECE0 reviewList
 static GameDialogReviewEntry gDialogReviewEntries[DIALOG_REVIEW_ENTRIES_CAPACITY];
 
-// 0x58F460
+// 0x58F460 custom_buttons_start
 static int _custom_buttons_start;
 
-// 0x58F464
+// 0x58F464 control_buttons_start
 static int _control_buttons_start;
 
-// 0x58F468
+// 0x58F468 reviewOldFont
 static int gGameDialogReviewWindowOldFont;
 
-// 0x58F470
+// 0x58F470 gdialog_buttons
 static int _gdialog_buttons[9];
 
-// 0x58F4C8
+// 0x58F4C8 oldFont
 static int _oldFont;
 
-// 0x58F4CC
+// 0x58F4CC fidgetLastTime
 static unsigned int gGameDialogFidgetLastUpdateTimestamp;
 
-// 0x58F4D0
+// 0x58F4D0 fidgetAnim
 static int gGameDialogFidgetReaction;
 
-// 0x58F4D4
+// 0x58F4D4 _dialogBlock
 static Program* gDialogReplyProgram;
 
 // 0x58F4D8
@@ -615,19 +615,19 @@ static int gDialogReplyTextOffset;
 // See `_gdProcessChoice` for more info how this unreferenced range plays
 // important role.
 //
-// 0x58F4E4
+// 0x58F4E4 destination
 static char gDialogReplyText[900];
 
 // 0x58FF70
 static GameDialogOptionEntry gDialogOptionEntries[DIALOG_OPTION_ENTRIES_CAPACITY];
 
-// 0x596C30
+// 0x596C30 talkOldFont
 static int _talkOldFont;
 
-// 0x596C34
+// 0x596C34 fidgetTocksPerFrame
 static unsigned int gGameDialogFidgetUpdateDelay;
 
-// 0x596C38
+// 0x596C38 fidgetFrameCounter
 static int gGameDialogFidgetFrmCurrentFrame;
 
 static FrmImage _reviewBackgroundFrmImage;
@@ -1951,7 +1951,7 @@ int _gdProcessExit()
     return 0;
 }
 
-// 0x446504 gdUpdateDudeCaps_
+// 0x446504 gdUpdateDudeCaps
 void gameDialogRenderCaps()
 {
     Rect rect;

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -1951,7 +1951,7 @@ int _gdProcessExit()
     return 0;
 }
 
-// 0x446504
+// 0x446504 gdUpdateDudeCaps_
 void gameDialogRenderCaps()
 {
     Rect rect;

--- a/src/game_memory.cc
+++ b/src/game_memory.cc
@@ -9,7 +9,7 @@ static void* gameMemoryMalloc(size_t size);
 static void* gameMemoryRealloc(void* ptr, size_t newSize);
 static void gameMemoryFree(void* ptr);
 
-// 0x44B250
+// 0x44B250 gmemory_init_
 int gameMemoryInit()
 {
     memoryManagerSetProcs(gameMemoryMalloc, gameMemoryRealloc, gameMemoryFree);
@@ -17,19 +17,19 @@ int gameMemoryInit()
     return 0;
 }
 
-// 0x44B294
+// 0x44B294 gmalloc_
 static void* gameMemoryMalloc(size_t size)
 {
     return internal_malloc(size);
 }
 
-// 0x44B29C
+// 0x44B29C grealloc_
 static void* gameMemoryRealloc(void* ptr, size_t newSize)
 {
     return internal_realloc(ptr, newSize);
 }
 
-// 0x44B2A4
+// 0x44B2A4 gfree_
 static void gameMemoryFree(void* ptr)
 {
     internal_free(ptr);

--- a/src/game_memory.cc
+++ b/src/game_memory.cc
@@ -9,7 +9,7 @@ static void* gameMemoryMalloc(size_t size);
 static void* gameMemoryRealloc(void* ptr, size_t newSize);
 static void gameMemoryFree(void* ptr);
 
-// 0x44B250 gmemory_init_
+// 0x44B250 gmemory_init
 int gameMemoryInit()
 {
     memoryManagerSetProcs(gameMemoryMalloc, gameMemoryRealloc, gameMemoryFree);
@@ -17,19 +17,19 @@ int gameMemoryInit()
     return 0;
 }
 
-// 0x44B294 gmalloc_
+// 0x44B294 gmalloc
 static void* gameMemoryMalloc(size_t size)
 {
     return internal_malloc(size);
 }
 
-// 0x44B29C grealloc_
+// 0x44B29C grealloc
 static void* gameMemoryRealloc(void* ptr, size_t newSize)
 {
     return internal_realloc(ptr, newSize);
 }
 
-// 0x44B2A4 gfree_
+// 0x44B2A4 gfree
 static void gameMemoryFree(void* ptr)
 {
     internal_free(ptr);

--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -331,7 +331,7 @@ static bool gameMouseClickOnInterfaceBar();
 
 static void customMouseModeFrmsInit();
 
-// 0x44B2B0
+// 0x44B2B0 gmouse_init_
 int gameMouseInit()
 {
     if (gGameMouseInitialized) {
@@ -353,7 +353,7 @@ int gameMouseInit()
     return 0;
 }
 
-// 0x44B2E8
+// 0x44B2E8 gmouse_reset_
 int gameMouseReset()
 {
     if (!gGameMouseInitialized) {
@@ -377,7 +377,7 @@ int gameMouseReset()
     return 0;
 }
 
-// 0x44B3B8
+// 0x44B3B8 gmouse_exit_
 void gameMouseExit()
 {
     if (!gGameMouseInitialized) {
@@ -401,7 +401,7 @@ void gameMouseExit()
     gGameMouseCursor = -1;
 }
 
-// 0x44B454
+// 0x44B454 gmouse_enable_
 void _gmouse_enable()
 {
     if (!_gmouse_enabled) {
@@ -413,7 +413,7 @@ void _gmouse_enable()
     }
 }
 
-// 0x44B48C
+// 0x44B48C gmouse_disable_
 void _gmouse_disable(int allowScrolling)
 {
     if (_gmouse_enabled) {
@@ -428,13 +428,13 @@ void _gmouse_disable(int allowScrolling)
     }
 }
 
-// 0x44B4CC
+// 0x44B4CC gmouse_enable_scrolling_
 void _gmouse_enable_scrolling()
 {
     _gmouse_scrolling_enabled = true;
 }
 
-// 0x44B4D8
+// 0x44B4D8 gmouse_disable_scrolling_
 void _gmouse_disable_scrolling()
 {
     _gmouse_scrolling_enabled = false;
@@ -442,13 +442,13 @@ void _gmouse_disable_scrolling()
 
 // NOTE: Inlined.
 //
-// 0x44B4E4
+// 0x44B4E4 gmouse_scrolling_is_enabled_
 bool gmouse_scrolling_is_enabled()
 {
     return _gmouse_scrolling_enabled;
 }
 
-// 0x44B504
+// 0x44B504 gmouse_get_click_to_scroll_
 bool _gmouse_get_click_to_scroll()
 {
     return _gmouse_click_to_scroll;
@@ -463,7 +463,7 @@ void _gmouse_set_click_to_scroll(bool value)
     }
 }
 
-// 0x44B54C
+// 0x44B54C gmouse_is_scrolling_
 int _gmouse_is_scrolling()
 {
     int isScrolling = 0;
@@ -501,7 +501,7 @@ int _gmouse_is_scrolling()
     return isScrolling;
 }
 
-// 0x44B684
+// 0x44B684 gmouse_bk_process_
 void gameMouseRefresh()
 {
     if (!gGameMouseInitialized) {
@@ -907,7 +907,7 @@ bool gameMouseClickOnInterfaceBar()
     return _mouse_click_in(interfaceBarWindowRectLeft, interfaceBarWindowRect.top, interfaceBarWindowRectRight, interfaceBarWindowRect.bottom);
 }
 
-// 0x44BFA8
+// 0x44BFA8 gmouse_handle_event_
 void _gmouse_handle_event(int mouseX, int mouseY, int mouseState)
 {
     if (!gGameMouseInitialized) {
@@ -1273,7 +1273,7 @@ void _gmouse_handle_event(int mouseX, int mouseY, int mouseState)
     }
 }
 
-// 0x44C840
+// 0x44C840 gmouse_set_cursor_
 int gameMouseSetCursor(int cursor)
 {
     if (!gGameMouseInitialized) {
@@ -1343,25 +1343,25 @@ int gameMouseSetCursor(int cursor)
     return 0;
 }
 
-// 0x44C9E8
+// 0x44C9E8 gmouse_get_cursor_
 int gameMouseGetCursor()
 {
     return gGameMouseCursor;
 }
 
-// 0x44C9F0
+// 0x44C9F0 gmouse_set_mapper_mode_
 void gmouse_set_mapper_mode(int mode)
 {
     _gmouse_mapper_mode = mode;
 }
 
-// 0x44C9F8
+// 0x44C9F8 gmouse_3d_enable_modes_
 void _gmouse_3d_enable_modes()
 {
     _gmouse_3d_modes_enabled = 1;
 }
 
-// 0x44CA18
+// 0x44CA18 gmouse_3d_set_mode_
 void gameMouseSetMode(int mode)
 {
     if (!gGameMouseInitialized) {
@@ -1448,7 +1448,7 @@ int gameMouseGetMode()
     return gGameMouseMode;
 }
 
-// 0x44CB74
+// 0x44CB74 gmouse_3d_toggle_mode_
 void gameMouseCycleMode()
 {
     int mode = (gGameMouseMode + 1) % 3;
@@ -1469,7 +1469,7 @@ void gameMouseCycleMode()
     gameMouseSetMode(mode);
 }
 
-// 0x44CBD0
+// 0x44CBD0 gmouse_3d_refresh_
 void _gmouse_3d_refresh()
 {
     gGameMouseLastX = -1;
@@ -1479,7 +1479,7 @@ void _gmouse_3d_refresh()
     gameMouseRefresh();
 }
 
-// 0x44CBFC
+// 0x44CBFC gmouse_3d_set_fid_
 int gameMouseSetBouncingCursorFid(int fid)
 {
     if (!gGameMouseInitialized) {
@@ -1528,14 +1528,14 @@ int gameMouseSetBouncingCursorFid(int fid)
     return rc;
 }
 
-// 0x44CD0C
+// 0x44CD0C gmouse_3d_reset_fid_
 void gameMouseResetBouncingCursorFid()
 {
     int fid = buildFid(OBJ_TYPE_INTERFACE, 0, 0, 0, 0);
     gameMouseSetBouncingCursorFid(fid);
 }
 
-// 0x44CD2C
+// 0x44CD2C gmouse_3d_on_
 void gameMouseObjectsShow()
 {
     if (!gGameMouseInitialized) {
@@ -1599,7 +1599,7 @@ void gameMouseObjectsShow()
     _gmouse_3d_last_move_time = getTicks() - 250;
 }
 
-// 0x44CE34
+// 0x44CE34 gmouse_3d_off_
 void gameMouseObjectsHide()
 {
     if (!gGameMouseInitialized) {
@@ -1628,13 +1628,13 @@ void gameMouseObjectsHide()
     }
 }
 
-// 0x44CEB0
+// 0x44CEB0 gmouse_3d_is_on_
 bool gameMouseObjectsIsVisible()
 {
     return (gGameMouseHexCursor->flags & OBJECT_HIDDEN) == 0;
 }
 
-// 0x44CEC4
+// 0x44CEC4 object_under_mouse_
 Object* gameMouseGetObjectUnderCursor(int objectType, bool includeDude, int elevation)
 {
     int mouseX;
@@ -1675,7 +1675,7 @@ Object* gameMouseGetObjectUnderCursor(int objectType, bool includeDude, int elev
     return found;
 }
 
-// 0x44CFA0
+// 0x44CFA0 gmouse_3d_build_pick_frame_
 int gameMouseRenderPrimaryAction(int x, int y, int menuItem, int width, int height)
 {
     CacheEntry* menuItemFrmHandle;
@@ -1753,7 +1753,7 @@ int gameMouseRenderPrimaryAction(int x, int y, int menuItem, int width, int heig
     return 0;
 }
 
-// 0x44D200
+// 0x44D200 gmouse_3d_pick_frame_hot_
 int _gmouse_3d_pick_frame_hot(int* x, int* y)
 {
     *x = _gmouse_3d_pick_frame_hot_x;
@@ -1761,7 +1761,7 @@ int _gmouse_3d_pick_frame_hot(int* x, int* y)
     return 0;
 }
 
-// 0x44D214
+// 0x44D214 gmouse_3d_build_menu_frame_
 int gameMouseRenderActionMenuItems(int x, int y, const int* menuItems, int menuItemsLength, int width, int height)
 {
     _gmouse_3d_menu_actions_start = nullptr;
@@ -1877,7 +1877,7 @@ int gameMouseRenderActionMenuItems(int x, int y, const int* menuItems, int menuI
     return 0;
 }
 
-// 0x44D630
+// 0x44D630 gmouse_3d_highlight_menu_frame_
 int gameMouseHighlightActionMenuItemAtIndex(int menuItemIndex)
 {
     if (menuItemIndex < 0 || menuItemIndex >= gGameMouseActionMenuItemsLength) {
@@ -1912,7 +1912,7 @@ int gameMouseHighlightActionMenuItemAtIndex(int menuItemIndex)
     return 0;
 }
 
-// 0x44D774
+// 0x44D774 gmouse_3d_build_to_hit_frame_
 int gameMouseRenderAccuracy(const char* string, int color)
 {
     CacheEntry* crosshairFrmHandle;
@@ -1956,7 +1956,7 @@ int gameMouseRenderAccuracy(const char* string, int color)
     return 0;
 }
 
-// 0x44D878
+// 0x44D878 gmouse_3d_build_hex_frame_
 int gameMouseRenderActionPoints(const char* string, int color)
 {
     memset(gGameMouseHexCursorFrmData, 0, gGameMouseHexCursorFrmWidth * gGameMouseHexCursorHeight);
@@ -1981,13 +1981,13 @@ int gameMouseRenderActionPoints(const char* string, int color)
     return 0;
 }
 
-// 0x44D954
+// 0x44D954 gmouse_3d_synch_item_highlight_
 void gameMouseLoadItemHighlight()
 {
     gGameMouseItemHighlightEnabled = settings.preferences.item_highlight;
 }
 
-// 0x44D984
+// 0x44D984 gmouse_3d_init_
 int gameMouseObjectsInit()
 {
     int fid;
@@ -2044,7 +2044,7 @@ int gameMouseObjectsInit()
 
 // NOTE: Inlined.
 //
-// 0x44DAC0
+// 0x44DAC0 gmouse_3d_reset_
 int gameMouseObjectsReset()
 {
     if (!gGameMouseObjectsInitialized) {
@@ -2071,7 +2071,7 @@ int gameMouseObjectsReset()
 
 // NOTE: Inlined.
 //
-// 0x44DB34
+// 0x44DB34 gmouse_3d_exit_
 void gameMouseObjectsFree()
 {
     if (gGameMouseObjectsInitialized) {
@@ -2087,7 +2087,7 @@ void gameMouseObjectsFree()
     }
 }
 
-// 0x44DB78
+// 0x44DB78 gmouse_3d_lock_frames_
 int gameMouseActionMenuInit()
 {
     int fid;
@@ -2164,7 +2164,7 @@ err:
     return -1;
 }
 
-// 0x44DE44
+// 0x44DE44 gmouse_3d_unlock_frames_
 void gameMouseActionMenuFree()
 {
     if (gGameMouseBouncingCursorFrmHandle != INVALID_CACHE_ENTRY) {
@@ -2206,7 +2206,7 @@ void gameMouseActionMenuFree()
 
 // NOTE: Inlined.
 //
-// 0x44DF1C
+// 0x44DF1C gmouse_3d_set_flat_fid_
 static int gmouse_3d_set_flat_fid(int fid, Rect* rect)
 {
     if (objectSetFid(gGameMouseHexCursor, fid, rect) == 0) {
@@ -2216,7 +2216,7 @@ static int gmouse_3d_set_flat_fid(int fid, Rect* rect)
     return -1;
 }
 
-// 0x44DF40
+// 0x44DF40 gmouse_3d_reset_flat_fid_
 int gameMouseUpdateHexCursorFid(Rect* rect)
 {
     int fid = buildFid(OBJ_TYPE_INTERFACE, gGameMouseModeFrmIds[gGameMouseMode], 0, 0, 0);
@@ -2228,7 +2228,7 @@ int gameMouseUpdateHexCursorFid(Rect* rect)
     return gmouse_3d_set_flat_fid(fid, rect);
 }
 
-// 0x44DF94
+// 0x44DF94 gmouse_3d_move_to_
 int _gmouse_3d_move_to(int x, int y, int elevation, Rect* rect)
 {
     if (_gmouse_mapper_mode == 0) {
@@ -2366,7 +2366,7 @@ int _gmouse_3d_move_to(int x, int y, int elevation, Rect* rect)
     return 0;
 }
 
-// 0x44E42C
+// 0x44E42C gmouse_check_scrolling_
 int gameMouseHandleScrolling(int x, int y, int cursor)
 {
     if (!_gmouse_scrolling_enabled) {
@@ -2465,7 +2465,7 @@ int gameMouseHandleScrolling(int x, int y, int cursor)
     return 0;
 }
 
-// 0x44E544
+// 0x44E544 gmouse_remove_item_outline_
 void _gmouse_remove_item_outline(Object* object)
 {
     if (gGameMouseHighlightedItem != nullptr && gGameMouseHighlightedItem == object) {
@@ -2477,7 +2477,7 @@ void _gmouse_remove_item_outline(Object* object)
     }
 }
 
-// 0x44E580
+// 0x44E580 gmObjIsValidTarget_
 int objectIsDoor(Object* object)
 {
     if (object == nullptr) {

--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -132,7 +132,7 @@ static int _gmouse_3d_menu_frame_hot_x = 0;
 // 0x518CA4 gmouse_3d_menu_frame_hot_y
 static int _gmouse_3d_menu_frame_hot_y = 0;
 
-// 0x518CA8 _gmouse_3d_menu_frame_data
+// 0x518CA8 gmouse_3d_menu_frame_data
 static unsigned char* gGameMouseActionMenuFrmData = nullptr;
 
 // actpick.frm
@@ -157,7 +157,7 @@ static int _gmouse_3d_pick_frame_hot_x = 0;
 // 0x518CC4 gmouse_3d_pick_frame_hot_y
 static int _gmouse_3d_pick_frame_hot_y = 0;
 
-// 0x518CC8 _gmouse_3d_pick_frame_data
+// 0x518CC8 gmouse_3d_pick_frame_data
 static unsigned char* gGameMouseActionPickFrmData = nullptr;
 
 // acttohit.frm
@@ -176,7 +176,7 @@ static int gGameMouseActionHitFrmHeight = 0;
 // 0x518CDC gmouse_3d_to_hit_frame_size
 static int gGameMouseActionHitFrmDataSize = 0;
 
-// 0x518CE0 _gmouse_3d_to_hit_frame_data
+// 0x518CE0 gmouse_3d_to_hit_frame_data
 static unsigned char* gGameMouseActionHitFrmData = nullptr;
 
 // blank.frm
@@ -214,7 +214,7 @@ static int gGameMouseHexCursorHeight = 0;
 // 0x518D0C gmouse_3d_hex_frame_size
 static int gGameMouseHexCursorDataSize = 0;
 
-// 0x518D10 _gmouse_3d_hex_frame_data
+// 0x518D10 gmouse_3d_hex_frame_data
 static unsigned char* gGameMouseHexCursorFrmData = nullptr;
 
 // 0x518D14 gmouse_3d_menu_available_actions
@@ -261,7 +261,7 @@ static int gGameMouseModeFrmIds[GAME_MOUSE_MODE_COUNT] = {
     293,
 };
 
-// 0x518D68 _gmouse_skill_table
+// 0x518D68 gmouse_skill_table
 static const int gGameMouseModeSkills[GAME_MOUSE_MODE_SKILL_COUNT] = {
     SKILL_FIRST_AID,
     SKILL_DOCTOR,
@@ -307,7 +307,7 @@ static int gGameMouseLastY;
 Object* gGameMouseBouncingCursor;
 
 // msef000.frm
-// 0x596C70 _obj_mouse_flat
+// 0x596C70 obj_mouse_flat
 Object* gGameMouseHexCursor;
 
 // 0x596C74

--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -49,28 +49,28 @@ static constexpr int REFRESH_BOUNCING_CURSOR = 0x01;
 static constexpr int REFRESH_HEX_CURSOR = 0x02;
 static constexpr int REFRESH_BOTH_CURSORS = REFRESH_BOUNCING_CURSOR | REFRESH_HEX_CURSOR;
 
-// 0x518BF8
+// 0x518BF8 gmouse_initialized
 static bool gGameMouseInitialized = false;
 
-// 0x518BFC
+// 0x518BFC gmouse_enabled
 static bool _gmouse_enabled = false;
 
-// 0x518C00
+// 0x518C00 gmouse_mapper_mode
 static int _gmouse_mapper_mode = 0;
 
-// 0x518C04
+// 0x518C04 gmouse_click_to_scroll
 static bool _gmouse_click_to_scroll = false;
 
-// 0x518C08
+// 0x518C08 gmouse_scrolling_enabled
 static bool _gmouse_scrolling_enabled = true;
 
-// 0x518C0C
+// 0x518C0C gmouse_current_cursor
 static int gGameMouseCursor = MOUSE_CURSOR_NONE;
 
-// 0x518C10
+// 0x518C10 gmouse_current_cursor_key
 static CacheEntry* gGameMouseCursorFrmHandle = INVALID_CACHE_ENTRY;
 
-// 0x518C14
+// 0x518C14 gmouse_cursor_nums
 static const int gGameMouseCursorFrmIds[MOUSE_CURSOR_TYPE_COUNT] = {
     266,
     267,
@@ -101,132 +101,132 @@ static const int gGameMouseCursorFrmIds[MOUSE_CURSOR_TYPE_COUNT] = {
     295,
 };
 
-// 0x518C80
+// 0x518C80 gmouse_3d_initialized
 static bool gGameMouseObjectsInitialized = false;
 
-// 0x518C84
+// 0x518C84 gmouse_3d_hover_test
 static bool _gmouse_3d_hover_test = false;
 
-// 0x518C88
+// 0x518C88 gmouse_3d_last_move_time
 static unsigned int _gmouse_3d_last_move_time = 0;
 
 // actmenu.frm
-// 0x518C8C
+// 0x518C8C gmouse_3d_menu_frame
 static Art* gGameMouseActionMenuFrm = nullptr;
 
-// 0x518C90
+// 0x518C90 gmouse_3d_menu_frame_key
 static CacheEntry* gGameMouseActionMenuFrmHandle = INVALID_CACHE_ENTRY;
 
-// 0x518C94
+// 0x518C94 gmouse_3d_menu_frame_width
 static int gGameMouseActionMenuFrmWidth = 0;
 
-// 0x518C98
+// 0x518C98 gmouse_3d_menu_frame_height
 static int gGameMouseActionMenuFrmHeight = 0;
 
-// 0x518C9C
+// 0x518C9C gmouse_3d_menu_frame_size
 static int gGameMouseActionMenuFrmDataSize = 0;
 
-// 0x518CA0
+// 0x518CA0 gmouse_3d_menu_frame_hot_x
 static int _gmouse_3d_menu_frame_hot_x = 0;
 
-// 0x518CA4
+// 0x518CA4 gmouse_3d_menu_frame_hot_y
 static int _gmouse_3d_menu_frame_hot_y = 0;
 
-// 0x518CA8
+// 0x518CA8 _gmouse_3d_menu_frame_data
 static unsigned char* gGameMouseActionMenuFrmData = nullptr;
 
 // actpick.frm
-// 0x518CAC
+// 0x518CAC gmouse_3d_pick_frame
 static Art* gGameMouseActionPickFrm = nullptr;
 
-// 0x518CB0
+// 0x518CB0 gmouse_3d_pick_frame_key
 static CacheEntry* gGameMouseActionPickFrmHandle = INVALID_CACHE_ENTRY;
 
-// 0x518CB4
+// 0x518CB4 gmouse_3d_pick_frame_width
 static int gGameMouseActionPickFrmWidth = 0;
 
-// 0x518CB8
+// 0x518CB8 gmouse_3d_pick_frame_height
 static int gGameMouseActionPickFrmHeight = 0;
 
-// 0x518CBC
+// 0x518CBC gmouse_3d_pick_frame_size
 static int gGameMouseActionPickFrmDataSize = 0;
 
-// 0x518CC0
+// 0x518CC0 gmouse_3d_pick_frame_hot_x
 static int _gmouse_3d_pick_frame_hot_x = 0;
 
-// 0x518CC4
+// 0x518CC4 gmouse_3d_pick_frame_hot_y
 static int _gmouse_3d_pick_frame_hot_y = 0;
 
-// 0x518CC8
+// 0x518CC8 _gmouse_3d_pick_frame_data
 static unsigned char* gGameMouseActionPickFrmData = nullptr;
 
 // acttohit.frm
-// 0x518CCC
+// 0x518CCC gmouse_3d_to_hit_frame
 static Art* gGameMouseActionHitFrm = nullptr;
 
-// 0x518CD0
+// 0x518CD0 gmouse_3d_to_hit_frame_key
 static CacheEntry* gGameMouseActionHitFrmHandle = INVALID_CACHE_ENTRY;
 
-// 0x518CD4
+// 0x518CD4 gmouse_3d_to_hit_frame_width
 static int gGameMouseActionHitFrmWidth = 0;
 
-// 0x518CD8
+// 0x518CD8 gmouse_3d_to_hit_frame_height
 static int gGameMouseActionHitFrmHeight = 0;
 
-// 0x518CDC
+// 0x518CDC gmouse_3d_to_hit_frame_size
 static int gGameMouseActionHitFrmDataSize = 0;
 
-// 0x518CE0
+// 0x518CE0 _gmouse_3d_to_hit_frame_data
 static unsigned char* gGameMouseActionHitFrmData = nullptr;
 
 // blank.frm
-// 0x518CE4
+// 0x518CE4 gmouse_3d_hex_base_frame
 static Art* gGameMouseBouncingCursorFrm = nullptr;
 
-// 0x518CE8
+// 0x518CE8 gmouse_3d_hex_base_frame_key
 static CacheEntry* gGameMouseBouncingCursorFrmHandle = INVALID_CACHE_ENTRY;
 
-// 0x518CEC
+// 0x518CEC gmouse_3d_hex_base_frame_width
 static int gGameMouseBouncingCursorFrmWidth = 0;
 
-// 0x518CF0
+// 0x518CF0 gmouse_3d_hex_base_frame_height
 static int gGameMouseBouncingCursorFrmHeight = 0;
 
-// 0x518CF4
+// 0x518CF4 gmouse_3d_hex_base_frame_size
 static int gGameMouseBouncingCursorFrmDataSize = 0;
 
-// 0x518CF8
+// 0x518CF8 gmouse_3d_hex_base_frame_data
 static unsigned char* gGameMouseBouncingCursorFrmData = nullptr;
 
 // msef000.frm
-// 0x518CFC
+// 0x518CFC gmouse_3d_hex_frame
 static Art* gGameMouseHexCursorFrm = nullptr;
 
-// 0x518D00
+// 0x518D00 gmouse_3d_hex_frame_key
 static CacheEntry* gGameMouseHexCursorFrmHandle = INVALID_CACHE_ENTRY;
 
-// 0x518D04
+// 0x518D04 gmouse_3d_hex_frame_width
 static int gGameMouseHexCursorFrmWidth = 0;
 
-// 0x518D08
+// 0x518D08 gmouse_3d_hex_frame_height
 static int gGameMouseHexCursorHeight = 0;
 
-// 0x518D0C
+// 0x518D0C gmouse_3d_hex_frame_size
 static int gGameMouseHexCursorDataSize = 0;
 
-// 0x518D10
+// 0x518D10 _gmouse_3d_hex_frame_data
 static unsigned char* gGameMouseHexCursorFrmData = nullptr;
 
-// 0x518D14
+// 0x518D14 gmouse_3d_menu_available_actions
 static unsigned char gGameMouseActionMenuItemsLength = 0;
 
-// 0x518D18
+// 0x518D18 gmouse_3d_menu_actions_start
 static unsigned char* _gmouse_3d_menu_actions_start = nullptr;
 
-// 0x518D1C
+// 0x518D1C gmouse_3d_menu_current_action_index
 static unsigned char gGameMouseActionMenuHighlightedItemIndex = 0;
 
-// 0x518D1E
+// 0x518D1E gmouse_3d_action_nums
 static const short gGameMouseActionMenuItemFrmIds[GAME_MOUSE_ACTION_MENU_ITEM_COUNT] = {
     253, // Cancel
     255, // Drop
@@ -240,13 +240,13 @@ static const short gGameMouseActionMenuItemFrmIds[GAME_MOUSE_ACTION_MENU_ITEM_CO
     435, // Push
 };
 
-// 0x518D34
+// 0x518D34 gmouse_3d_modes_enabled
 static int _gmouse_3d_modes_enabled = 1;
 
-// 0x518D38
+// 0x518D38 gmouse_3d_current_mode
 static int gGameMouseMode = GAME_MOUSE_MODE_MOVE;
 
-// 0x518D3C
+// 0x518D3C gmouse_3d_mode_nums
 static int gGameMouseModeFrmIds[GAME_MOUSE_MODE_COUNT] = {
     249,
     250,
@@ -261,7 +261,7 @@ static int gGameMouseModeFrmIds[GAME_MOUSE_MODE_COUNT] = {
     293,
 };
 
-// 0x518D68
+// 0x518D68 _gmouse_skill_table
 static const int gGameMouseModeSkills[GAME_MOUSE_MODE_SKILL_COUNT] = {
     SKILL_FIRST_AID,
     SKILL_DOCTOR,
@@ -272,42 +272,42 @@ static const int gGameMouseModeSkills[GAME_MOUSE_MODE_SKILL_COUNT] = {
     SKILL_REPAIR,
 };
 
-// 0x518D84
+// 0x518D84 gmouse_wait_cursor_frame
 static int gGameMouseAnimatedCursorNextFrame = 0;
 
-// 0x518D88
+// 0x518D88 gmouse_wait_cursor_time
 static unsigned int gGameMouseAnimatedCursorLastUpdateTimestamp = 0;
 
-// 0x518D8C
+// 0x518D8C gmouse_bk_last_cursor
 static int _gmouse_bk_last_cursor = -1;
 
-// 0x518D90
+// 0x518D90 gmouse_3d_item_highlight
 static bool gGameMouseItemHighlightEnabled = true;
 
-// 0x518D94
+// 0x518D94 outlined_object
 static Object* gGameMouseHighlightedItem = nullptr;
 
-// 0x518D98
+// 0x518D98 gmouse_clicked_on_edge
 bool _gmouse_clicked_on_edge = false;
 
-// 0x518D9C
+// 0x518D9C mouse_flat_tile
 static int dword_518D9C = -1;
 
-// 0x596C3C
+// 0x596C3C gmouse_3d_menu_frame_actions
 static int gGameMouseActionMenuItems[GAME_MOUSE_ACTION_MENU_ITEM_COUNT];
 
-// 0x596C64
+// 0x596C64 gmouse_3d_last_mouse_x
 static int gGameMouseLastX;
 
-// 0x596C68
+// 0x596C68 gmouse_3d_last_mouse_y
 static int gGameMouseLastY;
 
 // blank.frm
-// 0x596C6C
+// 0x596C6C obj_mouse
 Object* gGameMouseBouncingCursor;
 
 // msef000.frm
-// 0x596C70
+// 0x596C70 _obj_mouse_flat
 Object* gGameMouseHexCursor;
 
 // 0x596C74
@@ -331,7 +331,7 @@ static bool gameMouseClickOnInterfaceBar();
 
 static void customMouseModeFrmsInit();
 
-// 0x44B2B0 gmouse_init_
+// 0x44B2B0 gmouse_init
 int gameMouseInit()
 {
     if (gGameMouseInitialized) {
@@ -353,7 +353,7 @@ int gameMouseInit()
     return 0;
 }
 
-// 0x44B2E8 gmouse_reset_
+// 0x44B2E8 gmouse_reset
 int gameMouseReset()
 {
     if (!gGameMouseInitialized) {
@@ -377,7 +377,7 @@ int gameMouseReset()
     return 0;
 }
 
-// 0x44B3B8 gmouse_exit_
+// 0x44B3B8 gmouse_exit
 void gameMouseExit()
 {
     if (!gGameMouseInitialized) {
@@ -401,7 +401,7 @@ void gameMouseExit()
     gGameMouseCursor = -1;
 }
 
-// 0x44B454 gmouse_enable_
+// 0x44B454 gmouse_enable
 void _gmouse_enable()
 {
     if (!_gmouse_enabled) {
@@ -413,7 +413,7 @@ void _gmouse_enable()
     }
 }
 
-// 0x44B48C gmouse_disable_
+// 0x44B48C gmouse_disable
 void _gmouse_disable(int allowScrolling)
 {
     if (_gmouse_enabled) {
@@ -428,13 +428,13 @@ void _gmouse_disable(int allowScrolling)
     }
 }
 
-// 0x44B4CC gmouse_enable_scrolling_
+// 0x44B4CC gmouse_enable_scrolling
 void _gmouse_enable_scrolling()
 {
     _gmouse_scrolling_enabled = true;
 }
 
-// 0x44B4D8 gmouse_disable_scrolling_
+// 0x44B4D8 gmouse_disable_scrolling
 void _gmouse_disable_scrolling()
 {
     _gmouse_scrolling_enabled = false;
@@ -442,13 +442,13 @@ void _gmouse_disable_scrolling()
 
 // NOTE: Inlined.
 //
-// 0x44B4E4 gmouse_scrolling_is_enabled_
+// 0x44B4E4 gmouse_scrolling_is_enabled
 bool gmouse_scrolling_is_enabled()
 {
     return _gmouse_scrolling_enabled;
 }
 
-// 0x44B504 gmouse_get_click_to_scroll_
+// 0x44B504 gmouse_get_click_to_scroll
 bool _gmouse_get_click_to_scroll()
 {
     return _gmouse_click_to_scroll;
@@ -463,7 +463,7 @@ void _gmouse_set_click_to_scroll(bool value)
     }
 }
 
-// 0x44B54C gmouse_is_scrolling_
+// 0x44B54C gmouse_is_scrolling
 int _gmouse_is_scrolling()
 {
     int isScrolling = 0;
@@ -501,7 +501,7 @@ int _gmouse_is_scrolling()
     return isScrolling;
 }
 
-// 0x44B684 gmouse_bk_process_
+// 0x44B684 gmouse_bk_process
 void gameMouseRefresh()
 {
     if (!gGameMouseInitialized) {
@@ -907,7 +907,7 @@ bool gameMouseClickOnInterfaceBar()
     return _mouse_click_in(interfaceBarWindowRectLeft, interfaceBarWindowRect.top, interfaceBarWindowRectRight, interfaceBarWindowRect.bottom);
 }
 
-// 0x44BFA8 gmouse_handle_event_
+// 0x44BFA8 gmouse_handle_event
 void _gmouse_handle_event(int mouseX, int mouseY, int mouseState)
 {
     if (!gGameMouseInitialized) {
@@ -1273,7 +1273,7 @@ void _gmouse_handle_event(int mouseX, int mouseY, int mouseState)
     }
 }
 
-// 0x44C840 gmouse_set_cursor_
+// 0x44C840 gmouse_set_cursor
 int gameMouseSetCursor(int cursor)
 {
     if (!gGameMouseInitialized) {
@@ -1343,25 +1343,25 @@ int gameMouseSetCursor(int cursor)
     return 0;
 }
 
-// 0x44C9E8 gmouse_get_cursor_
+// 0x44C9E8 gmouse_get_cursor
 int gameMouseGetCursor()
 {
     return gGameMouseCursor;
 }
 
-// 0x44C9F0 gmouse_set_mapper_mode_
+// 0x44C9F0 gmouse_set_mapper_mode
 void gmouse_set_mapper_mode(int mode)
 {
     _gmouse_mapper_mode = mode;
 }
 
-// 0x44C9F8 gmouse_3d_enable_modes_
+// 0x44C9F8 gmouse_3d_enable_modes
 void _gmouse_3d_enable_modes()
 {
     _gmouse_3d_modes_enabled = 1;
 }
 
-// 0x44CA18 gmouse_3d_set_mode_
+// 0x44CA18 gmouse_3d_set_mode
 void gameMouseSetMode(int mode)
 {
     if (!gGameMouseInitialized) {
@@ -1448,7 +1448,7 @@ int gameMouseGetMode()
     return gGameMouseMode;
 }
 
-// 0x44CB74 gmouse_3d_toggle_mode_
+// 0x44CB74 gmouse_3d_toggle_mode
 void gameMouseCycleMode()
 {
     int mode = (gGameMouseMode + 1) % 3;
@@ -1469,7 +1469,7 @@ void gameMouseCycleMode()
     gameMouseSetMode(mode);
 }
 
-// 0x44CBD0 gmouse_3d_refresh_
+// 0x44CBD0 gmouse_3d_refresh
 void _gmouse_3d_refresh()
 {
     gGameMouseLastX = -1;
@@ -1479,7 +1479,7 @@ void _gmouse_3d_refresh()
     gameMouseRefresh();
 }
 
-// 0x44CBFC gmouse_3d_set_fid_
+// 0x44CBFC gmouse_3d_set_fid
 int gameMouseSetBouncingCursorFid(int fid)
 {
     if (!gGameMouseInitialized) {
@@ -1528,14 +1528,14 @@ int gameMouseSetBouncingCursorFid(int fid)
     return rc;
 }
 
-// 0x44CD0C gmouse_3d_reset_fid_
+// 0x44CD0C gmouse_3d_reset_fid
 void gameMouseResetBouncingCursorFid()
 {
     int fid = buildFid(OBJ_TYPE_INTERFACE, 0, 0, 0, 0);
     gameMouseSetBouncingCursorFid(fid);
 }
 
-// 0x44CD2C gmouse_3d_on_
+// 0x44CD2C gmouse_3d_on
 void gameMouseObjectsShow()
 {
     if (!gGameMouseInitialized) {
@@ -1599,7 +1599,7 @@ void gameMouseObjectsShow()
     _gmouse_3d_last_move_time = getTicks() - 250;
 }
 
-// 0x44CE34 gmouse_3d_off_
+// 0x44CE34 gmouse_3d_off
 void gameMouseObjectsHide()
 {
     if (!gGameMouseInitialized) {
@@ -1628,13 +1628,13 @@ void gameMouseObjectsHide()
     }
 }
 
-// 0x44CEB0 gmouse_3d_is_on_
+// 0x44CEB0 gmouse_3d_is_on
 bool gameMouseObjectsIsVisible()
 {
     return (gGameMouseHexCursor->flags & OBJECT_HIDDEN) == 0;
 }
 
-// 0x44CEC4 object_under_mouse_
+// 0x44CEC4 object_under_mouse
 Object* gameMouseGetObjectUnderCursor(int objectType, bool includeDude, int elevation)
 {
     int mouseX;
@@ -1675,7 +1675,7 @@ Object* gameMouseGetObjectUnderCursor(int objectType, bool includeDude, int elev
     return found;
 }
 
-// 0x44CFA0 gmouse_3d_build_pick_frame_
+// 0x44CFA0 gmouse_3d_build_pick_frame
 int gameMouseRenderPrimaryAction(int x, int y, int menuItem, int width, int height)
 {
     CacheEntry* menuItemFrmHandle;
@@ -1753,7 +1753,7 @@ int gameMouseRenderPrimaryAction(int x, int y, int menuItem, int width, int heig
     return 0;
 }
 
-// 0x44D200 gmouse_3d_pick_frame_hot_
+// 0x44D200 gmouse_3d_pick_frame_hot
 int _gmouse_3d_pick_frame_hot(int* x, int* y)
 {
     *x = _gmouse_3d_pick_frame_hot_x;
@@ -1761,7 +1761,7 @@ int _gmouse_3d_pick_frame_hot(int* x, int* y)
     return 0;
 }
 
-// 0x44D214 gmouse_3d_build_menu_frame_
+// 0x44D214 gmouse_3d_build_menu_frame
 int gameMouseRenderActionMenuItems(int x, int y, const int* menuItems, int menuItemsLength, int width, int height)
 {
     _gmouse_3d_menu_actions_start = nullptr;
@@ -1877,7 +1877,7 @@ int gameMouseRenderActionMenuItems(int x, int y, const int* menuItems, int menuI
     return 0;
 }
 
-// 0x44D630 gmouse_3d_highlight_menu_frame_
+// 0x44D630 gmouse_3d_highlight_menu_frame
 int gameMouseHighlightActionMenuItemAtIndex(int menuItemIndex)
 {
     if (menuItemIndex < 0 || menuItemIndex >= gGameMouseActionMenuItemsLength) {
@@ -1912,7 +1912,7 @@ int gameMouseHighlightActionMenuItemAtIndex(int menuItemIndex)
     return 0;
 }
 
-// 0x44D774 gmouse_3d_build_to_hit_frame_
+// 0x44D774 gmouse_3d_build_to_hit_frame
 int gameMouseRenderAccuracy(const char* string, int color)
 {
     CacheEntry* crosshairFrmHandle;
@@ -1956,7 +1956,7 @@ int gameMouseRenderAccuracy(const char* string, int color)
     return 0;
 }
 
-// 0x44D878 gmouse_3d_build_hex_frame_
+// 0x44D878 gmouse_3d_build_hex_frame
 int gameMouseRenderActionPoints(const char* string, int color)
 {
     memset(gGameMouseHexCursorFrmData, 0, gGameMouseHexCursorFrmWidth * gGameMouseHexCursorHeight);
@@ -1981,13 +1981,13 @@ int gameMouseRenderActionPoints(const char* string, int color)
     return 0;
 }
 
-// 0x44D954 gmouse_3d_synch_item_highlight_
+// 0x44D954 gmouse_3d_synch_item_highlight
 void gameMouseLoadItemHighlight()
 {
     gGameMouseItemHighlightEnabled = settings.preferences.item_highlight;
 }
 
-// 0x44D984 gmouse_3d_init_
+// 0x44D984 gmouse_3d_init
 int gameMouseObjectsInit()
 {
     int fid;
@@ -2044,7 +2044,7 @@ int gameMouseObjectsInit()
 
 // NOTE: Inlined.
 //
-// 0x44DAC0 gmouse_3d_reset_
+// 0x44DAC0 gmouse_3d_reset
 int gameMouseObjectsReset()
 {
     if (!gGameMouseObjectsInitialized) {
@@ -2071,7 +2071,7 @@ int gameMouseObjectsReset()
 
 // NOTE: Inlined.
 //
-// 0x44DB34 gmouse_3d_exit_
+// 0x44DB34 gmouse_3d_exit
 void gameMouseObjectsFree()
 {
     if (gGameMouseObjectsInitialized) {
@@ -2087,7 +2087,7 @@ void gameMouseObjectsFree()
     }
 }
 
-// 0x44DB78 gmouse_3d_lock_frames_
+// 0x44DB78 gmouse_3d_lock_frames
 int gameMouseActionMenuInit()
 {
     int fid;
@@ -2164,7 +2164,7 @@ err:
     return -1;
 }
 
-// 0x44DE44 gmouse_3d_unlock_frames_
+// 0x44DE44 gmouse_3d_unlock_frames
 void gameMouseActionMenuFree()
 {
     if (gGameMouseBouncingCursorFrmHandle != INVALID_CACHE_ENTRY) {
@@ -2206,7 +2206,7 @@ void gameMouseActionMenuFree()
 
 // NOTE: Inlined.
 //
-// 0x44DF1C gmouse_3d_set_flat_fid_
+// 0x44DF1C gmouse_3d_set_flat_fid
 static int gmouse_3d_set_flat_fid(int fid, Rect* rect)
 {
     if (objectSetFid(gGameMouseHexCursor, fid, rect) == 0) {
@@ -2216,7 +2216,7 @@ static int gmouse_3d_set_flat_fid(int fid, Rect* rect)
     return -1;
 }
 
-// 0x44DF40 gmouse_3d_reset_flat_fid_
+// 0x44DF40 gmouse_3d_reset_flat_fid
 int gameMouseUpdateHexCursorFid(Rect* rect)
 {
     int fid = buildFid(OBJ_TYPE_INTERFACE, gGameMouseModeFrmIds[gGameMouseMode], 0, 0, 0);
@@ -2228,7 +2228,7 @@ int gameMouseUpdateHexCursorFid(Rect* rect)
     return gmouse_3d_set_flat_fid(fid, rect);
 }
 
-// 0x44DF94 gmouse_3d_move_to_
+// 0x44DF94 gmouse_3d_move_to
 int _gmouse_3d_move_to(int x, int y, int elevation, Rect* rect)
 {
     if (_gmouse_mapper_mode == 0) {
@@ -2366,7 +2366,7 @@ int _gmouse_3d_move_to(int x, int y, int elevation, Rect* rect)
     return 0;
 }
 
-// 0x44E42C gmouse_check_scrolling_
+// 0x44E42C gmouse_check_scrolling
 int gameMouseHandleScrolling(int x, int y, int cursor)
 {
     if (!_gmouse_scrolling_enabled) {
@@ -2465,7 +2465,7 @@ int gameMouseHandleScrolling(int x, int y, int cursor)
     return 0;
 }
 
-// 0x44E544 gmouse_remove_item_outline_
+// 0x44E544 gmouse_remove_item_outline
 void _gmouse_remove_item_outline(Object* object)
 {
     if (gGameMouseHighlightedItem != nullptr && gGameMouseHighlightedItem == object) {
@@ -2477,7 +2477,7 @@ void _gmouse_remove_item_outline(Object* object)
     }
 }
 
-// 0x44E580 gmObjIsValidTarget_
+// 0x44E580 gmObjIsValidTarget
 int objectIsDoor(Object* object)
 {
     if (object == nullptr) {

--- a/src/game_movie.cc
+++ b/src/game_movie.cc
@@ -86,7 +86,7 @@ static unsigned char gGameMoviesSeen[MOVIE_COUNT];
 static char gGameMovieSubtitlesFilePath[COMPAT_MAX_PATH];
 
 // gmovie_init
-// 0x44E5C0
+// 0x44E5C0 gmovie_init_
 int gameMoviesInit()
 {
     int volume = 0;
@@ -106,7 +106,7 @@ int gameMoviesInit()
     return 0;
 }
 
-// 0x44E60C
+// 0x44E60C gmovie_reset_
 void gameMoviesReset()
 {
     memset(gGameMoviesSeen, 0, sizeof(gGameMoviesSeen));
@@ -115,7 +115,7 @@ void gameMoviesReset()
     gGameMovieFaded = false;
 }
 
-// 0x44E638
+// 0x44E638 gmovie_load_
 int gameMoviesLoad(File* stream)
 {
     if (fileRead(gGameMoviesSeen, sizeof(*gGameMoviesSeen), MOVIE_COUNT, stream) != MOVIE_COUNT) {
@@ -125,7 +125,7 @@ int gameMoviesLoad(File* stream)
     return 0;
 }
 
-// 0x44E664
+// 0x44E664 gmovie_save_
 int gameMoviesSave(File* stream)
 {
     if (fileWrite(gGameMoviesSeen, sizeof(*gGameMoviesSeen), MOVIE_COUNT, stream) != MOVIE_COUNT) {
@@ -136,7 +136,7 @@ int gameMoviesSave(File* stream)
 }
 
 // gmovie_play
-// 0x44E690
+// 0x44E690 gmovie_play_
 int gameMoviePlay(int movie, int flags)
 {
     gGameMovieIsPlaying = true;
@@ -313,7 +313,7 @@ int gameMoviePlay(int movie, int flags)
     return 0;
 }
 
-// 0x44EAE4
+// 0x44EAE4 gmPaletteFinish_
 void gameMovieFadeOut()
 {
     if (gGameMovieFaded) {
@@ -322,19 +322,19 @@ void gameMovieFadeOut()
     }
 }
 
-// 0x44EB04
+// 0x44EB04 gmovie_has_been_played_
 bool gameMovieIsSeen(int movie)
 {
     return gGameMoviesSeen[movie] == 1;
 }
 
-// 0x44EB14
+// 0x44EB14 gmovieIsPlaying_
 bool gameMovieIsPlaying()
 {
     return gGameMovieIsPlaying;
 }
 
-// 0x44EB1C
+// 0x44EB1C gmovie_subtitle_func_
 static char* gameMovieBuildSubtitlesFilePath(char* movieFilePath)
 {
     char* path = movieFilePath;

--- a/src/game_movie.cc
+++ b/src/game_movie.cc
@@ -31,7 +31,7 @@ static char* gameMovieBuildSubtitlesFilePath(char* movieFilePath);
 // 0x50352A
 static const float flt_50352A = 0.032258064f;
 
-// 0x518DA0
+// 0x518DA0 _movie_list
 static const char* gMovieFileNames[MOVIE_COUNT] = {
     "iplogo.mve",
     "intro.mve",
@@ -52,7 +52,7 @@ static const char* gMovieFileNames[MOVIE_COUNT] = {
     "credits.mve",
 };
 
-// 0x518DE4
+// 0x518DE4 subtitlePalList
 static const char* gMoviePaletteFilePaths[MOVIE_COUNT] = {
     nullptr,
     "art\\cuts\\introsub.pal",
@@ -73,20 +73,20 @@ static const char* gMoviePaletteFilePaths[MOVIE_COUNT] = {
     "art\\cuts\\crdtssub.pal",
 };
 
-// 0x518E28
+// 0x518E28 gmMovieIsPlaying
 static bool gGameMovieIsPlaying = false;
 
-// 0x518E2C
+// 0x518E2C gmPaletteWasFaded
 static bool gGameMovieFaded = false;
 
-// 0x596C78
+// 0x596C78 gmovie_played_list
 static unsigned char gGameMoviesSeen[MOVIE_COUNT];
 
-// 0x596C89
+// 0x596C89 full_path
 static char gGameMovieSubtitlesFilePath[COMPAT_MAX_PATH];
 
 // gmovie_init
-// 0x44E5C0 gmovie_init_
+// 0x44E5C0 gmovie_init
 int gameMoviesInit()
 {
     int volume = 0;
@@ -106,7 +106,7 @@ int gameMoviesInit()
     return 0;
 }
 
-// 0x44E60C gmovie_reset_
+// 0x44E60C gmovie_reset
 void gameMoviesReset()
 {
     memset(gGameMoviesSeen, 0, sizeof(gGameMoviesSeen));
@@ -115,7 +115,7 @@ void gameMoviesReset()
     gGameMovieFaded = false;
 }
 
-// 0x44E638 gmovie_load_
+// 0x44E638 gmovie_load
 int gameMoviesLoad(File* stream)
 {
     if (fileRead(gGameMoviesSeen, sizeof(*gGameMoviesSeen), MOVIE_COUNT, stream) != MOVIE_COUNT) {
@@ -125,7 +125,7 @@ int gameMoviesLoad(File* stream)
     return 0;
 }
 
-// 0x44E664 gmovie_save_
+// 0x44E664 gmovie_save
 int gameMoviesSave(File* stream)
 {
     if (fileWrite(gGameMoviesSeen, sizeof(*gGameMoviesSeen), MOVIE_COUNT, stream) != MOVIE_COUNT) {
@@ -136,7 +136,7 @@ int gameMoviesSave(File* stream)
 }
 
 // gmovie_play
-// 0x44E690 gmovie_play_
+// 0x44E690 gmovie_play
 int gameMoviePlay(int movie, int flags)
 {
     gGameMovieIsPlaying = true;
@@ -313,7 +313,7 @@ int gameMoviePlay(int movie, int flags)
     return 0;
 }
 
-// 0x44EAE4 gmPaletteFinish_
+// 0x44EAE4 gmPaletteFinish
 void gameMovieFadeOut()
 {
     if (gGameMovieFaded) {
@@ -322,19 +322,19 @@ void gameMovieFadeOut()
     }
 }
 
-// 0x44EB04 gmovie_has_been_played_
+// 0x44EB04 gmovie_has_been_played
 bool gameMovieIsSeen(int movie)
 {
     return gGameMoviesSeen[movie] == 1;
 }
 
-// 0x44EB14 gmovieIsPlaying_
+// 0x44EB14 gmovieIsPlaying
 bool gameMovieIsPlaying()
 {
     return gGameMovieIsPlaying;
 }
 
-// 0x44EB1C gmovie_subtitle_func_
+// 0x44EB1C gmovie_subtitle_func
 static char* gameMovieBuildSubtitlesFilePath(char* movieFilePath)
 {
     char* path = movieFilePath;

--- a/src/game_movie.cc
+++ b/src/game_movie.cc
@@ -31,7 +31,7 @@ static char* gameMovieBuildSubtitlesFilePath(char* movieFilePath);
 // 0x50352A
 static const float flt_50352A = 0.032258064f;
 
-// 0x518DA0 _movie_list
+// 0x518DA0 movie_list
 static const char* gMovieFileNames[MOVIE_COUNT] = {
     "iplogo.mve",
     "intro.mve",

--- a/src/game_sound.cc
+++ b/src/game_sound.cc
@@ -35,34 +35,34 @@ typedef enum SoundEffectActionType {
     SOUND_EFFECT_ACTION_TYPE_PASSIVE,
 } SoundEffectActionType;
 
-// 0x5035BC
+// 0x5035BC aSoundSfx
 static char _aSoundSfx[] = "sound\\sfx\\";
 
-// 0x5035C8
+// 0x5035C8 aSoundMusic_0
 static char _aSoundMusic_0[] = "sound\\music\\";
 
-// 0x5035D8
+// 0x5035D8 aSoundSpeech_0
 static char _aSoundSpeech_0[] = "sound\\speech\\";
 
-// 0x518E30
+// 0x518E30 gsound_initialized
 static bool gGameSoundInitialized = false;
 
-// 0x518E34
+// 0x518E34 gsound_debug
 static bool gGameSoundDebugEnabled = false;
 
-// 0x518E38
+// 0x518E38 gsound_background_enabled
 static bool gMusicEnabled = false;
 
-// 0x518E3C
+// 0x518E3C gsound_background_df_vol
 static int _gsound_background_df_vol = 0;
 
-// 0x518E40
+// 0x518E40 gsound_background_fade
 static int _gsound_background_fade = 0;
 
-// 0x518E44
+// 0x518E44 gsound_speech_enabled
 static bool gSpeechEnabled = false;
 
-// 0x518E48
+// 0x518E48 gsound_sfx_enabled
 static bool gSoundEffectsEnabled = false;
 
 // number of active effects (max 4)
@@ -72,16 +72,16 @@ static int _gsound_active_effect_counter;
 // background music
 static Sound* gBackgroundSound = nullptr;
 
-// 0x518E54
+// 0x518E54 gsound_speech_tag
 static Sound* gSpeechSound = nullptr;
 
-// 0x518E58
+// 0x518E58 _gsound_background_callback_fp
 static SoundEndCallback* gBackgroundSoundEndCallback = nullptr;
 
-// 0x518E5C
+// 0x518E5C _gsound_speech_callback_fp
 static SoundEndCallback* gSpeechEndCallback = nullptr;
 
-// 0x518E60
+// 0x518E60 _snd_lookup_weapon_type
 static char _snd_lookup_weapon_type[WEAPON_SOUND_EFFECT_COUNT] = {
     'R', // Ready
     'A', // Attack
@@ -90,7 +90,7 @@ static char _snd_lookup_weapon_type[WEAPON_SOUND_EFFECT_COUNT] = {
     'H', // Hit
 };
 
-// 0x518E65
+// 0x518E65 _snd_lookup_scenery_action
 static char _snd_lookup_scenery_action[SCENERY_SOUND_EFFECT_COUNT] = {
     'O', // Open
     'C', // Close
@@ -99,51 +99,51 @@ static char _snd_lookup_scenery_action[SCENERY_SOUND_EFFECT_COUNT] = {
     'U', // Use
 };
 
-// 0x518E6C
+// 0x518E6C background_storage_requested
 static GameSoundStorageType _background_storage_requested = GSOUND_STORAGE_INVALID;
 
-// 0x518E70
+// 0x518E70 background_loop_requested
 static GameSoundLoopingMode _background_loop_requested = GSOUND_LOOPING_INVALID;
 
-// 0x518E74
+// 0x518E74 _sound_sfx_path
 static char* _sound_sfx_path = _aSoundSfx;
 
-// 0x518E78
+// 0x518E78 _sound_music_path1
 static char* _sound_music_path1 = nullptr;
 
-// 0x518E7C
+// 0x518E7C _sound_music_path2
 static char* _sound_music_path2 = nullptr;
 
-// 0x518E80
+// 0x518E80 _sound_speech_path
 static char* _sound_speech_path = _aSoundSpeech_0;
 
-// 0x518E84
+// 0x518E84 master_volume
 static int gMasterVolume = VOLUME_MAX;
 
-// 0x518E88
+// 0x518E88 background_volume
 int gMusicVolume = VOLUME_MAX;
 
-// 0x518E8C
+// 0x518E8C speech_volume
 static int gSpeechVolume = VOLUME_MAX;
 
-// 0x518E90
+// 0x518E90 sndfx_volume
 static int gSoundEffectsVolume = VOLUME_MAX;
 
-// 0x518E94
+// 0x518E94 detectDevices
 static int _detectDevices = -1;
 
-// 0x518E98
+// 0x518E98 _lastTime_1
 static int _lastTime_1 = 0;
 
-// 0x596EB0
+// 0x596EB0 background_fname_copied
 static char _background_fname_copied[COMPAT_MAX_PATH];
 
-// 0x596FB5
+// 0x596FB5 sfx_file_name
 static char _sfx_file_name[13];
 
 // NOTE: I'm mot sure about it's size. Why not MAX_PATH?
 //
-// 0x596FC2
+// 0x596FC2 background_fname_requested
 static char gBackgroundSoundFileName[270];
 
 static void soundEffectsEnable();

--- a/src/game_sound.cc
+++ b/src/game_sound.cc
@@ -75,13 +75,13 @@ static Sound* gBackgroundSound = nullptr;
 // 0x518E54 gsound_speech_tag
 static Sound* gSpeechSound = nullptr;
 
-// 0x518E58 _gsound_background_callback_fp
+// 0x518E58 gsound_background_callback_fp
 static SoundEndCallback* gBackgroundSoundEndCallback = nullptr;
 
-// 0x518E5C _gsound_speech_callback_fp
+// 0x518E5C gsound_speech_callback_fp
 static SoundEndCallback* gSpeechEndCallback = nullptr;
 
-// 0x518E60 _snd_lookup_weapon_type
+// 0x518E60 snd_lookup_weapon_type
 static char _snd_lookup_weapon_type[WEAPON_SOUND_EFFECT_COUNT] = {
     'R', // Ready
     'A', // Attack
@@ -90,7 +90,7 @@ static char _snd_lookup_weapon_type[WEAPON_SOUND_EFFECT_COUNT] = {
     'H', // Hit
 };
 
-// 0x518E65 _snd_lookup_scenery_action
+// 0x518E65 snd_lookup_scenery_action
 static char _snd_lookup_scenery_action[SCENERY_SOUND_EFFECT_COUNT] = {
     'O', // Open
     'C', // Close
@@ -105,16 +105,16 @@ static GameSoundStorageType _background_storage_requested = GSOUND_STORAGE_INVAL
 // 0x518E70 background_loop_requested
 static GameSoundLoopingMode _background_loop_requested = GSOUND_LOOPING_INVALID;
 
-// 0x518E74 _sound_sfx_path
+// 0x518E74 sound_sfx_path
 static char* _sound_sfx_path = _aSoundSfx;
 
-// 0x518E78 _sound_music_path1
+// 0x518E78 sound_music_path1
 static char* _sound_music_path1 = nullptr;
 
-// 0x518E7C _sound_music_path2
+// 0x518E7C sound_music_path2
 static char* _sound_music_path2 = nullptr;
 
-// 0x518E80 _sound_speech_path
+// 0x518E80 sound_speech_path
 static char* _sound_speech_path = _aSoundSpeech_0;
 
 // 0x518E84 master_volume
@@ -132,7 +132,7 @@ static int gSoundEffectsVolume = VOLUME_MAX;
 // 0x518E94 detectDevices
 static int _detectDevices = -1;
 
-// 0x518E98 _lastTime_1
+// 0x518E98 lastTime_1
 static int _lastTime_1 = 0;
 
 // 0x596EB0 background_fname_copied

--- a/src/geometry.cc
+++ b/src/geometry.cc
@@ -11,7 +11,7 @@ namespace fallout {
 // 0x51DEF4
 static RectListNode* _rectList = nullptr;
 
-// 0x4C6900
+// 0x4C6900 GNW_rect_exit_
 void _GNW_rect_exit()
 {
     while (_rectList != nullptr) {
@@ -21,7 +21,7 @@ void _GNW_rect_exit()
     }
 }
 
-// 0x4C6924
+// 0x4C6924 rect_clip_list_
 void _rect_clip_list(RectListNode** rectListNodePtr, Rect* rect)
 {
     Rect clipRect;
@@ -107,7 +107,7 @@ void _rect_clip_list(RectListNode** rectListNodePtr, Rect* rect)
     }
 }
 
-// 0x4C6AAC
+// 0x4C6AAC rect_clip_
 RectListNode* rect_clip(Rect* b, Rect* t)
 {
     RectListNode* list = nullptr;
@@ -163,7 +163,7 @@ RectListNode* rect_clip(Rect* b, Rect* t)
     return list;
 }
 
-// 0x4C6BB8
+// 0x4C6BB8 rect_malloc_
 RectListNode* _rect_malloc()
 {
     if (_rectList == nullptr) {
@@ -188,7 +188,7 @@ RectListNode* _rect_malloc()
     return rectListNode;
 }
 
-// 0x4C6C04
+// 0x4C6C04 rect_free_
 void _rect_free(RectListNode* rectListNode)
 {
     rectListNode->next = _rectList;
@@ -198,7 +198,7 @@ void _rect_free(RectListNode* rectListNode)
 // Calculates a union of two source rectangles and places it into result
 // rectangle.
 //
-// 0x4C6C18
+// 0x4C6C18 rect_min_bound_
 void rectUnion(const Rect* s1, const Rect* s2, Rect* r)
 {
     r->left = std::min(s1->left, s2->left);
@@ -211,7 +211,7 @@ void rectUnion(const Rect* s1, const Rect* s2, Rect* r)
 // rectangle and returns 0. If two source rectangles do not have intersection
 // it returns -1 and resulting rectangle is a copy of s1.
 //
-// 0x4C6C68
+// 0x4C6C68 rect_inside_bound_
 int rectIntersection(const Rect* s1, const Rect* s2, Rect* r)
 {
     r->left = s1->left;

--- a/src/geometry.cc
+++ b/src/geometry.cc
@@ -8,10 +8,10 @@
 
 namespace fallout {
 
-// 0x51DEF4
+// 0x51DEF4 _rectList
 static RectListNode* _rectList = nullptr;
 
-// 0x4C6900 GNW_rect_exit_
+// 0x4C6900 GNW_rect_exit
 void _GNW_rect_exit()
 {
     while (_rectList != nullptr) {
@@ -21,7 +21,7 @@ void _GNW_rect_exit()
     }
 }
 
-// 0x4C6924 rect_clip_list_
+// 0x4C6924 rect_clip_list
 void _rect_clip_list(RectListNode** rectListNodePtr, Rect* rect)
 {
     Rect clipRect;
@@ -107,7 +107,7 @@ void _rect_clip_list(RectListNode** rectListNodePtr, Rect* rect)
     }
 }
 
-// 0x4C6AAC rect_clip_
+// 0x4C6AAC rect_clip
 RectListNode* rect_clip(Rect* b, Rect* t)
 {
     RectListNode* list = nullptr;
@@ -163,7 +163,7 @@ RectListNode* rect_clip(Rect* b, Rect* t)
     return list;
 }
 
-// 0x4C6BB8 rect_malloc_
+// 0x4C6BB8 rect_malloc
 RectListNode* _rect_malloc()
 {
     if (_rectList == nullptr) {
@@ -188,7 +188,7 @@ RectListNode* _rect_malloc()
     return rectListNode;
 }
 
-// 0x4C6C04 rect_free_
+// 0x4C6C04 rect_free
 void _rect_free(RectListNode* rectListNode)
 {
     rectListNode->next = _rectList;
@@ -198,7 +198,7 @@ void _rect_free(RectListNode* rectListNode)
 // Calculates a union of two source rectangles and places it into result
 // rectangle.
 //
-// 0x4C6C18 rect_min_bound_
+// 0x4C6C18 rect_min_bound
 void rectUnion(const Rect* s1, const Rect* s2, Rect* r)
 {
     r->left = std::min(s1->left, s2->left);
@@ -211,7 +211,7 @@ void rectUnion(const Rect* s1, const Rect* s2, Rect* r)
 // rectangle and returns 0. If two source rectangles do not have intersection
 // it returns -1 and resulting rectangle is a copy of s1.
 //
-// 0x4C6C68 rect_inside_bound_
+// 0x4C6C68 rect_inside_bound
 int rectIntersection(const Rect* s1, const Rect* s2, Rect* r)
 {
     r->left = s1->left;

--- a/src/geometry.cc
+++ b/src/geometry.cc
@@ -8,7 +8,7 @@
 
 namespace fallout {
 
-// 0x51DEF4 _rectList
+// 0x51DEF4 rectList
 static RectListNode* _rectList = nullptr;
 
 // 0x4C6900 GNW_rect_exit

--- a/src/graph_lib.cc
+++ b/src/graph_lib.cc
@@ -15,31 +15,31 @@ static void _InitTree();
 static void _InsertNode(int a1);
 static void _DeleteNode(int a1);
 
-// 0x596D90
+// 0x596D90 GreyTable
 static unsigned char _GreyTable[256];
 
-// 0x596E90
+// 0x596E90 dad_2
 static int* _dad_2;
 
-// 0x596E94
+// 0x596E94 match_length
 static int _match_length;
 
-// 0x596E98
+// 0x596E98 _textsize
 static int _textsize;
 
-// 0x596E9C
+// 0x596E9C rson
 static int* _rson;
 
-// 0x596EA0
+// 0x596EA0 lson
 static int* _lson;
 
-// 0x596EA4
+// 0x596EA4 _text_buf
 static unsigned char* _text_buf;
 
-// 0x596EA8
+// 0x596EA8 _codesize
 static int _codesize;
 
-// 0x596EAC
+// 0x596EAC match_position
 static int _match_position;
 
 // 0x44EBC0

--- a/src/graph_lib.cc
+++ b/src/graph_lib.cc
@@ -24,7 +24,7 @@ static int* _dad_2;
 // 0x596E94 match_length
 static int _match_length;
 
-// 0x596E98 _textsize
+// 0x596E98 textsize
 static int _textsize;
 
 // 0x596E9C rson
@@ -33,10 +33,10 @@ static int* _rson;
 // 0x596EA0 lson
 static int* _lson;
 
-// 0x596EA4 _text_buf
+// 0x596EA4 text_buf
 static unsigned char* _text_buf;
 
-// 0x596EA8 _codesize
+// 0x596EA8 codesize
 static int _codesize;
 
 // 0x596EAC match_position

--- a/src/heap.cc
+++ b/src/heap.cc
@@ -131,7 +131,7 @@ static int gHeapReservedFreeBlockIndexesLength = 0;
 // 0x518EBC
 static int gHeapsCount = 0;
 
-// 0x453304
+// 0x453304 heap_create_lists_
 static bool heapInternalsInit()
 {
     // NOTE: Original code is slightly different. It uses deep nesting or a
@@ -172,7 +172,7 @@ static bool heapInternalsInit()
     return false;
 }
 
-// 0x4533A0
+// 0x4533A0 heap_destroy_lists_
 static void heapInternalsFree()
 {
     if (gHeapReservedFreeBlockIndexes != nullptr) {
@@ -200,7 +200,7 @@ static void heapInternalsFree()
     gHeapFreeBlocksLength = 0;
 }
 
-// 0x452974
+// 0x452974 heap_init_
 bool heapInit(Heap* heap, int initialSize)
 {
     if (heap == nullptr) {
@@ -245,7 +245,7 @@ bool heapInit(Heap* heap, int initialSize)
     return false;
 }
 
-// 0x452A3C
+// 0x452A3C heap_exit_
 bool heapFree(Heap* heap)
 {
     if (heap == nullptr) {
@@ -279,7 +279,7 @@ bool heapFree(Heap* heap)
     return true;
 }
 
-// 0x453430
+// 0x453430 heap_init_handles_
 static bool heapHandleListInit(Heap* heap)
 {
     heap->handles = (HeapHandle*)internal_malloc(sizeof(*heap->handles) * HEAP_HANDLES_INITIAL_LENGTH);
@@ -299,7 +299,7 @@ static bool heapHandleListInit(Heap* heap)
     return true;
 }
 
-// 0x452AD0
+// 0x452AD0 heap_allocate_
 bool heapBlockAllocate(Heap* heap, int* handleIndexPtr, int size, int disallowSystemAllocation)
 {
     HeapBlockHeader* blockHeader;
@@ -419,7 +419,7 @@ err:
 }
 
 // heap_block_free
-// 0x452CB4
+// 0x452CB4 heap_deallocate_
 bool heapBlockDeallocate(Heap* heap, int* handleIndexPtr)
 {
     if (heap == nullptr || handleIndexPtr == nullptr) {
@@ -490,7 +490,7 @@ bool heapBlockDeallocate(Heap* heap, int* handleIndexPtr)
     return false;
 }
 
-// 0x452DE0
+// 0x452DE0 heap_lock_
 bool heapLock(Heap* heap, int handleIndex, unsigned char** bufferPtr)
 {
     if (heap == nullptr) {
@@ -551,7 +551,7 @@ bool heapLock(Heap* heap, int handleIndex, unsigned char** bufferPtr)
     return false;
 }
 
-// 0x452EE4
+// 0x452EE4 heap_unlock_
 bool heapUnlock(Heap* heap, int handleIndex)
 {
     if (heap == nullptr) {
@@ -600,7 +600,7 @@ bool heapUnlock(Heap* heap, int handleIndex)
     return true;
 }
 
-// 0x4532AC
+// 0x4532AC heap_stats_
 static bool heapPrintStats(Heap* heap, char* dest, size_t size)
 {
     if (heap == nullptr || dest == nullptr) {
@@ -634,7 +634,7 @@ static bool heapPrintStats(Heap* heap, char* dest, size_t size)
     return true;
 }
 
-// 0x4534B0
+// 0x4534B0 heap_acquire_handle_
 static bool heapFindFreeHandle(Heap* heap, int* handleIndexPtr)
 {
     // Loop thru already available handles and find first that is not currently
@@ -670,7 +670,7 @@ static bool heapFindFreeHandle(Heap* heap, int* handleIndexPtr)
 }
 
 // heap_find_free_block
-// 0x453588
+// 0x453588 heap_find_free_block_
 static bool heapFindFreeBlock(Heap* heap, int size, void** blockPtr, int disallowSystemAllocation)
 {
     unsigned char* biggestFreeBlock;
@@ -946,7 +946,7 @@ system:
 
 // Build list of pointers to moveable blocks in given extent.
 //
-// 0x453E80
+// 0x453E80 heap_build_subblock_list_
 static bool heapBuildMoveableBlocksList(int extentIndex)
 {
     HeapMoveableExtent* extent = &(gHeapMoveableExtents[extentIndex]);
@@ -973,7 +973,7 @@ static bool heapBuildMoveableBlocksList(int extentIndex)
     return moveableBlockIndex == extent->moveableBlocksLength;
 }
 
-// 0x453E74
+// 0x453E74 heap_qsort_compare_moveable_
 static int heapMoveableExtentsCompareBySize(const void* leftPtr, const void* rightPtr)
 {
     HeapMoveableExtent* left = (HeapMoveableExtent*)leftPtr;
@@ -981,7 +981,7 @@ static int heapMoveableExtentsCompareBySize(const void* leftPtr, const void* rig
     return left->size - right->size;
 }
 
-// 0x453BC4
+// 0x453BC4 heap_build_free_list_
 static bool heapBuildFreeBlocksList(Heap* heap)
 {
     if (heap->freeBlocks == 0) {
@@ -1042,7 +1042,7 @@ static bool heapBuildFreeBlocksList(Heap* heap)
     return true;
 }
 
-// 0x453CC4
+// 0x453CC4 heap_qsort_compare_free_
 static int heapBlockCompareBySize(const void* leftPtr, const void* rightPtr)
 {
     HeapBlockHeader* header1 = *(HeapBlockHeader**)leftPtr;
@@ -1050,7 +1050,7 @@ static int heapBlockCompareBySize(const void* leftPtr, const void* rightPtr)
     return header1->size - header2->size;
 }
 
-// 0x453CD0
+// 0x453CD0 heap_build_moveable_list_
 static bool heapBuildMoveableExtentsList(Heap* heap, int* moveableExtentsLengthPtr, int* maxBlocksLengthPtr)
 {
     // Calculate max number of extents. It's only possible when every
@@ -1134,7 +1134,7 @@ static bool heapBuildMoveableExtentsList(Heap* heap, int* moveableExtentsLengthP
     return true;
 }
 
-// 0x452FC4
+// 0x452FC4 heap_validate_
 bool heapValidate(Heap* heap)
 {
     debugPrint("Validating heap...\n");

--- a/src/heap.cc
+++ b/src/heap.cc
@@ -84,23 +84,23 @@ static bool heapBuildMoveableBlocksList(int extentIndex);
 
 // An array of pointers to free heap blocks.
 //
-// 0x518E9C _heap_free_list
+// 0x518E9C heap_free_list
 static unsigned char** gHeapFreeBlocks = nullptr;
 
 // An array of moveable extents in heap.
 //
-// 0x518EA0 _heap_moveable_list
+// 0x518EA0 heap_moveable_list
 static HeapMoveableExtent* gHeapMoveableExtents = nullptr;
 
 // An array of pointers to moveable heap blocks.
 //
-// 0x518EA4 _heap_subblock_list
+// 0x518EA4 heap_subblock_list
 static unsigned char** gHeapMoveableBlocks = nullptr;
 
 // An array of indexes into [gHeapFreeBlocks] array to track which free blocks
 // were already reserved for subsequent moving.
 //
-// 0x518EA8 _heap_fake_move_list
+// 0x518EA8 heap_fake_move_list
 static int* gHeapReservedFreeBlockIndexes = nullptr;
 
 // The length of the [gHeapFreeBlocks] array.
@@ -110,12 +110,12 @@ static int gHeapFreeBlocksLength = 0;
 
 // The length of [gHeapMoveableExtents] array.
 //
-// 0x518EB0 _heap_moveable_list_size
+// 0x518EB0 heap_moveable_list_size
 static int gHeapMoveableExtentsLength = 0;
 
 // The length of [gHeapMoveableBlocks] array.
 //
-// 0x518EB4 _heap_subblock_list_size
+// 0x518EB4 heap_subblock_list_size
 static int gHeapMoveableBlocksLength = 0;
 
 // The length of [gHeapReservedFreeBlockIndexes] array.

--- a/src/heap.cc
+++ b/src/heap.cc
@@ -84,43 +84,43 @@ static bool heapBuildMoveableBlocksList(int extentIndex);
 
 // An array of pointers to free heap blocks.
 //
-// 0x518E9C
+// 0x518E9C _heap_free_list
 static unsigned char** gHeapFreeBlocks = nullptr;
 
 // An array of moveable extents in heap.
 //
-// 0x518EA0
+// 0x518EA0 _heap_moveable_list
 static HeapMoveableExtent* gHeapMoveableExtents = nullptr;
 
 // An array of pointers to moveable heap blocks.
 //
-// 0x518EA4
+// 0x518EA4 _heap_subblock_list
 static unsigned char** gHeapMoveableBlocks = nullptr;
 
 // An array of indexes into [gHeapFreeBlocks] array to track which free blocks
 // were already reserved for subsequent moving.
 //
-// 0x518EA8
+// 0x518EA8 _heap_fake_move_list
 static int* gHeapReservedFreeBlockIndexes = nullptr;
 
 // The length of the [gHeapFreeBlocks] array.
 //
-// 0x518EAC
+// 0x518EAC heap_free_list_size
 static int gHeapFreeBlocksLength = 0;
 
 // The length of [gHeapMoveableExtents] array.
 //
-// 0x518EB0
+// 0x518EB0 _heap_moveable_list_size
 static int gHeapMoveableExtentsLength = 0;
 
 // The length of [gHeapMoveableBlocks] array.
 //
-// 0x518EB4
+// 0x518EB4 _heap_subblock_list_size
 static int gHeapMoveableBlocksLength = 0;
 
 // The length of [gHeapReservedFreeBlockIndexes] array.
 //
-// 0x518EB8
+// 0x518EB8 heap_fake_move_list_size
 static int gHeapReservedFreeBlockIndexesLength = 0;
 
 // The number of heaps.
@@ -128,10 +128,10 @@ static int gHeapReservedFreeBlockIndexesLength = 0;
 // This value is used to init/free internal temporary buffers
 // needed for any heap.
 //
-// 0x518EBC
+// 0x518EBC heap_count
 static int gHeapsCount = 0;
 
-// 0x453304 heap_create_lists_
+// 0x453304 heap_create_lists
 static bool heapInternalsInit()
 {
     // NOTE: Original code is slightly different. It uses deep nesting or a
@@ -172,7 +172,7 @@ static bool heapInternalsInit()
     return false;
 }
 
-// 0x4533A0 heap_destroy_lists_
+// 0x4533A0 heap_destroy_lists
 static void heapInternalsFree()
 {
     if (gHeapReservedFreeBlockIndexes != nullptr) {
@@ -200,7 +200,7 @@ static void heapInternalsFree()
     gHeapFreeBlocksLength = 0;
 }
 
-// 0x452974 heap_init_
+// 0x452974 heap_init
 bool heapInit(Heap* heap, int initialSize)
 {
     if (heap == nullptr) {
@@ -245,7 +245,7 @@ bool heapInit(Heap* heap, int initialSize)
     return false;
 }
 
-// 0x452A3C heap_exit_
+// 0x452A3C heap_exit
 bool heapFree(Heap* heap)
 {
     if (heap == nullptr) {
@@ -279,7 +279,7 @@ bool heapFree(Heap* heap)
     return true;
 }
 
-// 0x453430 heap_init_handles_
+// 0x453430 heap_init_handles
 static bool heapHandleListInit(Heap* heap)
 {
     heap->handles = (HeapHandle*)internal_malloc(sizeof(*heap->handles) * HEAP_HANDLES_INITIAL_LENGTH);
@@ -299,7 +299,7 @@ static bool heapHandleListInit(Heap* heap)
     return true;
 }
 
-// 0x452AD0 heap_allocate_
+// 0x452AD0 heap_allocate
 bool heapBlockAllocate(Heap* heap, int* handleIndexPtr, int size, int disallowSystemAllocation)
 {
     HeapBlockHeader* blockHeader;
@@ -419,7 +419,7 @@ err:
 }
 
 // heap_block_free
-// 0x452CB4 heap_deallocate_
+// 0x452CB4 heap_deallocate
 bool heapBlockDeallocate(Heap* heap, int* handleIndexPtr)
 {
     if (heap == nullptr || handleIndexPtr == nullptr) {
@@ -490,7 +490,7 @@ bool heapBlockDeallocate(Heap* heap, int* handleIndexPtr)
     return false;
 }
 
-// 0x452DE0 heap_lock_
+// 0x452DE0 heap_lock
 bool heapLock(Heap* heap, int handleIndex, unsigned char** bufferPtr)
 {
     if (heap == nullptr) {
@@ -551,7 +551,7 @@ bool heapLock(Heap* heap, int handleIndex, unsigned char** bufferPtr)
     return false;
 }
 
-// 0x452EE4 heap_unlock_
+// 0x452EE4 heap_unlock
 bool heapUnlock(Heap* heap, int handleIndex)
 {
     if (heap == nullptr) {
@@ -600,7 +600,7 @@ bool heapUnlock(Heap* heap, int handleIndex)
     return true;
 }
 
-// 0x4532AC heap_stats_
+// 0x4532AC heap_stats
 static bool heapPrintStats(Heap* heap, char* dest, size_t size)
 {
     if (heap == nullptr || dest == nullptr) {
@@ -634,7 +634,7 @@ static bool heapPrintStats(Heap* heap, char* dest, size_t size)
     return true;
 }
 
-// 0x4534B0 heap_acquire_handle_
+// 0x4534B0 heap_acquire_handle
 static bool heapFindFreeHandle(Heap* heap, int* handleIndexPtr)
 {
     // Loop thru already available handles and find first that is not currently
@@ -670,7 +670,7 @@ static bool heapFindFreeHandle(Heap* heap, int* handleIndexPtr)
 }
 
 // heap_find_free_block
-// 0x453588 heap_find_free_block_
+// 0x453588 heap_find_free_block
 static bool heapFindFreeBlock(Heap* heap, int size, void** blockPtr, int disallowSystemAllocation)
 {
     unsigned char* biggestFreeBlock;
@@ -946,7 +946,7 @@ system:
 
 // Build list of pointers to moveable blocks in given extent.
 //
-// 0x453E80 heap_build_subblock_list_
+// 0x453E80 heap_build_subblock_list
 static bool heapBuildMoveableBlocksList(int extentIndex)
 {
     HeapMoveableExtent* extent = &(gHeapMoveableExtents[extentIndex]);
@@ -973,7 +973,7 @@ static bool heapBuildMoveableBlocksList(int extentIndex)
     return moveableBlockIndex == extent->moveableBlocksLength;
 }
 
-// 0x453E74 heap_qsort_compare_moveable_
+// 0x453E74 heap_qsort_compare_moveable
 static int heapMoveableExtentsCompareBySize(const void* leftPtr, const void* rightPtr)
 {
     HeapMoveableExtent* left = (HeapMoveableExtent*)leftPtr;
@@ -981,7 +981,7 @@ static int heapMoveableExtentsCompareBySize(const void* leftPtr, const void* rig
     return left->size - right->size;
 }
 
-// 0x453BC4 heap_build_free_list_
+// 0x453BC4 heap_build_free_list
 static bool heapBuildFreeBlocksList(Heap* heap)
 {
     if (heap->freeBlocks == 0) {
@@ -1042,7 +1042,7 @@ static bool heapBuildFreeBlocksList(Heap* heap)
     return true;
 }
 
-// 0x453CC4 heap_qsort_compare_free_
+// 0x453CC4 heap_qsort_compare_free
 static int heapBlockCompareBySize(const void* leftPtr, const void* rightPtr)
 {
     HeapBlockHeader* header1 = *(HeapBlockHeader**)leftPtr;
@@ -1050,7 +1050,7 @@ static int heapBlockCompareBySize(const void* leftPtr, const void* rightPtr)
     return header1->size - header2->size;
 }
 
-// 0x453CD0 heap_build_moveable_list_
+// 0x453CD0 heap_build_moveable_list
 static bool heapBuildMoveableExtentsList(Heap* heap, int* moveableExtentsLengthPtr, int* maxBlocksLengthPtr)
 {
     // Calculate max number of extents. It's only possible when every
@@ -1134,7 +1134,7 @@ static bool heapBuildMoveableExtentsList(Heap* heap, int* moveableExtentsLengthP
     return true;
 }
 
-// 0x452FC4 heap_validate_
+// 0x452FC4 heap_validate
 bool heapValidate(Heap* heap)
 {
     debugPrint("Validating heap...\n");

--- a/src/input.cc
+++ b/src/input.cc
@@ -80,7 +80,7 @@ static int _input_my;
 // 0x6AC760 screendump_key
 static int gScreenshotKeyCode;
 
-// 0x6AC76C _screendump_func
+// 0x6AC76C screendump_func
 static ScreenshotHandler* gScreenshotHandler;
 
 // 0x6AC770 input_get

--- a/src/input.cc
+++ b/src/input.cc
@@ -49,15 +49,15 @@ static void _GNW95_process_key(KeyboardData* data);
 static int inputGetHookMouseButton(int sdlButton);
 static void inputHandleMouseClickHook(int sdlButton, bool pressed);
 
-// 0x51E23C
+// 0x51E23C GNW95_repeat_rate
 static int gKeyboardKeyRepeatRate = 80;
 
-// 0x51E240
+// 0x51E240 GNW95_repeat_delay
 static int gKeyboardKeyRepeatDelay = 500;
 
 // A map of SDL_SCANCODE_* constants normalized for QWERTY keyboard.
 //
-// 0x6ABC70
+// 0x6ABC70 GNW95_key_map
 static int gNormalizedQwertyKeys[SDL_NUM_SCANCODES];
 
 // Ring buffer of input events.
@@ -65,40 +65,40 @@ static int gNormalizedQwertyKeys[SDL_NUM_SCANCODES];
 // Looks like this buffer does not support overwriting of values. Once the
 // buffer is full it will not overwrite values until they are dequeued.
 //
-// 0x6ABD70
+// 0x6ABD70 input_buffer
 static InputEvent gInputEventQueue[40];
 
-// 0x6ABF50
+// 0x6ABF50 GNW95_key_time_stamps
 static RepeatInfo _GNW95_key_time_stamps[SDL_NUM_SCANCODES];
 
-// 0x6AC750
+// 0x6AC750 input_mx
 static int _input_mx;
 
-// 0x6AC754
+// 0x6AC754 input_my
 static int _input_my;
 
-// 0x6AC760
+// 0x6AC760 screendump_key
 static int gScreenshotKeyCode;
 
-// 0x6AC76C
+// 0x6AC76C _screendump_func
 static ScreenshotHandler* gScreenshotHandler;
 
-// 0x6AC770
+// 0x6AC770 input_get
 static int gInputEventQueueReadIndex;
 
-// 0x6AC774
+// 0x6AC774 screendump_buf
 static unsigned char* gScreenshotBuffer;
 
-// 0x6AC77C
+// 0x6AC77C input_put
 static int gInputEventQueueWriteIndex;
 
-// 0x6AC780
+// 0x6AC780 bk_disabled
 static bool gRunLoopDisabled;
 
-// 0x6AC784
+// 0x6AC784 bk_list
 static TickerListNode* gTickerListHead;
 
-// 0x6AC788
+// 0x6AC788 bk_process_time
 static unsigned int gTickerLastTimestamp;
 
 // global for inventoryOpenUseItemOn inventory to prevent click through bug

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -138,63 +138,63 @@ static void sidePanelsHide();
 static void sidePanelsShow();
 static void sidePanelsDraw(const char* path, int win, bool isLeading);
 
-// 0x518F08
+// 0x518F08 insideInit
 static bool gInterfaceBarInitialized = false;
 
-// 0x518F0C
+// 0x518F0C intface_fid_is_changing
 static bool gInterfaceBarSwapHandsInProgress = false;
 
-// 0x518F10
+// 0x518F10 intfaceEnabled
 static bool gInterfaceBarEnabled = false;
 
-// 0x518F14
+// 0x518F14 intfaceHidden
 static bool gInterfaceBarHidden = false;
 
-// 0x518F18
+// 0x518F18 inventoryButton
 static int gInventoryButton = -1;
 
-// 0x518F24
+// 0x518F24 optionsButton
 static int gOptionsButton = -1;
 
-// 0x518F30
+// 0x518F30 skilldexButton
 static int gSkilldexButton = -1;
 
-// 0x518F40
+// 0x518F40 automapButton
 static int gMapButton = -1;
 
-// 0x518F50
+// 0x518F50 pipboyButton
 static int gPipboyButton = -1;
 
-// 0x518F5C
+// 0x518F5C characterButton
 static int gCharacterButton = -1;
 
-// 0x518F68
+// 0x518F68 itemButton
 static int gSingleAttackButton = -1;
 
-// 0x518F78
+// 0x518F78 itemCurrentItem
 static int gInterfaceCurrentHand = HAND_LEFT;
 
-// 0x518F7C
+// 0x518F7C itemButtonRect
 static Rect gInterfaceBarMainActionRect;
 
-// 0x518F8C
+// 0x518F8C toggleButton
 static int gChangeHandsButton = -1;
 
-// 0x518F9C
+// 0x518F9C endWindowOpen
 static bool gInterfaceBarEndButtonsIsVisible = false;
 
 // Combat mode curtains rect.
 //
-// 0x518FA0
+// 0x518FA0 endWindowRect
 static Rect gInterfaceBarEndButtonsRect;
 
-// 0x518FB0
+// 0x518FB0 endTurnButton
 static int gEndTurnButton = -1;
 
-// 0x518FBC
+// 0x518FBC endCombatButton
 static int gEndCombatButton = -1;
 
-// 0x518FE8
+// 0x518FE8 bbox
 static IndicatorDescription gIndicatorDescriptions[INDICATOR_COUNT] = {
     { 102, true, nullptr }, // ADDICT
     { 100, false, nullptr }, // SNEAK
@@ -203,55 +203,55 @@ static IndicatorDescription gIndicatorDescriptions[INDICATOR_COUNT] = {
     { 104, true, nullptr }, // RADIATED
 };
 
-// 0x519024
+// 0x519024 interfaceWindow
 int gInterfaceBarWindow = -1;
 
-// 0x519028
+// 0x519028 bar_window
 static int gIndicatorBarWindow = -1;
 
 // Last hit points rendered in interface.
 //
 // Used to animate changes.
 //
-// 0x51902C
+// 0x51902C last_points
 static int gInterfaceLastRenderedHitPoints = 0;
 
 // Last color used to render hit points in interface.
 //
 // Used to animate changes.
 //
-// 0x519030
+// 0x519030 last_points_color
 static int gInterfaceLastRenderedHitPointsColor = INTERFACE_NUMBERS_COLOR_RED;
 
 // Last armor class rendered in interface.
 //
 // Used to animate changes.
 //
-// 0x519034
+// 0x519034 last_ac
 static int gInterfaceLastRenderedArmorClass = 0;
 
 // Each slot contains one of indicators or -1 if slot is empty.
 //
-// 0x5970E0
+// 0x5970E0 bboxslot
 static int gIndicatorSlots[INDICATOR_SLOTS_COUNT];
 
-// 0x5970F8
+// 0x5970F8 Hand
 static InterfaceItemState gInterfaceItemStates[HAND_COUNT];
 
-// 0x597138
+// 0x597138 box_status_flag
 static bool gIndicatorBarIsVisible;
 
-// 0x597154
+// 0x597154 itemButtonDown
 static unsigned char _itemButtonDown[INTERFACE_ITEM_ACTION_BUTTON_WIDTH * INTERFACE_ITEM_ACTION_BUTTON_HEIGHT];
 
-// 0x59A2B4
+// 0x59A2B4 itemButtonUp
 static unsigned char _itemButtonUp[INTERFACE_ITEM_ACTION_BUTTON_WIDTH * INTERFACE_ITEM_ACTION_BUTTON_HEIGHT];
 
-// 0x59D3F4
+// 0x59D3F4 _interfaceBuffer
 static unsigned char* gInterfaceWindowBuffer;
 
 // Rectangle within Interface Bar window covering the Action Points bar.
-// 0x518FD4
+// 0x518FD4 movePointRect
 static Rect apBarRect;
 
 // Width and height of AP bulbs.
@@ -269,7 +269,7 @@ constexpr int kApBarMaxWidth = (kApBarBulbSize + kApBarBulbMargin) * kApBarMaxBu
 //
 // This buffer is initialized once and does not change throughout the game.
 //
-// 0x59D40C
+// 0x59D40C movePointBackground
 static unsigned char apBarBackgroundData[kApBarMaxWidth * kApBarBulbSize];
 
 static int apBarMaxAP;
@@ -329,7 +329,7 @@ static Buffer2D apBarBackgroundBuf2D()
 }
 
 // intface_init
-// 0x45D880 intface_init_
+// 0x45D880 intface_init
 int interfaceInit()
 {
     int fid;
@@ -619,7 +619,7 @@ int interfaceInit()
     return 0;
 }
 
-// 0x45E3D0 intface_reset_
+// 0x45E3D0 intface_reset
 void interfaceReset()
 {
     interfaceBarEnable();
@@ -636,7 +636,7 @@ void interfaceReset()
     gInterfaceCurrentHand = 0;
 }
 
-// 0x45E440 intface_exit_
+// 0x45E440 intface_exit
 void interfaceFree()
 {
     quickToolbarFree();
@@ -732,7 +732,7 @@ void interfaceFree()
     interfaceBarFree();
 }
 
-// 0x45E860 intface_load_
+// 0x45E860 intface_load
 int interfaceLoad(File* stream)
 {
     if (gInterfaceBarWindow == -1) {
@@ -793,7 +793,7 @@ int interfaceLoad(File* stream)
     return 0;
 }
 
-// 0x45E988 intface_save_
+// 0x45E988 intface_save
 int interfaceSave(File* stream)
 {
     if (gInterfaceBarWindow == -1) {
@@ -810,7 +810,7 @@ int interfaceSave(File* stream)
 
 // NOTE: Inlined.
 //
-// 0x45E9E0 intface_hide_
+// 0x45E9E0 intface_hide
 void interfaceBarHide()
 {
     if (gInterfaceBarWindow != -1) {
@@ -828,7 +828,7 @@ void interfaceBarHide()
     indicatorBarRefresh();
 }
 
-// 0x45EA10 intface_show_
+// 0x45EA10 intface_show
 void interfaceBarShow()
 {
     if (gInterfaceBarWindow != -1) {
@@ -850,7 +850,7 @@ void interfaceBarShow()
     indicatorBarRefresh();
 }
 
-// 0x45EA64 intface_enable_
+// 0x45EA64 intface_enable
 void interfaceBarEnable()
 {
     if (!gInterfaceBarEnabled) {
@@ -873,7 +873,7 @@ void interfaceBarEnable()
     }
 }
 
-// 0x45EAFC intface_disable_
+// 0x45EAFC intface_disable
 void interfaceBarDisable()
 {
     if (gInterfaceBarEnabled) {
@@ -893,13 +893,13 @@ void interfaceBarDisable()
     }
 }
 
-// 0x45EB90 intface_is_enabled_
+// 0x45EB90 intface_is_enabled
 bool interfaceBarEnabled()
 {
     return gInterfaceBarEnabled;
 }
 
-// 0x45EB98 intface_redraw_
+// 0x45EB98 intface_redraw
 void interfaceBarRefresh()
 {
     if (gInterfaceBarWindow != -1) {
@@ -919,7 +919,7 @@ static int counterAnimationBaseDelayMs()
 
 // Render hit points.
 //
-// 0x45EBD8 intface_update_hit_points_
+// 0x45EBD8 intface_update_hit_points
 void interfaceRenderHitPoints(bool animate)
 {
     if (gInterfaceBarWindow == -1) {
@@ -993,7 +993,7 @@ void interfaceRenderHitPoints(bool animate)
 
 // Render armor class.
 //
-// 0x45EDA8 intface_update_ac_
+// 0x45EDA8 intface_update_ac
 void interfaceRenderArmorClass(bool animate)
 {
     int armorClass = critterGetStat(gDude, STAT_ARMOR_CLASS);
@@ -1008,7 +1008,7 @@ void interfaceRenderArmorClass(bool animate)
     gInterfaceLastRenderedArmorClass = armorClass;
 }
 
-// 0x45EE0C intface_update_move_points_
+// 0x45EE0C intface_update_move_points
 void interfaceRenderActionPoints(int actionPointsLeft, int bonusActionPoints)
 {
     ConstBuffer2D bulbFrmBuf {};
@@ -1057,7 +1057,7 @@ void interfaceRenderActionPoints(int actionPointsLeft, int bonusActionPoints)
     }
 }
 
-// 0x45EF6C intface_get_attack_
+// 0x45EF6C intface_get_attack
 int interfaceGetCurrentHitMode(int* hitMode, bool* aiming)
 {
     if (gInterfaceBarWindow == -1) {
@@ -1084,7 +1084,7 @@ int interfaceGetCurrentHitMode(int* hitMode, bool* aiming)
     return -1;
 }
 
-// 0x45EFEC intface_update_items_
+// 0x45EFEC intface_update_items
 int interfaceUpdateItems(bool animated, int leftItemAction, int rightItemAction)
 {
     if (isoIsDisabled()) {
@@ -1214,7 +1214,7 @@ int interfaceUpdateItems(bool animated, int leftItemAction, int rightItemAction)
     return 0;
 }
 
-// 0x45F404 intface_toggle_items_
+// 0x45F404 intface_toggle_items
 int interfaceBarSwapHands(bool animated)
 {
     if (gInterfaceBarWindow == -1) {
@@ -1245,7 +1245,7 @@ int interfaceBarSwapHands(bool animated)
     return 0;
 }
 
-// 0x45F4B4 intface_get_item_states_
+// 0x45F4B4 intface_get_item_states
 int interfaceGetItemActions(int* leftItemAction, int* rightItemAction)
 {
     *leftItemAction = gInterfaceItemStates[HAND_LEFT].action;
@@ -1253,7 +1253,7 @@ int interfaceGetItemActions(int* leftItemAction, int* rightItemAction)
     return 0;
 }
 
-// 0x45F4E0 intface_toggle_item_state_
+// 0x45F4E0 intface_toggle_item_state
 int interfaceCycleItemAction()
 {
     if (gInterfaceBarWindow == -1) {
@@ -1310,7 +1310,7 @@ int interfaceCycleItemAction()
     return 0;
 }
 
-// 0x45F5EC intface_use_item_
+// 0x45F5EC intface_use_item
 void _intface_use_item()
 {
     if (gInterfaceBarWindow == -1) {
@@ -1371,13 +1371,13 @@ void _intface_use_item()
     }
 }
 
-// 0x45F7FC intface_is_item_right_hand_
+// 0x45F7FC intface_is_item_right_hand
 int interfaceGetCurrentHand()
 {
     return gInterfaceCurrentHand;
 }
 
-// 0x45F804 intface_get_current_item_
+// 0x45F804 intface_get_current_item
 int interfaceGetActiveItem(Object** itemPtr)
 {
     if (gInterfaceBarWindow == -1) {
@@ -1389,7 +1389,7 @@ int interfaceGetActiveItem(Object** itemPtr)
     return 0;
 }
 
-// 0x45F838 intface_update_ammo_lights_
+// 0x45F838 intface_update_ammo_lights
 int _intface_update_ammo_lights()
 {
     if (gInterfaceBarWindow == -1) {
@@ -1426,7 +1426,7 @@ static int interfaceBarBaseDelayMs()
     return std::max(static_cast<int>(1000.0 / settings.ui.anim_speed), 100);
 }
 
-// 0x45F96C intface_end_window_open_
+// 0x45F96C intface_end_window_open
 void interfaceBarEndButtonsShow(bool animated)
 {
     if (gInterfaceBarWindow == -1) {
@@ -1483,7 +1483,7 @@ void interfaceBarEndButtonsShow(bool animated)
     interfaceBarEndButtonsRenderRedLights();
 }
 
-// 0x45FAC0 intface_end_window_close_
+// 0x45FAC0 intface_end_window_close
 void interfaceBarEndButtonsHide(bool animated)
 {
     if (gInterfaceBarWindow == -1) {
@@ -1540,7 +1540,7 @@ void interfaceBarEndButtonsHide(bool animated)
     gInterfaceBarEndButtonsIsVisible = false;
 }
 
-// 0x45FC04 intface_end_buttons_enable_
+// 0x45FC04 intface_end_buttons_enable
 void interfaceBarEndButtonsRenderGreenLights()
 {
     if (gInterfaceBarEndButtonsIsVisible) {
@@ -1560,7 +1560,7 @@ void interfaceBarEndButtonsRenderGreenLights()
     }
 }
 
-// 0x45FC98 intface_end_buttons_disable_
+// 0x45FC98 intface_end_buttons_disable
 void interfaceBarEndButtonsRenderRedLights()
 {
     if (gInterfaceBarEndButtonsIsVisible) {
@@ -1582,7 +1582,7 @@ void interfaceBarEndButtonsRenderRedLights()
 
 // NOTE: Inlined.
 //
-// 0x45FD2C intface_init_items_
+// 0x45FD2C intface_init_items
 static int intface_init_items()
 {
     // FIXME: For unknown reason these values initialized with -1. It's never
@@ -1593,7 +1593,7 @@ static int intface_init_items()
     return 0;
 }
 
-// 0x45FD88 intface_redraw_items_
+// 0x45FD88 intface_redraw_items
 static int interfaceBarRefreshMainAction()
 {
     if (gInterfaceBarWindow == -1) {
@@ -1836,21 +1836,21 @@ static void interfaceDrawActionButtonOverlay(unsigned char* data, int width, int
     }
 }
 
-// 0x460658 intface_redraw_items_callback_
+// 0x460658 intface_redraw_items_callback
 static int _intface_redraw_items_callback(Object* _, Object* __)
 {
     interfaceBarRefreshMainAction();
     return 0;
 }
 
-// 0x460660 intface_change_fid_callback_
+// 0x460660 intface_change_fid_callback
 static int _intface_change_fid_callback(Object* _, Object* __)
 {
     gInterfaceBarSwapHandsInProgress = false;
     return 0;
 }
 
-// 0x46066C intface_change_fid_animate_
+// 0x46066C intface_change_fid_animate
 static void interfaceBarSwapHandsAnimatePutAwayTakeOutSequence(int previousWeaponAnimationCode, int weaponAnimationCode)
 {
     gInterfaceBarSwapHandsInProgress = true;
@@ -1916,7 +1916,7 @@ static void interfaceBarSwapHandsAnimatePutAwayTakeOutSequence(int previousWeapo
     }
 }
 
-// 0x4607E0 intface_create_end_turn_button_
+// 0x4607E0 intface_create_end_turn_button
 static int endTurnButtonInit()
 {
     int fid;
@@ -1950,7 +1950,7 @@ static int endTurnButtonInit()
     return 0;
 }
 
-// 0x4608C4 intface_destroy_end_turn_button_
+// 0x4608C4 intface_destroy_end_turn_button
 static int endTurnButtonFree()
 {
     if (gInterfaceBarWindow == -1) {
@@ -1968,7 +1968,7 @@ static int endTurnButtonFree()
     return 0;
 }
 
-// 0x460940 intface_create_end_combat_button_
+// 0x460940 intface_create_end_combat_button
 static int endCombatButtonInit()
 {
     int fid;
@@ -2002,7 +2002,7 @@ static int endCombatButtonInit()
     return 0;
 }
 
-// 0x460A24 intface_destroy_end_combat_button_
+// 0x460A24 intface_destroy_end_combat_button
 static int endCombatButtonFree()
 {
     if (gInterfaceBarWindow == -1) {
@@ -2020,7 +2020,7 @@ static int endCombatButtonFree()
     return 0;
 }
 
-// 0x460AA0 intface_draw_ammo_lights_
+// 0x460AA0 intface_draw_ammo_lights
 static void interfaceUpdateAmmoBar(int x, int ratio)
 {
     if ((ratio & 1) != 0) {
@@ -2054,7 +2054,7 @@ static void interfaceUpdateAmmoBar(int x, int ratio)
     }
 }
 
-// 0x460B20 intface_item_reload_
+// 0x460B20 intface_item_reload
 static int _intface_item_reload()
 {
     if (gInterfaceBarWindow == -1) {
@@ -2100,7 +2100,7 @@ static void interfaceRenderCounterAnimationStep(unsigned char* src, unsigned cha
 // [previousValue] is only meaningful for animation.
 // [offset] = 0 - grey, 120 - yellow, 240 - red.
 //
-// 0x460BA0 intface_rotate_numbers_
+// 0x460BA0 intface_rotate_numbers
 static void interfaceRenderCounter(int x, int y, int previousValue, int value, int offset, int delay)
 {
     if (value > 999) {
@@ -2198,7 +2198,7 @@ static void interfaceRenderCounter(int x, int y, int previousValue, int value, i
 
 // NOTE: Inlined.
 //
-// 0x461128 intface_fatal_error_
+// 0x461128 intface_fatal_error
 static int intface_fatal_error(int rc)
 {
     interfaceFree();
@@ -2206,7 +2206,7 @@ static int intface_fatal_error(int rc)
     return rc;
 }
 
-// 0x461134 construct_box_bar_win_
+// 0x461134 construct_box_bar_win
 static int indicatorBarInit()
 {
     int oldFont = fontGetCurrent();
@@ -2292,7 +2292,7 @@ static int indicatorBarInit()
     return 0;
 }
 
-// 0x461454 deconstruct_box_bar_win_
+// 0x461454 deconstruct_box_bar_win
 static void interfaceBarFree()
 {
     if (gIndicatorBarWindow != -1) {
@@ -2311,7 +2311,7 @@ static void interfaceBarFree()
 
 // NOTE: This function is not referenced in the original code.
 //
-// 0x4614A0 reset_box_bar_win_
+// 0x4614A0 reset_box_bar_win
 static void indicatorBarReset()
 {
     if (gIndicatorBarWindow != -1) {
@@ -2324,7 +2324,7 @@ static void indicatorBarReset()
 
 // Updates indicator bar.
 //
-// 0x4614CC refresh_box_bar_win_
+// 0x4614CC refresh_box_bar_win
 int indicatorBarRefresh()
 {
     if (gInterfaceBarWindow != -1 && gIndicatorBarIsVisible && !gInterfaceBarHidden) {
@@ -2398,7 +2398,7 @@ int indicatorBarRefresh()
     return 0;
 }
 
-// 0x461624 bbox_comp_
+// 0x461624 bbox_comp
 static int indicatorBoxCompareByPosition(const void* a, const void* b)
 {
     int indicatorBox1 = *(int*)a;
@@ -2415,7 +2415,7 @@ static int indicatorBoxCompareByPosition(const void* a, const void* b)
 
 // Renders indicator boxes into the indicator bar window.
 //
-// 0x461648 draw_bboxes_
+// 0x461648 draw_bboxes
 static void indicatorBarRender(int count)
 {
     if (gIndicatorBarWindow == -1) {
@@ -2468,7 +2468,7 @@ static void indicatorBarRender(int count)
 // Returns `true` if indicator was added, or `false` if there is no available
 // space in the indicator bar.
 //
-// 0x4616F0 add_bar_box_
+// 0x4616F0 add_bar_box
 static bool indicatorBarAdd(int indicator)
 {
     for (int index = 0; index < INDICATOR_SLOTS_COUNT; index++) {
@@ -2483,7 +2483,7 @@ static bool indicatorBarAdd(int indicator)
     return false;
 }
 
-// 0x461740 enable_box_bar_win_
+// 0x461740 enable_box_bar_win
 bool indicatorBarShow()
 {
     bool oldIsVisible = gIndicatorBarIsVisible;
@@ -2494,7 +2494,7 @@ bool indicatorBarShow()
     return oldIsVisible;
 }
 
-// 0x461760 disable_box_bar_win_
+// 0x461760 disable_box_bar_win
 bool indicatorBarHide()
 {
     bool oldIsVisible = gIndicatorBarIsVisible;
@@ -2692,7 +2692,7 @@ static void sidePanelsDraw(const char* path, int win, bool isLeading)
 // differs from `interfaceGetCurrentHitMode` (can return one of `reload` hit
 // modes, the default is `punch`).
 //
-// 0x45EF6C intface_get_attack_
+// 0x45EF6C intface_get_attack
 bool interface_get_current_attack_mode(int* hit_mode)
 {
     if (gInterfaceBarWindow == -1) {

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -329,7 +329,7 @@ static Buffer2D apBarBackgroundBuf2D()
 }
 
 // intface_init
-// 0x45D880
+// 0x45D880 intface_init_
 int interfaceInit()
 {
     int fid;
@@ -619,7 +619,7 @@ int interfaceInit()
     return 0;
 }
 
-// 0x45E3D0
+// 0x45E3D0 intface_reset_
 void interfaceReset()
 {
     interfaceBarEnable();
@@ -636,7 +636,7 @@ void interfaceReset()
     gInterfaceCurrentHand = 0;
 }
 
-// 0x45E440
+// 0x45E440 intface_exit_
 void interfaceFree()
 {
     quickToolbarFree();
@@ -732,7 +732,7 @@ void interfaceFree()
     interfaceBarFree();
 }
 
-// 0x45E860
+// 0x45E860 intface_load_
 int interfaceLoad(File* stream)
 {
     if (gInterfaceBarWindow == -1) {
@@ -793,7 +793,7 @@ int interfaceLoad(File* stream)
     return 0;
 }
 
-// 0x45E988
+// 0x45E988 intface_save_
 int interfaceSave(File* stream)
 {
     if (gInterfaceBarWindow == -1) {
@@ -810,7 +810,7 @@ int interfaceSave(File* stream)
 
 // NOTE: Inlined.
 //
-// 0x45E9E0
+// 0x45E9E0 intface_hide_
 void interfaceBarHide()
 {
     if (gInterfaceBarWindow != -1) {
@@ -828,7 +828,7 @@ void interfaceBarHide()
     indicatorBarRefresh();
 }
 
-// 0x45EA10
+// 0x45EA10 intface_show_
 void interfaceBarShow()
 {
     if (gInterfaceBarWindow != -1) {
@@ -850,7 +850,7 @@ void interfaceBarShow()
     indicatorBarRefresh();
 }
 
-// 0x45EA64
+// 0x45EA64 intface_enable_
 void interfaceBarEnable()
 {
     if (!gInterfaceBarEnabled) {
@@ -873,7 +873,7 @@ void interfaceBarEnable()
     }
 }
 
-// 0x45EAFC
+// 0x45EAFC intface_disable_
 void interfaceBarDisable()
 {
     if (gInterfaceBarEnabled) {
@@ -893,13 +893,13 @@ void interfaceBarDisable()
     }
 }
 
-// 0x45EB90
+// 0x45EB90 intface_is_enabled_
 bool interfaceBarEnabled()
 {
     return gInterfaceBarEnabled;
 }
 
-// 0x45EB98
+// 0x45EB98 intface_redraw_
 void interfaceBarRefresh()
 {
     if (gInterfaceBarWindow != -1) {
@@ -919,7 +919,7 @@ static int counterAnimationBaseDelayMs()
 
 // Render hit points.
 //
-// 0x45EBD8
+// 0x45EBD8 intface_update_hit_points_
 void interfaceRenderHitPoints(bool animate)
 {
     if (gInterfaceBarWindow == -1) {
@@ -993,7 +993,7 @@ void interfaceRenderHitPoints(bool animate)
 
 // Render armor class.
 //
-// 0x45EDA8
+// 0x45EDA8 intface_update_ac_
 void interfaceRenderArmorClass(bool animate)
 {
     int armorClass = critterGetStat(gDude, STAT_ARMOR_CLASS);
@@ -1008,7 +1008,7 @@ void interfaceRenderArmorClass(bool animate)
     gInterfaceLastRenderedArmorClass = armorClass;
 }
 
-// 0x45EE0C
+// 0x45EE0C intface_update_move_points_
 void interfaceRenderActionPoints(int actionPointsLeft, int bonusActionPoints)
 {
     ConstBuffer2D bulbFrmBuf {};
@@ -1057,7 +1057,7 @@ void interfaceRenderActionPoints(int actionPointsLeft, int bonusActionPoints)
     }
 }
 
-// 0x45EF6C
+// 0x45EF6C intface_get_attack_
 int interfaceGetCurrentHitMode(int* hitMode, bool* aiming)
 {
     if (gInterfaceBarWindow == -1) {
@@ -1084,7 +1084,7 @@ int interfaceGetCurrentHitMode(int* hitMode, bool* aiming)
     return -1;
 }
 
-// 0x45EFEC
+// 0x45EFEC intface_update_items_
 int interfaceUpdateItems(bool animated, int leftItemAction, int rightItemAction)
 {
     if (isoIsDisabled()) {
@@ -1214,7 +1214,7 @@ int interfaceUpdateItems(bool animated, int leftItemAction, int rightItemAction)
     return 0;
 }
 
-// 0x45F404
+// 0x45F404 intface_toggle_items_
 int interfaceBarSwapHands(bool animated)
 {
     if (gInterfaceBarWindow == -1) {
@@ -1245,7 +1245,7 @@ int interfaceBarSwapHands(bool animated)
     return 0;
 }
 
-// 0x45F4B4
+// 0x45F4B4 intface_get_item_states_
 int interfaceGetItemActions(int* leftItemAction, int* rightItemAction)
 {
     *leftItemAction = gInterfaceItemStates[HAND_LEFT].action;
@@ -1253,7 +1253,7 @@ int interfaceGetItemActions(int* leftItemAction, int* rightItemAction)
     return 0;
 }
 
-// 0x45F4E0
+// 0x45F4E0 intface_toggle_item_state_
 int interfaceCycleItemAction()
 {
     if (gInterfaceBarWindow == -1) {
@@ -1310,7 +1310,7 @@ int interfaceCycleItemAction()
     return 0;
 }
 
-// 0x45F5EC
+// 0x45F5EC intface_use_item_
 void _intface_use_item()
 {
     if (gInterfaceBarWindow == -1) {
@@ -1371,13 +1371,13 @@ void _intface_use_item()
     }
 }
 
-// 0x45F7FC
+// 0x45F7FC intface_is_item_right_hand_
 int interfaceGetCurrentHand()
 {
     return gInterfaceCurrentHand;
 }
 
-// 0x45F804
+// 0x45F804 intface_get_current_item_
 int interfaceGetActiveItem(Object** itemPtr)
 {
     if (gInterfaceBarWindow == -1) {
@@ -1389,7 +1389,7 @@ int interfaceGetActiveItem(Object** itemPtr)
     return 0;
 }
 
-// 0x45F838
+// 0x45F838 intface_update_ammo_lights_
 int _intface_update_ammo_lights()
 {
     if (gInterfaceBarWindow == -1) {
@@ -1426,7 +1426,7 @@ static int interfaceBarBaseDelayMs()
     return std::max(static_cast<int>(1000.0 / settings.ui.anim_speed), 100);
 }
 
-// 0x45F96C
+// 0x45F96C intface_end_window_open_
 void interfaceBarEndButtonsShow(bool animated)
 {
     if (gInterfaceBarWindow == -1) {
@@ -1483,7 +1483,7 @@ void interfaceBarEndButtonsShow(bool animated)
     interfaceBarEndButtonsRenderRedLights();
 }
 
-// 0x45FAC0
+// 0x45FAC0 intface_end_window_close_
 void interfaceBarEndButtonsHide(bool animated)
 {
     if (gInterfaceBarWindow == -1) {
@@ -1540,7 +1540,7 @@ void interfaceBarEndButtonsHide(bool animated)
     gInterfaceBarEndButtonsIsVisible = false;
 }
 
-// 0x45FC04
+// 0x45FC04 intface_end_buttons_enable_
 void interfaceBarEndButtonsRenderGreenLights()
 {
     if (gInterfaceBarEndButtonsIsVisible) {
@@ -1560,7 +1560,7 @@ void interfaceBarEndButtonsRenderGreenLights()
     }
 }
 
-// 0x45FC98
+// 0x45FC98 intface_end_buttons_disable_
 void interfaceBarEndButtonsRenderRedLights()
 {
     if (gInterfaceBarEndButtonsIsVisible) {
@@ -1582,7 +1582,7 @@ void interfaceBarEndButtonsRenderRedLights()
 
 // NOTE: Inlined.
 //
-// 0x45FD2C
+// 0x45FD2C intface_init_items_
 static int intface_init_items()
 {
     // FIXME: For unknown reason these values initialized with -1. It's never
@@ -1593,7 +1593,7 @@ static int intface_init_items()
     return 0;
 }
 
-// 0x45FD88
+// 0x45FD88 intface_redraw_items_
 static int interfaceBarRefreshMainAction()
 {
     if (gInterfaceBarWindow == -1) {
@@ -1836,21 +1836,21 @@ static void interfaceDrawActionButtonOverlay(unsigned char* data, int width, int
     }
 }
 
-// 0x460658
+// 0x460658 intface_redraw_items_callback_
 static int _intface_redraw_items_callback(Object* _, Object* __)
 {
     interfaceBarRefreshMainAction();
     return 0;
 }
 
-// 0x460660
+// 0x460660 intface_change_fid_callback_
 static int _intface_change_fid_callback(Object* _, Object* __)
 {
     gInterfaceBarSwapHandsInProgress = false;
     return 0;
 }
 
-// 0x46066C
+// 0x46066C intface_change_fid_animate_
 static void interfaceBarSwapHandsAnimatePutAwayTakeOutSequence(int previousWeaponAnimationCode, int weaponAnimationCode)
 {
     gInterfaceBarSwapHandsInProgress = true;
@@ -1916,7 +1916,7 @@ static void interfaceBarSwapHandsAnimatePutAwayTakeOutSequence(int previousWeapo
     }
 }
 
-// 0x4607E0
+// 0x4607E0 intface_create_end_turn_button_
 static int endTurnButtonInit()
 {
     int fid;
@@ -1950,7 +1950,7 @@ static int endTurnButtonInit()
     return 0;
 }
 
-// 0x4608C4
+// 0x4608C4 intface_destroy_end_turn_button_
 static int endTurnButtonFree()
 {
     if (gInterfaceBarWindow == -1) {
@@ -1968,7 +1968,7 @@ static int endTurnButtonFree()
     return 0;
 }
 
-// 0x460940
+// 0x460940 intface_create_end_combat_button_
 static int endCombatButtonInit()
 {
     int fid;
@@ -2002,7 +2002,7 @@ static int endCombatButtonInit()
     return 0;
 }
 
-// 0x460A24
+// 0x460A24 intface_destroy_end_combat_button_
 static int endCombatButtonFree()
 {
     if (gInterfaceBarWindow == -1) {
@@ -2020,7 +2020,7 @@ static int endCombatButtonFree()
     return 0;
 }
 
-// 0x460AA0
+// 0x460AA0 intface_draw_ammo_lights_
 static void interfaceUpdateAmmoBar(int x, int ratio)
 {
     if ((ratio & 1) != 0) {
@@ -2054,7 +2054,7 @@ static void interfaceUpdateAmmoBar(int x, int ratio)
     }
 }
 
-// 0x460B20
+// 0x460B20 intface_item_reload_
 static int _intface_item_reload()
 {
     if (gInterfaceBarWindow == -1) {
@@ -2100,7 +2100,7 @@ static void interfaceRenderCounterAnimationStep(unsigned char* src, unsigned cha
 // [previousValue] is only meaningful for animation.
 // [offset] = 0 - grey, 120 - yellow, 240 - red.
 //
-// 0x460BA0
+// 0x460BA0 intface_rotate_numbers_
 static void interfaceRenderCounter(int x, int y, int previousValue, int value, int offset, int delay)
 {
     if (value > 999) {
@@ -2198,7 +2198,7 @@ static void interfaceRenderCounter(int x, int y, int previousValue, int value, i
 
 // NOTE: Inlined.
 //
-// 0x461128
+// 0x461128 intface_fatal_error_
 static int intface_fatal_error(int rc)
 {
     interfaceFree();
@@ -2206,7 +2206,7 @@ static int intface_fatal_error(int rc)
     return rc;
 }
 
-// 0x461134
+// 0x461134 construct_box_bar_win_
 static int indicatorBarInit()
 {
     int oldFont = fontGetCurrent();
@@ -2292,7 +2292,7 @@ static int indicatorBarInit()
     return 0;
 }
 
-// 0x461454
+// 0x461454 deconstruct_box_bar_win_
 static void interfaceBarFree()
 {
     if (gIndicatorBarWindow != -1) {
@@ -2311,7 +2311,7 @@ static void interfaceBarFree()
 
 // NOTE: This function is not referenced in the original code.
 //
-// 0x4614A0
+// 0x4614A0 reset_box_bar_win_
 static void indicatorBarReset()
 {
     if (gIndicatorBarWindow != -1) {
@@ -2324,7 +2324,7 @@ static void indicatorBarReset()
 
 // Updates indicator bar.
 //
-// 0x4614CC
+// 0x4614CC refresh_box_bar_win_
 int indicatorBarRefresh()
 {
     if (gInterfaceBarWindow != -1 && gIndicatorBarIsVisible && !gInterfaceBarHidden) {
@@ -2398,7 +2398,7 @@ int indicatorBarRefresh()
     return 0;
 }
 
-// 0x461624
+// 0x461624 bbox_comp_
 static int indicatorBoxCompareByPosition(const void* a, const void* b)
 {
     int indicatorBox1 = *(int*)a;
@@ -2415,7 +2415,7 @@ static int indicatorBoxCompareByPosition(const void* a, const void* b)
 
 // Renders indicator boxes into the indicator bar window.
 //
-// 0x461648
+// 0x461648 draw_bboxes_
 static void indicatorBarRender(int count)
 {
     if (gIndicatorBarWindow == -1) {
@@ -2468,7 +2468,7 @@ static void indicatorBarRender(int count)
 // Returns `true` if indicator was added, or `false` if there is no available
 // space in the indicator bar.
 //
-// 0x4616F0
+// 0x4616F0 add_bar_box_
 static bool indicatorBarAdd(int indicator)
 {
     for (int index = 0; index < INDICATOR_SLOTS_COUNT; index++) {
@@ -2483,7 +2483,7 @@ static bool indicatorBarAdd(int indicator)
     return false;
 }
 
-// 0x461740
+// 0x461740 enable_box_bar_win_
 bool indicatorBarShow()
 {
     bool oldIsVisible = gIndicatorBarIsVisible;
@@ -2494,7 +2494,7 @@ bool indicatorBarShow()
     return oldIsVisible;
 }
 
-// 0x461760
+// 0x461760 disable_box_bar_win_
 bool indicatorBarHide()
 {
     bool oldIsVisible = gIndicatorBarIsVisible;
@@ -2692,7 +2692,7 @@ static void sidePanelsDraw(const char* path, int win, bool isLeading)
 // differs from `interfaceGetCurrentHitMode` (can return one of `reload` hit
 // modes, the default is `punch`).
 //
-// 0x45EF6C
+// 0x45EF6C intface_get_attack_
 bool interface_get_current_attack_mode(int* hit_mode)
 {
     if (gInterfaceBarWindow == -1) {

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -247,7 +247,7 @@ static unsigned char _itemButtonDown[INTERFACE_ITEM_ACTION_BUTTON_WIDTH * INTERF
 // 0x59A2B4 itemButtonUp
 static unsigned char _itemButtonUp[INTERFACE_ITEM_ACTION_BUTTON_WIDTH * INTERFACE_ITEM_ACTION_BUTTON_HEIGHT];
 
-// 0x59D3F4 _interfaceBuffer
+// 0x59D3F4 interfaceBuffer
 static unsigned char* gInterfaceWindowBuffer;
 
 // Rectangle within Interface Bar window covering the Action Points bar.

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -196,7 +196,7 @@ char* _interpretMangleName(char* s)
     return interpreterFilenameMangler(s);
 }
 
-// 0x4670C0 (unused)
+// 0x4670C0 outputStr_ (unused)
 static int outputString(const char*)
 {
     return 1;

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -142,16 +142,16 @@ int _TimeOut = 0;
 // 0x51903C enabled
 static bool interpreterEnabled = true;
 
-// 0x519040 _timerFunc
+// 0x519040 timerFunc
 static InterpretTimerFunc* interpreterTimerFunc = _defaultTimerFunc;
 
 // 0x519044 timerTick
 static unsigned int interpreterTimerTick = 1000;
 
-// 0x519048 _filenameFunc
+// 0x519048 filenameFunc
 static char* (*interpreterFilenameMangler)(char*) = defaultFilename;
 
-// 0x51904C _outputFunc
+// 0x51904C outputFunc
 static int (*interpreterOutputFunc)(const char*) = outputString;
 
 // 0x519050 cpuBurstSize
@@ -160,10 +160,10 @@ static int interpreterCpuBurstSize = 10;
 // 0x59E230 opTable
 OpcodeHandler* gInterpreterOpcodeHandlers[OPCODE_MAX_COUNT];
 
-// 0x59E78C _currentProgram
+// 0x59E78C currentProgram
 static Program* gInterpreterCurrentProgram;
 
-// 0x59E790 _head
+// 0x59E790 head
 static ProgramListNode* gInterpreterProgramListHead;
 
 // 0x59E794 suspendEvents

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -132,44 +132,44 @@ static void interpreterPrintStats();
 
 constexpr int kDynamicStringsMaxBlockSize = 32766;
 
-// 0x50942C
+// 0x50942C aCouldnTFindPro
 static char interpreterMissingProcedureName[] = "<couldn't find proc>";
 
 // sayTimeoutMsg
-// 0x519038
+// 0x519038 TimeOut
 int _TimeOut = 0;
 
-// 0x51903C
+// 0x51903C enabled
 static bool interpreterEnabled = true;
 
-// 0x519040
+// 0x519040 _timerFunc
 static InterpretTimerFunc* interpreterTimerFunc = _defaultTimerFunc;
 
-// 0x519044
+// 0x519044 timerTick
 static unsigned int interpreterTimerTick = 1000;
 
-// 0x519048
+// 0x519048 _filenameFunc
 static char* (*interpreterFilenameMangler)(char*) = defaultFilename;
 
-// 0x51904C
+// 0x51904C _outputFunc
 static int (*interpreterOutputFunc)(const char*) = outputString;
 
-// 0x519050
+// 0x519050 cpuBurstSize
 static int interpreterCpuBurstSize = 10;
 
-// 0x59E230
+// 0x59E230 opTable
 OpcodeHandler* gInterpreterOpcodeHandlers[OPCODE_MAX_COUNT];
 
-// 0x59E78C
+// 0x59E78C _currentProgram
 static Program* gInterpreterCurrentProgram;
 
-// 0x59E790
+// 0x59E790 _head
 static ProgramListNode* gInterpreterProgramListHead;
 
-// 0x59E794
+// 0x59E794 suspendEvents
 static bool interpreterEventsSuspended;
 
-// 0x59E798
+// 0x59E798 busy
 static bool interpreterBusy;
 
 // 0x4670A0
@@ -196,7 +196,7 @@ char* _interpretMangleName(char* s)
     return interpreterFilenameMangler(s);
 }
 
-// 0x4670C0 outputStr_ (unused)
+// 0x4670C0 outputStr (unused)
 static int outputString(const char*)
 {
     return 1;

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -340,7 +340,7 @@ static char _aCritter[] = "<Critter>";
 // 0x453FC0 obj_on_screen_rect
 static Rect stru_453FC0 = { 0, 0, 640, 480 };
 
-// 0x518EC0 _dbg_error_strs
+// 0x518EC0 dbg_error_strs
 static const char* _dbg_error_strs[SCRIPT_ERROR_COUNT] = {
     "unimped",
     "obj is NULL",
@@ -353,7 +353,7 @@ static const char* _dbg_error_strs[SCRIPT_ERROR_COUNT] = {
 // 0x518F00 last_color
 static int _last_color = 1;
 
-// 0x518F04 _strName
+// 0x518F04 strName
 static char* _strName = _aCritter;
 
 // NOTE: This value is a little bit odd. It's used to handle 2 operations:

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -334,13 +334,13 @@ static void opTileGetObjectWithPid(Program* program);
 static void opGetObjectName(Program* program);
 static void opGetPcStat(Program* program);
 
-// 0x504B0C
+// 0x504B0C aCritter
 static char _aCritter[] = "<Critter>";
 
-// 0x453FC0
+// 0x453FC0 obj_on_screen_rect
 static Rect stru_453FC0 = { 0, 0, 640, 480 };
 
-// 0x518EC0
+// 0x518EC0 _dbg_error_strs
 static const char* _dbg_error_strs[SCRIPT_ERROR_COUNT] = {
     "unimped",
     "obj is NULL",
@@ -350,10 +350,10 @@ static const char* _dbg_error_strs[SCRIPT_ERROR_COUNT] = {
 
 // Last message type during op_float_msg sequential.
 //
-// 0x518F00
+// 0x518F00 last_color
 static int _last_color = 1;
 
-// 0x518F04
+// 0x518F04 _strName
 static char* _strName = _aCritter;
 
 // NOTE: This value is a little bit odd. It's used to handle 2 operations:
@@ -366,10 +366,10 @@ static char* _strName = _aCritter;
 // When used inside [opGameDialogReaction] this value contains specified
 // reaction (-1 - Good, 0 - Neutral, 1 - Bad).
 //
-// 0x5970D0
+// 0x5970D0 dialogue_mood
 static int gGameDialogReactionOrFidget;
 
-// 0x453FD0 dbg_error_
+// 0x453FD0 dbg_error
 static void scriptPredefinedError(Program* program, const char* name, int error)
 {
     char string[260];
@@ -379,7 +379,7 @@ static void scriptPredefinedError(Program* program, const char* name, int error)
     debugPrint(string);
 }
 
-// 0x45400C int_debug_
+// 0x45400C int_debug
 static void scriptError(const char* format, ...)
 {
     char string[260];
@@ -392,7 +392,7 @@ static void scriptError(const char* format, ...)
     debugPrint(string);
 }
 
-// 0x45404C scripts_tile_is_visible_
+// 0x45404C scripts_tile_is_visible
 static int tileIsVisible(int tile)
 {
     if (abs(gCenterTile - tile) % 200 < 5) {
@@ -406,7 +406,7 @@ static int tileIsVisible(int tile)
     return 0;
 }
 
-// 0x45409C correctFidForRemovedItem_
+// 0x45409C correctFidForRemovedItem
 static int _correctFidForRemovedItem(Object* critter, Object* item, int flags)
 {
     InvenSlot invenSlot = InvenSlot::Armor;
@@ -465,7 +465,7 @@ static int _correctFidForRemovedItem(Object* critter, Object* item, int flags)
 }
 
 // give_exp_points
-// 0x4541C8 op_give_exp_points_
+// 0x4541C8 op_give_exp_points
 static void opGiveExpPoints(Program* program)
 {
     int xp = programStackPopInteger(program);
@@ -476,7 +476,7 @@ static void opGiveExpPoints(Program* program)
 }
 
 // scr_return
-// 0x454238 op_scr_return_
+// 0x454238 op_scr_return
 static void opScrReturn(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -490,7 +490,7 @@ static void opScrReturn(Program* program)
 }
 
 // play_sfx
-// 0x4542AC op_play_sfx_
+// 0x4542AC op_play_sfx
 static void opPlaySfx(Program* program)
 {
     char* name = programStackPopString(program);
@@ -499,7 +499,7 @@ static void opPlaySfx(Program* program)
 }
 
 // set_map_start
-// 0x454314 op_set_map_start_
+// 0x454314 op_set_map_start
 static void opSetMapStart(Program* program)
 {
     int rotation = programStackPopInteger(program);
@@ -522,7 +522,7 @@ static void opSetMapStart(Program* program)
 }
 
 // override_map_start
-// 0x4543F4 op_override_map_start_
+// 0x4543F4 op_override_map_start
 static void opOverrideMapStart(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -560,7 +560,7 @@ static void opOverrideMapStart(Program* program)
 }
 
 // has_skill
-// 0x454568 op_has_skill_
+// 0x454568 op_has_skill
 static void opHasSkill(Program* program)
 {
     int skill = programStackPopInteger(program);
@@ -579,7 +579,7 @@ static void opHasSkill(Program* program)
 }
 
 // using_skill
-// 0x454634 op_using_skill_
+// 0x454634 op_using_skill
 static void opUsingSkill(Program* program)
 {
     int skill = programStackPopInteger(program);
@@ -598,7 +598,7 @@ static void opUsingSkill(Program* program)
 }
 
 // roll_vs_skill
-// 0x4546E8 op_roll_vs_skill_
+// 0x4546E8 op_roll_vs_skill
 static void opRollVsSkill(Program* program)
 {
     int modifier = programStackPopInteger(program);
@@ -623,7 +623,7 @@ static void opRollVsSkill(Program* program)
 }
 
 // skill_contest
-// 0x4547D4 op_skill_contest_
+// 0x4547D4 op_skill_contest
 static void opSkillContest(Program* program)
 {
     int data[3];
@@ -637,7 +637,7 @@ static void opSkillContest(Program* program)
 }
 
 // do_check
-// 0x454890 op_do_check_
+// 0x454890 op_do_check
 static void opDoCheck(Program* program)
 {
     int mod = programStackPopInteger(program);
@@ -673,7 +673,7 @@ static void opDoCheck(Program* program)
 }
 
 // is_success
-// 0x4549A8 op_is_success_
+// 0x4549A8 op_is_success
 static void opSuccess(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -695,7 +695,7 @@ static void opSuccess(Program* program)
 }
 
 // is_critical
-// 0x454A44 op_is_critical_
+// 0x454A44 op_is_critical
 static void opCritical(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -717,7 +717,7 @@ static void opCritical(Program* program)
 }
 
 // how_much
-// 0x454AD0 op_how_much_
+// 0x454AD0 op_how_much
 static void opHowMuch(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -737,7 +737,7 @@ static void opHowMuch(Program* program)
 }
 
 // mark_area_known
-// 0x454B6C op_mark_area_known_
+// 0x454B6C op_mark_area_known
 static void opMarkAreaKnown(Program* program)
 {
     int data[3];
@@ -760,7 +760,7 @@ static void opMarkAreaKnown(Program* program)
 }
 
 // reaction_influence
-// 0x454C34 op_reaction_influence_
+// 0x454C34 op_reaction_influence
 static void opReactionInfluence(Program* program)
 {
     int data[3];
@@ -774,7 +774,7 @@ static void opReactionInfluence(Program* program)
 }
 
 // random
-// 0x454CD4 op_random_
+// 0x454CD4 op_random
 static void opRandom(Program* program)
 {
     int data[2];
@@ -789,7 +789,7 @@ static void opRandom(Program* program)
 }
 
 // roll_dice
-// 0x454D88 op_roll_dice_
+// 0x454D88 op_roll_dice
 static void opRollDice(Program* program)
 {
     int data[2];
@@ -804,7 +804,7 @@ static void opRollDice(Program* program)
 }
 
 // move_to
-// 0x454E28 op_move_to_
+// 0x454E28 op_move_to
 static void opMoveTo(Program* program)
 {
     int elevation = programStackPopInteger(program);
@@ -863,7 +863,7 @@ static void opMoveTo(Program* program)
 }
 
 // create_object_sid
-// 0x454FA8 op_create_object_sid_
+// 0x454FA8 op_create_object_sid
 static void opCreateObject(Program* program)
 {
     int data[4];
@@ -951,7 +951,7 @@ out:
 }
 
 // destroy_object
-// 0x4551E4 op_destroy_object_
+// 0x4551E4 op_destroy_object
 static void opDestroyObject(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -1013,7 +1013,7 @@ static void opDestroyObject(Program* program)
 }
 
 // display_msg
-// 0x455388 op_display_msg_
+// 0x455388 op_display_msg
 static void opDisplayMsg(Program* program)
 {
     char* string = programStackPopString(program);
@@ -1026,7 +1026,7 @@ static void opDisplayMsg(Program* program)
 }
 
 // script_overrides
-// 0x455430 op_script_overrides_
+// 0x455430 op_script_overrides
 static void opScriptOverrides(Program* program)
 {
     int sid = scriptGetSid(program);
@@ -1040,7 +1040,7 @@ static void opScriptOverrides(Program* program)
 }
 
 // obj_is_carrying_obj_pid
-// 0x455470 op_obj_is_carrying_obj_pid_
+// 0x455470 op_obj_is_carrying_obj_pid
 static void opObjectIsCarryingObjectWithPid(Program* program)
 {
     int pid = programStackPopInteger(program);
@@ -1057,7 +1057,7 @@ static void opObjectIsCarryingObjectWithPid(Program* program)
 }
 
 // tile_contains_obj_pid
-// 0x455534 op_tile_contains_obj_pid_
+// 0x455534 op_tile_contains_obj_pid
 static void opTileContainsObjectWithPid(Program* program)
 {
     int pid = programStackPopInteger(program);
@@ -1079,7 +1079,7 @@ static void opTileContainsObjectWithPid(Program* program)
 }
 
 // self_obj
-// 0x455600 op_self_obj_
+// 0x455600 op_self_obj
 static void opGetSelf(Program* program)
 {
     Object* object = scriptGetSelf(program);
@@ -1087,7 +1087,7 @@ static void opGetSelf(Program* program)
 }
 
 // source_obj
-// 0x455624 op_source_obj_
+// 0x455624 op_source_obj
 static void opGetSource(Program* program)
 {
     Object* object = nullptr;
@@ -1105,7 +1105,7 @@ static void opGetSource(Program* program)
 }
 
 // target_obj
-// 0x455678 op_target_obj_
+// 0x455678 op_target_obj
 static void opGetTarget(Program* program)
 {
     Object* object = nullptr;
@@ -1123,7 +1123,7 @@ static void opGetTarget(Program* program)
 }
 
 // dude_obj
-// 0x4556CC op_dude_obj_
+// 0x4556CC op_dude_obj
 static void opGetDude(Program* program)
 {
     programStackPushPointer(program, gDude);
@@ -1132,7 +1132,7 @@ static void opGetDude(Program* program)
 // NOTE: The implementation is the same as in [opGetTarget].
 //
 // obj_being_used_with
-// 0x4556EC op_obj_being_used_with_
+// 0x4556EC op_obj_being_used_with
 static void opGetObjectBeingUsed(Program* program)
 {
     Object* object = nullptr;
@@ -1150,7 +1150,7 @@ static void opGetObjectBeingUsed(Program* program)
 }
 
 // local_var
-// 0x455740 op_local_var_
+// 0x455740 op_local_var
 static void opGetLocalVar(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -1166,7 +1166,7 @@ static void opGetLocalVar(Program* program)
 }
 
 // set_local_var
-// 0x4557C8 op_set_local_var_
+// 0x4557C8 op_set_local_var
 static void opSetLocalVar(Program* program)
 {
     ProgramValue value = programStackPopValue(program);
@@ -1177,7 +1177,7 @@ static void opSetLocalVar(Program* program)
 }
 
 // map_var
-// 0x455858 op_map_var_
+// 0x455858 op_map_var
 static void opGetMapVar(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -1192,7 +1192,7 @@ static void opGetMapVar(Program* program)
 }
 
 // set_map_var
-// 0x4558C8 op_set_map_var_
+// 0x4558C8 op_set_map_var
 static void opSetMapVar(Program* program)
 {
     ProgramValue value = programStackPopValue(program);
@@ -1202,7 +1202,7 @@ static void opSetMapVar(Program* program)
 }
 
 // global_var
-// 0x455950 op_global_var_
+// 0x455950 op_global_var
 static void opGetGlobalVar(Program* program)
 {
     int variable = programStackPopInteger(program);
@@ -1221,7 +1221,7 @@ static void opGetGlobalVar(Program* program)
 }
 
 // set_global_var
-// 0x4559EC op_set_global_var_
+// 0x4559EC op_set_global_var
 // 0x80C6
 static void opSetGlobalVar(Program* program)
 {
@@ -1242,7 +1242,7 @@ static void opSetGlobalVar(Program* program)
 }
 
 // script_action
-// 0x455A90 op_script_action_
+// 0x455A90 op_script_action
 static void opGetScriptAction(Program* program)
 {
     int action = 0;
@@ -1260,7 +1260,7 @@ static void opGetScriptAction(Program* program)
 }
 
 // obj_type
-// 0x455AE4 op_obj_type_
+// 0x455AE4 op_obj_type
 static void opGetObjectType(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -1274,7 +1274,7 @@ static void opGetObjectType(Program* program)
 }
 
 // obj_item_subtype
-// 0x455B6C op_obj_item_subtype_
+// 0x455B6C op_obj_item_subtype
 static void opGetItemType(Program* program)
 {
     Object* obj = static_cast<Object*>(programStackPopPointer(program));
@@ -1293,7 +1293,7 @@ static void opGetItemType(Program* program)
 }
 
 // get_critter_stat
-// 0x455C10 op_get_critter_stat_
+// 0x455C10 op_get_critter_stat
 static void opGetCritterStat(Program* program)
 {
     int stat = programStackPopInteger(program);
@@ -1313,7 +1313,7 @@ static void opGetCritterStat(Program* program)
 // it's last argument is amount of adjustment, not it's final value.
 //
 // set_critter_stat
-// 0x455CCC op_set_critter_stat_
+// 0x455CCC op_set_critter_stat
 static void opSetCritterStat(Program* program)
 {
     int value = programStackPopInteger(program);
@@ -1339,7 +1339,7 @@ static void opSetCritterStat(Program* program)
 }
 
 // animate_stand_obj
-// 0x455DC8 op_animate_stand_obj_
+// 0x455DC8 op_animate_stand_obj
 static void opAnimateStand(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -1363,7 +1363,7 @@ static void opAnimateStand(Program* program)
 }
 
 // animate_stand_reverse_obj
-// 0x455E7C op_animate_stand_reverse_obj_
+// 0x455E7C op_animate_stand_reverse_obj
 static void opAnimateStandReverse(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -1387,7 +1387,7 @@ static void opAnimateStandReverse(Program* program)
 }
 
 // animate_move_obj_to_tile
-// 0x455F30 op_animate_move_obj_to_tile_
+// 0x455F30 op_animate_move_obj_to_tile
 static void opAnimateMoveObjectToTile(Program* program)
 {
     int flags = programStackPopInteger(program);
@@ -1436,7 +1436,7 @@ static void opAnimateMoveObjectToTile(Program* program)
 }
 
 // tile_in_tile_rect
-// 0x45607C op_tile_in_tile_rect_
+// 0x45607C op_tile_in_tile_rect
 static void opTileInTileRect(Program* program)
 {
     Point points[5];
@@ -1472,7 +1472,7 @@ static void opMakeDayTime(Program* program)
 }
 
 // tile_distance
-// 0x456174 op_tile_distance_
+// 0x456174 op_tile_distance
 static void opTileDistanceBetween(Program* program)
 {
     int tile2 = programStackPopInteger(program);
@@ -1490,7 +1490,7 @@ static void opTileDistanceBetween(Program* program)
 }
 
 // tile_distance_objs
-// 0x456228 op_tile_distance_objs_
+// 0x456228 op_tile_distance_objs
 static void opTileDistanceBetweenObjects(Program* program)
 {
     Object* object2 = static_cast<Object*>(programStackPopPointer(program));
@@ -1514,7 +1514,7 @@ static void opTileDistanceBetweenObjects(Program* program)
 }
 
 // tile_num
-// 0x456324 op_tile_num_
+// 0x456324 op_tile_num
 static void opGetObjectTile(Program* program)
 {
     Object* obj = static_cast<Object*>(programStackPopPointer(program));
@@ -1530,7 +1530,7 @@ static void opGetObjectTile(Program* program)
 }
 
 // tile_num_in_direction
-// 0x4563B4 op_tile_num_in_direction_
+// 0x4563B4 op_tile_num_in_direction
 static void opGetTileInDirection(Program* program)
 {
     int distance = programStackPopInteger(program);
@@ -1561,7 +1561,7 @@ static void opGetTileInDirection(Program* program)
 }
 
 // pickup_obj
-// 0x4564D4 op_pickup_obj_
+// 0x4564D4 op_pickup_obj
 static void opPickup(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -1597,7 +1597,7 @@ static void opPickup(Program* program)
 }
 
 // drop_obj
-// 0x456580 op_drop_obj_
+// 0x456580 op_drop_obj
 static void opDrop(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -1625,7 +1625,7 @@ static void opDrop(Program* program)
 }
 
 // add_obj_to_inven
-// 0x45662C op_add_obj_to_inven_
+// 0x45662C op_add_obj_to_inven
 static void opAddObjectToInventory(Program* program)
 {
     Object* item = static_cast<Object*>(programStackPopPointer(program));
@@ -1648,7 +1648,7 @@ static void opAddObjectToInventory(Program* program)
 }
 
 // rm_obj_from_inven
-// 0x456708 op_rm_obj_from_inven_
+// 0x456708 op_rm_obj_from_inven
 static void opRemoveObjectFromInventory(Program* program)
 {
     Object* item = static_cast<Object*>(programStackPopPointer(program));
@@ -1689,7 +1689,7 @@ static void opRemoveObjectFromInventory(Program* program)
 }
 
 // wield_obj_critter
-// 0x45681C op_wield_obj_critter_
+// 0x45681C op_wield_obj_critter
 static void opWieldItem(Program* program)
 {
     Object* item = static_cast<Object*>(programStackPopPointer(program));
@@ -1750,7 +1750,7 @@ static void opWieldItem(Program* program)
 }
 
 // use_obj
-// 0x4569D0 op_use_obj_
+// 0x4569D0 op_use_obj
 static void opUseObject(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -1783,7 +1783,7 @@ static void opUseObject(Program* program)
 }
 
 // obj_can_see_obj
-// 0x456AC4 op_obj_can_see_obj_
+// 0x456AC4 op_obj_can_see_obj
 static void opObjectCanSeeObject(Program* program)
 {
     Object* object2 = static_cast<Object*>(programStackPopPointer(program));
@@ -1816,7 +1816,7 @@ static void opObjectCanSeeObject(Program* program)
 }
 
 // attack_complex
-// 0x456C00 op_attack_
+// 0x456C00 op_attack
 static void opAttackComplex(Program* program)
 {
     int data[8];
@@ -1896,7 +1896,7 @@ static void opAttackComplex(Program* program)
 }
 
 // start_gdialog
-// 0x456DF0 op_start_gdialog_
+// 0x456DF0 op_start_gdialog
 static void opStartGameDialog(Program* program)
 {
     int backgroundId = programStackPopInteger(program);
@@ -1951,7 +1951,7 @@ static void opStartGameDialog(Program* program)
 }
 
 // end_dialogue
-// 0x456F80 op_end_dialogue_
+// 0x456F80 op_end_dialogue
 static void opEndGameDialog(Program* program)
 {
     if (_gdialogExitFromScript() != -1) {
@@ -1961,7 +1961,7 @@ static void opEndGameDialog(Program* program)
 }
 
 // dialogue_reaction
-// 0x456FA4 op_dialogue_reaction_
+// 0x456FA4 op_dialogue_reaction
 static void opGameDialogReaction(Program* program)
 {
     int value = programStackPopInteger(program);
@@ -1971,7 +1971,7 @@ static void opGameDialogReaction(Program* program)
 }
 
 // metarule3
-// 0x457110 op_metarule3_
+// 0x457110 op_metarule3
 static void opMetarule3(Program* program)
 {
     ProgramValue param3 = programStackPopValue(program);
@@ -2067,7 +2067,7 @@ static void opMetarule3(Program* program)
 }
 
 // set_map_music
-// 0x45734C op_set_map_music_
+// 0x45734C op_set_map_music
 static void opSetMapMusic(Program* program)
 {
     char* string = programStackPopString(program);
@@ -2083,7 +2083,7 @@ static void opSetMapMusic(Program* program)
 //
 //
 // set_obj_visibility
-// 0x45741C op_set_obj_visibility_
+// 0x45741C op_set_obj_visibility
 static void opSetObjectVisibility(Program* program)
 {
     int invisible = programStackPopInteger(program);
@@ -2130,7 +2130,7 @@ static void opSetObjectVisibility(Program* program)
 }
 
 // load_map
-// 0x45755C op_load_map_
+// 0x45755C op_load_map
 static void opLoadMap(Program* program)
 {
     int param = programStackPopInteger(program);
@@ -2169,7 +2169,7 @@ static void opLoadMap(Program* program)
 }
 
 // wm_area_set_pos
-// 0x457680 op_wm_area_set_pos_
+// 0x457680 op_wm_area_set_pos
 static void opWorldmapCitySetPos(Program* program)
 {
     int y = programStackPopInteger(program);
@@ -2183,7 +2183,7 @@ static void opWorldmapCitySetPos(Program* program)
 }
 
 // set_exit_grids
-// 0x457730 op_set_exit_grids_
+// 0x457730 op_set_exit_grids
 static void opSetExitGrids(Program* program)
 {
     int destinationRotation = programStackPopInteger(program);
@@ -2204,7 +2204,7 @@ static void opSetExitGrids(Program* program)
 }
 
 // anim_busy
-// 0x4577EC op_anim_busy_
+// 0x4577EC op_anim_busy
 static void opAnimBusy(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -2220,7 +2220,7 @@ static void opAnimBusy(Program* program)
 }
 
 // critter_heal
-// 0x457880 op_critter_heal_
+// 0x457880 op_critter_heal
 static void opCritterHeal(Program* program)
 {
     int amount = programStackPopInteger(program);
@@ -2236,7 +2236,7 @@ static void opCritterHeal(Program* program)
 }
 
 // set_light_level
-// 0x457934 op_set_light_level_
+// 0x457934 op_set_light_level
 static void opSetLightLevel(Program* program)
 {
     // Maps light level to light intensity.
@@ -2272,7 +2272,7 @@ static void opSetLightLevel(Program* program)
 }
 
 // game_time
-// 0x4579F4 op_game_time_
+// 0x4579F4 op_game_time
 static void opGetGameTime(Program* program)
 {
     int time = gameTimeGetTime();
@@ -2280,7 +2280,7 @@ static void opGetGameTime(Program* program)
 }
 
 // game_time_in_seconds
-// 0x457A18 op_game_time_in_seconds_
+// 0x457A18 op_game_time_in_seconds
 static void opGetGameTimeInSeconds(Program* program)
 {
     int time = gameTimeGetTime();
@@ -2288,7 +2288,7 @@ static void opGetGameTimeInSeconds(Program* program)
 }
 
 // elevation
-// 0x457A44 op_elevation_
+// 0x457A44 op_elevation
 static void opGetObjectElevation(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -2304,7 +2304,7 @@ static void opGetObjectElevation(Program* program)
 }
 
 // kill_critter
-// 0x457AD4 op_kill_critter_
+// 0x457AD4 op_kill_critter
 static void opKillCritter(Program* program)
 {
     int deathFrame = programStackPopInteger(program);
@@ -2367,7 +2367,7 @@ static int _correctDeath(Object* critter, int anim, bool forceBack)
 }
 
 // kill_critter_type
-// 0x457CB4 op_kill_critter_type_
+// 0x457CB4 op_kill_critter_type
 static void opKillCritterType(Program* program)
 {
     // 0x518ED0
@@ -2474,7 +2474,7 @@ static void opKillCritterType(Program* program)
 }
 
 // critter_dmg
-// 0x457EB4 op_critter_damage_
+// 0x457EB4 op_critter_damage
 static void opCritterDamage(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -2512,7 +2512,7 @@ static void opCritterDamage(Program* program)
 }
 
 // add_timer_event
-// 0x457FF0 op_add_timer_event_
+// 0x457FF0 op_add_timer_event
 static void opAddTimerEvent(Program* program)
 {
     int param = programStackPopInteger(program);
@@ -2528,7 +2528,7 @@ static void opAddTimerEvent(Program* program)
 }
 
 // rm_timer_event
-// 0x458094 op_rm_timer_event_
+// 0x458094 op_rm_timer_event
 static void opRemoveTimerEvent(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -2545,7 +2545,7 @@ static void opRemoveTimerEvent(Program* program)
 // Converts seconds into game ticks.
 //
 // game_ticks
-// 0x458108 op_game_ticks_
+// 0x458108 op_game_ticks
 static void opGameTicks(Program* program)
 {
     int ticks = programStackPopInteger(program);
@@ -2562,7 +2562,7 @@ static void opGameTicks(Program* program)
 // information of the critters using passed parameters. It's like "metarule" but
 // for critters.
 //
-// 0x458180 op_has_trait_
+// 0x458180 op_has_trait
 // has_trait
 static void opHasTrait(Program* program)
 {
@@ -2623,7 +2623,7 @@ static void opHasTrait(Program* program)
 }
 
 // obj_can_hear_obj
-// 0x45835C op_obj_can_hear_obj_
+// 0x45835C op_obj_can_hear_obj
 static void opObjectCanHearObject(Program* program)
 {
     Object* object2 = static_cast<Object*>(programStackPopPointer(program));
@@ -2648,7 +2648,7 @@ static void opObjectCanHearObject(Program* program)
 }
 
 // game_time_hour
-// 0x458438 op_game_time_hour_
+// 0x458438 op_game_time_hour
 static void opGameTimeHour(Program* program)
 {
     int value = gameTimeGetHour();
@@ -2656,7 +2656,7 @@ static void opGameTimeHour(Program* program)
 }
 
 // fixed_param
-// 0x45845C op_fixed_param_
+// 0x45845C op_fixed_param
 static void opGetFixedParam(Program* program)
 {
     int fixedParam = 0;
@@ -2674,7 +2674,7 @@ static void opGetFixedParam(Program* program)
 }
 
 // tile_is_visible
-// 0x4584B0 op_tile_is_visible_
+// 0x4584B0 op_tile_is_visible
 static void opTileIsVisible(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -2688,7 +2688,7 @@ static void opTileIsVisible(Program* program)
 }
 
 // dialogue_system_enter
-// 0x458534 op_dialogue_system_enter_
+// 0x458534 op_dialogue_system_enter
 static void opGameDialogSystemEnter(Program* program)
 {
     int sid = scriptGetSid(program);
@@ -2717,7 +2717,7 @@ static void opGameDialogSystemEnter(Program* program)
 }
 
 // action_being_used
-// 0x458594 op_action_being_used_
+// 0x458594 op_action_being_used
 static void opGetActionBeingUsed(Program* program)
 {
     int action = -1;
@@ -2735,7 +2735,7 @@ static void opGetActionBeingUsed(Program* program)
 }
 
 // critter_state
-// 0x4585E8 op_critter_state_
+// 0x4585E8 op_critter_state
 static void opGetCritterState(Program* program)
 {
     Object* critter = static_cast<Object*>(programStackPopPointer(program));
@@ -2764,7 +2764,7 @@ static void opGetCritterState(Program* program)
 }
 
 // game_time_advance
-// 0x4586C8 op_game_time_advance_
+// 0x4586C8 op_game_time_advance
 static void opGameTimeAdvance(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -2782,7 +2782,7 @@ static void opGameTimeAdvance(Program* program)
 }
 
 // radiation_inc
-// 0x458760 op_radiation_inc_
+// 0x458760 op_radiation_inc
 static void opRadiationIncrease(Program* program)
 {
     int amount = programStackPopInteger(program);
@@ -2797,7 +2797,7 @@ static void opRadiationIncrease(Program* program)
 }
 
 // radiation_dec
-// 0x458800 op_radiation_dec_
+// 0x458800 op_radiation_dec
 static void opRadiationDecrease(Program* program)
 {
     int amount = programStackPopInteger(program);
@@ -2815,7 +2815,7 @@ static void opRadiationDecrease(Program* program)
 }
 
 // critter_attempt_placement
-// 0x4588B4 op_critter_attempt_placement_
+// 0x4588B4 op_critter_attempt_placement
 static void opCritterAttemptPlacement(Program* program)
 {
     int elevation = programStackPopInteger(program);
@@ -2838,7 +2838,7 @@ static void opCritterAttemptPlacement(Program* program)
 }
 
 // obj_pid
-// 0x4589A0 op_obj_pid_
+// 0x4589A0 op_obj_pid
 static void opGetObjectPid(Program* program)
 {
     Object* obj = static_cast<Object*>(programStackPopPointer(program));
@@ -2854,7 +2854,7 @@ static void opGetObjectPid(Program* program)
 }
 
 // cur_map_index
-// 0x458A30 op_cur_map_index_
+// 0x458A30 op_cur_map_index
 static void opGetCurrentMap(Program* program)
 {
     int mapIndex = mapGetCurrentMap();
@@ -2862,7 +2862,7 @@ static void opGetCurrentMap(Program* program)
 }
 
 // critter_add_trait
-// 0x458A54 op_critter_add_trait_
+// 0x458A54 op_critter_add_trait
 static void opCritterAddTrait(Program* program)
 {
     int value = programStackPopInteger(program);
@@ -2932,7 +2932,7 @@ static void opCritterAddTrait(Program* program)
 }
 
 // critter_rm_trait
-// 0x458C2C op_critter_rm_trait_
+// 0x458C2C op_critter_rm_trait
 static void opCritterRemoveTrait(Program* program)
 {
     int value = programStackPopInteger(program);
@@ -2965,7 +2965,7 @@ static void opCritterRemoveTrait(Program* program)
 }
 
 // proto_data
-// 0x458D38 op_proto_data_
+// 0x458D38 op_proto_data
 static void opGetProtoData(Program* program)
 {
     int member = programStackPopInteger(program);
@@ -2988,7 +2988,7 @@ static void opGetProtoData(Program* program)
 }
 
 // message_str
-// 0x458E10 op_message_str_
+// 0x458E10 op_message_str
 static void opGetMessageString(Program* program)
 {
     // 0x518EFC
@@ -3012,7 +3012,7 @@ static void opGetMessageString(Program* program)
 }
 
 // critter_inven_obj
-// 0x458F00 op_critter_inven_obj_
+// 0x458F00 op_critter_inven_obj
 static void opCritterGetInventoryObject(Program* program)
 {
     int type = programStackPopInteger(program);
@@ -3063,7 +3063,7 @@ static void opCritterGetInventoryObject(Program* program)
 }
 
 // obj_set_light_level
-// 0x459088 op_obj_set_light_level_
+// 0x459088 op_obj_set_light_level
 static void opSetObjectLightLevel(Program* program)
 {
     int lightDistance = programStackPopInteger(program);
@@ -3089,14 +3089,14 @@ static void opSetObjectLightLevel(Program* program)
 }
 
 // world_map
-// 0x459170 op_world_map_
+// 0x459170 op_world_map
 static void opWorldmap(Program* program)
 {
     scriptsRequestWorldMap();
 }
 
 // inven_cmds
-// 0x459178 op_inven_cmds_
+// 0x459178 op_inven_cmds
 static void _op_inven_cmds(Program* program)
 {
     int index = programStackPopInteger(program);
@@ -3119,7 +3119,7 @@ static void _op_inven_cmds(Program* program)
 }
 
 // float_msg
-// 0x459280 op_float_msg_
+// 0x459280 op_float_msg
 static void opFloatMessage(Program* program)
 {
     int floatingMessageType = programStackPopInteger(program);
@@ -3206,7 +3206,7 @@ static void opFloatMessage(Program* program)
 }
 
 // metarule
-// 0x4594A0 op_metarule_
+// 0x4594A0 op_metarule
 static void opMetarule(Program* program)
 {
     ProgramValue param = programStackPopValue(program);
@@ -3361,7 +3361,7 @@ static void opMetarule(Program* program)
 }
 
 // anim
-// 0x4598BC op_anim_
+// 0x4598BC op_anim
 static void opAnim(Program* program)
 {
     ProgramValue frameValue = programStackPopValue(program);
@@ -3444,7 +3444,7 @@ static void opAnim(Program* program)
 }
 
 // obj_carrying_pid_obj
-// 0x459B5C op_obj_carrying_pid_obj_
+// 0x459B5C op_obj_carrying_pid_obj
 static void opObjectCarryingObjectByPid(Program* program)
 {
     int pid = programStackPopInteger(program);
@@ -3461,7 +3461,7 @@ static void opObjectCarryingObjectByPid(Program* program)
 }
 
 // reg_anim_func
-// 0x459C20 op_reg_anim_func_
+// 0x459C20 op_reg_anim_func
 static void opRegAnimFunc(Program* program)
 {
     ProgramValue param = programStackPopValue(program);
@@ -3483,7 +3483,7 @@ static void opRegAnimFunc(Program* program)
 }
 
 // reg_anim_animate
-// 0x459CD4 op_reg_anim_animate_
+// 0x459CD4 op_reg_anim_animate
 static void opRegAnimAnimate(Program* program)
 {
     int delay = programStackPopInteger(program);
@@ -3502,7 +3502,7 @@ static void opRegAnimAnimate(Program* program)
 }
 
 // reg_anim_animate_reverse
-// 0x459DC4 op_reg_anim_animate_reverse_
+// 0x459DC4 op_reg_anim_animate_reverse
 static void opRegAnimAnimateReverse(Program* program)
 {
     int delay = programStackPopInteger(program);
@@ -3519,7 +3519,7 @@ static void opRegAnimAnimateReverse(Program* program)
 }
 
 // reg_anim_obj_move_to_obj
-// 0x459E74 op_reg_anim_obj_move_to_obj_
+// 0x459E74 op_reg_anim_obj_move_to_obj
 static void opRegAnimObjectMoveToObject(Program* program)
 {
     int delay = programStackPopInteger(program);
@@ -3536,7 +3536,7 @@ static void opRegAnimObjectMoveToObject(Program* program)
 }
 
 // reg_anim_obj_run_to_obj
-// 0x459F28 op_reg_anim_obj_run_to_obj_
+// 0x459F28 op_reg_anim_obj_run_to_obj
 static void opRegAnimObjectRunToObject(Program* program)
 {
     int delay = programStackPopInteger(program);
@@ -3553,7 +3553,7 @@ static void opRegAnimObjectRunToObject(Program* program)
 }
 
 // reg_anim_obj_move_to_tile
-// 0x459FDC op_reg_anim_obj_move_to_tile_
+// 0x459FDC op_reg_anim_obj_move_to_tile
 static void opRegAnimObjectMoveToTile(Program* program)
 {
     int delay = programStackPopInteger(program);
@@ -3570,7 +3570,7 @@ static void opRegAnimObjectMoveToTile(Program* program)
 }
 
 // reg_anim_obj_run_to_tile
-// 0x45A094 op_reg_anim_obj_run_to_tile_
+// 0x45A094 op_reg_anim_obj_run_to_tile
 static void opRegAnimObjectRunToTile(Program* program)
 {
     int delay = programStackPopInteger(program);
@@ -3587,7 +3587,7 @@ static void opRegAnimObjectRunToTile(Program* program)
 }
 
 // play_gmovie
-// 0x45A14C op_play_gmovie_
+// 0x45A14C op_play_gmovie
 static void opPlayGameMovie(Program* program)
 {
     // 0x453F9C
@@ -3636,7 +3636,7 @@ static void opPlayGameMovie(Program* program)
 }
 
 // add_mult_objs_to_inven
-// 0x45A200 op_add_mult_objs_to_inven_
+// 0x45A200 op_add_mult_objs_to_inven
 static void opAddMultipleObjectsToInventory(Program* program)
 {
     int quantity = programStackPopInteger(program);
@@ -3662,7 +3662,7 @@ static void opAddMultipleObjectsToInventory(Program* program)
 }
 
 // rm_mult_objs_from_inven
-// 0x45A2D4 op_rm_mult_objs_from_inven_
+// 0x45A2D4 op_rm_mult_objs_from_inven
 static void opRemoveMultipleObjectsFromInventory(Program* program)
 {
     int quantityToRemove = programStackPopInteger(program);
@@ -3699,7 +3699,7 @@ static void opRemoveMultipleObjectsFromInventory(Program* program)
 }
 
 // get_month
-// 0x45A40C op_get_month_
+// 0x45A40C op_get_month
 static void opGetMonth(Program* program)
 {
     int month;
@@ -3709,7 +3709,7 @@ static void opGetMonth(Program* program)
 }
 
 // get_day
-// 0x45A43C op_get_day_
+// 0x45A43C op_get_day
 static void opGetDay(Program* program)
 {
     int day;
@@ -3719,7 +3719,7 @@ static void opGetDay(Program* program)
 }
 
 // explosion
-// 0x45A46C op_explosion_
+// 0x45A46C op_explosion
 static void opExplosion(Program* program)
 {
     int maxDamage = programStackPopInteger(program);
@@ -3740,7 +3740,7 @@ static void opExplosion(Program* program)
 }
 
 // days_since_visited
-// 0x45A528 op_days_since_visited_
+// 0x45A528 op_days_since_visited
 static void opGetDaysSinceLastVisit(Program* program)
 {
     int days;
@@ -3755,7 +3755,7 @@ static void opGetDaysSinceLastVisit(Program* program)
 }
 
 // gsay_start
-// 0x45A56C op_gsay_start_
+// 0x45A56C op_gsay_start
 static void _op_gsay_start(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -3769,7 +3769,7 @@ static void _op_gsay_start(Program* program)
 }
 
 // gsay_end
-// 0x45A5B0 op_gsay_end_
+// 0x45A5B0 op_gsay_end
 static void _op_gsay_end(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -3778,7 +3778,7 @@ static void _op_gsay_end(Program* program)
 }
 
 // gsay_reply
-// 0x45A5D4 op_gsay_reply_
+// 0x45A5D4 op_gsay_reply
 static void _op_gsay_reply(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -3799,7 +3799,7 @@ static void _op_gsay_reply(Program* program)
 }
 
 // gsay_option
-// 0x45A6C4 op_gsay_option_
+// 0x45A6C4 op_gsay_option
 static void _op_gsay_option(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -3836,7 +3836,7 @@ static void _op_gsay_option(Program* program)
 }
 
 // gsay_message
-// 0x45A8AC op_gsay_message_
+// 0x45A8AC op_gsay_message
 static void _op_gsay_message(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -3861,7 +3861,7 @@ static void _op_gsay_message(Program* program)
 }
 
 // giq_option
-// 0x45A9B4 op_giq_option_
+// 0x45A9B4 op_giq_option
 static void _op_giq_option(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -3914,7 +3914,7 @@ static void _op_giq_option(Program* program)
 }
 
 // poison
-// 0x45AB90 op_poison_
+// 0x45AB90 op_poison
 static void opPoison(Program* program)
 {
     int amount = programStackPopInteger(program);
@@ -3931,7 +3931,7 @@ static void opPoison(Program* program)
 }
 
 // get_poison
-// 0x45AC44 op_get_poison_
+// 0x45AC44 op_get_poison
 static void opGetPoison(Program* program)
 {
     Object* obj = static_cast<Object*>(programStackPopPointer(program));
@@ -3951,7 +3951,7 @@ static void opGetPoison(Program* program)
 }
 
 // party_add
-// 0x45ACF4 op_party_add_
+// 0x45ACF4 op_party_add
 static void opPartyAdd(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -3964,7 +3964,7 @@ static void opPartyAdd(Program* program)
 }
 
 // party_remove
-// 0x45AD68 op_party_remove_
+// 0x45AD68 op_party_remove
 static void opPartyRemove(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -3977,7 +3977,7 @@ static void opPartyRemove(Program* program)
 }
 
 // reg_anim_animate_forever
-// 0x45ADDC op_reg_anim_animate_forever_
+// 0x45ADDC op_reg_anim_animate_forever
 static void opRegAnimAnimateForever(Program* program)
 {
     int anim = programStackPopInteger(program);
@@ -3993,7 +3993,7 @@ static void opRegAnimAnimateForever(Program* program)
 }
 
 // critter_injure
-// 0x45AE8C op_critter_injure_
+// 0x45AE8C op_critter_injure
 static void opCritterInjure(Program* program)
 {
     int flags = programStackPopInteger(program);
@@ -4025,14 +4025,14 @@ static void opCritterInjure(Program* program)
 }
 
 // combat_is_initialized
-// 0x45AF7C op_combat_is_initialized_
+// 0x45AF7C op_combat_is_initialized
 static void opCombatIsInitialized(Program* program)
 {
     programStackPushInteger(program, isInCombat() ? 1 : 0);
 }
 
 // gdialog_barter
-// 0x45AFA0 op_gdialog_barter_
+// 0x45AFA0 op_gdialog_barter
 static void _op_gdialog_barter(Program* program)
 {
     int modifier = programStackPopInteger(program);
@@ -4043,14 +4043,14 @@ static void _op_gdialog_barter(Program* program)
 }
 
 // difficulty_level
-// 0x45B010 op_difficulty_level_
+// 0x45B010 op_difficulty_level
 static void opGetGameDifficulty(Program* program)
 {
     programStackPushInteger(program, settings.preferences.game_difficulty);
 }
 
 // running_burning_guy
-// 0x45B05C op_running_burning_guy_
+// 0x45B05C op_running_burning_guy
 static void opGetRunningBurningGuy(Program* program)
 {
     programStackPushInteger(program, static_cast<int>(settings.preferences.running_burning_guy));
@@ -4073,7 +4073,7 @@ static void _op_inven_unwield(Program* program)
 }
 
 // obj_is_locked
-// 0x45B0D8 op_obj_is_locked_
+// 0x45B0D8 op_obj_is_locked
 static void opObjectIsLocked(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -4089,7 +4089,7 @@ static void opObjectIsLocked(Program* program)
 }
 
 // obj_lock
-// 0x45B16C op_obj_lock_
+// 0x45B16C op_obj_lock
 static void opObjectLock(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -4102,7 +4102,7 @@ static void opObjectLock(Program* program)
 }
 
 // obj_unlock
-// 0x45B1E0 op_obj_unlock_
+// 0x45B1E0 op_obj_unlock
 static void opObjectUnlock(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -4115,7 +4115,7 @@ static void opObjectUnlock(Program* program)
 }
 
 // obj_is_open
-// 0x45B254 op_obj_is_open_
+// 0x45B254 op_obj_is_open
 static void opObjectIsOpen(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -4131,7 +4131,7 @@ static void opObjectIsOpen(Program* program)
 }
 
 // obj_open
-// 0x45B2E8 op_obj_open_
+// 0x45B2E8 op_obj_open
 static void opObjectOpen(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -4144,7 +4144,7 @@ static void opObjectOpen(Program* program)
 }
 
 // obj_close
-// 0x45B35C op_obj_close_
+// 0x45B35C op_obj_close
 static void opObjectClose(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -4157,28 +4157,28 @@ static void opObjectClose(Program* program)
 }
 
 // game_ui_disable
-// 0x45B3D0 op_game_ui_disable_
+// 0x45B3D0 op_game_ui_disable
 static void opGameUiDisable(Program* program)
 {
     gameUiDisable(0);
 }
 
 // game_ui_enable
-// 0x45B3D8 op_game_ui_enable_
+// 0x45B3D8 op_game_ui_enable
 static void opGameUiEnable(Program* program)
 {
     gameUiEnable();
 }
 
 // game_ui_is_disabled
-// 0x45B3E0 op_game_ui_is_disabled_
+// 0x45B3E0 op_game_ui_is_disabled
 static void opGameUiIsDisabled(Program* program)
 {
     programStackPushInteger(program, gameUiIsDisabled() ? 1 : 0);
 }
 
 // gfade_out
-// 0x45B404 op_gfade_out_
+// 0x45B404 op_gfade_out
 static void opGameFadeOut(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -4191,7 +4191,7 @@ static void opGameFadeOut(Program* program)
 }
 
 // gfade_in
-// 0x45B47C op_gfade_in_
+// 0x45B47C op_gfade_in
 static void opGameFadeIn(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -4204,7 +4204,7 @@ static void opGameFadeIn(Program* program)
 }
 
 // item_caps_total
-// 0x45B4F4 op_item_caps_total_
+// 0x45B4F4 op_item_caps_total
 static void opItemCapsTotal(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -4220,7 +4220,7 @@ static void opItemCapsTotal(Program* program)
 }
 
 // item_caps_adjust
-// 0x45B588 op_item_caps_adjust_
+// 0x45B588 op_item_caps_adjust
 static void opItemCapsAdjust(Program* program)
 {
     int amount = programStackPopInteger(program);
@@ -4261,7 +4261,7 @@ static void _op_anim_action_frame(Program* program)
 }
 
 // reg_anim_play_sfx
-// 0x45B740 op_reg_anim_play_sfx_
+// 0x45B740 op_reg_anim_play_sfx
 static void opRegAnimPlaySfx(Program* program)
 {
     int delay = programStackPopInteger(program);
@@ -4281,7 +4281,7 @@ static void opRegAnimPlaySfx(Program* program)
 }
 
 // critter_mod_skill
-// 0x45B840 op_critter_mod_skill_
+// 0x45B840 op_critter_mod_skill
 static void opCritterModifySkill(Program* program)
 {
     int points = programStackPopInteger(program);
@@ -4331,7 +4331,7 @@ static void opCritterModifySkill(Program* program)
 }
 
 // sfx_build_char_name
-// 0x45B9C4 op_sfx_build_char_name_
+// 0x45B9C4 op_sfx_build_char_name
 static void opSfxBuildCharName(Program* program)
 {
     int extra = programStackPopInteger(program);
@@ -4349,7 +4349,7 @@ static void opSfxBuildCharName(Program* program)
 }
 
 // sfx_build_ambient_name
-// 0x45BAA8 op_sfx_build_ambient_name_
+// 0x45BAA8 op_sfx_build_ambient_name
 static void opSfxBuildAmbientName(Program* program)
 {
     char* baseName = programStackPopString(program);
@@ -4360,7 +4360,7 @@ static void opSfxBuildAmbientName(Program* program)
 }
 
 // sfx_build_interface_name
-// 0x45BB54 op_sfx_build_interface_name_
+// 0x45BB54 op_sfx_build_interface_name
 static void opSfxBuildInterfaceName(Program* program)
 {
     char* baseName = programStackPopString(program);
@@ -4371,7 +4371,7 @@ static void opSfxBuildInterfaceName(Program* program)
 }
 
 // sfx_build_item_name
-// 0x45BC00 op_sfx_build_item_name_
+// 0x45BC00 op_sfx_build_item_name
 static void opSfxBuildItemName(Program* program)
 {
     const char* baseName = programStackPopString(program);
@@ -4382,7 +4382,7 @@ static void opSfxBuildItemName(Program* program)
 }
 
 // sfx_build_weapon_name
-// 0x45BCAC op_sfx_build_weapon_name_
+// 0x45BCAC op_sfx_build_weapon_name
 static void opSfxBuildWeaponName(Program* program)
 {
     Object* target = static_cast<Object*>(programStackPopPointer(program));
@@ -4396,7 +4396,7 @@ static void opSfxBuildWeaponName(Program* program)
 }
 
 // sfx_build_scenery_name
-// 0x45BD7C op_sfx_build_scenery_name_
+// 0x45BD7C op_sfx_build_scenery_name
 static void opSfxBuildSceneryName(Program* program)
 {
     int actionType = programStackPopInteger(program);
@@ -4409,7 +4409,7 @@ static void opSfxBuildSceneryName(Program* program)
 }
 
 // sfx_build_open_name
-// 0x45BE58 op_sfx_build_open_name_
+// 0x45BE58 op_sfx_build_open_name
 static void opSfxBuildOpenName(Program* program)
 {
     int action = programStackPopInteger(program);
@@ -4426,7 +4426,7 @@ static void opSfxBuildOpenName(Program* program)
 }
 
 // attack_setup
-// 0x45BF38 op_attack_setup_
+// 0x45BF38 op_attack_setup
 static void opAttackSetup(Program* program)
 {
     Object* defender = static_cast<Object*>(programStackPopPointer(program));
@@ -4477,7 +4477,7 @@ static void opAttackSetup(Program* program)
 }
 
 // destroy_mult_objs
-// 0x45C0E8 op_destroy_mult_objs_
+// 0x45C0E8 op_destroy_mult_objs
 static void opDestroyMultipleObjects(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -4537,7 +4537,7 @@ static void opDestroyMultipleObjects(Program* program)
 }
 
 // use_obj_on_obj
-// 0x45C290 op_use_obj_on_obj_
+// 0x45C290 op_use_obj_on_obj
 static void opUseObjectOnObject(Program* program)
 {
     Object* target = static_cast<Object*>(programStackPopPointer(program));
@@ -4579,7 +4579,7 @@ static void opUseObjectOnObject(Program* program)
 }
 
 // endgame_slideshow
-// 0x45C3B0 op_endgame_slideshow_
+// 0x45C3B0 op_endgame_slideshow
 static void opEndgameSlideshow(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -4588,7 +4588,7 @@ static void opEndgameSlideshow(Program* program)
 }
 
 // move_obj_inven_to_obj
-// 0x45C3D0 op_move_obj_inven_to_obj_
+// 0x45C3D0 op_move_obj_inven_to_obj
 static void opMoveObjectInventoryToObject(Program* program)
 {
     Object* object2 = static_cast<Object*>(programStackPopPointer(program));
@@ -4659,7 +4659,7 @@ static void opMoveObjectInventoryToObject(Program* program)
 }
 
 // endgame_movie
-// 0x45C54C op_endgame_movie_
+// 0x45C54C op_endgame_movie
 static void opEndgameMovie(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -4668,7 +4668,7 @@ static void opEndgameMovie(Program* program)
 }
 
 // obj_art_fid
-// 0x45C56C op_obj_art_fid_
+// 0x45C56C op_obj_art_fid
 static void opGetObjectFid(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -4684,7 +4684,7 @@ static void opGetObjectFid(Program* program)
 }
 
 // art_anim
-// 0x45C5F8 op_art_anim_
+// 0x45C5F8 op_art_anim
 static void opGetFidAnim(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -4692,7 +4692,7 @@ static void opGetFidAnim(Program* program)
 }
 
 // party_member_obj
-// 0x45C66C op_party_member_obj_
+// 0x45C66C op_party_member_obj
 static void opGetPartyMember(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -4702,7 +4702,7 @@ static void opGetPartyMember(Program* program)
 }
 
 // rotation_to_tile
-// 0x45C6DC op_rotation_to_tile_
+// 0x45C6DC op_rotation_to_tile
 static void opGetRotationToTile(Program* program)
 {
     int tile2 = programStackPopInteger(program);
@@ -4713,7 +4713,7 @@ static void opGetRotationToTile(Program* program)
 }
 
 // jam_lock
-// 0x45C778 op_jam_lock_
+// 0x45C778 op_jam_lock
 static void opJamLock(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -4722,7 +4722,7 @@ static void opJamLock(Program* program)
 }
 
 // gdialog_set_barter_mod
-// 0x45C7D4 op_gdialog_set_barter_mod_
+// 0x45C7D4 op_gdialog_set_barter_mod
 static void opGameDialogSetBarterMod(Program* program)
 {
     int modifier = programStackPopInteger(program);
@@ -4731,14 +4731,14 @@ static void opGameDialogSetBarterMod(Program* program)
 }
 
 // combat_difficulty
-// 0x45C830 op_combat_difficulty_
+// 0x45C830 op_combat_difficulty
 static void opGetCombatDifficulty(Program* program)
 {
     programStackPushInteger(program, settings.preferences.combat_difficulty);
 }
 
 // obj_on_screen
-// 0x45C878 op_obj_on_screen_
+// 0x45C878 op_obj_on_screen
 static void opObjectOnScreen(Program* program)
 {
     Rect rect;
@@ -4765,7 +4765,7 @@ static void opObjectOnScreen(Program* program)
 }
 
 // critter_is_fleeing
-// 0x45C93C op_critter_is_fleeing_
+// 0x45C93C op_critter_is_fleeing
 static void opCritterIsFleeing(Program* program)
 {
     Object* obj = static_cast<Object*>(programStackPopPointer(program));
@@ -4781,7 +4781,7 @@ static void opCritterIsFleeing(Program* program)
 }
 
 // critter_set_flee_state
-// 0x45C9DC op_critter_set_flee_state_
+// 0x45C9DC op_critter_set_flee_state
 static void opCritterSetFleeState(Program* program)
 {
     int fleeing = programStackPopInteger(program);
@@ -4799,7 +4799,7 @@ static void opCritterSetFleeState(Program* program)
 }
 
 // terminate_combat
-// 0x45CA84 op_terminate_combat_
+// 0x45CA84 op_terminate_combat
 static void opTerminateCombat(Program* program)
 {
     if (isInCombat()) {
@@ -4816,7 +4816,7 @@ static void opTerminateCombat(Program* program)
 }
 
 // debug_msg
-// 0x45CAC8 op_debug_msg_
+// 0x45CAC8 op_debug_msg
 static void opDebugMessage(Program* program)
 {
     char* string = programStackPopString(program);
@@ -4830,7 +4830,7 @@ static void opDebugMessage(Program* program)
 }
 
 // critter_stop_attacking
-// 0x45CB70 op_critter_stop_attacking_
+// 0x45CB70 op_critter_stop_attacking
 static void opCritterStopAttacking(Program* program)
 {
     Object* obj = static_cast<Object*>(programStackPopPointer(program));
@@ -4845,7 +4845,7 @@ static void opCritterStopAttacking(Program* program)
 }
 
 // tile_contains_pid_obj
-// 0x45CBF8 op_tile_contains_pid_obj_
+// 0x45CBF8 op_tile_contains_pid_obj
 static void opTileGetObjectWithPid(Program* program)
 {
     int pid = programStackPopInteger(program);
@@ -4868,7 +4868,7 @@ static void opTileGetObjectWithPid(Program* program)
 }
 
 // obj_name
-// 0x45CCC8 op_obj_name_
+// 0x45CCC8 op_obj_name
 static void opGetObjectName(Program* program)
 {
     Object* obj = static_cast<Object*>(programStackPopPointer(program));
@@ -4882,7 +4882,7 @@ static void opGetObjectName(Program* program)
 }
 
 // get_pc_stat
-// 0x45CD64 op_get_pc_stat_
+// 0x45CD64 op_get_pc_stat
 static void opGetPcStat(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -4897,7 +4897,7 @@ void _intExtraClose_()
     sfallOpcodesExit();
 }
 
-// 0x45CDD8 initIntExtra_
+// 0x45CDD8 initIntExtra
 void _initIntExtra()
 {
     interpreterRegisterOpcode(0x80A1, opGiveExpPoints); // op_give_exp_points

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -369,7 +369,7 @@ static char* _strName = _aCritter;
 // 0x5970D0
 static int gGameDialogReactionOrFidget;
 
-// 0x453FD0
+// 0x453FD0 dbg_error_
 static void scriptPredefinedError(Program* program, const char* name, int error)
 {
     char string[260];
@@ -379,7 +379,7 @@ static void scriptPredefinedError(Program* program, const char* name, int error)
     debugPrint(string);
 }
 
-// 0x45400C
+// 0x45400C int_debug_
 static void scriptError(const char* format, ...)
 {
     char string[260];
@@ -392,7 +392,7 @@ static void scriptError(const char* format, ...)
     debugPrint(string);
 }
 
-// 0x45404C
+// 0x45404C scripts_tile_is_visible_
 static int tileIsVisible(int tile)
 {
     if (abs(gCenterTile - tile) % 200 < 5) {
@@ -406,7 +406,7 @@ static int tileIsVisible(int tile)
     return 0;
 }
 
-// 0x45409C
+// 0x45409C correctFidForRemovedItem_
 static int _correctFidForRemovedItem(Object* critter, Object* item, int flags)
 {
     InvenSlot invenSlot = InvenSlot::Armor;
@@ -465,7 +465,7 @@ static int _correctFidForRemovedItem(Object* critter, Object* item, int flags)
 }
 
 // give_exp_points
-// 0x4541C8
+// 0x4541C8 op_give_exp_points_
 static void opGiveExpPoints(Program* program)
 {
     int xp = programStackPopInteger(program);
@@ -476,7 +476,7 @@ static void opGiveExpPoints(Program* program)
 }
 
 // scr_return
-// 0x454238
+// 0x454238 op_scr_return_
 static void opScrReturn(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -490,7 +490,7 @@ static void opScrReturn(Program* program)
 }
 
 // play_sfx
-// 0x4542AC
+// 0x4542AC op_play_sfx_
 static void opPlaySfx(Program* program)
 {
     char* name = programStackPopString(program);
@@ -499,7 +499,7 @@ static void opPlaySfx(Program* program)
 }
 
 // set_map_start
-// 0x454314
+// 0x454314 op_set_map_start_
 static void opSetMapStart(Program* program)
 {
     int rotation = programStackPopInteger(program);
@@ -522,7 +522,7 @@ static void opSetMapStart(Program* program)
 }
 
 // override_map_start
-// 0x4543F4
+// 0x4543F4 op_override_map_start_
 static void opOverrideMapStart(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -560,7 +560,7 @@ static void opOverrideMapStart(Program* program)
 }
 
 // has_skill
-// 0x454568
+// 0x454568 op_has_skill_
 static void opHasSkill(Program* program)
 {
     int skill = programStackPopInteger(program);
@@ -579,7 +579,7 @@ static void opHasSkill(Program* program)
 }
 
 // using_skill
-// 0x454634
+// 0x454634 op_using_skill_
 static void opUsingSkill(Program* program)
 {
     int skill = programStackPopInteger(program);
@@ -598,7 +598,7 @@ static void opUsingSkill(Program* program)
 }
 
 // roll_vs_skill
-// 0x4546E8
+// 0x4546E8 op_roll_vs_skill_
 static void opRollVsSkill(Program* program)
 {
     int modifier = programStackPopInteger(program);
@@ -623,7 +623,7 @@ static void opRollVsSkill(Program* program)
 }
 
 // skill_contest
-// 0x4547D4
+// 0x4547D4 op_skill_contest_
 static void opSkillContest(Program* program)
 {
     int data[3];
@@ -637,7 +637,7 @@ static void opSkillContest(Program* program)
 }
 
 // do_check
-// 0x454890
+// 0x454890 op_do_check_
 static void opDoCheck(Program* program)
 {
     int mod = programStackPopInteger(program);
@@ -673,7 +673,7 @@ static void opDoCheck(Program* program)
 }
 
 // is_success
-// 0x4549A8
+// 0x4549A8 op_is_success_
 static void opSuccess(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -695,7 +695,7 @@ static void opSuccess(Program* program)
 }
 
 // is_critical
-// 0x454A44
+// 0x454A44 op_is_critical_
 static void opCritical(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -717,7 +717,7 @@ static void opCritical(Program* program)
 }
 
 // how_much
-// 0x454AD0
+// 0x454AD0 op_how_much_
 static void opHowMuch(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -737,7 +737,7 @@ static void opHowMuch(Program* program)
 }
 
 // mark_area_known
-// 0x454B6C
+// 0x454B6C op_mark_area_known_
 static void opMarkAreaKnown(Program* program)
 {
     int data[3];
@@ -760,7 +760,7 @@ static void opMarkAreaKnown(Program* program)
 }
 
 // reaction_influence
-// 0x454C34
+// 0x454C34 op_reaction_influence_
 static void opReactionInfluence(Program* program)
 {
     int data[3];
@@ -774,7 +774,7 @@ static void opReactionInfluence(Program* program)
 }
 
 // random
-// 0x454CD4
+// 0x454CD4 op_random_
 static void opRandom(Program* program)
 {
     int data[2];
@@ -789,7 +789,7 @@ static void opRandom(Program* program)
 }
 
 // roll_dice
-// 0x454D88
+// 0x454D88 op_roll_dice_
 static void opRollDice(Program* program)
 {
     int data[2];
@@ -804,7 +804,7 @@ static void opRollDice(Program* program)
 }
 
 // move_to
-// 0x454E28
+// 0x454E28 op_move_to_
 static void opMoveTo(Program* program)
 {
     int elevation = programStackPopInteger(program);
@@ -863,7 +863,7 @@ static void opMoveTo(Program* program)
 }
 
 // create_object_sid
-// 0x454FA8
+// 0x454FA8 op_create_object_sid_
 static void opCreateObject(Program* program)
 {
     int data[4];
@@ -951,7 +951,7 @@ out:
 }
 
 // destroy_object
-// 0x4551E4
+// 0x4551E4 op_destroy_object_
 static void opDestroyObject(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -1013,7 +1013,7 @@ static void opDestroyObject(Program* program)
 }
 
 // display_msg
-// 0x455388
+// 0x455388 op_display_msg_
 static void opDisplayMsg(Program* program)
 {
     char* string = programStackPopString(program);
@@ -1026,7 +1026,7 @@ static void opDisplayMsg(Program* program)
 }
 
 // script_overrides
-// 0x455430
+// 0x455430 op_script_overrides_
 static void opScriptOverrides(Program* program)
 {
     int sid = scriptGetSid(program);
@@ -1040,7 +1040,7 @@ static void opScriptOverrides(Program* program)
 }
 
 // obj_is_carrying_obj_pid
-// 0x455470
+// 0x455470 op_obj_is_carrying_obj_pid_
 static void opObjectIsCarryingObjectWithPid(Program* program)
 {
     int pid = programStackPopInteger(program);
@@ -1057,7 +1057,7 @@ static void opObjectIsCarryingObjectWithPid(Program* program)
 }
 
 // tile_contains_obj_pid
-// 0x455534
+// 0x455534 op_tile_contains_obj_pid_
 static void opTileContainsObjectWithPid(Program* program)
 {
     int pid = programStackPopInteger(program);
@@ -1079,7 +1079,7 @@ static void opTileContainsObjectWithPid(Program* program)
 }
 
 // self_obj
-// 0x455600
+// 0x455600 op_self_obj_
 static void opGetSelf(Program* program)
 {
     Object* object = scriptGetSelf(program);
@@ -1087,7 +1087,7 @@ static void opGetSelf(Program* program)
 }
 
 // source_obj
-// 0x455624
+// 0x455624 op_source_obj_
 static void opGetSource(Program* program)
 {
     Object* object = nullptr;
@@ -1105,7 +1105,7 @@ static void opGetSource(Program* program)
 }
 
 // target_obj
-// 0x455678
+// 0x455678 op_target_obj_
 static void opGetTarget(Program* program)
 {
     Object* object = nullptr;
@@ -1123,7 +1123,7 @@ static void opGetTarget(Program* program)
 }
 
 // dude_obj
-// 0x4556CC
+// 0x4556CC op_dude_obj_
 static void opGetDude(Program* program)
 {
     programStackPushPointer(program, gDude);
@@ -1132,7 +1132,7 @@ static void opGetDude(Program* program)
 // NOTE: The implementation is the same as in [opGetTarget].
 //
 // obj_being_used_with
-// 0x4556EC
+// 0x4556EC op_obj_being_used_with_
 static void opGetObjectBeingUsed(Program* program)
 {
     Object* object = nullptr;
@@ -1150,7 +1150,7 @@ static void opGetObjectBeingUsed(Program* program)
 }
 
 // local_var
-// 0x455740
+// 0x455740 op_local_var_
 static void opGetLocalVar(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -1166,7 +1166,7 @@ static void opGetLocalVar(Program* program)
 }
 
 // set_local_var
-// 0x4557C8
+// 0x4557C8 op_set_local_var_
 static void opSetLocalVar(Program* program)
 {
     ProgramValue value = programStackPopValue(program);
@@ -1177,7 +1177,7 @@ static void opSetLocalVar(Program* program)
 }
 
 // map_var
-// 0x455858
+// 0x455858 op_map_var_
 static void opGetMapVar(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -1192,7 +1192,7 @@ static void opGetMapVar(Program* program)
 }
 
 // set_map_var
-// 0x4558C8
+// 0x4558C8 op_set_map_var_
 static void opSetMapVar(Program* program)
 {
     ProgramValue value = programStackPopValue(program);
@@ -1202,7 +1202,7 @@ static void opSetMapVar(Program* program)
 }
 
 // global_var
-// 0x455950
+// 0x455950 op_global_var_
 static void opGetGlobalVar(Program* program)
 {
     int variable = programStackPopInteger(program);
@@ -1221,7 +1221,7 @@ static void opGetGlobalVar(Program* program)
 }
 
 // set_global_var
-// 0x4559EC
+// 0x4559EC op_set_global_var_
 // 0x80C6
 static void opSetGlobalVar(Program* program)
 {
@@ -1242,7 +1242,7 @@ static void opSetGlobalVar(Program* program)
 }
 
 // script_action
-// 0x455A90
+// 0x455A90 op_script_action_
 static void opGetScriptAction(Program* program)
 {
     int action = 0;
@@ -1260,7 +1260,7 @@ static void opGetScriptAction(Program* program)
 }
 
 // obj_type
-// 0x455AE4
+// 0x455AE4 op_obj_type_
 static void opGetObjectType(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -1274,7 +1274,7 @@ static void opGetObjectType(Program* program)
 }
 
 // obj_item_subtype
-// 0x455B6C
+// 0x455B6C op_obj_item_subtype_
 static void opGetItemType(Program* program)
 {
     Object* obj = static_cast<Object*>(programStackPopPointer(program));
@@ -1293,7 +1293,7 @@ static void opGetItemType(Program* program)
 }
 
 // get_critter_stat
-// 0x455C10
+// 0x455C10 op_get_critter_stat_
 static void opGetCritterStat(Program* program)
 {
     int stat = programStackPopInteger(program);
@@ -1313,7 +1313,7 @@ static void opGetCritterStat(Program* program)
 // it's last argument is amount of adjustment, not it's final value.
 //
 // set_critter_stat
-// 0x455CCC
+// 0x455CCC op_set_critter_stat_
 static void opSetCritterStat(Program* program)
 {
     int value = programStackPopInteger(program);
@@ -1339,7 +1339,7 @@ static void opSetCritterStat(Program* program)
 }
 
 // animate_stand_obj
-// 0x455DC8
+// 0x455DC8 op_animate_stand_obj_
 static void opAnimateStand(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -1363,7 +1363,7 @@ static void opAnimateStand(Program* program)
 }
 
 // animate_stand_reverse_obj
-// 0x455E7C
+// 0x455E7C op_animate_stand_reverse_obj_
 static void opAnimateStandReverse(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -1387,7 +1387,7 @@ static void opAnimateStandReverse(Program* program)
 }
 
 // animate_move_obj_to_tile
-// 0x455F30
+// 0x455F30 op_animate_move_obj_to_tile_
 static void opAnimateMoveObjectToTile(Program* program)
 {
     int flags = programStackPopInteger(program);
@@ -1436,7 +1436,7 @@ static void opAnimateMoveObjectToTile(Program* program)
 }
 
 // tile_in_tile_rect
-// 0x45607C
+// 0x45607C op_tile_in_tile_rect_
 static void opTileInTileRect(Program* program)
 {
     Point points[5];
@@ -1472,7 +1472,7 @@ static void opMakeDayTime(Program* program)
 }
 
 // tile_distance
-// 0x456174
+// 0x456174 op_tile_distance_
 static void opTileDistanceBetween(Program* program)
 {
     int tile2 = programStackPopInteger(program);
@@ -1490,7 +1490,7 @@ static void opTileDistanceBetween(Program* program)
 }
 
 // tile_distance_objs
-// 0x456228
+// 0x456228 op_tile_distance_objs_
 static void opTileDistanceBetweenObjects(Program* program)
 {
     Object* object2 = static_cast<Object*>(programStackPopPointer(program));
@@ -1514,7 +1514,7 @@ static void opTileDistanceBetweenObjects(Program* program)
 }
 
 // tile_num
-// 0x456324
+// 0x456324 op_tile_num_
 static void opGetObjectTile(Program* program)
 {
     Object* obj = static_cast<Object*>(programStackPopPointer(program));
@@ -1530,7 +1530,7 @@ static void opGetObjectTile(Program* program)
 }
 
 // tile_num_in_direction
-// 0x4563B4
+// 0x4563B4 op_tile_num_in_direction_
 static void opGetTileInDirection(Program* program)
 {
     int distance = programStackPopInteger(program);
@@ -1561,7 +1561,7 @@ static void opGetTileInDirection(Program* program)
 }
 
 // pickup_obj
-// 0x4564D4
+// 0x4564D4 op_pickup_obj_
 static void opPickup(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -1597,7 +1597,7 @@ static void opPickup(Program* program)
 }
 
 // drop_obj
-// 0x456580
+// 0x456580 op_drop_obj_
 static void opDrop(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -1625,7 +1625,7 @@ static void opDrop(Program* program)
 }
 
 // add_obj_to_inven
-// 0x45662C
+// 0x45662C op_add_obj_to_inven_
 static void opAddObjectToInventory(Program* program)
 {
     Object* item = static_cast<Object*>(programStackPopPointer(program));
@@ -1648,7 +1648,7 @@ static void opAddObjectToInventory(Program* program)
 }
 
 // rm_obj_from_inven
-// 0x456708
+// 0x456708 op_rm_obj_from_inven_
 static void opRemoveObjectFromInventory(Program* program)
 {
     Object* item = static_cast<Object*>(programStackPopPointer(program));
@@ -1689,7 +1689,7 @@ static void opRemoveObjectFromInventory(Program* program)
 }
 
 // wield_obj_critter
-// 0x45681C
+// 0x45681C op_wield_obj_critter_
 static void opWieldItem(Program* program)
 {
     Object* item = static_cast<Object*>(programStackPopPointer(program));
@@ -1750,7 +1750,7 @@ static void opWieldItem(Program* program)
 }
 
 // use_obj
-// 0x4569D0
+// 0x4569D0 op_use_obj_
 static void opUseObject(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -1783,7 +1783,7 @@ static void opUseObject(Program* program)
 }
 
 // obj_can_see_obj
-// 0x456AC4
+// 0x456AC4 op_obj_can_see_obj_
 static void opObjectCanSeeObject(Program* program)
 {
     Object* object2 = static_cast<Object*>(programStackPopPointer(program));
@@ -1816,7 +1816,7 @@ static void opObjectCanSeeObject(Program* program)
 }
 
 // attack_complex
-// 0x456C00
+// 0x456C00 op_attack_
 static void opAttackComplex(Program* program)
 {
     int data[8];
@@ -1896,7 +1896,7 @@ static void opAttackComplex(Program* program)
 }
 
 // start_gdialog
-// 0x456DF0
+// 0x456DF0 op_start_gdialog_
 static void opStartGameDialog(Program* program)
 {
     int backgroundId = programStackPopInteger(program);
@@ -1951,7 +1951,7 @@ static void opStartGameDialog(Program* program)
 }
 
 // end_dialogue
-// 0x456F80
+// 0x456F80 op_end_dialogue_
 static void opEndGameDialog(Program* program)
 {
     if (_gdialogExitFromScript() != -1) {
@@ -1961,7 +1961,7 @@ static void opEndGameDialog(Program* program)
 }
 
 // dialogue_reaction
-// 0x456FA4
+// 0x456FA4 op_dialogue_reaction_
 static void opGameDialogReaction(Program* program)
 {
     int value = programStackPopInteger(program);
@@ -1971,7 +1971,7 @@ static void opGameDialogReaction(Program* program)
 }
 
 // metarule3
-// 0x457110
+// 0x457110 op_metarule3_
 static void opMetarule3(Program* program)
 {
     ProgramValue param3 = programStackPopValue(program);
@@ -2067,7 +2067,7 @@ static void opMetarule3(Program* program)
 }
 
 // set_map_music
-// 0x45734C
+// 0x45734C op_set_map_music_
 static void opSetMapMusic(Program* program)
 {
     char* string = programStackPopString(program);
@@ -2083,7 +2083,7 @@ static void opSetMapMusic(Program* program)
 //
 //
 // set_obj_visibility
-// 0x45741C
+// 0x45741C op_set_obj_visibility_
 static void opSetObjectVisibility(Program* program)
 {
     int invisible = programStackPopInteger(program);
@@ -2130,7 +2130,7 @@ static void opSetObjectVisibility(Program* program)
 }
 
 // load_map
-// 0x45755C
+// 0x45755C op_load_map_
 static void opLoadMap(Program* program)
 {
     int param = programStackPopInteger(program);
@@ -2169,7 +2169,7 @@ static void opLoadMap(Program* program)
 }
 
 // wm_area_set_pos
-// 0x457680
+// 0x457680 op_wm_area_set_pos_
 static void opWorldmapCitySetPos(Program* program)
 {
     int y = programStackPopInteger(program);
@@ -2183,7 +2183,7 @@ static void opWorldmapCitySetPos(Program* program)
 }
 
 // set_exit_grids
-// 0x457730
+// 0x457730 op_set_exit_grids_
 static void opSetExitGrids(Program* program)
 {
     int destinationRotation = programStackPopInteger(program);
@@ -2204,7 +2204,7 @@ static void opSetExitGrids(Program* program)
 }
 
 // anim_busy
-// 0x4577EC
+// 0x4577EC op_anim_busy_
 static void opAnimBusy(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -2220,7 +2220,7 @@ static void opAnimBusy(Program* program)
 }
 
 // critter_heal
-// 0x457880
+// 0x457880 op_critter_heal_
 static void opCritterHeal(Program* program)
 {
     int amount = programStackPopInteger(program);
@@ -2236,7 +2236,7 @@ static void opCritterHeal(Program* program)
 }
 
 // set_light_level
-// 0x457934
+// 0x457934 op_set_light_level_
 static void opSetLightLevel(Program* program)
 {
     // Maps light level to light intensity.
@@ -2272,7 +2272,7 @@ static void opSetLightLevel(Program* program)
 }
 
 // game_time
-// 0x4579F4
+// 0x4579F4 op_game_time_
 static void opGetGameTime(Program* program)
 {
     int time = gameTimeGetTime();
@@ -2280,7 +2280,7 @@ static void opGetGameTime(Program* program)
 }
 
 // game_time_in_seconds
-// 0x457A18
+// 0x457A18 op_game_time_in_seconds_
 static void opGetGameTimeInSeconds(Program* program)
 {
     int time = gameTimeGetTime();
@@ -2288,7 +2288,7 @@ static void opGetGameTimeInSeconds(Program* program)
 }
 
 // elevation
-// 0x457A44
+// 0x457A44 op_elevation_
 static void opGetObjectElevation(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -2304,7 +2304,7 @@ static void opGetObjectElevation(Program* program)
 }
 
 // kill_critter
-// 0x457AD4
+// 0x457AD4 op_kill_critter_
 static void opKillCritter(Program* program)
 {
     int deathFrame = programStackPopInteger(program);
@@ -2367,7 +2367,7 @@ static int _correctDeath(Object* critter, int anim, bool forceBack)
 }
 
 // kill_critter_type
-// 0x457CB4
+// 0x457CB4 op_kill_critter_type_
 static void opKillCritterType(Program* program)
 {
     // 0x518ED0
@@ -2474,7 +2474,7 @@ static void opKillCritterType(Program* program)
 }
 
 // critter_dmg
-// 0x457EB4
+// 0x457EB4 op_critter_damage_
 static void opCritterDamage(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -2512,7 +2512,7 @@ static void opCritterDamage(Program* program)
 }
 
 // add_timer_event
-// 0x457FF0
+// 0x457FF0 op_add_timer_event_
 static void opAddTimerEvent(Program* program)
 {
     int param = programStackPopInteger(program);
@@ -2528,7 +2528,7 @@ static void opAddTimerEvent(Program* program)
 }
 
 // rm_timer_event
-// 0x458094
+// 0x458094 op_rm_timer_event_
 static void opRemoveTimerEvent(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -2545,7 +2545,7 @@ static void opRemoveTimerEvent(Program* program)
 // Converts seconds into game ticks.
 //
 // game_ticks
-// 0x458108
+// 0x458108 op_game_ticks_
 static void opGameTicks(Program* program)
 {
     int ticks = programStackPopInteger(program);
@@ -2562,7 +2562,7 @@ static void opGameTicks(Program* program)
 // information of the critters using passed parameters. It's like "metarule" but
 // for critters.
 //
-// 0x458180
+// 0x458180 op_has_trait_
 // has_trait
 static void opHasTrait(Program* program)
 {
@@ -2623,7 +2623,7 @@ static void opHasTrait(Program* program)
 }
 
 // obj_can_hear_obj
-// 0x45835C
+// 0x45835C op_obj_can_hear_obj_
 static void opObjectCanHearObject(Program* program)
 {
     Object* object2 = static_cast<Object*>(programStackPopPointer(program));
@@ -2648,7 +2648,7 @@ static void opObjectCanHearObject(Program* program)
 }
 
 // game_time_hour
-// 0x458438
+// 0x458438 op_game_time_hour_
 static void opGameTimeHour(Program* program)
 {
     int value = gameTimeGetHour();
@@ -2656,7 +2656,7 @@ static void opGameTimeHour(Program* program)
 }
 
 // fixed_param
-// 0x45845C
+// 0x45845C op_fixed_param_
 static void opGetFixedParam(Program* program)
 {
     int fixedParam = 0;
@@ -2674,7 +2674,7 @@ static void opGetFixedParam(Program* program)
 }
 
 // tile_is_visible
-// 0x4584B0
+// 0x4584B0 op_tile_is_visible_
 static void opTileIsVisible(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -2688,7 +2688,7 @@ static void opTileIsVisible(Program* program)
 }
 
 // dialogue_system_enter
-// 0x458534
+// 0x458534 op_dialogue_system_enter_
 static void opGameDialogSystemEnter(Program* program)
 {
     int sid = scriptGetSid(program);
@@ -2717,7 +2717,7 @@ static void opGameDialogSystemEnter(Program* program)
 }
 
 // action_being_used
-// 0x458594
+// 0x458594 op_action_being_used_
 static void opGetActionBeingUsed(Program* program)
 {
     int action = -1;
@@ -2735,7 +2735,7 @@ static void opGetActionBeingUsed(Program* program)
 }
 
 // critter_state
-// 0x4585E8
+// 0x4585E8 op_critter_state_
 static void opGetCritterState(Program* program)
 {
     Object* critter = static_cast<Object*>(programStackPopPointer(program));
@@ -2764,7 +2764,7 @@ static void opGetCritterState(Program* program)
 }
 
 // game_time_advance
-// 0x4586C8
+// 0x4586C8 op_game_time_advance_
 static void opGameTimeAdvance(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -2782,7 +2782,7 @@ static void opGameTimeAdvance(Program* program)
 }
 
 // radiation_inc
-// 0x458760
+// 0x458760 op_radiation_inc_
 static void opRadiationIncrease(Program* program)
 {
     int amount = programStackPopInteger(program);
@@ -2797,7 +2797,7 @@ static void opRadiationIncrease(Program* program)
 }
 
 // radiation_dec
-// 0x458800
+// 0x458800 op_radiation_dec_
 static void opRadiationDecrease(Program* program)
 {
     int amount = programStackPopInteger(program);
@@ -2815,7 +2815,7 @@ static void opRadiationDecrease(Program* program)
 }
 
 // critter_attempt_placement
-// 0x4588B4
+// 0x4588B4 op_critter_attempt_placement_
 static void opCritterAttemptPlacement(Program* program)
 {
     int elevation = programStackPopInteger(program);
@@ -2838,7 +2838,7 @@ static void opCritterAttemptPlacement(Program* program)
 }
 
 // obj_pid
-// 0x4589A0
+// 0x4589A0 op_obj_pid_
 static void opGetObjectPid(Program* program)
 {
     Object* obj = static_cast<Object*>(programStackPopPointer(program));
@@ -2854,7 +2854,7 @@ static void opGetObjectPid(Program* program)
 }
 
 // cur_map_index
-// 0x458A30
+// 0x458A30 op_cur_map_index_
 static void opGetCurrentMap(Program* program)
 {
     int mapIndex = mapGetCurrentMap();
@@ -2862,7 +2862,7 @@ static void opGetCurrentMap(Program* program)
 }
 
 // critter_add_trait
-// 0x458A54
+// 0x458A54 op_critter_add_trait_
 static void opCritterAddTrait(Program* program)
 {
     int value = programStackPopInteger(program);
@@ -2932,7 +2932,7 @@ static void opCritterAddTrait(Program* program)
 }
 
 // critter_rm_trait
-// 0x458C2C
+// 0x458C2C op_critter_rm_trait_
 static void opCritterRemoveTrait(Program* program)
 {
     int value = programStackPopInteger(program);
@@ -2965,7 +2965,7 @@ static void opCritterRemoveTrait(Program* program)
 }
 
 // proto_data
-// 0x458D38
+// 0x458D38 op_proto_data_
 static void opGetProtoData(Program* program)
 {
     int member = programStackPopInteger(program);
@@ -2988,7 +2988,7 @@ static void opGetProtoData(Program* program)
 }
 
 // message_str
-// 0x458E10
+// 0x458E10 op_message_str_
 static void opGetMessageString(Program* program)
 {
     // 0x518EFC
@@ -3012,7 +3012,7 @@ static void opGetMessageString(Program* program)
 }
 
 // critter_inven_obj
-// 0x458F00
+// 0x458F00 op_critter_inven_obj_
 static void opCritterGetInventoryObject(Program* program)
 {
     int type = programStackPopInteger(program);
@@ -3063,7 +3063,7 @@ static void opCritterGetInventoryObject(Program* program)
 }
 
 // obj_set_light_level
-// 0x459088
+// 0x459088 op_obj_set_light_level_
 static void opSetObjectLightLevel(Program* program)
 {
     int lightDistance = programStackPopInteger(program);
@@ -3089,14 +3089,14 @@ static void opSetObjectLightLevel(Program* program)
 }
 
 // world_map
-// 0x459170
+// 0x459170 op_world_map_
 static void opWorldmap(Program* program)
 {
     scriptsRequestWorldMap();
 }
 
 // inven_cmds
-// 0x459178
+// 0x459178 op_inven_cmds_
 static void _op_inven_cmds(Program* program)
 {
     int index = programStackPopInteger(program);
@@ -3119,7 +3119,7 @@ static void _op_inven_cmds(Program* program)
 }
 
 // float_msg
-// 0x459280
+// 0x459280 op_float_msg_
 static void opFloatMessage(Program* program)
 {
     int floatingMessageType = programStackPopInteger(program);
@@ -3206,7 +3206,7 @@ static void opFloatMessage(Program* program)
 }
 
 // metarule
-// 0x4594A0
+// 0x4594A0 op_metarule_
 static void opMetarule(Program* program)
 {
     ProgramValue param = programStackPopValue(program);
@@ -3361,7 +3361,7 @@ static void opMetarule(Program* program)
 }
 
 // anim
-// 0x4598BC
+// 0x4598BC op_anim_
 static void opAnim(Program* program)
 {
     ProgramValue frameValue = programStackPopValue(program);
@@ -3444,7 +3444,7 @@ static void opAnim(Program* program)
 }
 
 // obj_carrying_pid_obj
-// 0x459B5C
+// 0x459B5C op_obj_carrying_pid_obj_
 static void opObjectCarryingObjectByPid(Program* program)
 {
     int pid = programStackPopInteger(program);
@@ -3461,7 +3461,7 @@ static void opObjectCarryingObjectByPid(Program* program)
 }
 
 // reg_anim_func
-// 0x459C20
+// 0x459C20 op_reg_anim_func_
 static void opRegAnimFunc(Program* program)
 {
     ProgramValue param = programStackPopValue(program);
@@ -3483,7 +3483,7 @@ static void opRegAnimFunc(Program* program)
 }
 
 // reg_anim_animate
-// 0x459CD4
+// 0x459CD4 op_reg_anim_animate_
 static void opRegAnimAnimate(Program* program)
 {
     int delay = programStackPopInteger(program);
@@ -3502,7 +3502,7 @@ static void opRegAnimAnimate(Program* program)
 }
 
 // reg_anim_animate_reverse
-// 0x459DC4
+// 0x459DC4 op_reg_anim_animate_reverse_
 static void opRegAnimAnimateReverse(Program* program)
 {
     int delay = programStackPopInteger(program);
@@ -3519,7 +3519,7 @@ static void opRegAnimAnimateReverse(Program* program)
 }
 
 // reg_anim_obj_move_to_obj
-// 0x459E74
+// 0x459E74 op_reg_anim_obj_move_to_obj_
 static void opRegAnimObjectMoveToObject(Program* program)
 {
     int delay = programStackPopInteger(program);
@@ -3536,7 +3536,7 @@ static void opRegAnimObjectMoveToObject(Program* program)
 }
 
 // reg_anim_obj_run_to_obj
-// 0x459F28
+// 0x459F28 op_reg_anim_obj_run_to_obj_
 static void opRegAnimObjectRunToObject(Program* program)
 {
     int delay = programStackPopInteger(program);
@@ -3553,7 +3553,7 @@ static void opRegAnimObjectRunToObject(Program* program)
 }
 
 // reg_anim_obj_move_to_tile
-// 0x459FDC
+// 0x459FDC op_reg_anim_obj_move_to_tile_
 static void opRegAnimObjectMoveToTile(Program* program)
 {
     int delay = programStackPopInteger(program);
@@ -3570,7 +3570,7 @@ static void opRegAnimObjectMoveToTile(Program* program)
 }
 
 // reg_anim_obj_run_to_tile
-// 0x45A094
+// 0x45A094 op_reg_anim_obj_run_to_tile_
 static void opRegAnimObjectRunToTile(Program* program)
 {
     int delay = programStackPopInteger(program);
@@ -3587,7 +3587,7 @@ static void opRegAnimObjectRunToTile(Program* program)
 }
 
 // play_gmovie
-// 0x45A14C
+// 0x45A14C op_play_gmovie_
 static void opPlayGameMovie(Program* program)
 {
     // 0x453F9C
@@ -3636,7 +3636,7 @@ static void opPlayGameMovie(Program* program)
 }
 
 // add_mult_objs_to_inven
-// 0x45A200
+// 0x45A200 op_add_mult_objs_to_inven_
 static void opAddMultipleObjectsToInventory(Program* program)
 {
     int quantity = programStackPopInteger(program);
@@ -3662,7 +3662,7 @@ static void opAddMultipleObjectsToInventory(Program* program)
 }
 
 // rm_mult_objs_from_inven
-// 0x45A2D4
+// 0x45A2D4 op_rm_mult_objs_from_inven_
 static void opRemoveMultipleObjectsFromInventory(Program* program)
 {
     int quantityToRemove = programStackPopInteger(program);
@@ -3699,7 +3699,7 @@ static void opRemoveMultipleObjectsFromInventory(Program* program)
 }
 
 // get_month
-// 0x45A40C
+// 0x45A40C op_get_month_
 static void opGetMonth(Program* program)
 {
     int month;
@@ -3709,7 +3709,7 @@ static void opGetMonth(Program* program)
 }
 
 // get_day
-// 0x45A43C
+// 0x45A43C op_get_day_
 static void opGetDay(Program* program)
 {
     int day;
@@ -3719,7 +3719,7 @@ static void opGetDay(Program* program)
 }
 
 // explosion
-// 0x45A46C
+// 0x45A46C op_explosion_
 static void opExplosion(Program* program)
 {
     int maxDamage = programStackPopInteger(program);
@@ -3740,7 +3740,7 @@ static void opExplosion(Program* program)
 }
 
 // days_since_visited
-// 0x45A528
+// 0x45A528 op_days_since_visited_
 static void opGetDaysSinceLastVisit(Program* program)
 {
     int days;
@@ -3755,7 +3755,7 @@ static void opGetDaysSinceLastVisit(Program* program)
 }
 
 // gsay_start
-// 0x45A56C
+// 0x45A56C op_gsay_start_
 static void _op_gsay_start(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -3769,7 +3769,7 @@ static void _op_gsay_start(Program* program)
 }
 
 // gsay_end
-// 0x45A5B0
+// 0x45A5B0 op_gsay_end_
 static void _op_gsay_end(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -3778,7 +3778,7 @@ static void _op_gsay_end(Program* program)
 }
 
 // gsay_reply
-// 0x45A5D4
+// 0x45A5D4 op_gsay_reply_
 static void _op_gsay_reply(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -3799,7 +3799,7 @@ static void _op_gsay_reply(Program* program)
 }
 
 // gsay_option
-// 0x45A6C4
+// 0x45A6C4 op_gsay_option_
 static void _op_gsay_option(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -3836,7 +3836,7 @@ static void _op_gsay_option(Program* program)
 }
 
 // gsay_message
-// 0x45A8AC
+// 0x45A8AC op_gsay_message_
 static void _op_gsay_message(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -3861,7 +3861,7 @@ static void _op_gsay_message(Program* program)
 }
 
 // giq_option
-// 0x45A9B4
+// 0x45A9B4 op_giq_option_
 static void _op_giq_option(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -3914,7 +3914,7 @@ static void _op_giq_option(Program* program)
 }
 
 // poison
-// 0x45AB90
+// 0x45AB90 op_poison_
 static void opPoison(Program* program)
 {
     int amount = programStackPopInteger(program);
@@ -3931,7 +3931,7 @@ static void opPoison(Program* program)
 }
 
 // get_poison
-// 0x45AC44
+// 0x45AC44 op_get_poison_
 static void opGetPoison(Program* program)
 {
     Object* obj = static_cast<Object*>(programStackPopPointer(program));
@@ -3951,7 +3951,7 @@ static void opGetPoison(Program* program)
 }
 
 // party_add
-// 0x45ACF4
+// 0x45ACF4 op_party_add_
 static void opPartyAdd(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -3964,7 +3964,7 @@ static void opPartyAdd(Program* program)
 }
 
 // party_remove
-// 0x45AD68
+// 0x45AD68 op_party_remove_
 static void opPartyRemove(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -3977,7 +3977,7 @@ static void opPartyRemove(Program* program)
 }
 
 // reg_anim_animate_forever
-// 0x45ADDC
+// 0x45ADDC op_reg_anim_animate_forever_
 static void opRegAnimAnimateForever(Program* program)
 {
     int anim = programStackPopInteger(program);
@@ -3993,7 +3993,7 @@ static void opRegAnimAnimateForever(Program* program)
 }
 
 // critter_injure
-// 0x45AE8C
+// 0x45AE8C op_critter_injure_
 static void opCritterInjure(Program* program)
 {
     int flags = programStackPopInteger(program);
@@ -4025,14 +4025,14 @@ static void opCritterInjure(Program* program)
 }
 
 // combat_is_initialized
-// 0x45AF7C
+// 0x45AF7C op_combat_is_initialized_
 static void opCombatIsInitialized(Program* program)
 {
     programStackPushInteger(program, isInCombat() ? 1 : 0);
 }
 
 // gdialog_barter
-// 0x45AFA0
+// 0x45AFA0 op_gdialog_barter_
 static void _op_gdialog_barter(Program* program)
 {
     int modifier = programStackPopInteger(program);
@@ -4043,14 +4043,14 @@ static void _op_gdialog_barter(Program* program)
 }
 
 // difficulty_level
-// 0x45B010
+// 0x45B010 op_difficulty_level_
 static void opGetGameDifficulty(Program* program)
 {
     programStackPushInteger(program, settings.preferences.game_difficulty);
 }
 
 // running_burning_guy
-// 0x45B05C
+// 0x45B05C op_running_burning_guy_
 static void opGetRunningBurningGuy(Program* program)
 {
     programStackPushInteger(program, static_cast<int>(settings.preferences.running_burning_guy));
@@ -4073,7 +4073,7 @@ static void _op_inven_unwield(Program* program)
 }
 
 // obj_is_locked
-// 0x45B0D8
+// 0x45B0D8 op_obj_is_locked_
 static void opObjectIsLocked(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -4089,7 +4089,7 @@ static void opObjectIsLocked(Program* program)
 }
 
 // obj_lock
-// 0x45B16C
+// 0x45B16C op_obj_lock_
 static void opObjectLock(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -4102,7 +4102,7 @@ static void opObjectLock(Program* program)
 }
 
 // obj_unlock
-// 0x45B1E0
+// 0x45B1E0 op_obj_unlock_
 static void opObjectUnlock(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -4115,7 +4115,7 @@ static void opObjectUnlock(Program* program)
 }
 
 // obj_is_open
-// 0x45B254
+// 0x45B254 op_obj_is_open_
 static void opObjectIsOpen(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -4131,7 +4131,7 @@ static void opObjectIsOpen(Program* program)
 }
 
 // obj_open
-// 0x45B2E8
+// 0x45B2E8 op_obj_open_
 static void opObjectOpen(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -4144,7 +4144,7 @@ static void opObjectOpen(Program* program)
 }
 
 // obj_close
-// 0x45B35C
+// 0x45B35C op_obj_close_
 static void opObjectClose(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -4157,28 +4157,28 @@ static void opObjectClose(Program* program)
 }
 
 // game_ui_disable
-// 0x45B3D0
+// 0x45B3D0 op_game_ui_disable_
 static void opGameUiDisable(Program* program)
 {
     gameUiDisable(0);
 }
 
 // game_ui_enable
-// 0x45B3D8
+// 0x45B3D8 op_game_ui_enable_
 static void opGameUiEnable(Program* program)
 {
     gameUiEnable();
 }
 
 // game_ui_is_disabled
-// 0x45B3E0
+// 0x45B3E0 op_game_ui_is_disabled_
 static void opGameUiIsDisabled(Program* program)
 {
     programStackPushInteger(program, gameUiIsDisabled() ? 1 : 0);
 }
 
 // gfade_out
-// 0x45B404
+// 0x45B404 op_gfade_out_
 static void opGameFadeOut(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -4191,7 +4191,7 @@ static void opGameFadeOut(Program* program)
 }
 
 // gfade_in
-// 0x45B47C
+// 0x45B47C op_gfade_in_
 static void opGameFadeIn(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -4204,7 +4204,7 @@ static void opGameFadeIn(Program* program)
 }
 
 // item_caps_total
-// 0x45B4F4
+// 0x45B4F4 op_item_caps_total_
 static void opItemCapsTotal(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -4220,7 +4220,7 @@ static void opItemCapsTotal(Program* program)
 }
 
 // item_caps_adjust
-// 0x45B588
+// 0x45B588 op_item_caps_adjust_
 static void opItemCapsAdjust(Program* program)
 {
     int amount = programStackPopInteger(program);
@@ -4261,7 +4261,7 @@ static void _op_anim_action_frame(Program* program)
 }
 
 // reg_anim_play_sfx
-// 0x45B740
+// 0x45B740 op_reg_anim_play_sfx_
 static void opRegAnimPlaySfx(Program* program)
 {
     int delay = programStackPopInteger(program);
@@ -4281,7 +4281,7 @@ static void opRegAnimPlaySfx(Program* program)
 }
 
 // critter_mod_skill
-// 0x45B840
+// 0x45B840 op_critter_mod_skill_
 static void opCritterModifySkill(Program* program)
 {
     int points = programStackPopInteger(program);
@@ -4331,7 +4331,7 @@ static void opCritterModifySkill(Program* program)
 }
 
 // sfx_build_char_name
-// 0x45B9C4
+// 0x45B9C4 op_sfx_build_char_name_
 static void opSfxBuildCharName(Program* program)
 {
     int extra = programStackPopInteger(program);
@@ -4349,7 +4349,7 @@ static void opSfxBuildCharName(Program* program)
 }
 
 // sfx_build_ambient_name
-// 0x45BAA8
+// 0x45BAA8 op_sfx_build_ambient_name_
 static void opSfxBuildAmbientName(Program* program)
 {
     char* baseName = programStackPopString(program);
@@ -4360,7 +4360,7 @@ static void opSfxBuildAmbientName(Program* program)
 }
 
 // sfx_build_interface_name
-// 0x45BB54
+// 0x45BB54 op_sfx_build_interface_name_
 static void opSfxBuildInterfaceName(Program* program)
 {
     char* baseName = programStackPopString(program);
@@ -4371,7 +4371,7 @@ static void opSfxBuildInterfaceName(Program* program)
 }
 
 // sfx_build_item_name
-// 0x45BC00
+// 0x45BC00 op_sfx_build_item_name_
 static void opSfxBuildItemName(Program* program)
 {
     const char* baseName = programStackPopString(program);
@@ -4382,7 +4382,7 @@ static void opSfxBuildItemName(Program* program)
 }
 
 // sfx_build_weapon_name
-// 0x45BCAC
+// 0x45BCAC op_sfx_build_weapon_name_
 static void opSfxBuildWeaponName(Program* program)
 {
     Object* target = static_cast<Object*>(programStackPopPointer(program));
@@ -4396,7 +4396,7 @@ static void opSfxBuildWeaponName(Program* program)
 }
 
 // sfx_build_scenery_name
-// 0x45BD7C
+// 0x45BD7C op_sfx_build_scenery_name_
 static void opSfxBuildSceneryName(Program* program)
 {
     int actionType = programStackPopInteger(program);
@@ -4409,7 +4409,7 @@ static void opSfxBuildSceneryName(Program* program)
 }
 
 // sfx_build_open_name
-// 0x45BE58
+// 0x45BE58 op_sfx_build_open_name_
 static void opSfxBuildOpenName(Program* program)
 {
     int action = programStackPopInteger(program);
@@ -4426,7 +4426,7 @@ static void opSfxBuildOpenName(Program* program)
 }
 
 // attack_setup
-// 0x45BF38
+// 0x45BF38 op_attack_setup_
 static void opAttackSetup(Program* program)
 {
     Object* defender = static_cast<Object*>(programStackPopPointer(program));
@@ -4477,7 +4477,7 @@ static void opAttackSetup(Program* program)
 }
 
 // destroy_mult_objs
-// 0x45C0E8
+// 0x45C0E8 op_destroy_mult_objs_
 static void opDestroyMultipleObjects(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -4537,7 +4537,7 @@ static void opDestroyMultipleObjects(Program* program)
 }
 
 // use_obj_on_obj
-// 0x45C290
+// 0x45C290 op_use_obj_on_obj_
 static void opUseObjectOnObject(Program* program)
 {
     Object* target = static_cast<Object*>(programStackPopPointer(program));
@@ -4579,7 +4579,7 @@ static void opUseObjectOnObject(Program* program)
 }
 
 // endgame_slideshow
-// 0x45C3B0
+// 0x45C3B0 op_endgame_slideshow_
 static void opEndgameSlideshow(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -4588,7 +4588,7 @@ static void opEndgameSlideshow(Program* program)
 }
 
 // move_obj_inven_to_obj
-// 0x45C3D0
+// 0x45C3D0 op_move_obj_inven_to_obj_
 static void opMoveObjectInventoryToObject(Program* program)
 {
     Object* object2 = static_cast<Object*>(programStackPopPointer(program));
@@ -4659,7 +4659,7 @@ static void opMoveObjectInventoryToObject(Program* program)
 }
 
 // endgame_movie
-// 0x45C54C
+// 0x45C54C op_endgame_movie_
 static void opEndgameMovie(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -4668,7 +4668,7 @@ static void opEndgameMovie(Program* program)
 }
 
 // obj_art_fid
-// 0x45C56C
+// 0x45C56C op_obj_art_fid_
 static void opGetObjectFid(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -4684,7 +4684,7 @@ static void opGetObjectFid(Program* program)
 }
 
 // art_anim
-// 0x45C5F8
+// 0x45C5F8 op_art_anim_
 static void opGetFidAnim(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -4692,7 +4692,7 @@ static void opGetFidAnim(Program* program)
 }
 
 // party_member_obj
-// 0x45C66C
+// 0x45C66C op_party_member_obj_
 static void opGetPartyMember(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -4702,7 +4702,7 @@ static void opGetPartyMember(Program* program)
 }
 
 // rotation_to_tile
-// 0x45C6DC
+// 0x45C6DC op_rotation_to_tile_
 static void opGetRotationToTile(Program* program)
 {
     int tile2 = programStackPopInteger(program);
@@ -4713,7 +4713,7 @@ static void opGetRotationToTile(Program* program)
 }
 
 // jam_lock
-// 0x45C778
+// 0x45C778 op_jam_lock_
 static void opJamLock(Program* program)
 {
     Object* object = static_cast<Object*>(programStackPopPointer(program));
@@ -4722,7 +4722,7 @@ static void opJamLock(Program* program)
 }
 
 // gdialog_set_barter_mod
-// 0x45C7D4
+// 0x45C7D4 op_gdialog_set_barter_mod_
 static void opGameDialogSetBarterMod(Program* program)
 {
     int modifier = programStackPopInteger(program);
@@ -4731,14 +4731,14 @@ static void opGameDialogSetBarterMod(Program* program)
 }
 
 // combat_difficulty
-// 0x45C830
+// 0x45C830 op_combat_difficulty_
 static void opGetCombatDifficulty(Program* program)
 {
     programStackPushInteger(program, settings.preferences.combat_difficulty);
 }
 
 // obj_on_screen
-// 0x45C878
+// 0x45C878 op_obj_on_screen_
 static void opObjectOnScreen(Program* program)
 {
     Rect rect;
@@ -4765,7 +4765,7 @@ static void opObjectOnScreen(Program* program)
 }
 
 // critter_is_fleeing
-// 0x45C93C
+// 0x45C93C op_critter_is_fleeing_
 static void opCritterIsFleeing(Program* program)
 {
     Object* obj = static_cast<Object*>(programStackPopPointer(program));
@@ -4781,7 +4781,7 @@ static void opCritterIsFleeing(Program* program)
 }
 
 // critter_set_flee_state
-// 0x45C9DC
+// 0x45C9DC op_critter_set_flee_state_
 static void opCritterSetFleeState(Program* program)
 {
     int fleeing = programStackPopInteger(program);
@@ -4799,7 +4799,7 @@ static void opCritterSetFleeState(Program* program)
 }
 
 // terminate_combat
-// 0x45CA84
+// 0x45CA84 op_terminate_combat_
 static void opTerminateCombat(Program* program)
 {
     if (isInCombat()) {
@@ -4816,7 +4816,7 @@ static void opTerminateCombat(Program* program)
 }
 
 // debug_msg
-// 0x45CAC8
+// 0x45CAC8 op_debug_msg_
 static void opDebugMessage(Program* program)
 {
     char* string = programStackPopString(program);
@@ -4830,7 +4830,7 @@ static void opDebugMessage(Program* program)
 }
 
 // critter_stop_attacking
-// 0x45CB70
+// 0x45CB70 op_critter_stop_attacking_
 static void opCritterStopAttacking(Program* program)
 {
     Object* obj = static_cast<Object*>(programStackPopPointer(program));
@@ -4845,7 +4845,7 @@ static void opCritterStopAttacking(Program* program)
 }
 
 // tile_contains_pid_obj
-// 0x45CBF8
+// 0x45CBF8 op_tile_contains_pid_obj_
 static void opTileGetObjectWithPid(Program* program)
 {
     int pid = programStackPopInteger(program);
@@ -4868,7 +4868,7 @@ static void opTileGetObjectWithPid(Program* program)
 }
 
 // obj_name
-// 0x45CCC8
+// 0x45CCC8 op_obj_name_
 static void opGetObjectName(Program* program)
 {
     Object* obj = static_cast<Object*>(programStackPopPointer(program));
@@ -4882,7 +4882,7 @@ static void opGetObjectName(Program* program)
 }
 
 // get_pc_stat
-// 0x45CD64
+// 0x45CD64 op_get_pc_stat_
 static void opGetPcStat(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -4897,7 +4897,7 @@ void _intExtraClose_()
     sfallOpcodesExit();
 }
 
-// 0x45CDD8
+// 0x45CDD8 initIntExtra_
 void _initIntExtra()
 {
     interpreterRegisterOpcode(0x80A1, opGiveExpPoints); // op_give_exp_points

--- a/src/interpreter_lib.cc
+++ b/src/interpreter_lib.cc
@@ -162,7 +162,7 @@ static char gIntLibPlayMovieFileName[100];
 static char gIntLibPlayMovieRectFileName[100];
 
 // fillwin3x3
-// 0x461780
+// 0x461780 op_fillwin3x3_
 void opFillWin3x3(Program* program)
 {
     char* fileName = programStackPopString(program);
@@ -191,7 +191,7 @@ void opFillWin3x3(Program* program)
 }
 
 // format
-// 0x461850
+// 0x461850 op_format_
 static void opFormat(Program* program)
 {
     int textAlignment = programStackPopInteger(program);
@@ -207,7 +207,7 @@ static void opFormat(Program* program)
 }
 
 // print
-// 0x461A5C
+// 0x461A5C op_print_
 static void opPrint(Program* program)
 {
     scriptWindowSelectId(program->windowId);
@@ -240,7 +240,7 @@ static void opPrint(Program* program)
 }
 
 // selectfilelist
-// 0x461B10
+// 0x461B10 op_selectfilelist_
 void opSelectFileList(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -274,7 +274,7 @@ void opSelectFileList(Program* program)
 }
 
 // tokenize
-// 0x461CA0
+// 0x461CA0 op_tokenize_
 void opTokenize(Program* program)
 {
     int ch = programStackPopInteger(program);
@@ -341,7 +341,7 @@ void opTokenize(Program* program)
 }
 
 // printrect
-// 0x461F1C
+// 0x461F1C op_printrect_
 static void opPrintRect(Program* program)
 {
     scriptWindowSelectId(program->windowId);
@@ -372,7 +372,7 @@ static void opPrintRect(Program* program)
     }
 }
 
-// 0x46209C
+// 0x46209C op_selectwin_
 void opSelect(Program* program)
 {
     const char* windowName = programStackPopString(program);
@@ -387,7 +387,7 @@ void opSelect(Program* program)
 }
 
 // display
-// 0x46213C
+// 0x46213C op_display_
 void opDisplay(Program* program)
 {
     char* fileName = programStackPopString(program);
@@ -399,7 +399,7 @@ void opDisplay(Program* program)
 }
 
 // displayraw
-// 0x4621B4
+// 0x4621B4 op_displayraw_
 void opDisplayRaw(Program* program)
 {
     char* fileName = programStackPopString(program);
@@ -410,7 +410,7 @@ void opDisplayRaw(Program* program)
     _displayFileRaw(mangledFileName);
 }
 
-// 0x46222C
+// 0x46222C interpretFadePaletteBK_
 static void _interpretFadePaletteBK(unsigned char* oldPalette, unsigned char* newPalette, int a3, float duration, int shouldProcessBk)
 {
     unsigned int time;
@@ -457,7 +457,7 @@ static void _interpretFadePaletteBK(unsigned char* oldPalette, unsigned char* ne
 
 // NOTE: Unused.
 //
-// 0x462330
+// 0x462330 interpretFadePalette_
 static void interpretFadePalette(unsigned char* oldPalette, unsigned char* newPalette, int a3, float duration)
 {
     _interpretFadePaletteBK(oldPalette, newPalette, a3, duration, 1);
@@ -471,7 +471,7 @@ static int intlibGetFadeIn()
 
 // NOTE: Inlined.
 //
-// 0x462348
+// 0x462348 interpretFadeOut_
 static void interpretFadeOut(float duration)
 {
     int cursorWasHidden;
@@ -488,7 +488,7 @@ static void interpretFadeOut(float duration)
 
 // NOTE: Inlined.
 //
-// 0x462380
+// 0x462380 interpretFadeIn_
 static void interpretFadeIn(float duration)
 {
     _interpretFadePaletteBK(gIntLibFadePalette, _cmap, 64, duration, 1);
@@ -496,7 +496,7 @@ static void interpretFadeIn(float duration)
 
 // NOTE: Unused.
 //
-// 0x4623A4
+// 0x4623A4 interpretFadeOutNoBK_
 static void interpretFadeOutNoBK(float duration)
 {
     int cursorWasHidden;
@@ -513,14 +513,14 @@ static void interpretFadeOutNoBK(float duration)
 
 // NOTE: Unused.
 //
-// 0x4623DC
+// 0x4623DC interpretFadeInNoBK_
 static void interpretFadeInNoBK(float duration)
 {
     _interpretFadePaletteBK(gIntLibFadePalette, _cmap, 64, duration, 0);
 }
 
 // fadein
-// 0x462400
+// 0x462400 op_fadein_
 void opFadeIn(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -538,7 +538,7 @@ void opFadeIn(Program* program)
 }
 
 // fadeout
-// 0x4624B4
+// 0x4624B4 op_fadeout_
 void opFadeOut(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -560,7 +560,7 @@ void opFadeOut(Program* program)
     program->flags &= ~PROGRAM_FLAG_CHILD_CALL;
 }
 
-// 0x462570
+// 0x462570 checkMovie_
 int intLibCheckMovie(Program* program)
 {
     if (_dialogGetDialogDepth() > 0) {
@@ -571,7 +571,7 @@ int intLibCheckMovie(Program* program)
 }
 
 // movieflags
-// 0x462584
+// 0x462584 op_movieflags_
 static void opSetMovieFlags(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -582,7 +582,7 @@ static void opSetMovieFlags(Program* program)
 }
 
 // playmovie
-// 0x4625D0
+// 0x4625D0 op_playmovie_
 void opPlayMovie(Program* program)
 {
     char* movieFileName = programStackPopString(program);
@@ -605,7 +605,7 @@ void opPlayMovie(Program* program)
 }
 
 // playmovierect
-// 0x4626C4
+// 0x4626C4 op_playmovierect_
 void opPlayMovieRect(Program* program)
 {
     int height = programStackPopInteger(program);
@@ -632,7 +632,7 @@ void opPlayMovieRect(Program* program)
 }
 
 // stopmovie
-// 0x46287C
+// 0x46287C op_stopmovie_
 static void opStopMovie(Program* program)
 {
     scriptWindowStopMovie();
@@ -640,7 +640,7 @@ static void opStopMovie(Program* program)
 }
 
 // deleteregion
-// 0x462890
+// 0x462890 op_deleteregion_
 static void opDeleteRegion(Program* program)
 {
     ProgramValue value = programStackPopValue(program);
@@ -664,7 +664,7 @@ static void opDeleteRegion(Program* program)
 }
 
 // activateregion
-// 0x462924
+// 0x462924 op_activateregion_
 void opActivateRegion(Program* program)
 {
     int v1 = programStackPopInteger(program);
@@ -674,7 +674,7 @@ void opActivateRegion(Program* program)
 }
 
 // checkregion
-// 0x4629A0
+// 0x4629A0 op_checkregion_
 static void opCheckRegion(Program* program)
 {
     const char* regionName = programStackPopString(program);
@@ -684,7 +684,7 @@ static void opCheckRegion(Program* program)
 }
 
 // addregion
-// 0x462A1C
+// 0x462A1C op_addregion_
 void opAddRegion(Program* program)
 {
     int args = programStackPopInteger(program);
@@ -719,7 +719,7 @@ void opAddRegion(Program* program)
 }
 
 // addregionproc
-// 0x462C10
+// 0x462C10 op_addregionproc_
 static void opAddRegionProc(Program* program)
 {
     int v1 = programStackPopInteger(program);
@@ -736,7 +736,7 @@ static void opAddRegionProc(Program* program)
 }
 
 // addregionrightproc
-// 0x462DDC
+// 0x462DDC op_addregionrightproc_
 static void opAddRegionRightProc(Program* program)
 {
     int v1 = programStackPopInteger(program);
@@ -750,7 +750,7 @@ static void opAddRegionRightProc(Program* program)
 }
 
 // createwin
-// 0x462F08
+// 0x462F08 op_createwin_
 void opCreateWin(Program* program)
 {
     int height = programStackPopInteger(program);
@@ -770,7 +770,7 @@ void opCreateWin(Program* program)
 }
 
 // resizewin
-// 0x46308C
+// 0x46308C op_resizewin_
 void opResizeWin(Program* program)
 {
     int height = programStackPopInteger(program);
@@ -790,7 +790,7 @@ void opResizeWin(Program* program)
 }
 
 // scalewin
-// 0x463204
+// 0x463204 op_scalewin_
 void opScaleWin(Program* program)
 {
     int height = programStackPopInteger(program);
@@ -810,7 +810,7 @@ void opScaleWin(Program* program)
 }
 
 // deletewin
-// 0x46337C
+// 0x46337C op_deletewin_
 void opDeleteWin(Program* program)
 {
     char* windowName = programStackPopString(program);
@@ -823,7 +823,7 @@ void opDeleteWin(Program* program)
 }
 
 // saystart
-// 0x4633E4
+// 0x4633E4 op_saystart_
 static void opSayStart(Program* program)
 {
     gIntLibSayStartingPosition = 0;
@@ -838,7 +838,7 @@ static void opSayStart(Program* program)
 }
 
 // saystartpos
-// 0x463430
+// 0x463430 op_saystartpos_
 static void opSayStartPos(Program* program)
 {
     gIntLibSayStartingPosition = programStackPopInteger(program);
@@ -853,7 +853,7 @@ static void opSayStartPos(Program* program)
 }
 
 // sayreplytitle
-// 0x46349C
+// 0x46349C op_sayreplytitle_
 static void opSayReplyTitle(Program* program)
 {
     ProgramValue value = programStackPopValue(program);
@@ -869,7 +869,7 @@ static void opSayReplyTitle(Program* program)
 }
 
 // saygotoreply
-// 0x463510
+// 0x463510 op_saygotoreply_
 static void opSayGoToReply(Program* program)
 {
     ProgramValue value = programStackPopValue(program);
@@ -885,7 +885,7 @@ static void opSayGoToReply(Program* program)
 }
 
 // sayreply
-// 0x463584
+// 0x463584 op_sayoption_
 void opSayReply(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -948,14 +948,14 @@ void opSayOption(Program* program)
     program->flags &= ~PROGRAM_FLAG_CHILD_CALL;
 }
 
-// 0x46378C
+// 0x46378C checkDialog_
 int intLibCheckDialog(Program* program)
 {
     program->flags |= PROGRAM_FLAG_FINISHED;
     return _dialogGetDialogDepth() != -1;
 }
 
-// 0x4637A4
+// 0x4637A4 op_sayend_
 void opSayEnd(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -969,7 +969,7 @@ void opSayEnd(Program* program)
 }
 
 // saygetlastpos
-// 0x4637EC
+// 0x4637EC op_saygetlastpos_
 static void opSayGetLastPos(Program* program)
 {
     int value = _dialogGetExitPoint();
@@ -977,7 +977,7 @@ static void opSayGetLastPos(Program* program)
 }
 
 // sayquit
-// 0x463810
+// 0x463810 op_sayquit_
 static void opSayQuit(Program* program)
 {
     if (_dialogQuit() != 0) {
@@ -987,7 +987,7 @@ static void opSayQuit(Program* program)
 
 // NOTE: Unused.
 //
-// 0x463828
+// 0x463828 getTimeOut_
 static int getTimeOut()
 {
     return _TimeOut;
@@ -995,14 +995,14 @@ static int getTimeOut()
 
 // NOTE: Unused.
 //
-// 0x463830
+// 0x463830 setTimeOut_
 static void setTimeOut(int value)
 {
     _TimeOut = value;
 }
 
 // saymessagetimeout
-// 0x463838
+// 0x463838 op_saymessagetimeout_
 static void opSayMessageTimeout(Program* program)
 {
     ProgramValue value = programStackPopValue(program);
@@ -1016,7 +1016,7 @@ static void opSayMessageTimeout(Program* program)
 }
 
 // saymessage
-// 0x463890
+// 0x463890 op_saymessage_
 void opSayMessage(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -1047,7 +1047,7 @@ void opSayMessage(Program* program)
 }
 
 // gotoxy
-// 0x463980
+// 0x463980 op_gotoxy_
 void opGotoXY(Program* program)
 {
     int y = programStackPopInteger(program);
@@ -1059,7 +1059,7 @@ void opGotoXY(Program* program)
 }
 
 // addbuttonflag
-// 0x463A38
+// 0x463A38 op_addbuttonflag_
 static void opAddButtonFlag(Program* program)
 {
     int flag = programStackPopInteger(program);
@@ -1072,7 +1072,7 @@ static void opAddButtonFlag(Program* program)
 }
 
 // addregionflag
-// 0x463B10
+// 0x463B10 op_addregionflag_
 static void opAddRegionFlag(Program* program)
 {
     int flag = programStackPopInteger(program);
@@ -1085,7 +1085,7 @@ static void opAddRegionFlag(Program* program)
 }
 
 // addbutton
-// 0x463BE8
+// 0x463BE8 op_addbutton_
 void opAddButton(Program* program)
 {
     int height = programStackPopInteger(program);
@@ -1105,7 +1105,7 @@ void opAddButton(Program* program)
 }
 
 // addbuttontext
-// 0x463DF4
+// 0x463DF4 op_addbuttontext_
 void opAddButtonText(Program* program)
 {
     const char* text = programStackPopString(program);
@@ -1117,7 +1117,7 @@ void opAddButtonText(Program* program)
 }
 
 // addbuttongfx
-// 0x463EEC
+// 0x463EEC op_addbuttongfx_
 void opAddButtonGfx(Program* program)
 {
     ProgramValue v1 = programStackPopValue(program);
@@ -1143,7 +1143,7 @@ void opAddButtonGfx(Program* program)
 }
 
 // addbuttonproc
-// 0x4640DC
+// 0x4640DC op_addbuttonproc_
 static void opAddButtonProc(Program* program)
 {
     int v1 = programStackPopInteger(program);
@@ -1159,7 +1159,7 @@ static void opAddButtonProc(Program* program)
 }
 
 // addbuttonrightproc
-// 0x4642A8
+// 0x4642A8 op_addbuttonrightproc_
 static void opAddButtonRightProc(Program* program)
 {
     int v1 = programStackPopInteger(program);
@@ -1173,7 +1173,7 @@ static void opAddButtonRightProc(Program* program)
 }
 
 // showwin
-// 0x4643D4
+// 0x4643D4 op_showwin_
 static void opShowWin(Program* program)
 {
     scriptWindowSelectId(program->windowId);
@@ -1181,7 +1181,7 @@ static void opShowWin(Program* program)
 }
 
 // deletebutton
-// 0x4643E4
+// 0x4643E4 op_deletebutton_
 static void opDeleteButton(Program* program)
 {
     ProgramValue value = programStackPopValue(program);
@@ -1215,7 +1215,7 @@ static void opDeleteButton(Program* program)
 }
 
 // fillwin
-// 0x46449C
+// 0x46449C op_fillwin_
 void opFillWin(Program* program)
 {
     ProgramValue b = programStackPopValue(program);
@@ -1258,7 +1258,7 @@ void opFillWin(Program* program)
 }
 
 // fillrect
-// 0x4645FC
+// 0x4645FC op_fillrect_
 void opFillRect(Program* program)
 {
     ProgramValue b = programStackPopValue(program);
@@ -1305,21 +1305,21 @@ void opFillRect(Program* program)
 }
 
 // hidemouse
-// 0x46489C
+// 0x46489C op_hidemouse_
 static void opHideMouse(Program* program)
 {
     mouseHideCursor();
 }
 
 // showmouse
-// 0x4648A4
+// 0x4648A4 op_showmouse_
 static void opShowMouse(Program* program)
 {
     mouseShowCursor();
 }
 
 // mouseshape
-// 0x4648AC
+// 0x4648AC op_mouseshape_
 void opMouseShape(Program* program)
 {
     int v1 = programStackPopInteger(program);
@@ -1332,14 +1332,14 @@ void opMouseShape(Program* program)
 }
 
 // setglobalmousefunc
-// 0x4649C4
+// 0x4649C4 op_setglobalmousefunc_
 static void opSetGlobalMouseFunc(Program* Program)
 {
     programFatalError("setglobalmousefunc not defined");
 }
 
 // displaygfx
-// 0x4649D4
+// 0x4649D4 op_displaygfx_
 void opDisplayGfx(Program* program)
 {
     int height = programStackPopInteger(program);
@@ -1353,7 +1353,7 @@ void opDisplayGfx(Program* program)
 }
 
 // loadpalettetable
-// 0x464ADC
+// 0x464ADC op_loadpalettetable_
 static void opLoadPaletteTable(Program* program)
 {
     char* path = programStackPopString(program);
@@ -1363,7 +1363,7 @@ static void opLoadPaletteTable(Program* program)
 }
 
 // addnamedevent
-// 0x464B54
+// 0x464B54 op_addNamedEvent_
 static void opAddNamedEvent(Program* program)
 {
     int proc = programStackPopInteger(program);
@@ -1372,7 +1372,7 @@ static void opAddNamedEvent(Program* program)
 }
 
 // addnamedhandler
-// 0x464BE8
+// 0x464BE8 op_addNamedHandler_
 static void opAddNamedHandler(Program* program)
 {
     int proc = programStackPopInteger(program);
@@ -1381,7 +1381,7 @@ static void opAddNamedHandler(Program* program)
 }
 
 // clearnamed
-// 0x464C80
+// 0x464C80 op_clearNamed_
 static void opClearNamed(Program* program)
 {
     char* string = programStackPopString(program);
@@ -1389,7 +1389,7 @@ static void opClearNamed(Program* program)
 }
 
 // signalnamed
-// 0x464CE4
+// 0x464CE4 op_signalNamed_
 static void opSignalNamed(Program* program)
 {
     char* str = programStackPopString(program);
@@ -1397,7 +1397,7 @@ static void opSignalNamed(Program* program)
 }
 
 // addkey
-// 0x464D48
+// 0x464D48 op_addkey_
 static void opAddKey(Program* program)
 {
     int proc = programStackPopInteger(program);
@@ -1417,7 +1417,7 @@ static void opAddKey(Program* program)
 }
 
 // deletekey
-// 0x464E24
+// 0x464E24 op_deletekey_
 static void opDeleteKey(Program* program)
 {
     int key = programStackPopInteger(program);
@@ -1436,7 +1436,7 @@ static void opDeleteKey(Program* program)
 }
 
 // refreshmouse
-// 0x464EB0
+// 0x464EB0 op_refreshmouse_
 void opRefreshMouse(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -1447,7 +1447,7 @@ void opRefreshMouse(Program* program)
 }
 
 // setfont
-// 0x464F18
+// 0x464F18 op_setfont_
 static void opSetFont(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -1458,7 +1458,7 @@ static void opSetFont(Program* program)
 }
 
 // setflags
-// 0x464F84
+// 0x464F84 op_settextflags_
 static void opSetTextFlags(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -1469,7 +1469,7 @@ static void opSetTextFlags(Program* program)
 }
 
 // settextcolor
-// 0x464FF0
+// 0x464FF0 op_settextcolor_
 static void opSetTextColor(Program* program)
 {
     ProgramValue value[3];
@@ -1497,7 +1497,7 @@ static void opSetTextColor(Program* program)
 }
 
 // sayoptioncolor
-// 0x465140
+// 0x465140 op_sayoptioncolor_
 static void opSayOptionColor(Program* program)
 {
     ProgramValue value[3];
@@ -1525,7 +1525,7 @@ static void opSayOptionColor(Program* program)
 }
 
 // sayreplycolor
-// 0x465290
+// 0x465290 op_sayreplycolor_
 static void opSayReplyColor(Program* program)
 {
     ProgramValue value[3];
@@ -1553,7 +1553,7 @@ static void opSayReplyColor(Program* program)
 }
 
 // sethighlightcolor
-// 0x4653E0
+// 0x4653E0 op_sethighlightcolor_
 static void opSetHighlightColor(Program* program)
 {
     ProgramValue value[3];
@@ -1581,7 +1581,7 @@ static void opSetHighlightColor(Program* program)
 }
 
 // sayreplywindow
-// 0x465530
+// 0x465530 op_sayreplywindow_
 void opSayReplyWindow(Program* program)
 {
     ProgramValue v2 = programStackPopValue(program);
@@ -1607,7 +1607,7 @@ void opSayReplyWindow(Program* program)
 }
 
 // sayreplyflags
-// 0x465688
+// 0x465688 op_sayreplyflags_
 static void opSayReplyFlags(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -1618,7 +1618,7 @@ static void opSayReplyFlags(Program* program)
 }
 
 // sayoptionflags
-// 0x4656F4
+// 0x4656F4 op_sayoptionflags_
 static void opSayOptionFlags(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -1629,7 +1629,7 @@ static void opSayOptionFlags(Program* program)
 }
 
 // sayoptionwindow
-// 0x465760
+// 0x465760 op_sayoptionwindow_
 void opSayOptionWindow(Program* program)
 {
     ProgramValue v2 = programStackPopValue(program);
@@ -1655,7 +1655,7 @@ void opSayOptionWindow(Program* program)
 }
 
 // sayborder
-// 0x4658B8
+// 0x4658B8 op_sayborder_
 static void opSayBorder(Program* program)
 {
     int y = programStackPopInteger(program);
@@ -1667,7 +1667,7 @@ static void opSayBorder(Program* program)
 }
 
 // sayscrollup
-// 0x465978
+// 0x465978 op_sayscrollup_
 void opSayScrollUp(Program* program)
 {
     ProgramValue v6 = programStackPopValue(program);
@@ -1739,7 +1739,7 @@ void opSayScrollUp(Program* program)
 }
 
 // sayscrolldown
-// 0x465CAC
+// 0x465CAC op_sayscrolldown_
 void opSayScrollDown(Program* program)
 {
     ProgramValue v6 = programStackPopValue(program);
@@ -1813,7 +1813,7 @@ void opSayScrollDown(Program* program)
 }
 
 // saysetspacing
-// 0x465FE0
+// 0x465FE0 op_saysetspacing_
 static void opSaySetSpacing(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -1824,7 +1824,7 @@ static void opSaySetSpacing(Program* program)
 }
 
 // sayrestart
-// 0x46604C
+// 0x46604C op_sayrestart_
 static void opSayRestart(Program* program)
 {
     if (_dialogRestart() != 0) {
@@ -1832,7 +1832,7 @@ static void opSayRestart(Program* program)
     }
 }
 
-// 0x466064
+// 0x466064 soundCallbackInterpret_
 static void intLibSoundCallback(void* userData, int event)
 {
     if (event == SOUND_CALLBACK_EVENT_DONE) {
@@ -1841,7 +1841,7 @@ static void intLibSoundCallback(void* userData, int event)
     }
 }
 
-// 0x466070
+// 0x466070 soundDeleteInterpret_
 static int intLibSoundDelete(int value)
 {
     if (value == -1) {
@@ -1869,7 +1869,7 @@ static int intLibSoundDelete(int value)
     return 1;
 }
 
-// 0x466110
+// 0x466110 soundStartInterpret_
 static int intLibSoundPlay(char* fileName, int mode)
 {
     int type = SOUND_TYPE_MEMORY;
@@ -1988,7 +1988,7 @@ err:
     return -1;
 }
 
-// 0x46655C
+// 0x46655C soundPauseInterpret_
 static int intLibSoundPause(int value)
 {
     if (value == -1) {
@@ -2014,7 +2014,7 @@ static int intLibSoundPause(int value)
     return rc == SOUND_NO_ERROR;
 }
 
-// 0x4665C8
+// 0x4665C8 soundRewindInterpret_
 static int intLibSoundRewind(int value)
 {
     if (value == -1) {
@@ -2040,7 +2040,7 @@ static int intLibSoundRewind(int value)
     return soundPlay(sound) == SOUND_NO_ERROR;
 }
 
-// 0x46662C
+// 0x46662C soundUnpauseInterpret_
 static int intLibSoundResume(int value)
 {
     if (value == -1) {
@@ -2067,7 +2067,7 @@ static int intLibSoundResume(int value)
 }
 
 // soundplay
-// 0x466698
+// 0x466698 op_soundplay_
 static void opSoundPlay(Program* program)
 {
     int flags = programStackPopInteger(program);
@@ -2080,7 +2080,7 @@ static void opSoundPlay(Program* program)
 }
 
 // soundpause
-// 0x466768
+// 0x466768 op_soundpause_
 static void opSoundPause(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -2088,7 +2088,7 @@ static void opSoundPause(Program* program)
 }
 
 // soundresume
-// 0x4667C0
+// 0x4667C0 op_soundresume_
 static void opSoundResume(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -2096,7 +2096,7 @@ static void opSoundResume(Program* program)
 }
 
 // soundstop
-// 0x466818
+// 0x466818 op_soundstop_
 static void opSoundStop(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -2104,7 +2104,7 @@ static void opSoundStop(Program* program)
 }
 
 // soundrewind
-// 0x466870
+// 0x466870 op_soundrewind_
 static void opSoundRewind(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -2112,7 +2112,7 @@ static void opSoundRewind(Program* program)
 }
 
 // sounddelete
-// 0x4668C8
+// 0x4668C8 op_sounddelete_
 static void opSoundDelete(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -2120,7 +2120,7 @@ static void opSoundDelete(Program* program)
 }
 
 // SetOneOptPause
-// 0x466920
+// 0x466920 op_setoneoptpause_
 static void opSetOneOptPause(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -2138,14 +2138,14 @@ static void opSetOneOptPause(Program* program)
     _dialogToggleMediaFlag(8);
 }
 
-// 0x466994
+// 0x466994 updateIntLib_
 void intLibUpdate()
 {
     _nevs_update();
     intExtraUpdate();
 }
 
-// 0x4669A0
+// 0x4669A0 intlibClose_
 void intLibExit()
 {
     _dialogClose();
@@ -2166,7 +2166,7 @@ void intLibExit()
     }
 }
 
-// 0x466A04
+// 0x466A04 intLibDoInput_
 static bool intLibDoInput(int key)
 {
     if (key < 0 || key >= INT_LIB_KEY_HANDLERS_CAPACITY) {
@@ -2192,7 +2192,7 @@ static bool intLibDoInput(int key)
     return true;
 }
 
-// 0x466A70
+// 0x466A70 initIntlib_
 void intLibInit()
 {
     scriptWindowAddInputFunc(intLibDoInput);
@@ -2286,7 +2286,7 @@ void intLibInit()
     dialogInit();
 }
 
-// 0x466F6C
+// 0x466F6C interpretRegisterProgramDeleteCallback_
 void intLibRegisterProgramDeleteCallback(IntLibProgramDeleteCallback* callback)
 {
     int index;
@@ -2308,7 +2308,7 @@ void intLibRegisterProgramDeleteCallback(IntLibProgramDeleteCallback* callback)
     gIntLibProgramDeleteCallbacks[index] = callback;
 }
 
-// 0x467040
+// 0x467040 removeProgramReferences_1
 void intLibRemoveProgramReferences(Program* program)
 {
     for (int index = 0; index < INT_LIB_KEY_HANDLERS_CAPACITY; index++) {

--- a/src/interpreter_lib.cc
+++ b/src/interpreter_lib.cc
@@ -128,41 +128,41 @@ static void opSoundDelete(Program* program);
 static void opSetOneOptPause(Program* program);
 static bool intLibDoInput(int key);
 
-// 0x59D5D0
+// 0x59D5D0 _interpretSounds
 static Sound* gIntLibSounds[INT_LIB_SOUNDS_CAPACITY];
 
-// 0x59D650
+// 0x59D650 blackPal
 static unsigned char gIntLibFadePalette[256 * 3];
 
-// 0x59D950
+// 0x59D950 inputProc
 static IntLibKeyHandlerEntry gIntLibKeyHandlerEntries[INT_LIB_KEY_HANDLERS_CAPACITY];
 
-// 0x59E150
+// 0x59E150 currentlyFadedIn
 static bool gIntLibIsPaletteFaded;
 
-// 0x59E154
+// 0x59E154 anyKeyOffset
 static int gIntLibGenericKeyHandlerProc;
 
-// 0x59E158
+// 0x59E158 numCallbacks
 static int gIntLibProgramDeleteCallbacksLength;
 
-// 0x59E15C
+// 0x59E15C _anyKeyProg
 static Program* gIntLibGenericKeyHandlerProgram;
 
-// 0x59E160
+// 0x59E160 callbacks
 static IntLibProgramDeleteCallback** gIntLibProgramDeleteCallbacks;
 
-// 0x59E164
+// 0x59E164 sayStartingPosition
 static int gIntLibSayStartingPosition;
 
-// 0x59E168
+// 0x59E168 name1
 static char gIntLibPlayMovieFileName[100];
 
-// 0x59E1CC
+// 0x59E1CC name2
 static char gIntLibPlayMovieRectFileName[100];
 
 // fillwin3x3
-// 0x461780 op_fillwin3x3_
+// 0x461780 op_fillwin3x3
 void opFillWin3x3(Program* program)
 {
     char* fileName = programStackPopString(program);
@@ -191,7 +191,7 @@ void opFillWin3x3(Program* program)
 }
 
 // format
-// 0x461850 op_format_
+// 0x461850 op_format
 static void opFormat(Program* program)
 {
     int textAlignment = programStackPopInteger(program);
@@ -207,7 +207,7 @@ static void opFormat(Program* program)
 }
 
 // print
-// 0x461A5C op_print_
+// 0x461A5C op_print
 static void opPrint(Program* program)
 {
     scriptWindowSelectId(program->windowId);
@@ -240,7 +240,7 @@ static void opPrint(Program* program)
 }
 
 // selectfilelist
-// 0x461B10 op_selectfilelist_
+// 0x461B10 op_selectfilelist
 void opSelectFileList(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -274,7 +274,7 @@ void opSelectFileList(Program* program)
 }
 
 // tokenize
-// 0x461CA0 op_tokenize_
+// 0x461CA0 op_tokenize
 void opTokenize(Program* program)
 {
     int ch = programStackPopInteger(program);
@@ -341,7 +341,7 @@ void opTokenize(Program* program)
 }
 
 // printrect
-// 0x461F1C op_printrect_
+// 0x461F1C op_printrect
 static void opPrintRect(Program* program)
 {
     scriptWindowSelectId(program->windowId);
@@ -372,7 +372,7 @@ static void opPrintRect(Program* program)
     }
 }
 
-// 0x46209C op_selectwin_
+// 0x46209C op_selectwin
 void opSelect(Program* program)
 {
     const char* windowName = programStackPopString(program);
@@ -387,7 +387,7 @@ void opSelect(Program* program)
 }
 
 // display
-// 0x46213C op_display_
+// 0x46213C op_display
 void opDisplay(Program* program)
 {
     char* fileName = programStackPopString(program);
@@ -399,7 +399,7 @@ void opDisplay(Program* program)
 }
 
 // displayraw
-// 0x4621B4 op_displayraw_
+// 0x4621B4 op_displayraw
 void opDisplayRaw(Program* program)
 {
     char* fileName = programStackPopString(program);
@@ -410,7 +410,7 @@ void opDisplayRaw(Program* program)
     _displayFileRaw(mangledFileName);
 }
 
-// 0x46222C interpretFadePaletteBK_
+// 0x46222C interpretFadePaletteBK
 static void _interpretFadePaletteBK(unsigned char* oldPalette, unsigned char* newPalette, int a3, float duration, int shouldProcessBk)
 {
     unsigned int time;
@@ -457,7 +457,7 @@ static void _interpretFadePaletteBK(unsigned char* oldPalette, unsigned char* ne
 
 // NOTE: Unused.
 //
-// 0x462330 interpretFadePalette_
+// 0x462330 interpretFadePalette
 static void interpretFadePalette(unsigned char* oldPalette, unsigned char* newPalette, int a3, float duration)
 {
     _interpretFadePaletteBK(oldPalette, newPalette, a3, duration, 1);
@@ -471,7 +471,7 @@ static int intlibGetFadeIn()
 
 // NOTE: Inlined.
 //
-// 0x462348 interpretFadeOut_
+// 0x462348 interpretFadeOut
 static void interpretFadeOut(float duration)
 {
     int cursorWasHidden;
@@ -488,7 +488,7 @@ static void interpretFadeOut(float duration)
 
 // NOTE: Inlined.
 //
-// 0x462380 interpretFadeIn_
+// 0x462380 interpretFadeIn
 static void interpretFadeIn(float duration)
 {
     _interpretFadePaletteBK(gIntLibFadePalette, _cmap, 64, duration, 1);
@@ -496,7 +496,7 @@ static void interpretFadeIn(float duration)
 
 // NOTE: Unused.
 //
-// 0x4623A4 interpretFadeOutNoBK_
+// 0x4623A4 interpretFadeOutNoBK
 static void interpretFadeOutNoBK(float duration)
 {
     int cursorWasHidden;
@@ -513,14 +513,14 @@ static void interpretFadeOutNoBK(float duration)
 
 // NOTE: Unused.
 //
-// 0x4623DC interpretFadeInNoBK_
+// 0x4623DC interpretFadeInNoBK
 static void interpretFadeInNoBK(float duration)
 {
     _interpretFadePaletteBK(gIntLibFadePalette, _cmap, 64, duration, 0);
 }
 
 // fadein
-// 0x462400 op_fadein_
+// 0x462400 op_fadein
 void opFadeIn(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -538,7 +538,7 @@ void opFadeIn(Program* program)
 }
 
 // fadeout
-// 0x4624B4 op_fadeout_
+// 0x4624B4 op_fadeout
 void opFadeOut(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -560,7 +560,7 @@ void opFadeOut(Program* program)
     program->flags &= ~PROGRAM_FLAG_CHILD_CALL;
 }
 
-// 0x462570 checkMovie_
+// 0x462570 checkMovie
 int intLibCheckMovie(Program* program)
 {
     if (_dialogGetDialogDepth() > 0) {
@@ -571,7 +571,7 @@ int intLibCheckMovie(Program* program)
 }
 
 // movieflags
-// 0x462584 op_movieflags_
+// 0x462584 op_movieflags
 static void opSetMovieFlags(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -582,7 +582,7 @@ static void opSetMovieFlags(Program* program)
 }
 
 // playmovie
-// 0x4625D0 op_playmovie_
+// 0x4625D0 op_playmovie
 void opPlayMovie(Program* program)
 {
     char* movieFileName = programStackPopString(program);
@@ -605,7 +605,7 @@ void opPlayMovie(Program* program)
 }
 
 // playmovierect
-// 0x4626C4 op_playmovierect_
+// 0x4626C4 op_playmovierect
 void opPlayMovieRect(Program* program)
 {
     int height = programStackPopInteger(program);
@@ -632,7 +632,7 @@ void opPlayMovieRect(Program* program)
 }
 
 // stopmovie
-// 0x46287C op_stopmovie_
+// 0x46287C op_stopmovie
 static void opStopMovie(Program* program)
 {
     scriptWindowStopMovie();
@@ -640,7 +640,7 @@ static void opStopMovie(Program* program)
 }
 
 // deleteregion
-// 0x462890 op_deleteregion_
+// 0x462890 op_deleteregion
 static void opDeleteRegion(Program* program)
 {
     ProgramValue value = programStackPopValue(program);
@@ -664,7 +664,7 @@ static void opDeleteRegion(Program* program)
 }
 
 // activateregion
-// 0x462924 op_activateregion_
+// 0x462924 op_activateregion
 void opActivateRegion(Program* program)
 {
     int v1 = programStackPopInteger(program);
@@ -674,7 +674,7 @@ void opActivateRegion(Program* program)
 }
 
 // checkregion
-// 0x4629A0 op_checkregion_
+// 0x4629A0 op_checkregion
 static void opCheckRegion(Program* program)
 {
     const char* regionName = programStackPopString(program);
@@ -684,7 +684,7 @@ static void opCheckRegion(Program* program)
 }
 
 // addregion
-// 0x462A1C op_addregion_
+// 0x462A1C op_addregion
 void opAddRegion(Program* program)
 {
     int args = programStackPopInteger(program);
@@ -719,7 +719,7 @@ void opAddRegion(Program* program)
 }
 
 // addregionproc
-// 0x462C10 op_addregionproc_
+// 0x462C10 op_addregionproc
 static void opAddRegionProc(Program* program)
 {
     int v1 = programStackPopInteger(program);
@@ -736,7 +736,7 @@ static void opAddRegionProc(Program* program)
 }
 
 // addregionrightproc
-// 0x462DDC op_addregionrightproc_
+// 0x462DDC op_addregionrightproc
 static void opAddRegionRightProc(Program* program)
 {
     int v1 = programStackPopInteger(program);
@@ -750,7 +750,7 @@ static void opAddRegionRightProc(Program* program)
 }
 
 // createwin
-// 0x462F08 op_createwin_
+// 0x462F08 op_createwin
 void opCreateWin(Program* program)
 {
     int height = programStackPopInteger(program);
@@ -770,7 +770,7 @@ void opCreateWin(Program* program)
 }
 
 // resizewin
-// 0x46308C op_resizewin_
+// 0x46308C op_resizewin
 void opResizeWin(Program* program)
 {
     int height = programStackPopInteger(program);
@@ -790,7 +790,7 @@ void opResizeWin(Program* program)
 }
 
 // scalewin
-// 0x463204 op_scalewin_
+// 0x463204 op_scalewin
 void opScaleWin(Program* program)
 {
     int height = programStackPopInteger(program);
@@ -810,7 +810,7 @@ void opScaleWin(Program* program)
 }
 
 // deletewin
-// 0x46337C op_deletewin_
+// 0x46337C op_deletewin
 void opDeleteWin(Program* program)
 {
     char* windowName = programStackPopString(program);
@@ -823,7 +823,7 @@ void opDeleteWin(Program* program)
 }
 
 // saystart
-// 0x4633E4 op_saystart_
+// 0x4633E4 op_saystart
 static void opSayStart(Program* program)
 {
     gIntLibSayStartingPosition = 0;
@@ -838,7 +838,7 @@ static void opSayStart(Program* program)
 }
 
 // saystartpos
-// 0x463430 op_saystartpos_
+// 0x463430 op_saystartpos
 static void opSayStartPos(Program* program)
 {
     gIntLibSayStartingPosition = programStackPopInteger(program);
@@ -853,7 +853,7 @@ static void opSayStartPos(Program* program)
 }
 
 // sayreplytitle
-// 0x46349C op_sayreplytitle_
+// 0x46349C op_sayreplytitle
 static void opSayReplyTitle(Program* program)
 {
     ProgramValue value = programStackPopValue(program);
@@ -869,7 +869,7 @@ static void opSayReplyTitle(Program* program)
 }
 
 // saygotoreply
-// 0x463510 op_saygotoreply_
+// 0x463510 op_saygotoreply
 static void opSayGoToReply(Program* program)
 {
     ProgramValue value = programStackPopValue(program);
@@ -885,7 +885,7 @@ static void opSayGoToReply(Program* program)
 }
 
 // sayreply
-// 0x463584 op_sayoption_
+// 0x463584 op_sayoption
 void opSayReply(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -948,14 +948,14 @@ void opSayOption(Program* program)
     program->flags &= ~PROGRAM_FLAG_CHILD_CALL;
 }
 
-// 0x46378C checkDialog_
+// 0x46378C checkDialog
 int intLibCheckDialog(Program* program)
 {
     program->flags |= PROGRAM_FLAG_FINISHED;
     return _dialogGetDialogDepth() != -1;
 }
 
-// 0x4637A4 op_sayend_
+// 0x4637A4 op_sayend
 void opSayEnd(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -969,7 +969,7 @@ void opSayEnd(Program* program)
 }
 
 // saygetlastpos
-// 0x4637EC op_saygetlastpos_
+// 0x4637EC op_saygetlastpos
 static void opSayGetLastPos(Program* program)
 {
     int value = _dialogGetExitPoint();
@@ -977,7 +977,7 @@ static void opSayGetLastPos(Program* program)
 }
 
 // sayquit
-// 0x463810 op_sayquit_
+// 0x463810 op_sayquit
 static void opSayQuit(Program* program)
 {
     if (_dialogQuit() != 0) {
@@ -987,7 +987,7 @@ static void opSayQuit(Program* program)
 
 // NOTE: Unused.
 //
-// 0x463828 getTimeOut_
+// 0x463828 getTimeOut
 static int getTimeOut()
 {
     return _TimeOut;
@@ -995,14 +995,14 @@ static int getTimeOut()
 
 // NOTE: Unused.
 //
-// 0x463830 setTimeOut_
+// 0x463830 setTimeOut
 static void setTimeOut(int value)
 {
     _TimeOut = value;
 }
 
 // saymessagetimeout
-// 0x463838 op_saymessagetimeout_
+// 0x463838 op_saymessagetimeout
 static void opSayMessageTimeout(Program* program)
 {
     ProgramValue value = programStackPopValue(program);
@@ -1016,7 +1016,7 @@ static void opSayMessageTimeout(Program* program)
 }
 
 // saymessage
-// 0x463890 op_saymessage_
+// 0x463890 op_saymessage
 void opSayMessage(Program* program)
 {
     program->flags |= PROGRAM_FLAG_CHILD_CALL;
@@ -1047,7 +1047,7 @@ void opSayMessage(Program* program)
 }
 
 // gotoxy
-// 0x463980 op_gotoxy_
+// 0x463980 op_gotoxy
 void opGotoXY(Program* program)
 {
     int y = programStackPopInteger(program);
@@ -1059,7 +1059,7 @@ void opGotoXY(Program* program)
 }
 
 // addbuttonflag
-// 0x463A38 op_addbuttonflag_
+// 0x463A38 op_addbuttonflag
 static void opAddButtonFlag(Program* program)
 {
     int flag = programStackPopInteger(program);
@@ -1072,7 +1072,7 @@ static void opAddButtonFlag(Program* program)
 }
 
 // addregionflag
-// 0x463B10 op_addregionflag_
+// 0x463B10 op_addregionflag
 static void opAddRegionFlag(Program* program)
 {
     int flag = programStackPopInteger(program);
@@ -1085,7 +1085,7 @@ static void opAddRegionFlag(Program* program)
 }
 
 // addbutton
-// 0x463BE8 op_addbutton_
+// 0x463BE8 op_addbutton
 void opAddButton(Program* program)
 {
     int height = programStackPopInteger(program);
@@ -1105,7 +1105,7 @@ void opAddButton(Program* program)
 }
 
 // addbuttontext
-// 0x463DF4 op_addbuttontext_
+// 0x463DF4 op_addbuttontext
 void opAddButtonText(Program* program)
 {
     const char* text = programStackPopString(program);
@@ -1117,7 +1117,7 @@ void opAddButtonText(Program* program)
 }
 
 // addbuttongfx
-// 0x463EEC op_addbuttongfx_
+// 0x463EEC op_addbuttongfx
 void opAddButtonGfx(Program* program)
 {
     ProgramValue v1 = programStackPopValue(program);
@@ -1143,7 +1143,7 @@ void opAddButtonGfx(Program* program)
 }
 
 // addbuttonproc
-// 0x4640DC op_addbuttonproc_
+// 0x4640DC op_addbuttonproc
 static void opAddButtonProc(Program* program)
 {
     int v1 = programStackPopInteger(program);
@@ -1159,7 +1159,7 @@ static void opAddButtonProc(Program* program)
 }
 
 // addbuttonrightproc
-// 0x4642A8 op_addbuttonrightproc_
+// 0x4642A8 op_addbuttonrightproc
 static void opAddButtonRightProc(Program* program)
 {
     int v1 = programStackPopInteger(program);
@@ -1173,7 +1173,7 @@ static void opAddButtonRightProc(Program* program)
 }
 
 // showwin
-// 0x4643D4 op_showwin_
+// 0x4643D4 op_showwin
 static void opShowWin(Program* program)
 {
     scriptWindowSelectId(program->windowId);
@@ -1181,7 +1181,7 @@ static void opShowWin(Program* program)
 }
 
 // deletebutton
-// 0x4643E4 op_deletebutton_
+// 0x4643E4 op_deletebutton
 static void opDeleteButton(Program* program)
 {
     ProgramValue value = programStackPopValue(program);
@@ -1215,7 +1215,7 @@ static void opDeleteButton(Program* program)
 }
 
 // fillwin
-// 0x46449C op_fillwin_
+// 0x46449C op_fillwin
 void opFillWin(Program* program)
 {
     ProgramValue b = programStackPopValue(program);
@@ -1258,7 +1258,7 @@ void opFillWin(Program* program)
 }
 
 // fillrect
-// 0x4645FC op_fillrect_
+// 0x4645FC op_fillrect
 void opFillRect(Program* program)
 {
     ProgramValue b = programStackPopValue(program);
@@ -1305,21 +1305,21 @@ void opFillRect(Program* program)
 }
 
 // hidemouse
-// 0x46489C op_hidemouse_
+// 0x46489C op_hidemouse
 static void opHideMouse(Program* program)
 {
     mouseHideCursor();
 }
 
 // showmouse
-// 0x4648A4 op_showmouse_
+// 0x4648A4 op_showmouse
 static void opShowMouse(Program* program)
 {
     mouseShowCursor();
 }
 
 // mouseshape
-// 0x4648AC op_mouseshape_
+// 0x4648AC op_mouseshape
 void opMouseShape(Program* program)
 {
     int v1 = programStackPopInteger(program);
@@ -1332,14 +1332,14 @@ void opMouseShape(Program* program)
 }
 
 // setglobalmousefunc
-// 0x4649C4 op_setglobalmousefunc_
+// 0x4649C4 op_setglobalmousefunc
 static void opSetGlobalMouseFunc(Program* Program)
 {
     programFatalError("setglobalmousefunc not defined");
 }
 
 // displaygfx
-// 0x4649D4 op_displaygfx_
+// 0x4649D4 op_displaygfx
 void opDisplayGfx(Program* program)
 {
     int height = programStackPopInteger(program);
@@ -1353,7 +1353,7 @@ void opDisplayGfx(Program* program)
 }
 
 // loadpalettetable
-// 0x464ADC op_loadpalettetable_
+// 0x464ADC op_loadpalettetable
 static void opLoadPaletteTable(Program* program)
 {
     char* path = programStackPopString(program);
@@ -1363,7 +1363,7 @@ static void opLoadPaletteTable(Program* program)
 }
 
 // addnamedevent
-// 0x464B54 op_addNamedEvent_
+// 0x464B54 op_addNamedEvent
 static void opAddNamedEvent(Program* program)
 {
     int proc = programStackPopInteger(program);
@@ -1372,7 +1372,7 @@ static void opAddNamedEvent(Program* program)
 }
 
 // addnamedhandler
-// 0x464BE8 op_addNamedHandler_
+// 0x464BE8 op_addNamedHandler
 static void opAddNamedHandler(Program* program)
 {
     int proc = programStackPopInteger(program);
@@ -1381,7 +1381,7 @@ static void opAddNamedHandler(Program* program)
 }
 
 // clearnamed
-// 0x464C80 op_clearNamed_
+// 0x464C80 op_clearNamed
 static void opClearNamed(Program* program)
 {
     char* string = programStackPopString(program);
@@ -1389,7 +1389,7 @@ static void opClearNamed(Program* program)
 }
 
 // signalnamed
-// 0x464CE4 op_signalNamed_
+// 0x464CE4 op_signalNamed
 static void opSignalNamed(Program* program)
 {
     char* str = programStackPopString(program);
@@ -1397,7 +1397,7 @@ static void opSignalNamed(Program* program)
 }
 
 // addkey
-// 0x464D48 op_addkey_
+// 0x464D48 op_addkey
 static void opAddKey(Program* program)
 {
     int proc = programStackPopInteger(program);
@@ -1417,7 +1417,7 @@ static void opAddKey(Program* program)
 }
 
 // deletekey
-// 0x464E24 op_deletekey_
+// 0x464E24 op_deletekey
 static void opDeleteKey(Program* program)
 {
     int key = programStackPopInteger(program);
@@ -1436,7 +1436,7 @@ static void opDeleteKey(Program* program)
 }
 
 // refreshmouse
-// 0x464EB0 op_refreshmouse_
+// 0x464EB0 op_refreshmouse
 void opRefreshMouse(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -1447,7 +1447,7 @@ void opRefreshMouse(Program* program)
 }
 
 // setfont
-// 0x464F18 op_setfont_
+// 0x464F18 op_setfont
 static void opSetFont(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -1458,7 +1458,7 @@ static void opSetFont(Program* program)
 }
 
 // setflags
-// 0x464F84 op_settextflags_
+// 0x464F84 op_settextflags
 static void opSetTextFlags(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -1469,7 +1469,7 @@ static void opSetTextFlags(Program* program)
 }
 
 // settextcolor
-// 0x464FF0 op_settextcolor_
+// 0x464FF0 op_settextcolor
 static void opSetTextColor(Program* program)
 {
     ProgramValue value[3];
@@ -1497,7 +1497,7 @@ static void opSetTextColor(Program* program)
 }
 
 // sayoptioncolor
-// 0x465140 op_sayoptioncolor_
+// 0x465140 op_sayoptioncolor
 static void opSayOptionColor(Program* program)
 {
     ProgramValue value[3];
@@ -1525,7 +1525,7 @@ static void opSayOptionColor(Program* program)
 }
 
 // sayreplycolor
-// 0x465290 op_sayreplycolor_
+// 0x465290 op_sayreplycolor
 static void opSayReplyColor(Program* program)
 {
     ProgramValue value[3];
@@ -1553,7 +1553,7 @@ static void opSayReplyColor(Program* program)
 }
 
 // sethighlightcolor
-// 0x4653E0 op_sethighlightcolor_
+// 0x4653E0 op_sethighlightcolor
 static void opSetHighlightColor(Program* program)
 {
     ProgramValue value[3];
@@ -1581,7 +1581,7 @@ static void opSetHighlightColor(Program* program)
 }
 
 // sayreplywindow
-// 0x465530 op_sayreplywindow_
+// 0x465530 op_sayreplywindow
 void opSayReplyWindow(Program* program)
 {
     ProgramValue v2 = programStackPopValue(program);
@@ -1607,7 +1607,7 @@ void opSayReplyWindow(Program* program)
 }
 
 // sayreplyflags
-// 0x465688 op_sayreplyflags_
+// 0x465688 op_sayreplyflags
 static void opSayReplyFlags(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -1618,7 +1618,7 @@ static void opSayReplyFlags(Program* program)
 }
 
 // sayoptionflags
-// 0x4656F4 op_sayoptionflags_
+// 0x4656F4 op_sayoptionflags
 static void opSayOptionFlags(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -1629,7 +1629,7 @@ static void opSayOptionFlags(Program* program)
 }
 
 // sayoptionwindow
-// 0x465760 op_sayoptionwindow_
+// 0x465760 op_sayoptionwindow
 void opSayOptionWindow(Program* program)
 {
     ProgramValue v2 = programStackPopValue(program);
@@ -1655,7 +1655,7 @@ void opSayOptionWindow(Program* program)
 }
 
 // sayborder
-// 0x4658B8 op_sayborder_
+// 0x4658B8 op_sayborder
 static void opSayBorder(Program* program)
 {
     int y = programStackPopInteger(program);
@@ -1667,7 +1667,7 @@ static void opSayBorder(Program* program)
 }
 
 // sayscrollup
-// 0x465978 op_sayscrollup_
+// 0x465978 op_sayscrollup
 void opSayScrollUp(Program* program)
 {
     ProgramValue v6 = programStackPopValue(program);
@@ -1739,7 +1739,7 @@ void opSayScrollUp(Program* program)
 }
 
 // sayscrolldown
-// 0x465CAC op_sayscrolldown_
+// 0x465CAC op_sayscrolldown
 void opSayScrollDown(Program* program)
 {
     ProgramValue v6 = programStackPopValue(program);
@@ -1813,7 +1813,7 @@ void opSayScrollDown(Program* program)
 }
 
 // saysetspacing
-// 0x465FE0 op_saysetspacing_
+// 0x465FE0 op_saysetspacing
 static void opSaySetSpacing(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -1824,7 +1824,7 @@ static void opSaySetSpacing(Program* program)
 }
 
 // sayrestart
-// 0x46604C op_sayrestart_
+// 0x46604C op_sayrestart
 static void opSayRestart(Program* program)
 {
     if (_dialogRestart() != 0) {
@@ -1832,7 +1832,7 @@ static void opSayRestart(Program* program)
     }
 }
 
-// 0x466064 soundCallbackInterpret_
+// 0x466064 soundCallbackInterpret
 static void intLibSoundCallback(void* userData, int event)
 {
     if (event == SOUND_CALLBACK_EVENT_DONE) {
@@ -1841,7 +1841,7 @@ static void intLibSoundCallback(void* userData, int event)
     }
 }
 
-// 0x466070 soundDeleteInterpret_
+// 0x466070 soundDeleteInterpret
 static int intLibSoundDelete(int value)
 {
     if (value == -1) {
@@ -1869,7 +1869,7 @@ static int intLibSoundDelete(int value)
     return 1;
 }
 
-// 0x466110 soundStartInterpret_
+// 0x466110 soundStartInterpret
 static int intLibSoundPlay(char* fileName, int mode)
 {
     int type = SOUND_TYPE_MEMORY;
@@ -1988,7 +1988,7 @@ err:
     return -1;
 }
 
-// 0x46655C soundPauseInterpret_
+// 0x46655C soundPauseInterpret
 static int intLibSoundPause(int value)
 {
     if (value == -1) {
@@ -2014,7 +2014,7 @@ static int intLibSoundPause(int value)
     return rc == SOUND_NO_ERROR;
 }
 
-// 0x4665C8 soundRewindInterpret_
+// 0x4665C8 soundRewindInterpret
 static int intLibSoundRewind(int value)
 {
     if (value == -1) {
@@ -2040,7 +2040,7 @@ static int intLibSoundRewind(int value)
     return soundPlay(sound) == SOUND_NO_ERROR;
 }
 
-// 0x46662C soundUnpauseInterpret_
+// 0x46662C soundUnpauseInterpret
 static int intLibSoundResume(int value)
 {
     if (value == -1) {
@@ -2067,7 +2067,7 @@ static int intLibSoundResume(int value)
 }
 
 // soundplay
-// 0x466698 op_soundplay_
+// 0x466698 op_soundplay
 static void opSoundPlay(Program* program)
 {
     int flags = programStackPopInteger(program);
@@ -2080,7 +2080,7 @@ static void opSoundPlay(Program* program)
 }
 
 // soundpause
-// 0x466768 op_soundpause_
+// 0x466768 op_soundpause
 static void opSoundPause(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -2088,7 +2088,7 @@ static void opSoundPause(Program* program)
 }
 
 // soundresume
-// 0x4667C0 op_soundresume_
+// 0x4667C0 op_soundresume
 static void opSoundResume(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -2096,7 +2096,7 @@ static void opSoundResume(Program* program)
 }
 
 // soundstop
-// 0x466818 op_soundstop_
+// 0x466818 op_soundstop
 static void opSoundStop(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -2104,7 +2104,7 @@ static void opSoundStop(Program* program)
 }
 
 // soundrewind
-// 0x466870 op_soundrewind_
+// 0x466870 op_soundrewind
 static void opSoundRewind(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -2112,7 +2112,7 @@ static void opSoundRewind(Program* program)
 }
 
 // sounddelete
-// 0x4668C8 op_sounddelete_
+// 0x4668C8 op_sounddelete
 static void opSoundDelete(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -2120,7 +2120,7 @@ static void opSoundDelete(Program* program)
 }
 
 // SetOneOptPause
-// 0x466920 op_setoneoptpause_
+// 0x466920 op_setoneoptpause
 static void opSetOneOptPause(Program* program)
 {
     int data = programStackPopInteger(program);
@@ -2138,14 +2138,14 @@ static void opSetOneOptPause(Program* program)
     _dialogToggleMediaFlag(8);
 }
 
-// 0x466994 updateIntLib_
+// 0x466994 updateIntLib
 void intLibUpdate()
 {
     _nevs_update();
     intExtraUpdate();
 }
 
-// 0x4669A0 intlibClose_
+// 0x4669A0 intlibClose
 void intLibExit()
 {
     _dialogClose();
@@ -2166,7 +2166,7 @@ void intLibExit()
     }
 }
 
-// 0x466A04 intLibDoInput_
+// 0x466A04 intLibDoInput
 static bool intLibDoInput(int key)
 {
     if (key < 0 || key >= INT_LIB_KEY_HANDLERS_CAPACITY) {
@@ -2192,7 +2192,7 @@ static bool intLibDoInput(int key)
     return true;
 }
 
-// 0x466A70 initIntlib_
+// 0x466A70 initIntlib
 void intLibInit()
 {
     scriptWindowAddInputFunc(intLibDoInput);
@@ -2286,7 +2286,7 @@ void intLibInit()
     dialogInit();
 }
 
-// 0x466F6C interpretRegisterProgramDeleteCallback_
+// 0x466F6C interpretRegisterProgramDeleteCallback
 void intLibRegisterProgramDeleteCallback(IntLibProgramDeleteCallback* callback)
 {
     int index;

--- a/src/interpreter_lib.cc
+++ b/src/interpreter_lib.cc
@@ -128,7 +128,7 @@ static void opSoundDelete(Program* program);
 static void opSetOneOptPause(Program* program);
 static bool intLibDoInput(int key);
 
-// 0x59D5D0 _interpretSounds
+// 0x59D5D0 interpretSounds
 static Sound* gIntLibSounds[INT_LIB_SOUNDS_CAPACITY];
 
 // 0x59D650 blackPal
@@ -146,7 +146,7 @@ static int gIntLibGenericKeyHandlerProc;
 // 0x59E158 numCallbacks
 static int gIntLibProgramDeleteCallbacksLength;
 
-// 0x59E15C _anyKeyProg
+// 0x59E15C anyKeyProg
 static Program* gIntLibGenericKeyHandlerProgram;
 
 // 0x59E160 callbacks

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -404,7 +404,7 @@ static InventoryLootLayout inventoryLootLayout;
 static FrmImage inventoryFrmImage;
 static FrmImage inventoryLootFrmImage;
 
-// 0x519058 _inven_dude
+// 0x519058 inven_dude
 static Object* _inven_dude = nullptr;
 
 // Probably fid of armor to display in inventory dialog.
@@ -514,7 +514,7 @@ static int _target_stack_offset[10];
 static MessageList gInventoryMessageList;
 
 // Current target critter or container for every nesting level (stack).
-// 0x59E81C _target_stack
+// 0x59E81C target_stack
 static Object* _target_stack[10];
 
 // Scroll offsets to main inventory for every container nesting level (stack).
@@ -522,7 +522,7 @@ static Object* _target_stack[10];
 static int _stack_offset[10];
 
 // Current critter or container for every nesting level (stack).
-// 0x59E86C _stack
+// 0x59E86C stack
 static Object* _stack[10];
 
 // 0x59E894 mt_wid
@@ -553,10 +553,10 @@ static Inventory* gPlayerTableInventory;
 static InventoryCursorData gInventoryCursorData[INVENTORY_WINDOW_CURSOR_COUNT];
 
 // An object (PID -1) with an inventory containing a subset of Player's items offered to the NPC during barter.
-// 0x59E934 _ptable
+// 0x59E934 ptable
 static Object* gPlayerTableObj;
 
-// 0x59E938 _display_msg
+// 0x59E938 display_msg
 static InventoryPrintItemDescriptionHandler* gInventoryPrintItemDescriptionHandler;
 
 // 0x59E93C im_value
@@ -566,7 +566,7 @@ static int _im_value; // "keyCode" corresponding to an inventory item "button", 
 static int gInventoryCursor;
 
 // An object (PID -1) with an inventory containing a subset of NPC's items asked for by the player during barter.
-// 0x59E944 _btable
+// 0x59E944 btable
 static Object* gBartererTableObj;
 
 // Current nesting level for viewing target's bag/backpack contents.
@@ -579,10 +579,10 @@ static Inventory* gBartererTableInventory;
 // 0x59E950 inven_ui_was_disabled
 static bool _inven_ui_was_disabled;
 
-// 0x59E954 _i_worn
+// 0x59E954 i_worn
 static Object* gInventoryArmor;
 
-// 0x59E958 _i_lhand
+// 0x59E958 i_lhand
 static Object* gInventoryLeftHandItem;
 
 // Rotating character's fid.
@@ -597,7 +597,7 @@ static Inventory* _pud;
 static int gInventoryWindow;
 
 // item2
-// 0x59E968 _i_rhand
+// 0x59E968 i_rhand
 static Object* gInventoryRightHandItem;
 
 // Current nesting level for viewing bag/backpack contents.
@@ -610,7 +610,7 @@ static int gInventoryWindowMaxY;
 // 0x59E974 i_wid_max_x
 static int gInventoryWindowMaxX;
 
-// 0x59E978 _target_pud
+// 0x59E978 target_pud
 static Inventory* _target_pud;
 
 // 0x59E97C barter_back_win

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -363,7 +363,7 @@ static int inventoryComputeAlignedMaxOffset(int length, int visibleSlots, int sc
 static int inventoryGetCenteredWindowY(int windowHeight);
 static void inventoryDisplayLeftPaneCompanionName(unsigned char* windowBuffer, int windowPitch, const Rect& rect, int index);
 
-// 0x46E6D0
+// 0x46E6D0 stats_array0
 static const int gSummaryStats[7] = {
     STAT_CURRENT_HIT_POINTS,
     STAT_ARMOR_CLASS,
@@ -374,7 +374,7 @@ static const int gSummaryStats[7] = {
     STAT_DAMAGE_THRESHOLD_EXPLOSION,
 };
 
-// 0x46E6EC
+// 0x46E6EC stats_array1
 static const int gSummaryStats2[7] = {
     STAT_MAXIMUM_HIT_POINTS,
     -1,
@@ -395,7 +395,7 @@ static const int gInventoryArrowFrmIds[INVENTORY_ARROW_FRM_COUNT] = {
 
 // The number of items to show in scroller.
 //
-// 0x519054
+// 0x519054 inven_cur_disp
 static int gInventorySlotsCount = 6;
 
 static InventoryNormalLayout inventoryLayout;
@@ -404,21 +404,21 @@ static InventoryLootLayout inventoryLootLayout;
 static FrmImage inventoryFrmImage;
 static FrmImage inventoryLootFrmImage;
 
-// 0x519058 inven_dude
+// 0x519058 _inven_dude
 static Object* _inven_dude = nullptr;
 
 // Probably fid of armor to display in inventory dialog.
 //
-// 0x51905C
+// 0x51905C inven_pid
 static int _inven_pid = -1;
 
-// 0x519060
+// 0x519060 inven_is_initialized
 static bool _inven_is_initialized = false;
 
-// 0x519064
+// 0x519064 inven_display_msg_line
 static int _inven_display_msg_line = 1;
 
-// 0x519068
+// 0x519068 iscr_data
 static const InventoryWindowDescription gInventoryWindowDescriptions[INVENTORY_WINDOW_TYPE_COUNT] = {
     { INVENTORY_NORMAL_BACKGROUND_FRM_ID, INVENTORY_WINDOW_WIDTH, 377, 80, 0 },
     { 113, INVENTORY_USE_ON_WINDOW_WIDTH, 376, 80, 0 },
@@ -428,28 +428,28 @@ static const InventoryWindowDescription gInventoryWindowDescriptions[INVENTORY_W
     { 305, INVENTORY_TIMER_WINDOW_WIDTH, 162, 140, 80 },
 };
 
-// 0x5190E0
+// 0x5190E0 dropped_explosive
 static bool _dropped_explosive = false;
 
-// 0x5190E4
+// 0x5190E4 inven_scroll_up_bid
 static int gInventoryScrollUpButton = -1;
 
-// 0x5190E8
+// 0x5190E8 inven_scroll_dn_bid
 static int gInventoryScrollDownButton = -1;
 
-// 0x5190EC
+// 0x5190EC loot_scroll_up_bid
 static int gSecondaryInventoryScrollUpButton = -1;
 
-// 0x5190F0
+// 0x5190F0 loot_scroll_dn_bid
 static int gSecondaryInventoryScrollDownButton = -1;
 
-// 0x5190F4
+// 0x5190F4 ticker
 static unsigned int gInventoryWindowDudeRotationTimestamp = 0;
 
-// 0x5190F8
+// 0x5190F8 curr_rot
 static int gInventoryWindowDudeRotation = 0;
 
-// 0x5190FC
+// 0x5190FC num
 static const int gInventoryWindowCursorFrmIds[INVENTORY_WINDOW_CURSOR_COUNT] = {
     286, // pointing hand
     250, // action arrow
@@ -458,10 +458,10 @@ static const int gInventoryWindowCursorFrmIds[INVENTORY_WINDOW_CURSOR_COUNT] = {
     266, // blank
 };
 
-// 0x519110
+// 0x519110 last_target
 static Object* _last_target = nullptr;
 
-// 0x519114
+// 0x519114 act_use
 static const int _act_use[4] = {
     GAME_MOUSE_ACTION_MENU_ITEM_LOOK,
     GAME_MOUSE_ACTION_MENU_ITEM_USE,
@@ -469,27 +469,27 @@ static const int _act_use[4] = {
     GAME_MOUSE_ACTION_MENU_ITEM_CANCEL,
 };
 
-// 0x519124
+// 0x519124 act_no_use
 static const int _act_no_use[3] = {
     GAME_MOUSE_ACTION_MENU_ITEM_LOOK,
     GAME_MOUSE_ACTION_MENU_ITEM_DROP,
     GAME_MOUSE_ACTION_MENU_ITEM_CANCEL,
 };
 
-// 0x519130
+// 0x519130 act_just_use
 static const int _act_just_use[3] = {
     GAME_MOUSE_ACTION_MENU_ITEM_LOOK,
     GAME_MOUSE_ACTION_MENU_ITEM_USE,
     GAME_MOUSE_ACTION_MENU_ITEM_CANCEL,
 };
 
-// 0x51913C
+// 0x51913C act_nothing
 static const int _act_nothing[2] = {
     GAME_MOUSE_ACTION_MENU_ITEM_LOOK,
     GAME_MOUSE_ACTION_MENU_ITEM_CANCEL,
 };
 
-// 0x519144
+// 0x519144 act_weap
 static const int _act_weap[4] = {
     GAME_MOUSE_ACTION_MENU_ITEM_LOOK,
     GAME_MOUSE_ACTION_MENU_ITEM_UNLOAD,
@@ -497,7 +497,7 @@ static const int _act_weap[4] = {
     GAME_MOUSE_ACTION_MENU_ITEM_CANCEL,
 };
 
-// 0x519154
+// 0x519154 act_weap2
 static const int _act_weap2[3] = {
     GAME_MOUSE_ACTION_MENU_ITEM_LOOK,
     GAME_MOUSE_ACTION_MENU_ITEM_UNLOAD,
@@ -505,27 +505,27 @@ static const int _act_weap2[3] = {
 };
 
 // Scroll offsets to target inventory for every container nesting level (stack).
-// 0x59E7EC
+// 0x59E7EC target_stack_offset
 static int _target_stack_offset[10];
 
 // inventory.msg
 //
-// 0x59E814
+// 0x59E814 inventry_message_file
 static MessageList gInventoryMessageList;
 
 // Current target critter or container for every nesting level (stack).
-// 0x59E81C
+// 0x59E81C _target_stack
 static Object* _target_stack[10];
 
 // Scroll offsets to main inventory for every container nesting level (stack).
-// 0x59E844
+// 0x59E844 stack_offset
 static int _stack_offset[10];
 
 // Current critter or container for every nesting level (stack).
-// 0x59E86C
+// 0x59E86C _stack
 static Object* _stack[10];
 
-// 0x59E894
+// 0x59E894 mt_wid
 static int _mt_wid;
 
 // Note: Sfall also has InventoryApCost and QuickPocketsApCostReduction settings which we don't look at
@@ -546,23 +546,23 @@ static int gBartererTableOffset;
 static int gPlayerTableOffset;
 
 // An inventory containing a subset of Player's items offered to the NPC during barter.
-// 0x59E8A4 _ptable_pud
+// 0x59E8A4 ptable_pud
 static Inventory* gPlayerTableInventory;
 
-// 0x59E8A8
+// 0x59E8A8 imdata
 static InventoryCursorData gInventoryCursorData[INVENTORY_WINDOW_CURSOR_COUNT];
 
 // An object (PID -1) with an inventory containing a subset of Player's items offered to the NPC during barter.
 // 0x59E934 _ptable
 static Object* gPlayerTableObj;
 
-// 0x59E938
+// 0x59E938 _display_msg
 static InventoryPrintItemDescriptionHandler* gInventoryPrintItemDescriptionHandler;
 
-// 0x59E93C
+// 0x59E93C im_value
 static int _im_value; // "keyCode" corresponding to an inventory item "button", or -1 if nothing
 
-// 0x59E940
+// 0x59E940 immode
 static int gInventoryCursor;
 
 // An object (PID -1) with an inventory containing a subset of NPC's items asked for by the player during barter.
@@ -570,47 +570,47 @@ static int gInventoryCursor;
 static Object* gBartererTableObj;
 
 // Current nesting level for viewing target's bag/backpack contents.
-// 0x59E948
+// 0x59E948 target_curr_stack
 static int _target_curr_stack;
 
 // 0x59E94C btable_pud
 static Inventory* gBartererTableInventory;
 
-// 0x59E950
+// 0x59E950 inven_ui_was_disabled
 static bool _inven_ui_was_disabled;
 
-// 0x59E954
+// 0x59E954 _i_worn
 static Object* gInventoryArmor;
 
-// 0x59E958
+// 0x59E958 _i_lhand
 static Object* gInventoryLeftHandItem;
 
 // Rotating character's fid.
 //
-// 0x59E95C
+// 0x59E95C i_fid
 static int gInventoryWindowDudeFid;
 
-// 0x59E960
+// 0x59E960 pud
 static Inventory* _pud;
 
-// 0x59E964
+// 0x59E964 i_wid
 static int gInventoryWindow;
 
 // item2
-// 0x59E968
+// 0x59E968 _i_rhand
 static Object* gInventoryRightHandItem;
 
 // Current nesting level for viewing bag/backpack contents.
-// 0x59E96C
+// 0x59E96C curr_stack
 static int _curr_stack;
 
-// 0x59E970
+// 0x59E970 i_wid_max_y
 static int gInventoryWindowMaxY;
 
-// 0x59E974
+// 0x59E974 i_wid_max_x
 static int gInventoryWindowMaxX;
 
-// 0x59E978
+// 0x59E978 _target_pud
 static Inventory* _target_pud;
 
 // 0x59E97C barter_back_win

--- a/src/item.cc
+++ b/src/item.cc
@@ -92,12 +92,12 @@ typedef struct ExplosiveDescription {
     int maxDamage;
 } ExplosiveDescription;
 
-// 0x509FFC
+// 0x509FFC aItem_1
 static char _aItem_1[] = "<item>";
 
 // Maps weapon extended flags to skill.
 //
-// 0x519160
+// 0x519160 attack_skill
 static const int _attack_skill[9] = {
     -1,
     SKILL_UNARMED,
@@ -112,7 +112,7 @@ static const int _attack_skill[9] = {
 
 // A map of item's extendedFlags to animation.
 //
-// 0x519184
+// 0x519184 attack_anim
 static const int _attack_anim[9] = {
     ANIM_STAND,
     ANIM_THROW_PUNCH,
@@ -127,7 +127,7 @@ static const int _attack_anim[9] = {
 
 // Maps weapon extended flags to weapon class
 //
-// 0x5191A8
+// 0x5191A8 attack_subtype
 static const int _attack_subtype[9] = {
     ATTACK_TYPE_NONE, // 0 // None
     ATTACK_TYPE_UNARMED, // 1 // Punch // Brass Knuckles, Power First
@@ -140,7 +140,7 @@ static const int _attack_subtype[9] = {
     ATTACK_TYPE_RANGED, // 8 // Continous // Only: Flamer, Improved Flamer, Flame Breath
 };
 
-// 0x5191CC
+// 0x5191CC drugInfoList
 static DrugDescription gDrugDescriptions[ADDICTION_COUNT] = {
     { PROTO_ID_NUKA_COLA, GVAR_NUKA_COLA_ADDICT, 0 },
     { PROTO_ID_BUFF_OUT, GVAR_BUFF_OUT_ADDICT, 4 },
@@ -153,21 +153,21 @@ static DrugDescription gDrugDescriptions[ADDICTION_COUNT] = {
     { PROTO_ID_DECK_OF_TRAGIC_CARDS, GVAR_ADDICT_TRAGIC, 0 },
 };
 
-// 0x519238
+// 0x519238 _name_item
 static char* _name_item = _aItem_1;
 
 // item.msg
 //
-// 0x59E980
+// 0x59E980 item_message_file
 static MessageList gItemsMessageList;
 
-// 0x59E988
+// 0x59E988 wd_onset
 static int _wd_onset;
 
-// 0x59E98C
+// 0x59E98C _wd_obj
 static Object* _wd_obj;
 
-// 0x59E990
+// 0x59E990 wd_gvar
 static int _wd_gvar;
 
 static std::vector<BookDescription> gBooks;

--- a/src/item.cc
+++ b/src/item.cc
@@ -153,7 +153,7 @@ static DrugDescription gDrugDescriptions[ADDICTION_COUNT] = {
     { PROTO_ID_DECK_OF_TRAGIC_CARDS, GVAR_ADDICT_TRAGIC, 0 },
 };
 
-// 0x519238 _name_item
+// 0x519238 name_item
 static char* _name_item = _aItem_1;
 
 // item.msg
@@ -164,7 +164,7 @@ static MessageList gItemsMessageList;
 // 0x59E988 wd_onset
 static int _wd_onset;
 
-// 0x59E98C _wd_obj
+// 0x59E98C wd_obj
 static Object* _wd_obj;
 
 // 0x59E990 wd_gvar

--- a/src/kb.cc
+++ b/src/kb.cc
@@ -92,7 +92,7 @@ int gKeyboardLayout;
 // 0x6AD93C
 unsigned char gPressedPhysicalKeysCount;
 
-// 0x4CBC90
+// 0x4CBC90 GNW_kb_set_
 int keyboardInit()
 {
     if (_kb_installed) {
@@ -112,7 +112,7 @@ int keyboardInit()
     return 0;
 }
 
-// 0x4CBD00
+// 0x4CBD00 GNW_kb_restore_
 void keyboardFree()
 {
     if (_kb_installed) {
@@ -120,7 +120,7 @@ void keyboardFree()
     }
 }
 
-// 0x4CBDA8
+// 0x4CBDA8 kb_clear_
 void keyboardReset()
 {
     if (_kb_installed) {
@@ -147,25 +147,25 @@ int _kb_getch()
     return rc;
 }
 
-// 0x4CBE00
+// 0x4CBE00 kb_disable_
 void keyboardDisable()
 {
     gKeyboardDisabled = true;
 }
 
-// 0x4CBE0C
+// 0x4CBE0C kb_enable_
 void keyboardEnable()
 {
     gKeyboardDisabled = false;
 }
 
-// 0x4CBE18
+// 0x4CBE18 kb_is_disabled_
 int keyboardIsDisabled()
 {
     return gKeyboardDisabled;
 }
 
-// 0x4CBE74
+// 0x4CBE74 kb_set_layout_
 void keyboardSetLayout(int keyboardLayout)
 {
     int oldKeyboardLayout = gKeyboardLayout;
@@ -198,7 +198,7 @@ void keyboardSetLayout(int keyboardLayout)
     }
 }
 
-// 0x4CBEEC
+// 0x4CBEEC kb_get_layout_
 int keyboardGetLayout()
 {
     return gKeyboardLayout;
@@ -314,7 +314,7 @@ void _kb_simulate_key(KeyboardData* data)
     }
 }
 
-// 0x4CC2F0
+// 0x4CC2F0 kb_next_ascii_English_US_
 static int _kb_next_ascii_English_US()
 {
     KeyboardEvent* keyboardEvent;
@@ -396,7 +396,7 @@ static int _kb_next_ascii_English_US()
     return keyboardDequeueLogicalKeyCode();
 }
 
-// 0x4CDA4C
+// 0x4CDA4C kb_next_ascii_
 static int keyboardDequeueLogicalKeyCode()
 {
     KeyboardEvent* keyboardEvent;
@@ -470,7 +470,7 @@ static int keyboardDequeueLogicalKeyCode()
     return logicalKey;
 }
 
-// 0x4CDC08
+// 0x4CDC08 kb_map_ascii_English_US_
 static void keyboardBuildQwertyConfiguration()
 {
     int k;
@@ -1268,7 +1268,7 @@ static void keyboardBuildQwertyConfiguration()
     gLogicalKeyEntries[SDL_SCANCODE_KP_DECIMAL].ctrl = KEY_CTRL_DELETE;
 }
 
-// 0x4D0400
+// 0x4D0400 kb_map_ascii_French_
 static void keyboardBuildFrenchConfiguration()
 {
     int k;
@@ -1448,7 +1448,7 @@ static void keyboardBuildFrenchConfiguration()
     gLogicalKeyEntries[SDL_SCANCODE_SLASH].ctrl = -1;
 }
 
-// 0x4D0C54
+// 0x4D0C54 kb_map_ascii_German_
 static void keyboardBuildGermanConfiguration()
 {
     int k;
@@ -1658,7 +1658,7 @@ static void keyboardBuildGermanConfiguration()
     gLogicalKeyEntries[SDL_SCANCODE_KP_DECIMAL].ctrl = KEY_CTRL_DELETE;
 }
 
-// 0x4D1758
+// 0x4D1758 kb_map_ascii_Italian_
 static void keyboardBuildItalianConfiguration()
 {
     int k;
@@ -1798,7 +1798,7 @@ static void keyboardBuildItalianConfiguration()
     gLogicalKeyEntries[k].ctrl = -1;
 }
 
-// 0x4D1E24
+// 0x4D1E24 kb_map_ascii_Spanish_
 static void keyboardBuildSpanishConfiguration()
 {
     int k;
@@ -1956,7 +1956,7 @@ static void keyboardBuildSpanishConfiguration()
     gLogicalKeyEntries[k].ctrl = -1;
 }
 
-// 0x4D24F8
+// 0x4D24F8 kb_init_lock_status_
 static void _kb_init_lock_status()
 {
     if ((SDL_GetModState() & KMOD_CAPS) != 0) {
@@ -1976,7 +1976,7 @@ static void _kb_init_lock_status()
 
 // Get pointer to pending key event from the queue but do not consume it.
 //
-// 0x4D2614
+// 0x4D2614 kb_buffer_peek_
 static int keyboardPeekEvent(int index, KeyboardEvent** keyboardEventPtr)
 {
     int rc = -1;

--- a/src/kb.cc
+++ b/src/kb.cc
@@ -34,10 +34,10 @@ static int keyboardPeekEvent(int index, KeyboardEvent** keyboardEventPtr);
 // 0x51E2D0 kb_installed
 static unsigned char _kb_installed = 0;
 
-// 0x51E2D4 _kb_disabled
+// 0x51E2D4 kb_disabled
 static bool gKeyboardDisabled = false;
 
-// 0x51E2D8 _kb_numpad_disabled
+// 0x51E2D8 kb_numpad_disabled
 static bool gKeyboardNumpadDisabled = false;
 
 // 0x51E2DC kb_numlock_disabled
@@ -57,7 +57,7 @@ static int gModifierKeysState = 0;
 
 // TODO: It's _kb_next_ascii_English_US (not implemented yet).
 //
-// 0x51E2EC _kb_scan_to_ascii
+// 0x51E2EC kb_scan_to_ascii
 static int (*_kb_scan_to_ascii)() = keyboardDequeueLogicalKeyCode;
 
 // Ring buffer of keyboard events.

--- a/src/kb.cc
+++ b/src/kb.cc
@@ -31,38 +31,38 @@ static void keyboardBuildSpanishConfiguration();
 static void _kb_init_lock_status();
 static int keyboardPeekEvent(int index, KeyboardEvent** keyboardEventPtr);
 
-// 0x51E2D0
+// 0x51E2D0 kb_installed
 static unsigned char _kb_installed = 0;
 
-// 0x51E2D4
+// 0x51E2D4 _kb_disabled
 static bool gKeyboardDisabled = false;
 
-// 0x51E2D8
+// 0x51E2D8 _kb_numpad_disabled
 static bool gKeyboardNumpadDisabled = false;
 
-// 0x51E2DC
+// 0x51E2DC kb_numlock_disabled
 static bool gKeyboardNumlockDisabled = false;
 
-// 0x51E2E0
+// 0x51E2E0 kb_put
 static int gKeyboardEventQueueWriteIndex = 0;
 
-// 0x51E2E4
+// 0x51E2E4 kb_get
 static int gKeyboardEventQueueReadIndex = 0;
 
-// 0x51E2E8
+// 0x51E2E8 extended_code
 static short word_51E2E8 = 0;
 
-// 0x51E2EA
+// 0x51E2EA kb_lock_flags
 static int gModifierKeysState = 0;
 
 // TODO: It's _kb_next_ascii_English_US (not implemented yet).
 //
-// 0x51E2EC
+// 0x51E2EC _kb_scan_to_ascii
 static int (*_kb_scan_to_ascii)() = keyboardDequeueLogicalKeyCode;
 
 // Ring buffer of keyboard events.
 //
-// 0x6ACB30
+// 0x6ACB30 kb_buffer
 static KeyboardEvent gKeyboardEventsQueue[64];
 
 // A map of logical key configurations for physical scan codes [SDL_SCANCODE_*].
@@ -75,24 +75,24 @@ static LogicalKeyEntry gLogicalKeyEntries[SDL_NUM_SCANCODES];
 // 0 - key is not pressed.
 // 1 - key pressed.
 //
-// 0x6AD830
+// 0x6AD830 keys
 unsigned char gPressedPhysicalKeys[SDL_NUM_SCANCODES];
 
-// 0x6AD930
+// 0x6AD930 kb_idle_start_time
 static unsigned int _kb_idle_start_time;
 
-// 0x6AD934
+// 0x6AD934 temp
 static KeyboardEvent gLastKeyboardEvent;
 
-// 0x6AD938
+// 0x6AD938 kb_layout
 int gKeyboardLayout;
 
 // The number of keys currently pressed.
 //
-// 0x6AD93C
+// 0x6AD93C keynumpress
 unsigned char gPressedPhysicalKeysCount;
 
-// 0x4CBC90 GNW_kb_set_
+// 0x4CBC90 GNW_kb_set
 int keyboardInit()
 {
     if (_kb_installed) {
@@ -112,7 +112,7 @@ int keyboardInit()
     return 0;
 }
 
-// 0x4CBD00 GNW_kb_restore_
+// 0x4CBD00 GNW_kb_restore
 void keyboardFree()
 {
     if (_kb_installed) {
@@ -120,7 +120,7 @@ void keyboardFree()
     }
 }
 
-// 0x4CBDA8 kb_clear_
+// 0x4CBDA8 kb_clear
 void keyboardReset()
 {
     if (_kb_installed) {
@@ -147,25 +147,25 @@ int _kb_getch()
     return rc;
 }
 
-// 0x4CBE00 kb_disable_
+// 0x4CBE00 kb_disable
 void keyboardDisable()
 {
     gKeyboardDisabled = true;
 }
 
-// 0x4CBE0C kb_enable_
+// 0x4CBE0C kb_enable
 void keyboardEnable()
 {
     gKeyboardDisabled = false;
 }
 
-// 0x4CBE18 kb_is_disabled_
+// 0x4CBE18 kb_is_disabled
 int keyboardIsDisabled()
 {
     return gKeyboardDisabled;
 }
 
-// 0x4CBE74 kb_set_layout_
+// 0x4CBE74 kb_set_layout
 void keyboardSetLayout(int keyboardLayout)
 {
     int oldKeyboardLayout = gKeyboardLayout;
@@ -198,7 +198,7 @@ void keyboardSetLayout(int keyboardLayout)
     }
 }
 
-// 0x4CBEEC kb_get_layout_
+// 0x4CBEEC kb_get_layout
 int keyboardGetLayout()
 {
     return gKeyboardLayout;
@@ -314,7 +314,7 @@ void _kb_simulate_key(KeyboardData* data)
     }
 }
 
-// 0x4CC2F0 kb_next_ascii_English_US_
+// 0x4CC2F0 kb_next_ascii_English_US
 static int _kb_next_ascii_English_US()
 {
     KeyboardEvent* keyboardEvent;
@@ -396,7 +396,7 @@ static int _kb_next_ascii_English_US()
     return keyboardDequeueLogicalKeyCode();
 }
 
-// 0x4CDA4C kb_next_ascii_
+// 0x4CDA4C kb_next_ascii
 static int keyboardDequeueLogicalKeyCode()
 {
     KeyboardEvent* keyboardEvent;
@@ -470,7 +470,7 @@ static int keyboardDequeueLogicalKeyCode()
     return logicalKey;
 }
 
-// 0x4CDC08 kb_map_ascii_English_US_
+// 0x4CDC08 kb_map_ascii_English_US
 static void keyboardBuildQwertyConfiguration()
 {
     int k;
@@ -1268,7 +1268,7 @@ static void keyboardBuildQwertyConfiguration()
     gLogicalKeyEntries[SDL_SCANCODE_KP_DECIMAL].ctrl = KEY_CTRL_DELETE;
 }
 
-// 0x4D0400 kb_map_ascii_French_
+// 0x4D0400 kb_map_ascii_French
 static void keyboardBuildFrenchConfiguration()
 {
     int k;
@@ -1448,7 +1448,7 @@ static void keyboardBuildFrenchConfiguration()
     gLogicalKeyEntries[SDL_SCANCODE_SLASH].ctrl = -1;
 }
 
-// 0x4D0C54 kb_map_ascii_German_
+// 0x4D0C54 kb_map_ascii_German
 static void keyboardBuildGermanConfiguration()
 {
     int k;
@@ -1658,7 +1658,7 @@ static void keyboardBuildGermanConfiguration()
     gLogicalKeyEntries[SDL_SCANCODE_KP_DECIMAL].ctrl = KEY_CTRL_DELETE;
 }
 
-// 0x4D1758 kb_map_ascii_Italian_
+// 0x4D1758 kb_map_ascii_Italian
 static void keyboardBuildItalianConfiguration()
 {
     int k;
@@ -1798,7 +1798,7 @@ static void keyboardBuildItalianConfiguration()
     gLogicalKeyEntries[k].ctrl = -1;
 }
 
-// 0x4D1E24 kb_map_ascii_Spanish_
+// 0x4D1E24 kb_map_ascii_Spanish
 static void keyboardBuildSpanishConfiguration()
 {
     int k;
@@ -1956,7 +1956,7 @@ static void keyboardBuildSpanishConfiguration()
     gLogicalKeyEntries[k].ctrl = -1;
 }
 
-// 0x4D24F8 kb_init_lock_status_
+// 0x4D24F8 kb_init_lock_status
 static void _kb_init_lock_status()
 {
     if ((SDL_GetModState() & KMOD_CAPS) != 0) {
@@ -1976,7 +1976,7 @@ static void _kb_init_lock_status()
 
 // Get pointer to pending key event from the queue but do not consume it.
 //
-// 0x4D2614 kb_buffer_peek_
+// 0x4D2614 kb_buffer_peek
 static int keyboardPeekEvent(int index, KeyboardEvent** keyboardEventPtr)
 {
     int rc = -1;

--- a/src/light.cc
+++ b/src/light.cc
@@ -19,32 +19,32 @@ static int gAmbientIntensity = LIGHT_INTENSITY_MAX;
 // 0x59E994
 static int gTileIntensity[ELEVATION_COUNT][HEX_GRID_SIZE];
 
-// 0x47A8F0
+// 0x47A8F0 light_init_
 int lightInit()
 {
     lightResetTileIntensity();
     return 0;
 }
 
-// 0x47A8F0
+// 0x47A8F0 light_init_
 void lightReset()
 {
     lightResetTileIntensity();
 }
 
-// 0x47A8F0
+// 0x47A8F0 light_init_
 void lightExit()
 {
     lightResetTileIntensity();
 }
 
-// 0x47A8F8
+// 0x47A8F8 light_get_ambient_
 int lightGetAmbientIntensity()
 {
     return gAmbientIntensity;
 }
 
-// 0x47A908
+// 0x47A908 light_set_ambient_
 void lightSetAmbientIntensity(int intensity, bool shouldUpdateScreen)
 {
     int adjustedIntensity = intensity + perkGetRank(gDude, PERK_NIGHT_VISION) * LIGHT_LEVEL_NIGHT_VISION_BONUS;
@@ -60,7 +60,7 @@ void lightSetAmbientIntensity(int intensity, bool shouldUpdateScreen)
     }
 }
 
-// 0x47A980
+// 0x47A980 light_get_tile_
 int lightGetTileIntensity(int elevation, int tile)
 {
     if (!elevationIsValid(elevation)) {
@@ -74,7 +74,7 @@ int lightGetTileIntensity(int elevation, int tile)
     return std::min(gTileIntensity[elevation][tile], LIGHT_INTENSITY_MAX);
 }
 
-// 0x47A9C4
+// 0x47A9C4 light_get_tile_true_
 int lightGetTrueTileIntensity(int elevation, int tile)
 {
     if (!elevationIsValid(elevation)) {
@@ -88,7 +88,7 @@ int lightGetTrueTileIntensity(int elevation, int tile)
     return gTileIntensity[elevation][tile];
 }
 
-// 0x47A9EC
+// 0x47A9EC light_set_tile_
 void lightSetTileIntensity(int elevation, int tile, int intensity)
 {
     if (!elevationIsValid(elevation)) {
@@ -102,7 +102,7 @@ void lightSetTileIntensity(int elevation, int tile, int intensity)
     gTileIntensity[elevation][tile] = intensity;
 }
 
-// 0x47AA10
+// 0x47AA10 light_add_to_tile_
 void lightIncreaseTileIntensity(int elevation, int tile, int intensity)
 {
     if (!elevationIsValid(elevation)) {
@@ -116,7 +116,7 @@ void lightIncreaseTileIntensity(int elevation, int tile, int intensity)
     gTileIntensity[elevation][tile] += intensity;
 }
 
-// 0x47AA48
+// 0x47AA48 light_subtract_from_tile_
 void lightDecreaseTileIntensity(int elevation, int tile, int intensity)
 {
     if (!elevationIsValid(elevation)) {
@@ -130,7 +130,7 @@ void lightDecreaseTileIntensity(int elevation, int tile, int intensity)
     gTileIntensity[elevation][tile] -= intensity;
 }
 
-// 0x47AA84
+// 0x47AA84 light_reset_tiles_
 void lightResetTileIntensity()
 {
     for (int elevation = 0; elevation < ELEVATION_COUNT; elevation++) {

--- a/src/light.cc
+++ b/src/light.cc
@@ -12,39 +12,39 @@ namespace fallout {
 // 20% of max light per "Night Vision" rank
 #define LIGHT_LEVEL_NIGHT_VISION_BONUS (65536 / 5)
 
-// 0x51923C
+// 0x51923C ambient_light
 static int gAmbientIntensity = LIGHT_INTENSITY_MAX;
 
 // light intensity per elevation per tile
-// 0x59E994
+// 0x59E994 tile_intensity
 static int gTileIntensity[ELEVATION_COUNT][HEX_GRID_SIZE];
 
-// 0x47A8F0 light_init_
+// 0x47A8F0 light_init
 int lightInit()
 {
     lightResetTileIntensity();
     return 0;
 }
 
-// 0x47A8F0 light_init_
+// 0x47A8F0 light_init
 void lightReset()
 {
     lightResetTileIntensity();
 }
 
-// 0x47A8F0 light_init_
+// 0x47A8F0 light_init
 void lightExit()
 {
     lightResetTileIntensity();
 }
 
-// 0x47A8F8 light_get_ambient_
+// 0x47A8F8 light_get_ambient
 int lightGetAmbientIntensity()
 {
     return gAmbientIntensity;
 }
 
-// 0x47A908 light_set_ambient_
+// 0x47A908 light_set_ambient
 void lightSetAmbientIntensity(int intensity, bool shouldUpdateScreen)
 {
     int adjustedIntensity = intensity + perkGetRank(gDude, PERK_NIGHT_VISION) * LIGHT_LEVEL_NIGHT_VISION_BONUS;
@@ -60,7 +60,7 @@ void lightSetAmbientIntensity(int intensity, bool shouldUpdateScreen)
     }
 }
 
-// 0x47A980 light_get_tile_
+// 0x47A980 light_get_tile
 int lightGetTileIntensity(int elevation, int tile)
 {
     if (!elevationIsValid(elevation)) {
@@ -74,7 +74,7 @@ int lightGetTileIntensity(int elevation, int tile)
     return std::min(gTileIntensity[elevation][tile], LIGHT_INTENSITY_MAX);
 }
 
-// 0x47A9C4 light_get_tile_true_
+// 0x47A9C4 light_get_tile_true
 int lightGetTrueTileIntensity(int elevation, int tile)
 {
     if (!elevationIsValid(elevation)) {
@@ -88,7 +88,7 @@ int lightGetTrueTileIntensity(int elevation, int tile)
     return gTileIntensity[elevation][tile];
 }
 
-// 0x47A9EC light_set_tile_
+// 0x47A9EC light_set_tile
 void lightSetTileIntensity(int elevation, int tile, int intensity)
 {
     if (!elevationIsValid(elevation)) {
@@ -102,7 +102,7 @@ void lightSetTileIntensity(int elevation, int tile, int intensity)
     gTileIntensity[elevation][tile] = intensity;
 }
 
-// 0x47AA10 light_add_to_tile_
+// 0x47AA10 light_add_to_tile
 void lightIncreaseTileIntensity(int elevation, int tile, int intensity)
 {
     if (!elevationIsValid(elevation)) {
@@ -116,7 +116,7 @@ void lightIncreaseTileIntensity(int elevation, int tile, int intensity)
     gTileIntensity[elevation][tile] += intensity;
 }
 
-// 0x47AA48 light_subtract_from_tile_
+// 0x47AA48 light_subtract_from_tile
 void lightDecreaseTileIntensity(int elevation, int tile, int intensity)
 {
     if (!elevationIsValid(elevation)) {
@@ -130,7 +130,7 @@ void lightDecreaseTileIntensity(int elevation, int tile, int intensity)
     gTileIntensity[elevation][tile] -= intensity;
 }
 
-// 0x47AA84 light_reset_tiles_
+// 0x47AA84 light_reset_tiles
 void lightResetTileIntensity()
 {
     for (int elevation = 0; elevation < ELEVATION_COUNT; elevation++) {

--- a/src/lips.cc
+++ b/src/lips.cc
@@ -65,7 +65,7 @@ static int _speechStartTime = 0;
 // 0x613CA0
 static char _lips_subdir_name[14];
 
-// 0x47AAC0
+// 0x47AAC0 lips_fix_string_
 static char* lips_fix_string(const char* fileName, size_t length)
 {
     // 0x613CAE
@@ -76,7 +76,7 @@ static char* lips_fix_string(const char* fileName, size_t length)
     return tmp_str;
 }
 
-// 0x47AAD8
+// 0x47AAD8 lips_bkg_proc_
 void lipsTicker()
 {
     int v0;
@@ -145,7 +145,7 @@ void lipsTicker()
     soundContinueAll();
 }
 
-// 0x47AC2C
+// 0x47AC2C lips_play_speech_
 int lipsStart()
 {
     gLipsData.flags |= LIPS_FLAG_0x02;
@@ -185,7 +185,7 @@ int lipsStart()
     return 0;
 }
 
-// 0x47AD98
+// 0x47AD98 lips_read_lipsynch_info_
 static int lipsReadV1(LipsData* lipsData, File* stream)
 {
     int sound;
@@ -231,7 +231,7 @@ static int lipsReadV1(LipsData* lipsData, File* stream)
 }
 
 // lips_load_file
-// 0x47AFAC
+// 0x47AFAC lips_load_file_
 int lipsLoad(const char* audioFileName, const char* headFileName)
 {
     char* sep;
@@ -397,7 +397,7 @@ int lipsLoad(const char* audioFileName, const char* headFileName)
 }
 
 // lips_make_speech
-// 0x47B5D0
+// 0x47B5D0 lips_make_speech_
 static int _lips_make_speech()
 {
     if (gLipsData.field_14 != nullptr) {
@@ -439,7 +439,7 @@ static int _lips_make_speech()
     return 0;
 }
 
-// 0x47B730
+// 0x47B730 lips_free_speech_
 int lipsFree()
 {
     if (gLipsData.field_14 != nullptr) {

--- a/src/lips.cc
+++ b/src/lips.cc
@@ -19,7 +19,7 @@ static char* lips_fix_string(const char* fileName, size_t length);
 static int lipsReadV1(LipsData* lipsData, File* stream);
 static int _lips_make_speech();
 
-// 0x519240 _head_phoneme_current
+// 0x519240 head_phoneme_current
 unsigned char gLipsCurrentPhoneme = 0;
 
 // 0x519241 head_phoneme_drawn

--- a/src/lips.cc
+++ b/src/lips.cc
@@ -19,19 +19,19 @@ static char* lips_fix_string(const char* fileName, size_t length);
 static int lipsReadV1(LipsData* lipsData, File* stream);
 static int _lips_make_speech();
 
-// 0x519240
+// 0x519240 _head_phoneme_current
 unsigned char gLipsCurrentPhoneme = 0;
 
-// 0x519241
+// 0x519241 head_phoneme_drawn
 static unsigned char gLipsPreviousPhoneme = 0;
 
-// 0x519244
+// 0x519244 head_marker_current
 static int _head_marker_current = 0;
 
-// 0x519248
+// 0x519248 lips_draw_head
 bool gLipsPhonemeChanged = true;
 
-// 0x51924C
+// 0x51924C lip_info
 LipsData gLipsData = {
     2,
     22528,
@@ -59,13 +59,13 @@ LipsData gLipsData = {
     "LIP",
 };
 
-// 0x5193B4
+// 0x5193B4 speechStartTime
 static int _speechStartTime = 0;
 
-// 0x613CA0
+// 0x613CA0 lips_subdir_name
 static char _lips_subdir_name[14];
 
-// 0x47AAC0 lips_fix_string_
+// 0x47AAC0 lips_fix_string
 static char* lips_fix_string(const char* fileName, size_t length)
 {
     // 0x613CAE
@@ -76,7 +76,7 @@ static char* lips_fix_string(const char* fileName, size_t length)
     return tmp_str;
 }
 
-// 0x47AAD8 lips_bkg_proc_
+// 0x47AAD8 lips_bkg_proc
 void lipsTicker()
 {
     int v0;
@@ -145,7 +145,7 @@ void lipsTicker()
     soundContinueAll();
 }
 
-// 0x47AC2C lips_play_speech_
+// 0x47AC2C lips_play_speech
 int lipsStart()
 {
     gLipsData.flags |= LIPS_FLAG_0x02;
@@ -185,7 +185,7 @@ int lipsStart()
     return 0;
 }
 
-// 0x47AD98 lips_read_lipsynch_info_
+// 0x47AD98 lips_read_lipsynch_info
 static int lipsReadV1(LipsData* lipsData, File* stream)
 {
     int sound;
@@ -231,7 +231,7 @@ static int lipsReadV1(LipsData* lipsData, File* stream)
 }
 
 // lips_load_file
-// 0x47AFAC lips_load_file_
+// 0x47AFAC lips_load_file
 int lipsLoad(const char* audioFileName, const char* headFileName)
 {
     char* sep;
@@ -397,7 +397,7 @@ int lipsLoad(const char* audioFileName, const char* headFileName)
 }
 
 // lips_make_speech
-// 0x47B5D0 lips_make_speech_
+// 0x47B5D0 lips_make_speech
 static int _lips_make_speech()
 {
     if (gLipsData.field_14 != nullptr) {
@@ -439,7 +439,7 @@ static int _lips_make_speech()
     return 0;
 }
 
-// 0x47B730 lips_free_speech_
+// 0x47B730 lips_free_speech
 int lipsFree()
 {
     if (gLipsData.field_14 != nullptr) {

--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -223,7 +223,7 @@ static bool _automap_db_flag = false;
 // 0x5193CC patches
 static const char* _patches = nullptr;
 
-// 0x5193EC _master_save_list
+// 0x5193EC master_save_list
 static SaveGameHandler* _master_save_list[LOAD_SAVE_HANDLER_COUNT] = {
     _DummyFunc,
     _SaveObjDudeCid,
@@ -254,7 +254,7 @@ static SaveGameHandler* _master_save_list[LOAD_SAVE_HANDLER_COUNT] = {
     _DummyFunc,
 };
 
-// 0x519458 _master_load_list
+// 0x519458 master_load_list
 static LoadGameHandler* _master_load_list[LOAD_SAVE_HANDLER_COUNT] = {
     _PrepLoad,
     _LoadObjDudeCid,
@@ -299,10 +299,10 @@ static LoadSaveSlotData _LSData[saveLoadTotalSlots];
 // 0x614280 LSstatus
 static int _LSstatus[saveLoadTotalSlots];
 
-// 0x6142A8 _thumbnail_image
+// 0x6142A8 thumbnail_image
 static unsigned char* _thumbnail_image;
 
-// 0x6142AC _snapshotBuf
+// 0x6142AC snapshotBuf
 static unsigned char* _snapshotBuf;
 
 // 0x6142B0 lsgmesg
@@ -314,7 +314,7 @@ static int _dbleclkcntr;
 // 0x6142C4 lsgwin
 static int gLoadSaveWindow;
 
-// 0x6142EC _snapshot
+// 0x6142EC snapshot
 static unsigned char* _snapshot;
 
 // 0x6142F0 str2
@@ -335,7 +335,7 @@ static unsigned char* gLoadSaveWindowBuffer;
 // 0x614704 gmpath
 static char _gmpath[COMPAT_MAX_PATH];
 
-// 0x614808 _flptr
+// 0x614808 flptr
 static File* _flptr;
 
 // 0x61480C ls_error_code

--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -181,7 +181,7 @@ static int _LoadObjDudeCid(File* stream);
 static int _SaveObjDudeCid(File* stream);
 static int _EraseSave();
 
-// 0x47B7C0
+// 0x47B7C0 lsgrphs
 static const int gLoadSaveFrmIds[LOAD_SAVE_FRM_COUNT] = {
     237, // lsgame.frm - load/save game
     238, // lsgbox.frm - load/save game
@@ -203,27 +203,27 @@ constexpr int kLoadSaveActionDone = 500;
 // Global variable to track the current slot page
 static int _currentSlotPage = 0;
 
-// 0x5193B8
+// 0x5193B8 slot_cursor
 static int _slot_cursor = 0;
 
 static int gDevLoadGameSlot = -1;
 
-// 0x5193BC
+// 0x5193BC quick_done
 static bool _quick_done = false;
 
-// 0x5193C0
+// 0x5193C0 bk_enable_3
 static bool gLoadSaveWindowIsoWasEnabled = false;
 
-// 0x5193C4
+// 0x5193C4 map_backup_count
 static int _map_backup_count = -1;
 
-// 0x5193C8
+// 0x5193C8 automap_db_flag
 static bool _automap_db_flag = false;
 
-// 0x5193CC
+// 0x5193CC patches
 static const char* _patches = nullptr;
 
-// 0x5193EC
+// 0x5193EC _master_save_list
 static SaveGameHandler* _master_save_list[LOAD_SAVE_HANDLER_COUNT] = {
     _DummyFunc,
     _SaveObjDudeCid,
@@ -254,7 +254,7 @@ static SaveGameHandler* _master_save_list[LOAD_SAVE_HANDLER_COUNT] = {
     _DummyFunc,
 };
 
-// 0x519458
+// 0x519458 _master_load_list
 static LoadGameHandler* _master_load_list[LOAD_SAVE_HANDLER_COUNT] = {
     _PrepLoad,
     _LoadObjDudeCid,
@@ -285,63 +285,63 @@ static LoadGameHandler* _master_load_list[LOAD_SAVE_HANDLER_COUNT] = {
     _EndLoad,
 };
 
-// 0x5194C4
+// 0x5194C4 loadingGame
 static bool _loadingGame = false;
 
 // lsgame.msg
 //
-// 0x613D28
+// 0x613D28 lsgame_msgfl
 static MessageList gLoadSaveMessageList;
 
-// 0x613D30
+// 0x613D30 LSData
 static LoadSaveSlotData _LSData[saveLoadTotalSlots];
 
-// 0x614280
+// 0x614280 LSstatus
 static int _LSstatus[saveLoadTotalSlots];
 
-// 0x6142A8
+// 0x6142A8 _thumbnail_image
 static unsigned char* _thumbnail_image;
 
-// 0x6142AC
+// 0x6142AC _snapshotBuf
 static unsigned char* _snapshotBuf;
 
-// 0x6142B0
+// 0x6142B0 lsgmesg
 static MessageListItem gLoadSaveMessageListItem;
 
-// 0x6142C0
+// 0x6142C0 dbleclkcntr
 static int _dbleclkcntr;
 
-// 0x6142C4
+// 0x6142C4 lsgwin
 static int gLoadSaveWindow;
 
-// 0x6142EC
+// 0x6142EC _snapshot
 static unsigned char* _snapshot;
 
-// 0x6142F0
+// 0x6142F0 str2
 static char _str2[COMPAT_MAX_PATH];
 
-// 0x6143F4
+// 0x6143F4 str0
 static char _str0[COMPAT_MAX_PATH];
 
-// 0x6144F8
+// 0x6144F8 str1
 static char _str1[COMPAT_MAX_PATH];
 
-// 0x6145FC
+// 0x6145FC str
 static char _str[COMPAT_MAX_PATH];
 
-// 0x614700
+// 0x614700 lsgbuf
 static unsigned char* gLoadSaveWindowBuffer;
 
-// 0x614704
+// 0x614704 gmpath
 static char _gmpath[COMPAT_MAX_PATH];
 
-// 0x614808
+// 0x614808 _flptr
 static File* _flptr;
 
-// 0x61480C
+// 0x61480C ls_error_code
 static int _ls_error_code;
 
-// 0x614810
+// 0x614810 fontsave_2
 static int gLoadSaveWindowOldFont;
 
 static FrmImage _loadsaveFrmImages[LOAD_SAVE_FRM_COUNT];

--- a/src/main.cc
+++ b/src/main.cc
@@ -62,16 +62,16 @@ static void _main_death_voiceover_callback();
 static int _mainDeathGrabTextFile(const char* fileName, char* dest);
 static int _mainDeathWordWrap(char* text, int width, short* beginnings, short* count);
 
-// 0x5194C8
+// 0x5194C8 mainMap
 static char _mainMap[] = "artemple.map";
 
-// 0x5194D8
+// 0x5194D8 main_game_paused
 static int _main_game_paused = 0;
 
-// 0x5194E8
+// 0x5194E8 main_show_death_scene
 static bool _main_show_death_scene = false;
 
-// 0x614838
+// 0x614838 main_death_voiceover_done
 static bool _main_death_voiceover_done;
 
 static int commandLineDevLoadGameSlot = -1;

--- a/src/mainmenu.cc
+++ b/src/mainmenu.cc
@@ -85,7 +85,7 @@ static FrmImage _mainMenuBackgroundFrmImage;
 static FrmImage _mainMenuButtonNormalFrmImage;
 static FrmImage _mainMenuButtonPressedFrmImage;
 
-// 0x481650
+// 0x481650 main_menu_create_
 int mainMenuWindowInit()
 {
     int fid;
@@ -237,7 +237,7 @@ int mainMenuWindowInit()
     return 0;
 }
 
-// 0x481968
+// 0x481968 main_menu_destroy_
 void mainMenuWindowFree()
 {
     if (!gMainMenuWindowInitialized) {
@@ -261,7 +261,7 @@ void mainMenuWindowFree()
     gMainMenuWindowInitialized = false;
 }
 
-// 0x481A00
+// 0x481A00 main_menu_hide_
 void mainMenuWindowHide(bool animate)
 {
     if (!gMainMenuWindowInitialized) {
@@ -285,7 +285,7 @@ void mainMenuWindowHide(bool animate)
     gMainMenuWindowHidden = true;
 }
 
-// 0x481A48
+// 0x481A48 main_menu_show_
 void mainMenuWindowUnhide(bool animate)
 {
     if (!gMainMenuWindowInitialized) {
@@ -307,13 +307,13 @@ void mainMenuWindowUnhide(bool animate)
     gMainMenuWindowHidden = false;
 }
 
-// 0x481AA8
+// 0x481AA8 main_menu_is_enabled_
 int _main_menu_is_enabled()
 {
     return 1;
 }
 
-// 0x481AEC
+// 0x481AEC main_menu_loop_
 int mainMenuWindowHandleEvents()
 {
     _in_main_menu = true;
@@ -405,7 +405,7 @@ void mainMenuRequestExit()
 
 // NOTE: Inlined.
 //
-// 0x481C88
+// 0x481C88 main_menu_fatal_error_
 static int main_menu_fatal_error()
 {
     mainMenuWindowFree();
@@ -415,7 +415,7 @@ static int main_menu_fatal_error()
 
 // NOTE: Inlined.
 //
-// 0x481C94
+// 0x481C94 main_menu_play_sound_
 static void main_menu_play_sound(const char* fileName)
 {
     soundPlayFile(fileName);

--- a/src/mainmenu.cc
+++ b/src/mainmenu.cc
@@ -41,7 +41,7 @@ static void main_menu_play_sound(const char* fileName);
 // 0x5194F0 main_window
 static int gMainMenuWindow = -1;
 
-// 0x5194F4 _main_window_buf
+// 0x5194F4 main_window_buf
 static unsigned char* gMainMenuWindowBuffer = nullptr;
 
 // 0x519504 in_main_menu

--- a/src/mainmenu.cc
+++ b/src/mainmenu.cc
@@ -38,24 +38,24 @@ typedef enum MainMenuButton {
 static int main_menu_fatal_error();
 static void main_menu_play_sound(const char* fileName);
 
-// 0x5194F0
+// 0x5194F0 main_window
 static int gMainMenuWindow = -1;
 
-// 0x5194F4
+// 0x5194F4 _main_window_buf
 static unsigned char* gMainMenuWindowBuffer = nullptr;
 
-// 0x519504
+// 0x519504 in_main_menu
 static bool _in_main_menu = false;
 
-// 0x519508
+// 0x519508 main_menu_created
 static bool gMainMenuWindowInitialized = false;
 
 static bool gMainMenuExitRequested = false;
 
-// 0x51950C
+// 0x51950C main_menu_timeout
 static unsigned int gMainMenuScreensaverDelay = 120000;
 
-// 0x519510
+// 0x519510 button_values
 static const int gMainMenuButtonKeyBindings[MAIN_MENU_BUTTON_COUNT] = {
     KEY_LOWERCASE_I, // intro
     KEY_LOWERCASE_N, // new game
@@ -65,7 +65,7 @@ static const int gMainMenuButtonKeyBindings[MAIN_MENU_BUTTON_COUNT] = {
     KEY_LOWERCASE_E, // exit
 };
 
-// 0x519528
+// 0x519528 return_values
 static const int _return_values[MAIN_MENU_BUTTON_COUNT] = {
     MAIN_MENU_INTRO,
     MAIN_MENU_NEW_GAME,
@@ -75,17 +75,17 @@ static const int _return_values[MAIN_MENU_BUTTON_COUNT] = {
     MAIN_MENU_EXIT,
 };
 
-// 0x614840
+// 0x614840 buttons
 static int gMainMenuButtons[MAIN_MENU_BUTTON_COUNT];
 
-// 0x614858
+// 0x614858 main_menu_is_hidden
 static bool gMainMenuWindowHidden;
 
 static FrmImage _mainMenuBackgroundFrmImage;
 static FrmImage _mainMenuButtonNormalFrmImage;
 static FrmImage _mainMenuButtonPressedFrmImage;
 
-// 0x481650 main_menu_create_
+// 0x481650 main_menu_create
 int mainMenuWindowInit()
 {
     int fid;
@@ -237,7 +237,7 @@ int mainMenuWindowInit()
     return 0;
 }
 
-// 0x481968 main_menu_destroy_
+// 0x481968 main_menu_destroy
 void mainMenuWindowFree()
 {
     if (!gMainMenuWindowInitialized) {
@@ -261,7 +261,7 @@ void mainMenuWindowFree()
     gMainMenuWindowInitialized = false;
 }
 
-// 0x481A00 main_menu_hide_
+// 0x481A00 main_menu_hide
 void mainMenuWindowHide(bool animate)
 {
     if (!gMainMenuWindowInitialized) {
@@ -285,7 +285,7 @@ void mainMenuWindowHide(bool animate)
     gMainMenuWindowHidden = true;
 }
 
-// 0x481A48 main_menu_show_
+// 0x481A48 main_menu_show
 void mainMenuWindowUnhide(bool animate)
 {
     if (!gMainMenuWindowInitialized) {
@@ -307,13 +307,13 @@ void mainMenuWindowUnhide(bool animate)
     gMainMenuWindowHidden = false;
 }
 
-// 0x481AA8 main_menu_is_enabled_
+// 0x481AA8 main_menu_is_enabled
 int _main_menu_is_enabled()
 {
     return 1;
 }
 
-// 0x481AEC main_menu_loop_
+// 0x481AEC main_menu_loop
 int mainMenuWindowHandleEvents()
 {
     _in_main_menu = true;
@@ -405,7 +405,7 @@ void mainMenuRequestExit()
 
 // NOTE: Inlined.
 //
-// 0x481C88 main_menu_fatal_error_
+// 0x481C88 main_menu_fatal_error
 static int main_menu_fatal_error()
 {
     mainMenuWindowFree();
@@ -415,7 +415,7 @@ static int main_menu_fatal_error()
 
 // NOTE: Inlined.
 //
-// 0x481C94 main_menu_play_sound_
+// 0x481C94 main_menu_play_sound
 static void main_menu_play_sound(const char* fileName)
 {
     soundPlayFile(fileName);

--- a/src/map.cc
+++ b/src/map.cc
@@ -78,7 +78,7 @@ static char byte_50B058[] = "";
 // 0x50B30C aErrorF2
 static char _aErrorF2[] = "ERROR! F2";
 
-// 0x519540 _map_scroll_refresh
+// 0x519540 map_scroll_refresh
 static IsoWindowRefreshProc* _map_scroll_refresh = isoWindowRefreshRectGame;
 
 // 0x519544 map_data_elev_flags
@@ -107,11 +107,11 @@ static int gEnteringRotation = ROTATION_NE;
 int gMapSid = -1;
 
 // local_vars
-// 0x519568 _map_local_vars
+// 0x519568 map_local_vars
 int* gMapLocalVars = nullptr;
 
 // map_vars
-// 0x51956C _map_global_vars
+// 0x51956C map_global_vars
 int* gMapGlobalVars = nullptr;
 
 // local_vars_num
@@ -127,7 +127,7 @@ int gMapGlobalVarsLength = 0;
 // 0x519578 map_elevation
 int gElevation = 0;
 
-// 0x51957C _errMapName
+// 0x51957C errMapName
 static char* _errMapName = byte_50B058;
 
 // 0x519584 wmMapIdx
@@ -148,7 +148,7 @@ static Rect gIsoWindowRect;
 // 0x631D48 map_msg_file
 MessageList gMapMessageList;
 
-// 0x631D50 _display_buf
+// 0x631D50 display_buf
 static unsigned char* gIsoWindowBuffer;
 
 // 0x631D54 map_data

--- a/src/map.cc
+++ b/src/map.cc
@@ -75,92 +75,92 @@ static int mapHeaderRead(MapHeader* ptr, File* stream);
 // 0x50B058
 static char byte_50B058[] = "";
 
-// 0x50B30C
+// 0x50B30C aErrorF2
 static char _aErrorF2[] = "ERROR! F2";
 
-// 0x519540
+// 0x519540 _map_scroll_refresh
 static IsoWindowRefreshProc* _map_scroll_refresh = isoWindowRefreshRectGame;
 
-// 0x519544
+// 0x519544 map_data_elev_flags
 static const int _map_data_elev_flags[ELEVATION_COUNT] = {
     2,
     4,
     8,
 };
 
-// 0x519550
+// 0x519550 map_last_scroll_time
 static unsigned int gIsoWindowScrollTimestamp = 0;
 
-// 0x519554
+// 0x519554 map_bk_enabled
 static bool gIsoEnabled = false;
 
-// 0x519558
+// 0x519558 mapEntranceElevation
 static int gEnteringElevation = 0;
 
-// 0x51955C
+// 0x51955C mapEntranceTileNum
 static int gEnteringTile = -1;
 
-// 0x519560
+// 0x519560 mapEntranceRotation
 static int gEnteringRotation = ROTATION_NE;
 
-// 0x519564
+// 0x519564 map_script_id
 int gMapSid = -1;
 
 // local_vars
-// 0x519568
+// 0x519568 _map_local_vars
 int* gMapLocalVars = nullptr;
 
 // map_vars
-// 0x51956C
+// 0x51956C _map_global_vars
 int* gMapGlobalVars = nullptr;
 
 // local_vars_num
-// 0x519570
+// 0x519570 num_map_local_vars
 int gMapLocalVarsLength = 0;
 
 // map_vars_num
-// 0x519574
+// 0x519574 num_map_global_vars
 int gMapGlobalVarsLength = 0;
 
 // Current elevation.
 //
-// 0x519578
+// 0x519578 map_elevation
 int gElevation = 0;
 
-// 0x51957C
+// 0x51957C _errMapName
 static char* _errMapName = byte_50B058;
 
-// 0x519584
+// 0x519584 wmMapIdx
 static int _wmMapIdx = -1;
 
-// 0x614868
+// 0x614868 square_data
 static TileData _square_data[ELEVATION_COUNT];
 
-// 0x631D28
+// 0x631D28 map_state
 static MapTransition gMapTransition;
 
-// 0x631D38
+// 0x631D38 map_display_rect
 static Rect gIsoWindowRect;
 
 // map.msg
 //
 // map_msg_file
-// 0x631D48
+// 0x631D48 map_msg_file
 MessageList gMapMessageList;
 
-// 0x631D50
+// 0x631D50 _display_buf
 static unsigned char* gIsoWindowBuffer;
 
-// 0x631D54
+// 0x631D54 map_data
 MapHeader gMapHeader;
 
-// 0x631E40
+// 0x631E40 square
 TileData* _square[ELEVATION_COUNT];
 
-// 0x631E4C
+// 0x631E4C display_win
 int gIsoWindow;
 
-// 0x631E50
+// 0x631E50 scratchStr
 static char _scratchStr[40];
 
 // CE: Basically the same problem described in |gMapLocalPointers|, but this

--- a/src/mapper/mapper.cc
+++ b/src/mapper/mapper.cc
@@ -2291,7 +2291,7 @@ void redraw_toolname()
     windowRefreshRect(tool_win, &rect);
 }
 
-// 0x48B278 obj_action_can_talk_to_
+// 0x48B278 obj_action_can_talk_to
 void clear_toolname()
 {
     windowDrawText(tool_win, "", kToolNameWidth, kToolNameX, kToolNameY1, 260);

--- a/src/mapper/mapper.cc
+++ b/src/mapper/mapper.cc
@@ -2291,7 +2291,7 @@ void redraw_toolname()
     windowRefreshRect(tool_win, &rect);
 }
 
-// 0x48B278
+// 0x48B278 obj_action_can_talk_to_
 void clear_toolname()
 {
     windowDrawText(tool_win, "", kToolNameWidth, kToolNameX, kToolNameY1, 260);

--- a/src/mapper/mapper.cc
+++ b/src/mapper/mapper.cc
@@ -2291,7 +2291,7 @@ void redraw_toolname()
     windowRefreshRect(tool_win, &rect);
 }
 
-// 0x48B278 obj_action_can_talk_to
+// 0x48B278
 void clear_toolname()
 {
     windowDrawText(tool_win, "", kToolNameWidth, kToolNameX, kToolNameY1, 260);

--- a/src/memory.cc
+++ b/src/memory.cc
@@ -36,19 +36,19 @@ static void memoryBlockFreeImpl(void* ptr);
 static void* mem_prep_block(void* block, size_t size);
 static void memoryBlockValidate(void* block);
 
-// 0x51DED0 _p_malloc
+// 0x51DED0 p_malloc
 static MallocProc* gMallocProc = memoryBlockMallocImpl;
 
-// 0x51DED4 _p_realloc
+// 0x51DED4 p_realloc
 static ReallocProc* gReallocProc = memoryBlockReallocImpl;
 
-// 0x51DED8 _p_free
+// 0x51DED8 p_free
 static FreeProc* gFreeProc = memoryBlockFreeImpl;
 
 // 0x51DEDC num_blocks
 static int gMemoryBlocksCurrentCount = 0;
 
-// 0x51DEE0 _max_blocks
+// 0x51DEE0 max_blocks
 static int gMemoryBlockMaximumCount = 0;
 
 // 0x51DEE4 mem_allocated

--- a/src/memory.cc
+++ b/src/memory.cc
@@ -36,28 +36,28 @@ static void memoryBlockFreeImpl(void* ptr);
 static void* mem_prep_block(void* block, size_t size);
 static void memoryBlockValidate(void* block);
 
-// 0x51DED0
+// 0x51DED0 _p_malloc
 static MallocProc* gMallocProc = memoryBlockMallocImpl;
 
-// 0x51DED4
+// 0x51DED4 _p_realloc
 static ReallocProc* gReallocProc = memoryBlockReallocImpl;
 
-// 0x51DED8
+// 0x51DED8 _p_free
 static FreeProc* gFreeProc = memoryBlockFreeImpl;
 
-// 0x51DEDC
+// 0x51DEDC num_blocks
 static int gMemoryBlocksCurrentCount = 0;
 
-// 0x51DEE0
+// 0x51DEE0 _max_blocks
 static int gMemoryBlockMaximumCount = 0;
 
-// 0x51DEE4
+// 0x51DEE4 mem_allocated
 static size_t gMemoryBlocksCurrentSize = 0;
 
-// 0x51DEE8
+// 0x51DEE8 max_allocated
 static size_t gMemoryBlocksMaximumSize = 0;
 
-// 0x4C5A80 mem_strdup_
+// 0x4C5A80 mem_strdup
 char* internal_strdup(const char* string)
 {
     char* copy = nullptr;
@@ -68,13 +68,13 @@ char* internal_strdup(const char* string)
     return copy;
 }
 
-// 0x4C5AD0 mem_malloc_
+// 0x4C5AD0 mem_malloc
 void* internal_malloc(size_t size)
 {
     return gMallocProc(size);
 }
 
-// 0x4C5AD8 my_malloc_
+// 0x4C5AD8 my_malloc
 static void* memoryBlockMallocImpl(size_t size)
 {
     void* ptr = nullptr;
@@ -103,13 +103,13 @@ static void* memoryBlockMallocImpl(size_t size)
     return ptr;
 }
 
-// 0x4C5B50 mem_realloc_
+// 0x4C5B50 mem_realloc
 void* internal_realloc(void* ptr, size_t size)
 {
     return gReallocProc(ptr, size);
 }
 
-// 0x4C5B58 my_realloc_
+// 0x4C5B58 my_realloc
 static void* memoryBlockReallocImpl(void* ptr, size_t size)
 {
     if (ptr != nullptr) {
@@ -154,13 +154,13 @@ static void* memoryBlockReallocImpl(void* ptr, size_t size)
     return ptr;
 }
 
-// 0x4C5C24 mem_free_
+// 0x4C5C24 mem_free
 void internal_free(void* ptr)
 {
     gFreeProc(ptr);
 }
 
-// 0x4C5C2C my_free_
+// 0x4C5C2C my_free
 static void memoryBlockFreeImpl(void* ptr)
 {
     if (ptr != nullptr) {
@@ -176,7 +176,7 @@ static void memoryBlockFreeImpl(void* ptr)
     }
 }
 
-// 0x4C5C5C mem_check_
+// 0x4C5C5C mem_check
 void mem_check()
 {
     if (gMallocProc == memoryBlockMallocImpl) {
@@ -187,7 +187,7 @@ void mem_check()
 
 // NOTE: Inlined.
 //
-// 0x4C5CC4 mem_prep_block_
+// 0x4C5CC4 mem_prep_block
 static void* mem_prep_block(void* block, size_t size)
 {
     MemoryBlockHeader* header;
@@ -207,7 +207,7 @@ static void* mem_prep_block(void* block, size_t size)
 //
 // [block] is a pointer to the the memory block itself, not it's data.
 //
-// 0x4C5CE4 mem_check_block_
+// 0x4C5CE4 mem_check_block
 static void memoryBlockValidate(void* block)
 {
     MemoryBlockHeader* header = (MemoryBlockHeader*)block;

--- a/src/memory.cc
+++ b/src/memory.cc
@@ -57,7 +57,7 @@ static size_t gMemoryBlocksCurrentSize = 0;
 // 0x51DEE8
 static size_t gMemoryBlocksMaximumSize = 0;
 
-// 0x4C5A80
+// 0x4C5A80 mem_strdup_
 char* internal_strdup(const char* string)
 {
     char* copy = nullptr;
@@ -68,13 +68,13 @@ char* internal_strdup(const char* string)
     return copy;
 }
 
-// 0x4C5AD0
+// 0x4C5AD0 mem_malloc_
 void* internal_malloc(size_t size)
 {
     return gMallocProc(size);
 }
 
-// 0x4C5AD8
+// 0x4C5AD8 my_malloc_
 static void* memoryBlockMallocImpl(size_t size)
 {
     void* ptr = nullptr;
@@ -103,13 +103,13 @@ static void* memoryBlockMallocImpl(size_t size)
     return ptr;
 }
 
-// 0x4C5B50
+// 0x4C5B50 mem_realloc_
 void* internal_realloc(void* ptr, size_t size)
 {
     return gReallocProc(ptr, size);
 }
 
-// 0x4C5B58
+// 0x4C5B58 my_realloc_
 static void* memoryBlockReallocImpl(void* ptr, size_t size)
 {
     if (ptr != nullptr) {
@@ -154,13 +154,13 @@ static void* memoryBlockReallocImpl(void* ptr, size_t size)
     return ptr;
 }
 
-// 0x4C5C24
+// 0x4C5C24 mem_free_
 void internal_free(void* ptr)
 {
     gFreeProc(ptr);
 }
 
-// 0x4C5C2C
+// 0x4C5C2C my_free_
 static void memoryBlockFreeImpl(void* ptr)
 {
     if (ptr != nullptr) {
@@ -176,7 +176,7 @@ static void memoryBlockFreeImpl(void* ptr)
     }
 }
 
-// 0x4C5C5C
+// 0x4C5C5C mem_check_
 void mem_check()
 {
     if (gMallocProc == memoryBlockMallocImpl) {
@@ -187,7 +187,7 @@ void mem_check()
 
 // NOTE: Inlined.
 //
-// 0x4C5CC4
+// 0x4C5CC4 mem_prep_block_
 static void* mem_prep_block(void* block, size_t size)
 {
     MemoryBlockHeader* header;
@@ -207,7 +207,7 @@ static void* mem_prep_block(void* block, size_t size)
 //
 // [block] is a pointer to the the memory block itself, not it's data.
 //
-// 0x4C5CE4
+// 0x4C5CE4 mem_check_block_
 static void memoryBlockValidate(void* block)
 {
     MemoryBlockHeader* header = (MemoryBlockHeader*)block;

--- a/src/memory_manager.cc
+++ b/src/memory_manager.cc
@@ -28,13 +28,13 @@ static ReallocProc* gMemoryManagerReallocProc = memoryManagerDefaultReallocImpl;
 // 0x519594
 static FreeProc* gMemoryManagerFreeProc = memoryManagerDefaultFreeImpl;
 
-// 0x4845B0
+// 0x4845B0 defaultOutput_
 static void memoryManagerDefaultPrintErrorImpl(const char* string)
 {
     printf("%s", string);
 }
 
-// 0x4845C8
+// 0x4845C8 debug_printf_0
 static int memoryManagerPrintError(const char* format, ...)
 {
     // 0x631F7C
@@ -54,32 +54,32 @@ static int memoryManagerPrintError(const char* format, ...)
     return length;
 }
 
-// 0x484610
+// 0x484610 error_
 [[noreturn]] static void memoryManagerFatalAllocationError(const char* func, size_t size, const char* file, int line)
 {
     memoryManagerPrintError("%s: Error allocating block of size %ld (%x), %s %d\n", func, size, size, file, line);
     exit(1);
 }
 
-// 0x48462C
+// 0x48462C defaultMalloc_
 static void* memoryManagerDefaultMallocImpl(size_t size)
 {
     return malloc(size);
 }
 
-// 0x484634
+// 0x484634 defaultRealloc_
 static void* memoryManagerDefaultReallocImpl(void* ptr, size_t size)
 {
     return realloc(ptr, size);
 }
 
-// 0x48463C
+// 0x48463C defaultFree_
 static void memoryManagerDefaultFreeImpl(void* ptr)
 {
     free(ptr);
 }
 
-// 0x484644
+// 0x484644 memoryRegisterAlloc_
 void memoryManagerSetProcs(MallocProc* mallocProc, ReallocProc* reallocProc, FreeProc* freeProc)
 {
     gMemoryManagerMallocProc = mallocProc;
@@ -87,7 +87,7 @@ void memoryManagerSetProcs(MallocProc* mallocProc, ReallocProc* reallocProc, Fre
     gMemoryManagerFreeProc = freeProc;
 }
 
-// 0x484660
+// 0x484660 mymalloc_
 void* internal_malloc_safe(size_t size, const char* file, int line)
 {
     void* ptr = gMemoryManagerMallocProc(size);
@@ -98,7 +98,7 @@ void* internal_malloc_safe(size_t size, const char* file, int line)
     return ptr;
 }
 
-// 0x4846B4
+// 0x4846B4 myrealloc_
 void* internal_realloc_safe(void* ptr, size_t size, const char* file, int line)
 {
     ptr = gMemoryManagerReallocProc(ptr, size);
@@ -109,7 +109,7 @@ void* internal_realloc_safe(void* ptr, size_t size, const char* file, int line)
     return ptr;
 }
 
-// 0x484688
+// 0x484688 myfree_
 void internal_free_safe(void* ptr, const char* file, int line)
 {
     if (ptr == nullptr) {
@@ -120,7 +120,7 @@ void internal_free_safe(void* ptr, const char* file, int line)
     gMemoryManagerFreeProc(ptr);
 }
 
-// 0x4846D8
+// 0x4846D8 mycalloc_
 void* internal_calloc_safe(int count, int size, const char* file, int line)
 {
     void* ptr = gMemoryManagerMallocProc(count * size);
@@ -133,7 +133,7 @@ void* internal_calloc_safe(int count, int size, const char* file, int line)
     return ptr;
 }
 
-// 0x484710
+// 0x484710 mystrdup_
 char* strdup_safe(const char* string, const char* file, int line)
 {
     size_t size = strlen(string) + 1;

--- a/src/memory_manager.cc
+++ b/src/memory_manager.cc
@@ -16,16 +16,16 @@ static void* memoryManagerDefaultMallocImpl(size_t size);
 static void* memoryManagerDefaultReallocImpl(void* ptr, size_t size);
 static void memoryManagerDefaultFreeImpl(void* ptr);
 
-// 0x519588 _outputFunc_
+// 0x519588 outputFunc_
 static MemoryManagerPrintErrorProc* gMemoryManagerPrintErrorProc = memoryManagerDefaultPrintErrorImpl;
 
-// 0x51958C _mallocPtr
+// 0x51958C mallocPtr
 static MallocProc* gMemoryManagerMallocProc = memoryManagerDefaultMallocImpl;
 
-// 0x519590 _reallocPtr
+// 0x519590 reallocPtr
 static ReallocProc* gMemoryManagerReallocProc = memoryManagerDefaultReallocImpl;
 
-// 0x519594 _freePtr
+// 0x519594 freePtr
 static FreeProc* gMemoryManagerFreeProc = memoryManagerDefaultFreeImpl;
 
 // 0x4845B0 defaultOutput

--- a/src/memory_manager.cc
+++ b/src/memory_manager.cc
@@ -16,19 +16,19 @@ static void* memoryManagerDefaultMallocImpl(size_t size);
 static void* memoryManagerDefaultReallocImpl(void* ptr, size_t size);
 static void memoryManagerDefaultFreeImpl(void* ptr);
 
-// 0x519588
+// 0x519588 _outputFunc_
 static MemoryManagerPrintErrorProc* gMemoryManagerPrintErrorProc = memoryManagerDefaultPrintErrorImpl;
 
-// 0x51958C
+// 0x51958C _mallocPtr
 static MallocProc* gMemoryManagerMallocProc = memoryManagerDefaultMallocImpl;
 
-// 0x519590
+// 0x519590 _reallocPtr
 static ReallocProc* gMemoryManagerReallocProc = memoryManagerDefaultReallocImpl;
 
-// 0x519594
+// 0x519594 _freePtr
 static FreeProc* gMemoryManagerFreeProc = memoryManagerDefaultFreeImpl;
 
-// 0x4845B0 defaultOutput_
+// 0x4845B0 defaultOutput
 static void memoryManagerDefaultPrintErrorImpl(const char* string)
 {
     printf("%s", string);
@@ -54,32 +54,32 @@ static int memoryManagerPrintError(const char* format, ...)
     return length;
 }
 
-// 0x484610 error_
+// 0x484610 error
 [[noreturn]] static void memoryManagerFatalAllocationError(const char* func, size_t size, const char* file, int line)
 {
     memoryManagerPrintError("%s: Error allocating block of size %ld (%x), %s %d\n", func, size, size, file, line);
     exit(1);
 }
 
-// 0x48462C defaultMalloc_
+// 0x48462C defaultMalloc
 static void* memoryManagerDefaultMallocImpl(size_t size)
 {
     return malloc(size);
 }
 
-// 0x484634 defaultRealloc_
+// 0x484634 defaultRealloc
 static void* memoryManagerDefaultReallocImpl(void* ptr, size_t size)
 {
     return realloc(ptr, size);
 }
 
-// 0x48463C defaultFree_
+// 0x48463C defaultFree
 static void memoryManagerDefaultFreeImpl(void* ptr)
 {
     free(ptr);
 }
 
-// 0x484644 memoryRegisterAlloc_
+// 0x484644 memoryRegisterAlloc
 void memoryManagerSetProcs(MallocProc* mallocProc, ReallocProc* reallocProc, FreeProc* freeProc)
 {
     gMemoryManagerMallocProc = mallocProc;
@@ -87,7 +87,7 @@ void memoryManagerSetProcs(MallocProc* mallocProc, ReallocProc* reallocProc, Fre
     gMemoryManagerFreeProc = freeProc;
 }
 
-// 0x484660 mymalloc_
+// 0x484660 mymalloc
 void* internal_malloc_safe(size_t size, const char* file, int line)
 {
     void* ptr = gMemoryManagerMallocProc(size);
@@ -98,7 +98,7 @@ void* internal_malloc_safe(size_t size, const char* file, int line)
     return ptr;
 }
 
-// 0x4846B4 myrealloc_
+// 0x4846B4 myrealloc
 void* internal_realloc_safe(void* ptr, size_t size, const char* file, int line)
 {
     ptr = gMemoryManagerReallocProc(ptr, size);
@@ -109,7 +109,7 @@ void* internal_realloc_safe(void* ptr, size_t size, const char* file, int line)
     return ptr;
 }
 
-// 0x484688 myfree_
+// 0x484688 myfree
 void internal_free_safe(void* ptr, const char* file, int line)
 {
     if (ptr == nullptr) {
@@ -120,7 +120,7 @@ void internal_free_safe(void* ptr, const char* file, int line)
     gMemoryManagerFreeProc(ptr);
 }
 
-// 0x4846D8 mycalloc_
+// 0x4846D8 mycalloc
 void* internal_calloc_safe(int count, int size, const char* file, int line)
 {
     void* ptr = gMemoryManagerMallocProc(count * size);
@@ -133,7 +133,7 @@ void* internal_calloc_safe(int count, int size, const char* file, int line)
     return ptr;
 }
 
-// 0x484710 mystrdup_
+// 0x484710 mystrdup
 char* strdup_safe(const char* string, const char* file, int line)
 {
     size_t size = strlen(string) + 1;

--- a/src/message.cc
+++ b/src/message.cc
@@ -86,7 +86,7 @@ static char _bad_copy[MESSAGE_LIST_ITEM_FIELD_MAX_SIZE];
 
 static MessageListRepositoryState* _messageListRepositoryState;
 
-// 0x484770
+// 0x484770 init_message_
 int badwordsInit()
 {
     File* stream = fileOpen("data\\badwords.txt", "rt");
@@ -154,7 +154,7 @@ int badwordsInit()
     return 0;
 }
 
-// 0x4848F0
+// 0x4848F0 exit_message_
 void badwordsExit()
 {
     for (int index = 0; index < gBadwordsCount; index++) {
@@ -170,7 +170,7 @@ void badwordsExit()
 }
 
 // message_init
-// 0x48494C
+// 0x48494C message_init_
 bool messageListInit(MessageList* messageList)
 {
     if (messageList != nullptr) {
@@ -180,7 +180,7 @@ bool messageListInit(MessageList* messageList)
     return true;
 }
 
-// 0x484964
+// 0x484964 message_exit_
 bool messageListFree(MessageList* messageList)
 {
     int i;
@@ -213,7 +213,7 @@ bool messageListFree(MessageList* messageList)
 }
 
 // message_load
-// 0x484AA4
+// 0x484AA4 message_load_
 bool messageListLoad(MessageList* messageList, const char* path)
 {
     char localized_path[COMPAT_MAX_PATH];
@@ -297,7 +297,7 @@ err:
     return success;
 }
 
-// 0x484C30
+// 0x484C30 message_search_
 bool messageListGetItem(MessageList* msg, MessageListItem* entry)
 {
     int index;
@@ -329,7 +329,7 @@ bool messageListGetItem(MessageList* msg, MessageListItem* entry)
 
 // Builds language-aware path in "text" subfolder.
 //
-// 0x484CB8
+// 0x484CB8 message_make_path_
 bool _message_make_path(char* dest, size_t size, const char* path)
 {
     if (dest == nullptr) {
@@ -345,7 +345,7 @@ bool _message_make_path(char* dest, size_t size, const char* path)
     return true;
 }
 
-// 0x484D10
+// 0x484D10 message_find_
 static bool _message_find(MessageList* msg, int num, int* out_index)
 {
     int r, l, mid;
@@ -383,7 +383,7 @@ static bool _message_find(MessageList* msg, int num, int* out_index)
     return false;
 }
 
-// 0x484D68
+// 0x484D68 message_add_
 static bool _message_add(MessageList* msg, MessageListItem* new_entry)
 {
     int index;
@@ -444,7 +444,7 @@ static bool _message_add(MessageList* msg, MessageListItem* new_entry)
     return true;
 }
 
-// 0x484F60
+// 0x484F60 message_parse_number_
 static bool _message_parse_number(int* out_num, const char* str)
 {
     const char* ch;
@@ -482,7 +482,7 @@ static bool _message_parse_number(int* out_num, const char* str)
 // 3 - unterminated field
 // 4 - limit exceeded (> `MESSAGE_LIST_ITEM_FIELD_MAX_SIZE`)
 //
-// 0x484FB4
+// 0x484FB4 message_load_field_
 static int _message_load_field(File* file, char* str)
 {
     int ch;
@@ -533,7 +533,7 @@ static int _message_load_field(File* file, char* str)
     return 0;
 }
 
-// 0x48504C
+// 0x48504C getmsg_
 char* getmsg(MessageList* msg, MessageListItem* entry, int num)
 {
     entry->num = num;
@@ -546,7 +546,7 @@ char* getmsg(MessageList* msg, MessageListItem* entry, int num)
     return entry->text;
 }
 
-// 0x485078
+// 0x485078 message_filter_
 bool messageListFilterBadwords(MessageList* messageList)
 {
     if (messageList == nullptr) {

--- a/src/message.cc
+++ b/src/message.cc
@@ -59,34 +59,34 @@ static std::string messageListRepositoryNormalizePath(const char* path)
     return normalizedPath;
 }
 
-// 0x50B79C
+// 0x50B79C Error_1
 static char _Error_1[] = "Error";
 
-// 0x50B960
+// 0x50B960 a____
 static const char* gBadwordsReplacements = "!@#$%&*@#*!&$%#&%#*%!$&%@*$@&";
 
-// 0x519598
+// 0x519598 bad_word
 static char** gBadwords = nullptr;
 
-// 0x51959C
+// 0x51959C bad_total
 static int gBadwordsCount = 0;
 
-// 0x5195A0
+// 0x5195A0 bad_len
 static int* gBadwordsLengths = nullptr;
 
 // Default text for getmsg when no entry is found.
 //
-// 0x5195A4
+// 0x5195A4 _message_error_str
 static char* _message_error_str = _Error_1;
 
 // Temporary message list item text used during filtering badwords.
 //
-// 0x63207C
+// 0x63207C bad_copy
 static char _bad_copy[MESSAGE_LIST_ITEM_FIELD_MAX_SIZE];
 
 static MessageListRepositoryState* _messageListRepositoryState;
 
-// 0x484770 init_message_
+// 0x484770 init_message
 int badwordsInit()
 {
     File* stream = fileOpen("data\\badwords.txt", "rt");
@@ -154,7 +154,7 @@ int badwordsInit()
     return 0;
 }
 
-// 0x4848F0 exit_message_
+// 0x4848F0 exit_message
 void badwordsExit()
 {
     for (int index = 0; index < gBadwordsCount; index++) {
@@ -170,7 +170,7 @@ void badwordsExit()
 }
 
 // message_init
-// 0x48494C message_init_
+// 0x48494C message_init
 bool messageListInit(MessageList* messageList)
 {
     if (messageList != nullptr) {
@@ -180,7 +180,7 @@ bool messageListInit(MessageList* messageList)
     return true;
 }
 
-// 0x484964 message_exit_
+// 0x484964 message_exit
 bool messageListFree(MessageList* messageList)
 {
     int i;
@@ -213,7 +213,7 @@ bool messageListFree(MessageList* messageList)
 }
 
 // message_load
-// 0x484AA4 message_load_
+// 0x484AA4 message_load
 bool messageListLoad(MessageList* messageList, const char* path)
 {
     char localized_path[COMPAT_MAX_PATH];
@@ -297,7 +297,7 @@ err:
     return success;
 }
 
-// 0x484C30 message_search_
+// 0x484C30 message_search
 bool messageListGetItem(MessageList* msg, MessageListItem* entry)
 {
     int index;
@@ -329,7 +329,7 @@ bool messageListGetItem(MessageList* msg, MessageListItem* entry)
 
 // Builds language-aware path in "text" subfolder.
 //
-// 0x484CB8 message_make_path_
+// 0x484CB8 message_make_path
 bool _message_make_path(char* dest, size_t size, const char* path)
 {
     if (dest == nullptr) {
@@ -345,7 +345,7 @@ bool _message_make_path(char* dest, size_t size, const char* path)
     return true;
 }
 
-// 0x484D10 message_find_
+// 0x484D10 message_find
 static bool _message_find(MessageList* msg, int num, int* out_index)
 {
     int r, l, mid;
@@ -383,7 +383,7 @@ static bool _message_find(MessageList* msg, int num, int* out_index)
     return false;
 }
 
-// 0x484D68 message_add_
+// 0x484D68 message_add
 static bool _message_add(MessageList* msg, MessageListItem* new_entry)
 {
     int index;
@@ -444,7 +444,7 @@ static bool _message_add(MessageList* msg, MessageListItem* new_entry)
     return true;
 }
 
-// 0x484F60 message_parse_number_
+// 0x484F60 message_parse_number
 static bool _message_parse_number(int* out_num, const char* str)
 {
     const char* ch;
@@ -482,7 +482,7 @@ static bool _message_parse_number(int* out_num, const char* str)
 // 3 - unterminated field
 // 4 - limit exceeded (> `MESSAGE_LIST_ITEM_FIELD_MAX_SIZE`)
 //
-// 0x484FB4 message_load_field_
+// 0x484FB4 message_load_field
 static int _message_load_field(File* file, char* str)
 {
     int ch;
@@ -533,7 +533,7 @@ static int _message_load_field(File* file, char* str)
     return 0;
 }
 
-// 0x48504C getmsg_
+// 0x48504C getmsg
 char* getmsg(MessageList* msg, MessageListItem* entry, int num)
 {
     entry->num = num;
@@ -546,7 +546,7 @@ char* getmsg(MessageList* msg, MessageListItem* entry, int num)
     return entry->text;
 }
 
-// 0x485078 message_filter_
+// 0x485078 message_filter
 bool messageListFilterBadwords(MessageList* messageList)
 {
     if (messageList == nullptr) {

--- a/src/message.cc
+++ b/src/message.cc
@@ -76,7 +76,7 @@ static int* gBadwordsLengths = nullptr;
 
 // Default text for getmsg when no entry is found.
 //
-// 0x5195A4 _message_error_str
+// 0x5195A4 message_error_str
 static char* _message_error_str = _Error_1;
 
 // Temporary message list item text used during filtering badwords.

--- a/src/mouse.cc
+++ b/src/mouse.cc
@@ -48,7 +48,7 @@ static unsigned char gMouseDefaultCursor[MOUSE_DEFAULT_CURSOR_SIZE] = {
 // 0x51E290 mouse_idling
 static int _mouse_idling = 0;
 
-// 0x51E294 _mouse_buf
+// 0x51E294 mouse_buf
 static unsigned char* gMouseCursorData = nullptr;
 
 // 0x51E298 mouse_shape
@@ -117,10 +117,10 @@ static int _mouse_hotx;
 // 0x6AC7D4 mouse_idle_start_time
 static unsigned int _mouse_idle_start_time;
 
-// 0x6AC7D8 _mouse_blit_trans
+// 0x6AC7D8 mouse_blit_trans
 WindowDrawingProc2* _mouse_blit_trans;
 
-// 0x6AC7DC _mouse_blit
+// 0x6AC7DC mouse_blit
 WINDOWDRAWINGPROC _mouse_blit;
 
 // 0x6AC7E0 mouse_trans

--- a/src/mouse.cc
+++ b/src/mouse.cc
@@ -31,7 +31,7 @@ static void _mouse_clip();
 // - 1: white
 // - 15: black
 //
-// 0x51E250
+// 0x51E250 or_mask
 static unsigned char gMouseDefaultCursor[MOUSE_DEFAULT_CURSOR_SIZE] = {
     // clang-format off
     1,  1,  1,  1,  1,  1,  1, 0,
@@ -45,85 +45,85 @@ static unsigned char gMouseDefaultCursor[MOUSE_DEFAULT_CURSOR_SIZE] = {
     // clang-format on
 };
 
-// 0x51E290
+// 0x51E290 mouse_idling
 static int _mouse_idling = 0;
 
-// 0x51E294
+// 0x51E294 _mouse_buf
 static unsigned char* gMouseCursorData = nullptr;
 
-// 0x51E298
+// 0x51E298 mouse_shape
 static unsigned char* _mouse_shape = nullptr;
 
-// 0x51E29C
+// 0x51E29C mouse_fptr
 static unsigned char* _mouse_fptr = nullptr;
 
-// 0x51E2A0
+// 0x51E2A0 mouse_sensitivity
 static double gMouseSensitivity = 1.0;
 
-// 0x51E2AC
+// 0x51E2AC last_buttons
 static int last_buttons = 0;
 
-// 0x6AC790
+// 0x6AC790 mouse_is_hidden
 static bool gCursorIsHidden;
 
-// 0x6AC794
+// 0x6AC794 raw_x
 static int _raw_x;
 
-// 0x6AC798
+// 0x6AC798 mouse_length
 static int gMouseCursorHeight;
 
-// 0x6AC79C
+// 0x6AC79C raw_y
 static int _raw_y;
 
-// 0x6AC7A0
+// 0x6AC7A0 raw_buttons
 static int _raw_buttons;
 
-// 0x6AC7A4
+// 0x6AC7A4 mouse_y
 static int gMouseCursorY;
 
-// 0x6AC7A8
+// 0x6AC7A8 mouse_x
 static int gMouseCursorX;
 
-// 0x6AC7AC
+// 0x6AC7AC mouse_disabled
 static int _mouse_disabled;
 
-// 0x6AC7B0
+// 0x6AC7B0 mouse_buttons
 static int gMouseEvent;
 
-// 0x6AC7B4
+// 0x6AC7B4 mouse_speed
 static unsigned int _mouse_speed;
 
-// 0x6AC7B8
+// 0x6AC7B8 mouse_curr_frame
 static int _mouse_curr_frame;
 
-// 0x6AC7BC
+// 0x6AC7BC have_mouse
 static bool gMouseInitialized;
 
-// 0x6AC7C0
+// 0x6AC7C0 mouse_pitch
 static int gMouseCursorPitch;
 
-// 0x6AC7C4
+// 0x6AC7C4 mouse_width
 static int gMouseCursorWidth;
 
-// 0x6AC7C8
+// 0x6AC7C8 mouse_num_frames
 static int _mouse_num_frames;
 
-// 0x6AC7CC
+// 0x6AC7CC mouse_hoty
 static int _mouse_hoty;
 
-// 0x6AC7D0
+// 0x6AC7D0 mouse_hotx
 static int _mouse_hotx;
 
-// 0x6AC7D4
+// 0x6AC7D4 mouse_idle_start_time
 static unsigned int _mouse_idle_start_time;
 
-// 0x6AC7D8
+// 0x6AC7D8 _mouse_blit_trans
 WindowDrawingProc2* _mouse_blit_trans;
 
-// 0x6AC7DC
+// 0x6AC7DC _mouse_blit
 WINDOWDRAWINGPROC _mouse_blit;
 
-// 0x6AC7E0
+// 0x6AC7E0 mouse_trans
 static char _mouse_trans;
 
 static int gMouseWheelX = 0;

--- a/src/mouse_manager.cc
+++ b/src/mouse_manager.cc
@@ -43,31 +43,31 @@ unsigned char* gMouseManagerCurrentStaticData;
 // 0x638E0C
 int gMouseManagerCurrentCacheEntryIndex;
 
-// 0x485250
+// 0x485250 defaultNameMangler_
 char* mouseManagerNameManglerDefaultImpl(char* name)
 {
     return name;
 }
 
-// 0x485254
+// 0x485254 defaultRateCallback_
 int mouseManagerRateProviderDefaultImpl()
 {
     return 1000;
 }
 
-// 0x48525C
+// 0x48525C defaultTimeCallback_
 int mouseManagerTimeProviderDefaultImpl()
 {
     return getTicks();
 }
 
-// 0x485288
+// 0x485288 mousemgrSetNameMangler_
 void mouseManagerSetNameMangler(MouseManagerNameMangler* func)
 {
     gMouseManagerNameMangler = func;
 }
 
-// 0x4852B8
+// 0x4852B8 freeCacheEntry_
 void mouseManagerFreeCacheEntry(MouseManagerCacheEntry* entry)
 {
     switch (entry->type) {
@@ -103,7 +103,7 @@ void mouseManagerFreeCacheEntry(MouseManagerCacheEntry* entry)
     entry->fileName[0] = '\0';
 }
 
-// 0x4853F8
+// 0x4853F8 cacheInsert_
 int mouseManagerInsertCacheEntry(void** data, int type, unsigned char* palette, const char* fileName)
 {
     int foundIndex = -1;
@@ -158,7 +158,7 @@ int mouseManagerInsertCacheEntry(void** data, int type, unsigned char* palette, 
 
 // NOTE: Inlined.
 //
-// 0x4853D4
+// 0x4853D4 cacheFlush_
 void mouseManagerFlushCache()
 {
     for (int index = 0; index < MOUSE_MGR_CACHE_CAPACITY; index++) {
@@ -166,7 +166,7 @@ void mouseManagerFlushCache()
     }
 }
 
-// 0x48554C
+// 0x48554C cacheFind_
 MouseManagerCacheEntry* mouseManagerFindCacheEntry(const char* fileName, unsigned char** palettePtr, int* a3, int* a4, int* widthPtr, int* heightPtr, int* typePtr)
 {
     for (int index = 0; index < MOUSE_MGR_CACHE_CAPACITY; index++) {
@@ -199,13 +199,13 @@ MouseManagerCacheEntry* mouseManagerFindCacheEntry(const char* fileName, unsigne
     return nullptr;
 }
 
-// 0x48568C
+// 0x48568C initMousemgr_
 void mouseManagerInit()
 {
     mouseSetSensitivity(1.0);
 }
 
-// 0x48569C
+// 0x48569C mousemgrClose_
 void mouseManagerExit()
 {
     mouseSetFrame(nullptr, 0, 0, 0, 0, 0, 0);
@@ -222,7 +222,7 @@ void mouseManagerExit()
     gMouseManagerCurrentAnimatedData = nullptr;
 }
 
-// 0x485704
+// 0x485704 mousemgrUpdate_
 void mouseManagerUpdate()
 {
     if (!gMouseManagerIsAnimating) {
@@ -264,7 +264,7 @@ void mouseManagerUpdate()
     }
 }
 
-// 0x485868
+// 0x485868 mouseSetFrame_
 int mouseManagerSetFrame(char* fileName, int a2)
 {
     char* mangledFileName = gMouseManagerNameMangler(fileName);
@@ -427,7 +427,7 @@ int mouseManagerSetFrame(char* fileName, int a2)
     return true;
 }
 
-// 0x485E58
+// 0x485E58 mouseSetMouseShape_
 bool mouseManagerSetMouseShape(char* fileName, int a2, int a3)
 {
     unsigned char* palette;
@@ -480,7 +480,7 @@ bool mouseManagerSetMouseShape(char* fileName, int a2, int a3)
     return true;
 }
 
-// 0x486010
+// 0x486010 mouseSetMousePointer_
 bool mouseManagerSetMousePointer(char* fileName)
 {
     unsigned char* palette;
@@ -572,7 +572,7 @@ bool mouseManagerSetMousePointer(char* fileName)
     return rc;
 }
 
-// 0x4862AC
+// 0x4862AC mousemgrResetMouse_
 void mouseManagerResetMouse()
 {
     MouseManagerCacheEntry* entry = &(gMouseManagerCache[gMouseManagerCurrentCacheEntryIndex]);
@@ -632,13 +632,13 @@ void mouseManagerResetMouse()
     }
 }
 
-// 0x4865C4
+// 0x4865C4 mouseHide_
 void mouseManagerHideMouse()
 {
     mouseHideCursor();
 }
 
-// 0x4865CC
+// 0x4865CC mouseShow_
 void mouseManagerShowMouse()
 {
     mouseShowCursor();

--- a/src/mouse_manager.cc
+++ b/src/mouse_manager.cc
@@ -13,16 +13,16 @@
 
 namespace fallout {
 
-// 0x5195A8 _mouseNameMangler
+// 0x5195A8 mouseNameMangler
 MouseManagerNameMangler* gMouseManagerNameMangler = mouseManagerNameManglerDefaultImpl;
 
-// 0x5195AC _rateCallback
+// 0x5195AC rateCallback
 MouseManagerRateProvider* gMouseManagerRateProvider = mouseManagerRateProviderDefaultImpl;
 
-// 0x5195B0 _currentTimeCallback
+// 0x5195B0 currentTimeCallback
 MouseManagerTimeProvider* gMouseManagerTimeProvider = mouseManagerTimeProviderDefaultImpl;
 
-// 0x5195B4 _curref
+// 0x5195B4 curref
 int gMouseManagerCurrentRef = 1;
 
 // 0x63247C Cache
@@ -37,7 +37,7 @@ unsigned char* gMouseManagerCurrentPalette;
 // 0x638E04 curAnim
 MouseManagerAnimatedData* gMouseManagerCurrentAnimatedData;
 
-// 0x638E08 _curMouseBuf
+// 0x638E08 curMouseBuf
 unsigned char* gMouseManagerCurrentStaticData;
 
 // 0x638E0C lastMouseIndex

--- a/src/mouse_manager.cc
+++ b/src/mouse_manager.cc
@@ -13,61 +13,61 @@
 
 namespace fallout {
 
-// 0x5195A8
+// 0x5195A8 _mouseNameMangler
 MouseManagerNameMangler* gMouseManagerNameMangler = mouseManagerNameManglerDefaultImpl;
 
-// 0x5195AC
+// 0x5195AC _rateCallback
 MouseManagerRateProvider* gMouseManagerRateProvider = mouseManagerRateProviderDefaultImpl;
 
-// 0x5195B0
+// 0x5195B0 _currentTimeCallback
 MouseManagerTimeProvider* gMouseManagerTimeProvider = mouseManagerTimeProviderDefaultImpl;
 
-// 0x5195B4
+// 0x5195B4 _curref
 int gMouseManagerCurrentRef = 1;
 
-// 0x63247C
+// 0x63247C Cache
 MouseManagerCacheEntry gMouseManagerCache[MOUSE_MGR_CACHE_CAPACITY];
 
-// 0x638DFC
+// 0x638DFC animating
 bool gMouseManagerIsAnimating;
 
-// 0x638E00
+// 0x638E00 curPal
 unsigned char* gMouseManagerCurrentPalette;
 
-// 0x638E04
+// 0x638E04 curAnim
 MouseManagerAnimatedData* gMouseManagerCurrentAnimatedData;
 
-// 0x638E08
+// 0x638E08 _curMouseBuf
 unsigned char* gMouseManagerCurrentStaticData;
 
-// 0x638E0C
+// 0x638E0C lastMouseIndex
 int gMouseManagerCurrentCacheEntryIndex;
 
-// 0x485250 defaultNameMangler_
+// 0x485250 defaultNameMangler
 char* mouseManagerNameManglerDefaultImpl(char* name)
 {
     return name;
 }
 
-// 0x485254 defaultRateCallback_
+// 0x485254 defaultRateCallback
 int mouseManagerRateProviderDefaultImpl()
 {
     return 1000;
 }
 
-// 0x48525C defaultTimeCallback_
+// 0x48525C defaultTimeCallback
 int mouseManagerTimeProviderDefaultImpl()
 {
     return getTicks();
 }
 
-// 0x485288 mousemgrSetNameMangler_
+// 0x485288 mousemgrSetNameMangler
 void mouseManagerSetNameMangler(MouseManagerNameMangler* func)
 {
     gMouseManagerNameMangler = func;
 }
 
-// 0x4852B8 freeCacheEntry_
+// 0x4852B8 freeCacheEntry
 void mouseManagerFreeCacheEntry(MouseManagerCacheEntry* entry)
 {
     switch (entry->type) {
@@ -103,7 +103,7 @@ void mouseManagerFreeCacheEntry(MouseManagerCacheEntry* entry)
     entry->fileName[0] = '\0';
 }
 
-// 0x4853F8 cacheInsert_
+// 0x4853F8 cacheInsert
 int mouseManagerInsertCacheEntry(void** data, int type, unsigned char* palette, const char* fileName)
 {
     int foundIndex = -1;
@@ -158,7 +158,7 @@ int mouseManagerInsertCacheEntry(void** data, int type, unsigned char* palette, 
 
 // NOTE: Inlined.
 //
-// 0x4853D4 cacheFlush_
+// 0x4853D4 cacheFlush
 void mouseManagerFlushCache()
 {
     for (int index = 0; index < MOUSE_MGR_CACHE_CAPACITY; index++) {
@@ -166,7 +166,7 @@ void mouseManagerFlushCache()
     }
 }
 
-// 0x48554C cacheFind_
+// 0x48554C cacheFind
 MouseManagerCacheEntry* mouseManagerFindCacheEntry(const char* fileName, unsigned char** palettePtr, int* a3, int* a4, int* widthPtr, int* heightPtr, int* typePtr)
 {
     for (int index = 0; index < MOUSE_MGR_CACHE_CAPACITY; index++) {
@@ -199,13 +199,13 @@ MouseManagerCacheEntry* mouseManagerFindCacheEntry(const char* fileName, unsigne
     return nullptr;
 }
 
-// 0x48568C initMousemgr_
+// 0x48568C initMousemgr
 void mouseManagerInit()
 {
     mouseSetSensitivity(1.0);
 }
 
-// 0x48569C mousemgrClose_
+// 0x48569C mousemgrClose
 void mouseManagerExit()
 {
     mouseSetFrame(nullptr, 0, 0, 0, 0, 0, 0);
@@ -222,7 +222,7 @@ void mouseManagerExit()
     gMouseManagerCurrentAnimatedData = nullptr;
 }
 
-// 0x485704 mousemgrUpdate_
+// 0x485704 mousemgrUpdate
 void mouseManagerUpdate()
 {
     if (!gMouseManagerIsAnimating) {
@@ -264,7 +264,7 @@ void mouseManagerUpdate()
     }
 }
 
-// 0x485868 mouseSetFrame_
+// 0x485868 mouseSetFrame
 int mouseManagerSetFrame(char* fileName, int a2)
 {
     char* mangledFileName = gMouseManagerNameMangler(fileName);
@@ -427,7 +427,7 @@ int mouseManagerSetFrame(char* fileName, int a2)
     return true;
 }
 
-// 0x485E58 mouseSetMouseShape_
+// 0x485E58 mouseSetMouseShape
 bool mouseManagerSetMouseShape(char* fileName, int a2, int a3)
 {
     unsigned char* palette;
@@ -480,7 +480,7 @@ bool mouseManagerSetMouseShape(char* fileName, int a2, int a3)
     return true;
 }
 
-// 0x486010 mouseSetMousePointer_
+// 0x486010 mouseSetMousePointer
 bool mouseManagerSetMousePointer(char* fileName)
 {
     unsigned char* palette;
@@ -572,7 +572,7 @@ bool mouseManagerSetMousePointer(char* fileName)
     return rc;
 }
 
-// 0x4862AC mousemgrResetMouse_
+// 0x4862AC mousemgrResetMouse
 void mouseManagerResetMouse()
 {
     MouseManagerCacheEntry* entry = &(gMouseManagerCache[gMouseManagerCurrentCacheEntryIndex]);
@@ -632,13 +632,13 @@ void mouseManagerResetMouse()
     }
 }
 
-// 0x4865C4 mouseHide_
+// 0x4865C4 mouseHide
 void mouseManagerHideMouse()
 {
     mouseHideCursor();
 }
 
-// 0x4865CC mouseShow_
+// 0x4865CC mouseShow
 void mouseManagerShowMouse()
 {
     mouseShowCursor();

--- a/src/movie.cc
+++ b/src/movie.cc
@@ -186,25 +186,25 @@ static unsigned char* _alphaBuf;
 
 static unsigned char* MVE_lastBuffer = nullptr;
 
-// 0x4865FC
+// 0x4865FC movieMalloc_
 static void* movieMallocImpl(size_t size)
 {
     return internal_malloc_safe(size, __FILE__, __LINE__); // "..\\int\\MOVIE.C", 209
 }
 
-// 0x486614
+// 0x486614 movieFree_
 static void movieFreeImpl(void* ptr)
 {
     internal_free_safe(ptr, __FILE__, __LINE__); // "..\\int\\MOVIE.C", 213
 }
 
-// 0x48662C
+// 0x48662C movieRead_
 static bool movieReadImpl(void* handle, void* buf, int count)
 {
     return fileRead(buf, 1, count, (File*)handle) == count;
 }
 
-// 0x486654
+// 0x486654 movie_MVE_ShowFrame_
 static void movieDirectImpl(unsigned char* pixels, int src_width, int src_height, int src_x, int src_y, int dst_width, int dst_height, int dst_x, int dst_y)
 {
     int movieWindowWidth;
@@ -265,7 +265,7 @@ static void movieDirectImpl(unsigned char* pixels, int src_width, int src_height
     renderPresent();
 }
 
-// 0x486900
+// 0x486900 movieShowFrame_
 static void movieBufferedImpl(unsigned char* pixels, int src_width, int src_height, int src_x, int src_y, int dst_width, int dst_height, int dst_x, int dst_y)
 {
     if (gMovieWindow == -1) {
@@ -288,7 +288,7 @@ static void movieBufferedImpl(unsigned char* pixels, int src_width, int src_heig
     }
 }
 
-// 0x486B68
+// 0x486B68 movieScaleSubRect_
 int _movieScaleSubRect(int win, unsigned char* data, int width, int height, int pitch)
 {
     int windowWidth = windowGetWidth(win);
@@ -324,7 +324,7 @@ int _movieScaleSubRect(int win, unsigned char* data, int width, int height, int 
     return 1;
 }
 
-// 0x486C74
+// 0x486C74 movieScaleSubRectAlpha_
 int _movieScaleSubRectAlpha(int win, unsigned char* data, int width, int height, int pitch)
 {
     gMovieFlags |= 1;
@@ -338,7 +338,7 @@ int _movieScaleWindowAlpha(int win, unsigned char* data, int width, int height, 
     return 0;
 }
 
-// 0x486C80
+// 0x486C80 blitAlpha_
 int _blitAlpha(int win, unsigned char* data, int width, int height, int pitch)
 {
     int windowWidth = windowGetWidth(win);
@@ -347,7 +347,7 @@ int _blitAlpha(int win, unsigned char* data, int width, int height, int pitch)
     return 1;
 }
 
-// 0x486CD4
+// 0x486CD4 movieScaleWindow_
 int _movieScaleWindow(int win, unsigned char* data, int width, int height, int pitch)
 {
     int windowWidth = windowGetWidth(win);
@@ -376,7 +376,7 @@ int _movieScaleWindow(int win, unsigned char* data, int width, int height, int p
     return 1;
 }
 
-// 0x486D84
+// 0x486D84 blitNormal_
 int _blitNormal(int win, unsigned char* data, int width, int height, int pitch)
 {
     int windowWidth = windowGetWidth(win);
@@ -385,7 +385,7 @@ int _blitNormal(int win, unsigned char* data, int width, int height, int pitch)
     return 1;
 }
 
-// 0x486DDC
+// 0x486DDC movieSetPalette_
 static void movieSetPaletteEntriesImpl(unsigned char* palette, int start, int end)
 {
     if (end != 0) {
@@ -394,7 +394,7 @@ static void movieSetPaletteEntriesImpl(unsigned char* palette, int start, int en
 }
 
 // initMovie
-// 0x486E0C
+// 0x486E0C initMovie_
 void movieInit()
 {
     MveSetMemory(movieMallocImpl, movieFreeImpl);
@@ -403,7 +403,7 @@ void movieInit()
     MveSetIO(movieReadImpl);
 }
 
-// 0x486E98
+// 0x486E98 cleanupMovie_
 static void _cleanupMovie(bool shouldEndMovie)
 {
     if (!_running) {
@@ -469,7 +469,7 @@ static void _cleanupMovie(bool shouldEndMovie)
     gMovieWindow = -1;
 }
 
-// 0x48711C
+// 0x48711C movieClose_
 void movieExit()
 {
     _cleanupMovie(1);
@@ -480,7 +480,7 @@ void movieExit()
     }
 }
 
-// 0x487150
+// 0x487150 movieStop_
 void _movieStop()
 {
     if (_running) {
@@ -488,7 +488,7 @@ void _movieStop()
     }
 }
 
-// 0x487164
+// 0x487164 movieSetFlags_
 int movieSetFlags(int flags)
 {
     if ((flags & MOVIE_FLAG_0x04) != 0) {
@@ -521,19 +521,19 @@ int movieSetFlags(int flags)
     return 0;
 }
 
-// 0x48725C
+// 0x48725C movieSetPaletteFunc_
 void _movieSetPaletteFunc(MovieSetPaletteEntriesProc* proc)
 {
     gMovieSetPaletteEntriesProc = proc != nullptr ? proc : _setSystemPaletteEntries;
 }
 
-// 0x487274
+// 0x487274 movieSetCallback_
 void movieSetPaletteProc(MovieSetPaletteProc* proc)
 {
     gMoviePaletteProc = proc;
 }
 
-// 0x4872E8
+// 0x4872E8 cleanupLast_
 static void _cleanupLast()
 {
     if (_lastMovieBuffer != nullptr) {
@@ -544,7 +544,7 @@ static void _cleanupLast()
     MVE_lastBuffer = nullptr;
 }
 
-// 0x48731C
+// 0x48731C openFile_
 static File* movieOpen(char* filePath)
 {
     gMovieFileStream = fileOpen(filePath, "rb");
@@ -555,7 +555,7 @@ static File* movieOpen(char* filePath)
     return gMovieFileStream;
 }
 
-// 0x487380
+// 0x487380 openSubtitle_
 static void movieLoadSubtitles(char* filePath)
 {
     _subtitleW = windowGetWidth(gMovieWindow);
@@ -626,7 +626,7 @@ static void movieLoadSubtitles(char* filePath)
     debugPrint("Read %d subtitles\n", subtitleCount);
 }
 
-// 0x48755C
+// 0x48755C doSubtitle_
 static void movieRenderSubtitles()
 {
     if (gMovieSubtitleHead == nullptr) {
@@ -684,7 +684,7 @@ static void movieRenderSubtitles()
     }
 }
 
-// 0x487710
+// 0x487710 movieStart_
 static int _movieStart(int win, char* filePath)
 {
     if (_running) {
@@ -752,7 +752,7 @@ static int _movieStart(int win, char* filePath)
     return 0;
 }
 
-// 0x487964
+// 0x487964 localMovieCallback_
 static bool _localMovieCallback()
 {
     movieRenderSubtitles();
@@ -764,7 +764,7 @@ static bool _localMovieCallback()
     return inputGetInput() != -1;
 }
 
-// 0x487AC8
+// 0x487AC8 movieRun_
 int _movieRun(int win, char* filePath)
 {
     if (_running) {
@@ -780,7 +780,7 @@ int _movieRun(int win, char* filePath)
     return _movieStart(win, filePath);
 }
 
-// 0x487B1C
+// 0x487B1C movieRunRect_
 int _movieRunRect(int win, char* filePath, int x, int y, int w, int h)
 {
     if (_running) {
@@ -797,7 +797,7 @@ int _movieRunRect(int win, char* filePath, int x, int y, int w, int h)
     return _movieStart(win, filePath);
 }
 
-// 0x487B7C
+// 0x487B7C stepMovie_
 static int _stepMovie()
 {
     if (_alphaHandle != nullptr) {
@@ -814,20 +814,20 @@ static int _stepMovie()
     return stepResult;
 }
 
-// 0x487BC8
+// 0x487BC8 movieSetSubtitleFunc_
 void movieSetBuildSubtitleFilePathProc(MovieBuildSubtitleFilePathProc* proc)
 {
     gMovieBuildSubtitleFilePathProc = proc;
 }
 
-// 0x487BD0
+// 0x487BD0 movieSetVolume_
 void movieSetVolume(int volume)
 {
     int normalizedVolume = _soundVolumeHMItoDirectSound(volume);
     MveSetVolume(normalizedVolume);
 }
 
-// 0x487BEC
+// 0x487BEC movieUpdate_
 void _movieUpdate()
 {
     if (!_running) {
@@ -859,7 +859,7 @@ void _movieUpdate()
     }
 }
 
-// 0x487C88
+// 0x487C88 moviePlaying_
 int _moviePlaying()
 {
     return _running;

--- a/src/movie.cc
+++ b/src/movie.cc
@@ -55,7 +55,7 @@ static int gMovieWindow = -1;
 // 0x5195BC subtitleFont
 static int gMovieSubtitlesFont = -1;
 
-// 0x5195C0 _showFrameFuncs
+// 0x5195C0 showFrameFuncs
 static MovieBlitFunc* gMovieBlitFuncs[2][2][2] = {
     {
         {
@@ -79,7 +79,7 @@ static MovieBlitFunc* gMovieBlitFuncs[2][2][2] = {
     },
 };
 
-// 0x5195E0 _paletteFunc
+// 0x5195E0 paletteFunc
 static MovieSetPaletteEntriesProc* gMovieSetPaletteEntriesProc = _setSystemPaletteEntries;
 
 // 0x5195E4 subtitleR
@@ -97,13 +97,13 @@ static Rect gMovieWindowRect;
 // 0x638E20 movieRect
 static Rect _movieRect;
 
-// 0x638E30 _movieCallback
+// 0x638E30 movieCallback
 static void (*_movieCallback)();
 
-// 0x638E38 _updateCallbackFunc
+// 0x638E38 updateCallbackFunc
 static MovieSetPaletteProc* gMoviePaletteProc;
 
-// 0x638E40 _subtitleFilenameFunc
+// 0x638E40 subtitleFilenameFunc
 static MovieBuildSubtitleFilePathProc* gMovieBuildSubtitleFilePathProc;
 
 // 0x638E48 subtitleW
@@ -136,7 +136,7 @@ static int _lastMovieX;
 // 0x638E70 lastMovieY
 static int _lastMovieY;
 
-// 0x638E74 _subtitleList
+// 0x638E74 subtitleList
 static MovieSubtitleListNode* gMovieSubtitleHead;
 
 // 0x638E78 movieFlags
@@ -166,10 +166,10 @@ static int _subtitleH;
 // 0x638EA4 mve_running
 static int _running;
 
-// 0x638EA8 _MVE_handle_file
+// 0x638EA8 MVE_handle_file
 static File* gMovieFileStream;
 
-// 0x638EAC _alphaWindowBuf
+// 0x638EAC alphaWindowBuf
 static unsigned char* _alphaWindowBuf;
 
 // 0x638EB0 movieX
@@ -178,7 +178,7 @@ static int _movieX;
 // 0x638EB4 movieY
 static int _movieY;
 
-// 0x638EBC _alphaHandle
+// 0x638EBC alphaHandle
 static File* _alphaHandle;
 
 // 0x638EC0 alphaBuf

--- a/src/movie.cc
+++ b/src/movie.cc
@@ -49,13 +49,13 @@ static int _movieStart(int win, char* filePath);
 static bool _localMovieCallback();
 static int _stepMovie();
 
-// 0x5195B8
+// 0x5195B8 GNWWin
 static int gMovieWindow = -1;
 
-// 0x5195BC
+// 0x5195BC subtitleFont
 static int gMovieSubtitlesFont = -1;
 
-// 0x5195C0
+// 0x5195C0 _showFrameFuncs
 static MovieBlitFunc* gMovieBlitFuncs[2][2][2] = {
     {
         {
@@ -79,132 +79,132 @@ static MovieBlitFunc* gMovieBlitFuncs[2][2][2] = {
     },
 };
 
-// 0x5195E0
+// 0x5195E0 _paletteFunc
 static MovieSetPaletteEntriesProc* gMovieSetPaletteEntriesProc = _setSystemPaletteEntries;
 
-// 0x5195E4
+// 0x5195E4 subtitleR
 static int gMovieSubtitlesColorR = 31;
 
-// 0x5195E8
+// 0x5195E8 subtitleG
 static int gMovieSubtitlesColorG = 31;
 
-// 0x5195EC
+// 0x5195EC subtitleB
 static int gMovieSubtitlesColorB = 31;
 
-// 0x638E10
+// 0x638E10 mve_win_rect
 static Rect gMovieWindowRect;
 
-// 0x638E20
+// 0x638E20 movieRect
 static Rect _movieRect;
 
-// 0x638E30
+// 0x638E30 _movieCallback
 static void (*_movieCallback)();
 
-// 0x638E38
+// 0x638E38 _updateCallbackFunc
 static MovieSetPaletteProc* gMoviePaletteProc;
 
-// 0x638E40
+// 0x638E40 _subtitleFilenameFunc
 static MovieBuildSubtitleFilePathProc* gMovieBuildSubtitleFilePathProc;
 
-// 0x638E48
+// 0x638E48 subtitleW
 static int _subtitleW;
 
-// 0x638E4C
+// 0x638E4C lastMovieBH
 static int _lastMovieBH;
 
-// 0x638E50
+// 0x638E50 lastMovieBW
 static int _lastMovieBW;
 
-// 0x638E54
+// 0x638E54 lastMovieSX
 static int _lastMovieSX;
 
-// 0x638E58
+// 0x638E58 lastMovieSY
 static int _lastMovieSY;
 
-// 0x638E5C
+// 0x638E5C movieScaleFlag
 static int _movieScaleFlag;
 
-// 0x638E64
+// 0x638E64 lastMovieH
 static int _lastMovieH;
 
-// 0x638E68
+// 0x638E68 lastMovieW
 static int _lastMovieW;
 
-// 0x638E6C
+// 0x638E6C lastMovieX
 static int _lastMovieX;
 
-// 0x638E70
+// 0x638E70 lastMovieY
 static int _lastMovieY;
 
-// 0x638E74
+// 0x638E74 _subtitleList
 static MovieSubtitleListNode* gMovieSubtitleHead;
 
-// 0x638E78
+// 0x638E78 movieFlags
 static unsigned int gMovieFlags;
 
-// 0x638E7C
+// 0x638E7C movieAlphaFlag
 static int _movieAlphaFlag;
 
-// 0x638E80
+// 0x638E80 movieSubRectFlag
 static bool _movieSubRectFlag;
 
-// 0x638E84
+// 0x638E84 movieH
 static int _movieH;
 
-// 0x638E88
+// 0x638E88 movieOffset
 static int _movieOffset;
 
-// 0x638E90
+// 0x638E90 lastMovieBuffer
 static unsigned char* _lastMovieBuffer;
 
-// 0x638E94
+// 0x638E94 movieW
 static int _movieW;
 
-// 0x638EA0
+// 0x638EA0 subtitleH
 static int _subtitleH;
 
-// 0x638EA4
+// 0x638EA4 mve_running
 static int _running;
 
-// 0x638EA8
+// 0x638EA8 _MVE_handle_file
 static File* gMovieFileStream;
 
-// 0x638EAC
+// 0x638EAC _alphaWindowBuf
 static unsigned char* _alphaWindowBuf;
 
-// 0x638EB0
+// 0x638EB0 movieX
 static int _movieX;
 
-// 0x638EB4
+// 0x638EB4 movieY
 static int _movieY;
 
-// 0x638EBC
+// 0x638EBC _alphaHandle
 static File* _alphaHandle;
 
-// 0x638EC0
+// 0x638EC0 alphaBuf
 static unsigned char* _alphaBuf;
 
 static unsigned char* MVE_lastBuffer = nullptr;
 
-// 0x4865FC movieMalloc_
+// 0x4865FC movieMalloc
 static void* movieMallocImpl(size_t size)
 {
     return internal_malloc_safe(size, __FILE__, __LINE__); // "..\\int\\MOVIE.C", 209
 }
 
-// 0x486614 movieFree_
+// 0x486614 movieFree
 static void movieFreeImpl(void* ptr)
 {
     internal_free_safe(ptr, __FILE__, __LINE__); // "..\\int\\MOVIE.C", 213
 }
 
-// 0x48662C movieRead_
+// 0x48662C movieRead
 static bool movieReadImpl(void* handle, void* buf, int count)
 {
     return fileRead(buf, 1, count, (File*)handle) == count;
 }
 
-// 0x486654 movie_MVE_ShowFrame_
+// 0x486654 movie_MVE_ShowFrame
 static void movieDirectImpl(unsigned char* pixels, int src_width, int src_height, int src_x, int src_y, int dst_width, int dst_height, int dst_x, int dst_y)
 {
     int movieWindowWidth;
@@ -265,7 +265,7 @@ static void movieDirectImpl(unsigned char* pixels, int src_width, int src_height
     renderPresent();
 }
 
-// 0x486900 movieShowFrame_
+// 0x486900 movieShowFrame
 static void movieBufferedImpl(unsigned char* pixels, int src_width, int src_height, int src_x, int src_y, int dst_width, int dst_height, int dst_x, int dst_y)
 {
     if (gMovieWindow == -1) {
@@ -288,7 +288,7 @@ static void movieBufferedImpl(unsigned char* pixels, int src_width, int src_heig
     }
 }
 
-// 0x486B68 movieScaleSubRect_
+// 0x486B68 movieScaleSubRect
 int _movieScaleSubRect(int win, unsigned char* data, int width, int height, int pitch)
 {
     int windowWidth = windowGetWidth(win);
@@ -324,7 +324,7 @@ int _movieScaleSubRect(int win, unsigned char* data, int width, int height, int 
     return 1;
 }
 
-// 0x486C74 movieScaleSubRectAlpha_
+// 0x486C74 movieScaleSubRectAlpha
 int _movieScaleSubRectAlpha(int win, unsigned char* data, int width, int height, int pitch)
 {
     gMovieFlags |= 1;
@@ -338,7 +338,7 @@ int _movieScaleWindowAlpha(int win, unsigned char* data, int width, int height, 
     return 0;
 }
 
-// 0x486C80 blitAlpha_
+// 0x486C80 blitAlpha
 int _blitAlpha(int win, unsigned char* data, int width, int height, int pitch)
 {
     int windowWidth = windowGetWidth(win);
@@ -347,7 +347,7 @@ int _blitAlpha(int win, unsigned char* data, int width, int height, int pitch)
     return 1;
 }
 
-// 0x486CD4 movieScaleWindow_
+// 0x486CD4 movieScaleWindow
 int _movieScaleWindow(int win, unsigned char* data, int width, int height, int pitch)
 {
     int windowWidth = windowGetWidth(win);
@@ -376,7 +376,7 @@ int _movieScaleWindow(int win, unsigned char* data, int width, int height, int p
     return 1;
 }
 
-// 0x486D84 blitNormal_
+// 0x486D84 blitNormal
 int _blitNormal(int win, unsigned char* data, int width, int height, int pitch)
 {
     int windowWidth = windowGetWidth(win);
@@ -385,7 +385,7 @@ int _blitNormal(int win, unsigned char* data, int width, int height, int pitch)
     return 1;
 }
 
-// 0x486DDC movieSetPalette_
+// 0x486DDC movieSetPalette
 static void movieSetPaletteEntriesImpl(unsigned char* palette, int start, int end)
 {
     if (end != 0) {
@@ -394,7 +394,7 @@ static void movieSetPaletteEntriesImpl(unsigned char* palette, int start, int en
 }
 
 // initMovie
-// 0x486E0C initMovie_
+// 0x486E0C initMovie
 void movieInit()
 {
     MveSetMemory(movieMallocImpl, movieFreeImpl);
@@ -403,7 +403,7 @@ void movieInit()
     MveSetIO(movieReadImpl);
 }
 
-// 0x486E98 cleanupMovie_
+// 0x486E98 cleanupMovie
 static void _cleanupMovie(bool shouldEndMovie)
 {
     if (!_running) {
@@ -469,7 +469,7 @@ static void _cleanupMovie(bool shouldEndMovie)
     gMovieWindow = -1;
 }
 
-// 0x48711C movieClose_
+// 0x48711C movieClose
 void movieExit()
 {
     _cleanupMovie(1);
@@ -480,7 +480,7 @@ void movieExit()
     }
 }
 
-// 0x487150 movieStop_
+// 0x487150 movieStop
 void _movieStop()
 {
     if (_running) {
@@ -488,7 +488,7 @@ void _movieStop()
     }
 }
 
-// 0x487164 movieSetFlags_
+// 0x487164 movieSetFlags
 int movieSetFlags(int flags)
 {
     if ((flags & MOVIE_FLAG_0x04) != 0) {
@@ -521,19 +521,19 @@ int movieSetFlags(int flags)
     return 0;
 }
 
-// 0x48725C movieSetPaletteFunc_
+// 0x48725C movieSetPaletteFunc
 void _movieSetPaletteFunc(MovieSetPaletteEntriesProc* proc)
 {
     gMovieSetPaletteEntriesProc = proc != nullptr ? proc : _setSystemPaletteEntries;
 }
 
-// 0x487274 movieSetCallback_
+// 0x487274 movieSetCallback
 void movieSetPaletteProc(MovieSetPaletteProc* proc)
 {
     gMoviePaletteProc = proc;
 }
 
-// 0x4872E8 cleanupLast_
+// 0x4872E8 cleanupLast
 static void _cleanupLast()
 {
     if (_lastMovieBuffer != nullptr) {
@@ -544,7 +544,7 @@ static void _cleanupLast()
     MVE_lastBuffer = nullptr;
 }
 
-// 0x48731C openFile_
+// 0x48731C openFile
 static File* movieOpen(char* filePath)
 {
     gMovieFileStream = fileOpen(filePath, "rb");
@@ -555,7 +555,7 @@ static File* movieOpen(char* filePath)
     return gMovieFileStream;
 }
 
-// 0x487380 openSubtitle_
+// 0x487380 openSubtitle
 static void movieLoadSubtitles(char* filePath)
 {
     _subtitleW = windowGetWidth(gMovieWindow);
@@ -626,7 +626,7 @@ static void movieLoadSubtitles(char* filePath)
     debugPrint("Read %d subtitles\n", subtitleCount);
 }
 
-// 0x48755C doSubtitle_
+// 0x48755C doSubtitle
 static void movieRenderSubtitles()
 {
     if (gMovieSubtitleHead == nullptr) {
@@ -684,7 +684,7 @@ static void movieRenderSubtitles()
     }
 }
 
-// 0x487710 movieStart_
+// 0x487710 movieStart
 static int _movieStart(int win, char* filePath)
 {
     if (_running) {
@@ -752,7 +752,7 @@ static int _movieStart(int win, char* filePath)
     return 0;
 }
 
-// 0x487964 localMovieCallback_
+// 0x487964 localMovieCallback
 static bool _localMovieCallback()
 {
     movieRenderSubtitles();
@@ -764,7 +764,7 @@ static bool _localMovieCallback()
     return inputGetInput() != -1;
 }
 
-// 0x487AC8 movieRun_
+// 0x487AC8 movieRun
 int _movieRun(int win, char* filePath)
 {
     if (_running) {
@@ -780,7 +780,7 @@ int _movieRun(int win, char* filePath)
     return _movieStart(win, filePath);
 }
 
-// 0x487B1C movieRunRect_
+// 0x487B1C movieRunRect
 int _movieRunRect(int win, char* filePath, int x, int y, int w, int h)
 {
     if (_running) {
@@ -797,7 +797,7 @@ int _movieRunRect(int win, char* filePath, int x, int y, int w, int h)
     return _movieStart(win, filePath);
 }
 
-// 0x487B7C stepMovie_
+// 0x487B7C stepMovie
 static int _stepMovie()
 {
     if (_alphaHandle != nullptr) {
@@ -814,20 +814,20 @@ static int _stepMovie()
     return stepResult;
 }
 
-// 0x487BC8 movieSetSubtitleFunc_
+// 0x487BC8 movieSetSubtitleFunc
 void movieSetBuildSubtitleFilePathProc(MovieBuildSubtitleFilePathProc* proc)
 {
     gMovieBuildSubtitleFilePathProc = proc;
 }
 
-// 0x487BD0 movieSetVolume_
+// 0x487BD0 movieSetVolume
 void movieSetVolume(int volume)
 {
     int normalizedVolume = _soundVolumeHMItoDirectSound(volume);
     MveSetVolume(normalizedVolume);
 }
 
-// 0x487BEC movieUpdate_
+// 0x487BEC movieUpdate
 void _movieUpdate()
 {
     if (!_running) {
@@ -859,7 +859,7 @@ void _movieUpdate()
     }
 }
 
-// 0x487C88 moviePlaying_
+// 0x487C88 moviePlaying
 int _moviePlaying()
 {
     return _running;

--- a/src/movie_effect.cc
+++ b/src/movie_effect.cc
@@ -49,7 +49,7 @@ static unsigned char _source_palette[768];
 // 0x6391C4
 static bool _inside_fade;
 
-// 0x487CC0
+// 0x487CC0 moviefx_init_
 int movieEffectsInit()
 {
     if (gMovieEffectsInitialized) {
@@ -63,7 +63,7 @@ int movieEffectsInit()
     return 0;
 }
 
-// 0x487CF4
+// 0x487CF4 moviefx_reset_
 void movieEffectsReset()
 {
     if (!gMovieEffectsInitialized) {
@@ -79,7 +79,7 @@ void movieEffectsReset()
     memset(_source_palette, 0, sizeof(_source_palette));
 }
 
-// 0x487D30
+// 0x487D30 moviefx_exit_
 void movieEffectsExit()
 {
     if (!gMovieEffectsInitialized) {
@@ -95,7 +95,7 @@ void movieEffectsExit()
     memset(_source_palette, 0, sizeof(_source_palette));
 }
 
-// 0x487D7C
+// 0x487D7C moviefx_start_
 int movieEffectsLoad(const char* filePath)
 {
     if (!gMovieEffectsInitialized) {
@@ -224,7 +224,7 @@ out:
     return rc;
 }
 
-// 0x4880F0
+// 0x4880F0 moviefx_stop_
 void _moviefx_stop()
 {
     if (!gMovieEffectsInitialized) {
@@ -240,7 +240,7 @@ void _moviefx_stop()
     memset(_source_palette, 0, sizeof(_source_palette));
 }
 
-// 0x488144
+// 0x488144 moviefx_callback_func_
 static void _moviefx_callback_func(int frame)
 {
     MovieEffect* movieEffect = gMovieEffectHead;
@@ -275,7 +275,7 @@ static void _moviefx_callback_func(int frame)
     _inside_fade = movieEffect != nullptr;
 }
 
-// 0x4882AC
+// 0x4882AC moviefx_palette_func_
 static void _moviefx_palette_func(unsigned char* palette, int start, int end)
 {
     memcpy(_source_palette + 3 * start, palette, 3 * (end - start + 1));
@@ -285,7 +285,7 @@ static void _moviefx_palette_func(unsigned char* palette, int start, int end)
     }
 }
 
-// 0x488310
+// 0x488310 moviefx_remove_all_
 static void movieEffectsClear()
 {
     MovieEffect* movieEffect = gMovieEffectHead;

--- a/src/movie_effect.cc
+++ b/src/movie_effect.cc
@@ -37,19 +37,19 @@ static void _moviefx_callback_func(int frame);
 static void _moviefx_palette_func(unsigned char* palette, int start, int end);
 static void movieEffectsClear();
 
-// 0x5195F0
+// 0x5195F0 moviefx_initialized
 static bool gMovieEffectsInitialized = false;
 
-// 0x5195F4
+// 0x5195F4 moviefx_effects_list
 static MovieEffect* gMovieEffectHead = nullptr;
 
-// 0x638EC4
+// 0x638EC4 source_palette
 static unsigned char _source_palette[768];
 
-// 0x6391C4
+// 0x6391C4 inside_fade
 static bool _inside_fade;
 
-// 0x487CC0 moviefx_init_
+// 0x487CC0 moviefx_init
 int movieEffectsInit()
 {
     if (gMovieEffectsInitialized) {
@@ -63,7 +63,7 @@ int movieEffectsInit()
     return 0;
 }
 
-// 0x487CF4 moviefx_reset_
+// 0x487CF4 moviefx_reset
 void movieEffectsReset()
 {
     if (!gMovieEffectsInitialized) {
@@ -79,7 +79,7 @@ void movieEffectsReset()
     memset(_source_palette, 0, sizeof(_source_palette));
 }
 
-// 0x487D30 moviefx_exit_
+// 0x487D30 moviefx_exit
 void movieEffectsExit()
 {
     if (!gMovieEffectsInitialized) {
@@ -95,7 +95,7 @@ void movieEffectsExit()
     memset(_source_palette, 0, sizeof(_source_palette));
 }
 
-// 0x487D7C moviefx_start_
+// 0x487D7C moviefx_start
 int movieEffectsLoad(const char* filePath)
 {
     if (!gMovieEffectsInitialized) {
@@ -224,7 +224,7 @@ out:
     return rc;
 }
 
-// 0x4880F0 moviefx_stop_
+// 0x4880F0 moviefx_stop
 void _moviefx_stop()
 {
     if (!gMovieEffectsInitialized) {
@@ -240,7 +240,7 @@ void _moviefx_stop()
     memset(_source_palette, 0, sizeof(_source_palette));
 }
 
-// 0x488144 moviefx_callback_func_
+// 0x488144 moviefx_callback_func
 static void _moviefx_callback_func(int frame)
 {
     MovieEffect* movieEffect = gMovieEffectHead;
@@ -275,7 +275,7 @@ static void _moviefx_callback_func(int frame)
     _inside_fade = movieEffect != nullptr;
 }
 
-// 0x4882AC moviefx_palette_func_
+// 0x4882AC moviefx_palette_func
 static void _moviefx_palette_func(unsigned char* palette, int start, int end)
 {
     memcpy(_source_palette + 3 * start, palette, 3 * (end - start + 1));
@@ -285,7 +285,7 @@ static void _moviefx_palette_func(unsigned char* palette, int start, int end)
     }
 }
 
-// 0x488310 moviefx_remove_all_
+// 0x488310 moviefx_remove_all
 static void movieEffectsClear()
 {
     MovieEffect* movieEffect = gMovieEffectHead;

--- a/src/movie_lib.cc
+++ b/src/movie_lib.cc
@@ -1211,7 +1211,7 @@ static int nfConfig(int width, int height, int a3, int is_16_bpp)
     return 1;
 }
 
-// 0x4F5F20 sub_4F5F20
+// 0x4F5F20 swap_nf_mve_buf
 static void movieSwapSurfaces()
 {
     unsigned char* tmp = nf_buf_prv;

--- a/src/movie_lib.cc
+++ b/src/movie_lib.cc
@@ -410,20 +410,20 @@ static unsigned char* nf_buf_prv;
 static int gMveSoundBuffer = -1;
 static unsigned int gMveBufferBytes;
 
-// 0x4F4800
+// 0x4F4800 MVE_memCallbacks_
 void MveSetMemory(MveMallocFunc* malloc_func, MveFreeFunc* free_func)
 {
     mve_malloc_func = malloc_func;
     mve_free_func = free_func;
 }
 
-// 0x4F4860
+// 0x4F4860 MVE_ioCallbacks_
 void MveSetIO(MveReadFunc* read_func)
 {
     mve_read_func = read_func;
 }
 
-// 0x4F4890
+// 0x4F4890 MVE_MemInit_
 static void MVE_MemInit(MveMem* mem, unsigned int size, void* ptr)
 {
     if (ptr == nullptr) {
@@ -437,7 +437,7 @@ static void MVE_MemInit(MveMem* mem, unsigned int size, void* ptr)
     mem->alloced = 0;
 }
 
-// 0x4F48C0
+// 0x4F48C0 MVE_MemFree_
 static void MVE_MemFree(MveMem* mem)
 {
     if (mem->alloced && mve_free_func != nullptr) {
@@ -447,7 +447,7 @@ static void MVE_MemFree(MveMem* mem)
     mem->size = 0;
 }
 
-// 0x4F4900
+// 0x4F4900 sub_4F4900
 void MveSetVolume(int volume)
 {
     mve_volume = volume;
@@ -457,39 +457,39 @@ void MveSetVolume(int volume)
     }
 }
 
-// 0x4F4940
+// 0x4F4940 MVE_sfSVGA_
 void MveSetScreenSize(int width, int height)
 {
     sf_ScreenWidth = width;
     sf_ScreenHeight = height;
 }
 
-// 0x4F49F0
+// 0x4F49F0 MVE_sfCallbacks_
 void MveSetShowFrame(MveShowFrameFunc* show_frame_func)
 {
     sf_ShowFrame = show_frame_func;
 }
 
-// 0x4F4A10
+// 0x4F4A10 MVE_palCallbacks_
 void MveSetPalette(MveSetPaletteFunc* set_palette_func)
 {
     pal_SetPalette = set_palette_func;
 }
 
-// 0x4F4B50
+// 0x4F4B50 sub_4F4B50
 static int _sub_4F4B5()
 {
     return 0;
 }
 
-// 0x4F4BD0
+// 0x4F4BD0 MVE_rmFrameCounts_
 void MVE_rmFrameCounts(int* frame_count_ptr, int* frame_drop_count_ptr)
 {
     *frame_count_ptr = rm_FrameCount;
     *frame_drop_count_ptr = rm_FrameDropCount;
 }
 
-// 0x4F4BF0
+// 0x4F4BF0 MVE_rmPrepMovie_
 int MVE_rmPrepMovie(void* handle, int dx, int dy, unsigned char track)
 {
     rm_dx = dx;
@@ -520,7 +520,7 @@ int MVE_rmPrepMovie(void* handle, int dx, int dy, unsigned char track)
     return 0;
 }
 
-// 0x4F4C90
+// 0x4F4C90 ioReset_
 static int ioReset(void* handle)
 {
     MveHeader* mve;
@@ -546,7 +546,7 @@ static int ioReset(void* handle)
 
 // Reads data from movie file.
 //
-// 0x4F4D00
+// 0x4F4D00 ioRead_
 static void* ioRead(int size)
 {
     void* buf;
@@ -563,7 +563,7 @@ static void* ioRead(int size)
     return buf;
 }
 
-// 0x4F4D40
+// 0x4F4D40 MVE_MemAlloc_
 static void* MVE_MemAlloc(MveMem* mem, unsigned int size)
 {
     void* ptr;
@@ -590,7 +590,7 @@ static void* MVE_MemAlloc(MveMem* mem, unsigned int size)
     return mem->ptr;
 }
 
-// 0x4F4DA0
+// 0x4F4DA0 ioNextRecord_
 static unsigned char* ioNextRecord()
 {
     unsigned char* buf;
@@ -605,7 +605,7 @@ static unsigned char* ioNextRecord()
     return buf;
 }
 
-// 0x4F4E40
+// 0x4F4E40 syncWait_
 static int syncWait()
 {
     int late;
@@ -622,7 +622,7 @@ static int syncWait()
     return late;
 }
 
-// 0x4F4EA0
+// 0x4F4EA0 MVE_sndPause_
 static void _MVE_sndPause()
 {
     if (gMveSoundBuffer != -1) {
@@ -630,7 +630,7 @@ static void _MVE_sndPause()
     }
 }
 
-// 0x4F4EC0
+// 0x4F4EC0 MVE_rmStepMovie_
 int _MVE_rmStepMovie()
 {
     int v0;
@@ -814,7 +814,7 @@ LABEL_5:
     return v6;
 }
 
-// 0x4F54F0
+// 0x4F54F0 syncInit_
 static int syncInit(int rate, int resolution)
 {
     int quanta;
@@ -830,14 +830,14 @@ static int syncInit(int rate, int resolution)
     return 1;
 }
 
-// 0x4F5540
+// 0x4F5540 syncReset_
 static void syncReset(int quanta)
 {
     sync_active = 1;
     sync_time = -1000 * compat_timeGetTime() + quanta;
 }
 
-// 0x4F5570
+// 0x4F5570 MVE_sndConfigure_
 static int _MVE_sndConfigure(int a1, int a2, int a3, int a4, int a5, int a6)
 {
     MVE_syncSync();
@@ -864,7 +864,7 @@ static int _MVE_sndConfigure(int a1, int a2, int a3, int a4, int a5, int a6)
     return 1;
 }
 
-// 0x4F56C0
+// 0x4F56C0 MVE_syncSync_
 static void MVE_syncSync()
 {
     if (sync_active) {
@@ -873,7 +873,7 @@ static void MVE_syncSync()
     }
 }
 
-// 0x4F56F0
+// 0x4F56F0 MVE_sndReset_
 static void _MVE_sndReset()
 {
     if (gMveSoundBuffer != -1) {
@@ -883,7 +883,7 @@ static void _MVE_sndReset()
     }
 }
 
-// 0x4F5720
+// 0x4F5720 MVE_sndSync_
 static void _MVE_sndSync()
 {
     unsigned int dwCurrentPlayCursor;
@@ -1026,7 +1026,7 @@ static void _MVE_sndSync()
     }
 }
 
-// 0x4F59B0
+// 0x4F59B0 syncWaitLevel_
 static int syncWaitLevel(int wait)
 {
     int deadline;
@@ -1050,7 +1050,7 @@ static int syncWaitLevel(int wait)
     return diff;
 }
 
-// 0x4F5A00
+// 0x4F5A00 CallsSndBuff_Lock
 static void _CallsSndBuff_Loc(unsigned char* a1, int a2)
 {
     int v2;
@@ -1116,7 +1116,7 @@ static void _CallsSndBuff_Loc(unsigned char* a1, int a2)
     }
 }
 
-// 0x4F5B70
+// 0x4F5B70 MVE_sndAdd_
 static int _MVE_sndAdd(unsigned char* dest, unsigned char** src_ptr, int a3, int a4, int a5)
 {
     unsigned char* src;
@@ -1181,12 +1181,12 @@ static int _MVE_sndAdd(unsigned char* dest, unsigned char** src_ptr, int a3, int
     return result;
 }
 
-// 0x4F5CA0
+// 0x4F5CA0 MVE_sndResume_
 static void _MVE_sndResume()
 {
 }
 
-// 0x4F5CB0
+// 0x4F5CB0 nfConfig_
 static int nfConfig(int width, int height, int a3, int is_16_bpp)
 {
     byte_6B4016 = a3;
@@ -1211,7 +1211,7 @@ static int nfConfig(int width, int height, int a3, int is_16_bpp)
     return 1;
 }
 
-// 0x4F5F20
+// 0x4F5F20 sub_4F5F20
 static void movieSwapSurfaces()
 {
     unsigned char* tmp = nf_buf_prv;
@@ -1219,7 +1219,7 @@ static void movieSwapSurfaces()
     nf_buf_cur = tmp;
 }
 
-// 0x4F5F40
+// 0x4F5F40 sfShowFrame_
 static void sfShowFrame(int dst_x, int dst_y, int a3)
 {
     dst_x = (sf_ScreenWidth - nf_width) / 2;
@@ -1230,18 +1230,18 @@ static void sfShowFrame(int dst_x, int dst_y, int a3)
     }
 }
 
-// 0x4F6080
+// 0x4F6080 do_nothing_3
 static void _do_nothing_(int a1, int a2, unsigned short* a3)
 {
 }
 
-// 0x4F6090
+// 0x4F6090 SetPalette_1
 static void palSetPalette(int start, int count)
 {
     pal_SetPalette(pal_tbl, start, count);
 }
 
-// 0x4F60C0
+// 0x4F60C0 SetPalette_2
 static void palClrPalette(int start, int count)
 {
     unsigned char palette[768];
@@ -1250,7 +1250,7 @@ static void palClrPalette(int start, int count)
     pal_SetPalette(palette, start, count);
 }
 
-// 0x4F60F0
+// 0x4F60F0 palMakeSynthPalette_
 static void palMakeSynthPalette(int a1, int a2, int a3, int a4, int a5, int a6)
 {
     int i;
@@ -1273,13 +1273,13 @@ static void palMakeSynthPalette(int a1, int a2, int a3, int a4, int a5, int a6)
     }
 }
 
-// 0x4F6210
+// 0x4F6210 palLoadPalette_
 static void palLoadPalette(unsigned char* palette, int start, int count)
 {
     memcpy(&(pal_tbl[start * 3]), palette, count * 3);
 }
 
-// 0x4F6240
+// 0x4F6240 MVE_rmEndMovie_
 void MVE_rmEndMovie()
 {
     if (rm_active) {
@@ -1290,13 +1290,13 @@ void MVE_rmEndMovie()
     }
 }
 
-// 0x4F6270
+// 0x4F6270 syncRelease_
 static void syncRelease()
 {
     sync_active = 0;
 }
 
-// 0x4F6350
+// 0x4F6350 MVE_ReleaseMem_
 void MVE_ReleaseMem()
 {
     MVE_rmEndMovie();
@@ -1305,18 +1305,18 @@ void MVE_ReleaseMem()
     nfRelease();
 }
 
-// 0x4F6370
+// 0x4F6370 ioRelease_
 static void ioRelease()
 {
     MVE_MemFree(&io_mem_buf);
 }
 
-// 0x4F6380
+// 0x4F6380 MVE_sndRelease_
 static void _MVE_sndRelease()
 {
 }
 
-// 0x4F6390
+// 0x4F6390 nfRelease_
 static void nfRelease()
 {
     MVE_MemFree(&nf_mem_cur);
@@ -1326,7 +1326,7 @@ static void nfRelease()
     nf_buf_prv = nullptr;
 }
 
-// 0x4F697C
+// 0x4F697C MVE_sndDecompM16_
 static int _MVE_sndDecompM16(unsigned short* a1, unsigned char* a2, int a3, int a4)
 {
     int i;
@@ -1345,7 +1345,7 @@ static int _MVE_sndDecompM16(unsigned short* a1, unsigned char* a2, int a3, int 
     return result;
 }
 
-// 0x4F69AD
+// 0x4F69AD MVE_sndDecompS16_
 static int _MVE_sndDecompS16(unsigned short* a1, unsigned char* a2, int a3, int a4)
 {
     int i;
@@ -1370,7 +1370,7 @@ static int _MVE_sndDecompS16(unsigned short* a1, unsigned char* a2, int a3, int 
     return (v5 << 16) | v4;
 }
 
-// 0x4F731D
+// 0x4F731D nfPkConfig_
 static void _nfPkConfig()
 {
     int* ptr;
@@ -1400,7 +1400,7 @@ static void _nfPkConfig()
     } while (v5);
 }
 
-// 0x4F7359
+// 0x4F7359 nfPkDecomp_
 static void _nfPkDecomp(unsigned char* a1, unsigned char* a2, int a3, int a4, int a5, int a6)
 {
     int v49;

--- a/src/movie_lib.cc
+++ b/src/movie_lib.cc
@@ -66,7 +66,7 @@ static int _MVE_sndDecompS16(unsigned short* a1, unsigned char* a2, int a3, int 
 static void _nfPkConfig();
 static void _nfPkDecomp(unsigned char* buf, unsigned char* a2, int a3, int a4, int a5, int a6);
 
-// 0x51EBE0
+// 0x51EBE0 _snd_8to16
 static unsigned short word_51EBE0[256] = {
     // clang-format off
     0x0000, 0x0001, 0x0002, 0x0003, 0x0004, 0x0005, 0x0006, 0x0007,
@@ -104,25 +104,25 @@ static unsigned short word_51EBE0[256] = {
     // clang-format on
 };
 
-// 0x51EDE4
+// 0x51EDE4 sync_active
 static int sync_active = 0;
 
-// 0x51EDE8
+// 0x51EDE8 sync_late
 static int sync_late = 0;
 
-// 0x51EDEC
+// 0x51EDEC sync_FrameDropped
 static int sync_FrameDropped = 0;
 
 // 0x51EDF8
 static int mve_volume = 0;
 
-// 0x51EE08
+// 0x51EE08 _sf_ShowFrame
 static MveShowFrameFunc* sf_ShowFrame;
 
-// 0x51EE14
+// 0x51EE14 _pal_SetPalette
 static MveSetPaletteFunc* pal_SetPalette;
 
-// 0x51EE1C
+// 0x51EE1C rm_active
 static int rm_active = 0;
 
 // 0x51EE20
@@ -294,19 +294,19 @@ static unsigned int _$$R0063[256] = {
 // 0x6B3660
 static int dword_6B3660;
 
-// 0x6B367C
+// 0x6B367C sf_ScreenWidth
 static int sf_ScreenWidth;
 
-// 0x6B3684
+// 0x6B3684 rm_FrameDropCount
 static int rm_FrameDropCount;
 
-// 0x6B3688
+// 0x6B3688 snd_buf
 static int _snd_buf;
 
-// 0x6B3690
+// 0x6B3690 io_mem_buf
 static MveMem io_mem_buf;
 
-// 0x6B369C
+// 0x6B369C io_next_hdr
 static unsigned int io_next_hdr;
 
 // 0x6B36A0
@@ -315,52 +315,52 @@ static int dword_6B36A0;
 // 0x6B36A4
 static unsigned int dword_6B36A4;
 
-// 0x6B36A8
+// 0x6B36A8 rm_FrameCount
 static int rm_FrameCount;
 
-// 0x6B36AC
+// 0x6B36AC sf_ScreenHeight
 static int sf_ScreenHeight;
 
-// 0x6B39B8
+// 0x6B39B8 _mem_alloc
 static MveMallocFunc* mve_malloc_func;
 
-// 0x6B39C0
+// 0x6B39C0 rm_dx
 static int rm_dx;
 
-// 0x6B39C4
+// 0x6B39C4 rm_dy
 static int rm_dy;
 
-// 0x6B39C8
+// 0x6B39C8 gSoundTimeBase
 static int _gSoundTimeBase;
 
-// 0x6B39CC
+// 0x6B39CC io_handle
 static void* io_handle;
 
-// 0x6B39D0
+// 0x6B39D0 rm_len
 static int rm_len;
 
-// 0x6B39D4
+// 0x6B39D4 _mem_free
 static MveFreeFunc* mve_free_func;
 
-// 0x6B39D8
+// 0x6B39D8 snd_comp
 static int _snd_comp;
 
-// 0x6B39DC
+// 0x6B39DC rm_p
 static unsigned char* rm_p;
 
 // 0x6B39E0
 static int dword_6B39E0[60];
 
-// 0x6B3AD0
+// 0x6B3AD0 sync_wait_quanta
 static int sync_wait_quanta;
 
-// 0x6B3AD8
+// 0x6B3AD8 rm_track_bit
 static int rm_track_bit;
 
-// 0x6B3ADC
+// 0x6B3ADC sync_time
 static int sync_time;
 
-// 0x6B3AE0
+// 0x6B3AE0 _io_read
 static MveReadFunc* mve_read_func;
 
 // 0x6B3AE4
@@ -372,34 +372,34 @@ static int dword_6B3CEC;
 // 0x6B3CF8
 static int dword_6B3CF8;
 
-// 0x6B3CFC
+// 0x6B3CFC mveBW
 static int nf_width;
 
 // 0x6B3D00
 static int dword_6B3D00;
 
-// 0x6B3D0C
+// 0x6B3D0C _pal_tbl
 static unsigned char pal_tbl[768];
 
 // 0x6B4016
 static unsigned char byte_6B4016;
 
-// 0x6B4017
+// 0x6B4017 mve_w
 static int dword_6B4017;
 
-// 0x6B401B
+// 0x6B401B mve_x
 static int dword_6B401B;
 
-// 0x6B401F
+// 0x6B401F mve_y
 static int dword_6B401F;
 
-// 0x6B4023
+// 0x6B4023 mve_h
 static int dword_6B4023;
 
 // 0x6B402B
 static int dword_6B402B;
 
-// 0x6B402F
+// 0x6B402F mveBH
 static int nf_height;
 
 static MveMem nf_mem_cur;
@@ -410,20 +410,20 @@ static unsigned char* nf_buf_prv;
 static int gMveSoundBuffer = -1;
 static unsigned int gMveBufferBytes;
 
-// 0x4F4800 MVE_memCallbacks_
+// 0x4F4800 MVE_memCallbacks
 void MveSetMemory(MveMallocFunc* malloc_func, MveFreeFunc* free_func)
 {
     mve_malloc_func = malloc_func;
     mve_free_func = free_func;
 }
 
-// 0x4F4860 MVE_ioCallbacks_
+// 0x4F4860 MVE_ioCallbacks
 void MveSetIO(MveReadFunc* read_func)
 {
     mve_read_func = read_func;
 }
 
-// 0x4F4890 MVE_MemInit_
+// 0x4F4890 MVE_MemInit
 static void MVE_MemInit(MveMem* mem, unsigned int size, void* ptr)
 {
     if (ptr == nullptr) {
@@ -437,7 +437,7 @@ static void MVE_MemInit(MveMem* mem, unsigned int size, void* ptr)
     mem->alloced = 0;
 }
 
-// 0x4F48C0 MVE_MemFree_
+// 0x4F48C0 MVE_MemFree
 static void MVE_MemFree(MveMem* mem)
 {
     if (mem->alloced && mve_free_func != nullptr) {
@@ -447,7 +447,7 @@ static void MVE_MemFree(MveMem* mem)
     mem->size = 0;
 }
 
-// 0x4F4900 sub_4F4900
+// 0x4F4900
 void MveSetVolume(int volume)
 {
     mve_volume = volume;
@@ -457,39 +457,39 @@ void MveSetVolume(int volume)
     }
 }
 
-// 0x4F4940 MVE_sfSVGA_
+// 0x4F4940 MVE_sfSVGA
 void MveSetScreenSize(int width, int height)
 {
     sf_ScreenWidth = width;
     sf_ScreenHeight = height;
 }
 
-// 0x4F49F0 MVE_sfCallbacks_
+// 0x4F49F0 MVE_sfCallbacks
 void MveSetShowFrame(MveShowFrameFunc* show_frame_func)
 {
     sf_ShowFrame = show_frame_func;
 }
 
-// 0x4F4A10 MVE_palCallbacks_
+// 0x4F4A10 MVE_palCallbacks
 void MveSetPalette(MveSetPaletteFunc* set_palette_func)
 {
     pal_SetPalette = set_palette_func;
 }
 
-// 0x4F4B50 sub_4F4B50
+// 0x4F4B50
 static int _sub_4F4B5()
 {
     return 0;
 }
 
-// 0x4F4BD0 MVE_rmFrameCounts_
+// 0x4F4BD0 MVE_rmFrameCounts
 void MVE_rmFrameCounts(int* frame_count_ptr, int* frame_drop_count_ptr)
 {
     *frame_count_ptr = rm_FrameCount;
     *frame_drop_count_ptr = rm_FrameDropCount;
 }
 
-// 0x4F4BF0 MVE_rmPrepMovie_
+// 0x4F4BF0 MVE_rmPrepMovie
 int MVE_rmPrepMovie(void* handle, int dx, int dy, unsigned char track)
 {
     rm_dx = dx;
@@ -520,7 +520,7 @@ int MVE_rmPrepMovie(void* handle, int dx, int dy, unsigned char track)
     return 0;
 }
 
-// 0x4F4C90 ioReset_
+// 0x4F4C90 ioReset
 static int ioReset(void* handle)
 {
     MveHeader* mve;
@@ -546,7 +546,7 @@ static int ioReset(void* handle)
 
 // Reads data from movie file.
 //
-// 0x4F4D00 ioRead_
+// 0x4F4D00 ioRead
 static void* ioRead(int size)
 {
     void* buf;
@@ -563,7 +563,7 @@ static void* ioRead(int size)
     return buf;
 }
 
-// 0x4F4D40 MVE_MemAlloc_
+// 0x4F4D40 MVE_MemAlloc
 static void* MVE_MemAlloc(MveMem* mem, unsigned int size)
 {
     void* ptr;
@@ -590,7 +590,7 @@ static void* MVE_MemAlloc(MveMem* mem, unsigned int size)
     return mem->ptr;
 }
 
-// 0x4F4DA0 ioNextRecord_
+// 0x4F4DA0 ioNextRecord
 static unsigned char* ioNextRecord()
 {
     unsigned char* buf;
@@ -605,7 +605,7 @@ static unsigned char* ioNextRecord()
     return buf;
 }
 
-// 0x4F4E40 syncWait_
+// 0x4F4E40 syncWait
 static int syncWait()
 {
     int late;
@@ -622,7 +622,7 @@ static int syncWait()
     return late;
 }
 
-// 0x4F4EA0 MVE_sndPause_
+// 0x4F4EA0 MVE_sndPause
 static void _MVE_sndPause()
 {
     if (gMveSoundBuffer != -1) {
@@ -630,7 +630,7 @@ static void _MVE_sndPause()
     }
 }
 
-// 0x4F4EC0 MVE_rmStepMovie_
+// 0x4F4EC0 MVE_rmStepMovie
 int _MVE_rmStepMovie()
 {
     int v0;
@@ -814,7 +814,7 @@ LABEL_5:
     return v6;
 }
 
-// 0x4F54F0 syncInit_
+// 0x4F54F0 syncInit
 static int syncInit(int rate, int resolution)
 {
     int quanta;
@@ -830,14 +830,14 @@ static int syncInit(int rate, int resolution)
     return 1;
 }
 
-// 0x4F5540 syncReset_
+// 0x4F5540 syncReset
 static void syncReset(int quanta)
 {
     sync_active = 1;
     sync_time = -1000 * compat_timeGetTime() + quanta;
 }
 
-// 0x4F5570 MVE_sndConfigure_
+// 0x4F5570 MVE_sndConfigure
 static int _MVE_sndConfigure(int a1, int a2, int a3, int a4, int a5, int a6)
 {
     MVE_syncSync();
@@ -864,7 +864,7 @@ static int _MVE_sndConfigure(int a1, int a2, int a3, int a4, int a5, int a6)
     return 1;
 }
 
-// 0x4F56C0 MVE_syncSync_
+// 0x4F56C0 MVE_syncSync
 static void MVE_syncSync()
 {
     if (sync_active) {
@@ -873,7 +873,7 @@ static void MVE_syncSync()
     }
 }
 
-// 0x4F56F0 MVE_sndReset_
+// 0x4F56F0 MVE_sndReset
 static void _MVE_sndReset()
 {
     if (gMveSoundBuffer != -1) {
@@ -883,7 +883,7 @@ static void _MVE_sndReset()
     }
 }
 
-// 0x4F5720 MVE_sndSync_
+// 0x4F5720 MVE_sndSync
 static void _MVE_sndSync()
 {
     unsigned int dwCurrentPlayCursor;
@@ -1026,7 +1026,7 @@ static void _MVE_sndSync()
     }
 }
 
-// 0x4F59B0 syncWaitLevel_
+// 0x4F59B0 syncWaitLevel
 static int syncWaitLevel(int wait)
 {
     int deadline;
@@ -1116,7 +1116,7 @@ static void _CallsSndBuff_Loc(unsigned char* a1, int a2)
     }
 }
 
-// 0x4F5B70 MVE_sndAdd_
+// 0x4F5B70 MVE_sndAdd
 static int _MVE_sndAdd(unsigned char* dest, unsigned char** src_ptr, int a3, int a4, int a5)
 {
     unsigned char* src;
@@ -1181,12 +1181,12 @@ static int _MVE_sndAdd(unsigned char* dest, unsigned char** src_ptr, int a3, int
     return result;
 }
 
-// 0x4F5CA0 MVE_sndResume_
+// 0x4F5CA0 MVE_sndResume
 static void _MVE_sndResume()
 {
 }
 
-// 0x4F5CB0 nfConfig_
+// 0x4F5CB0 nfConfig
 static int nfConfig(int width, int height, int a3, int is_16_bpp)
 {
     byte_6B4016 = a3;
@@ -1219,7 +1219,7 @@ static void movieSwapSurfaces()
     nf_buf_cur = tmp;
 }
 
-// 0x4F5F40 sfShowFrame_
+// 0x4F5F40 sfShowFrame
 static void sfShowFrame(int dst_x, int dst_y, int a3)
 {
     dst_x = (sf_ScreenWidth - nf_width) / 2;
@@ -1250,7 +1250,7 @@ static void palClrPalette(int start, int count)
     pal_SetPalette(palette, start, count);
 }
 
-// 0x4F60F0 palMakeSynthPalette_
+// 0x4F60F0 palMakeSynthPalette
 static void palMakeSynthPalette(int a1, int a2, int a3, int a4, int a5, int a6)
 {
     int i;
@@ -1273,13 +1273,13 @@ static void palMakeSynthPalette(int a1, int a2, int a3, int a4, int a5, int a6)
     }
 }
 
-// 0x4F6210 palLoadPalette_
+// 0x4F6210 palLoadPalette
 static void palLoadPalette(unsigned char* palette, int start, int count)
 {
     memcpy(&(pal_tbl[start * 3]), palette, count * 3);
 }
 
-// 0x4F6240 MVE_rmEndMovie_
+// 0x4F6240 MVE_rmEndMovie
 void MVE_rmEndMovie()
 {
     if (rm_active) {
@@ -1290,13 +1290,13 @@ void MVE_rmEndMovie()
     }
 }
 
-// 0x4F6270 syncRelease_
+// 0x4F6270 syncRelease
 static void syncRelease()
 {
     sync_active = 0;
 }
 
-// 0x4F6350 MVE_ReleaseMem_
+// 0x4F6350 MVE_ReleaseMem
 void MVE_ReleaseMem()
 {
     MVE_rmEndMovie();
@@ -1305,18 +1305,18 @@ void MVE_ReleaseMem()
     nfRelease();
 }
 
-// 0x4F6370 ioRelease_
+// 0x4F6370 ioRelease
 static void ioRelease()
 {
     MVE_MemFree(&io_mem_buf);
 }
 
-// 0x4F6380 MVE_sndRelease_
+// 0x4F6380 MVE_sndRelease
 static void _MVE_sndRelease()
 {
 }
 
-// 0x4F6390 nfRelease_
+// 0x4F6390 nfRelease
 static void nfRelease()
 {
     MVE_MemFree(&nf_mem_cur);
@@ -1326,7 +1326,7 @@ static void nfRelease()
     nf_buf_prv = nullptr;
 }
 
-// 0x4F697C MVE_sndDecompM16_
+// 0x4F697C MVE_sndDecompM16
 static int _MVE_sndDecompM16(unsigned short* a1, unsigned char* a2, int a3, int a4)
 {
     int i;
@@ -1345,7 +1345,7 @@ static int _MVE_sndDecompM16(unsigned short* a1, unsigned char* a2, int a3, int 
     return result;
 }
 
-// 0x4F69AD MVE_sndDecompS16_
+// 0x4F69AD MVE_sndDecompS16
 static int _MVE_sndDecompS16(unsigned short* a1, unsigned char* a2, int a3, int a4)
 {
     int i;
@@ -1370,7 +1370,7 @@ static int _MVE_sndDecompS16(unsigned short* a1, unsigned char* a2, int a3, int 
     return (v5 << 16) | v4;
 }
 
-// 0x4F731D nfPkConfig_
+// 0x4F731D nfPkConfig
 static void _nfPkConfig()
 {
     int* ptr;
@@ -1400,7 +1400,7 @@ static void _nfPkConfig()
     } while (v5);
 }
 
-// 0x4F7359 nfPkDecomp_
+// 0x4F7359 nfPkDecomp
 static void _nfPkDecomp(unsigned char* a1, unsigned char* a2, int a3, int a4, int a5, int a6)
 {
     int v49;

--- a/src/movie_lib.cc
+++ b/src/movie_lib.cc
@@ -66,7 +66,7 @@ static int _MVE_sndDecompS16(unsigned short* a1, unsigned char* a2, int a3, int 
 static void _nfPkConfig();
 static void _nfPkDecomp(unsigned char* buf, unsigned char* a2, int a3, int a4, int a5, int a6);
 
-// 0x51EBE0 _snd_8to16
+// 0x51EBE0 snd_8to16
 static unsigned short word_51EBE0[256] = {
     // clang-format off
     0x0000, 0x0001, 0x0002, 0x0003, 0x0004, 0x0005, 0x0006, 0x0007,
@@ -116,10 +116,10 @@ static int sync_FrameDropped = 0;
 // 0x51EDF8
 static int mve_volume = 0;
 
-// 0x51EE08 _sf_ShowFrame
+// 0x51EE08 sf_ShowFrame
 static MveShowFrameFunc* sf_ShowFrame;
 
-// 0x51EE14 _pal_SetPalette
+// 0x51EE14 pal_SetPalette
 static MveSetPaletteFunc* pal_SetPalette;
 
 // 0x51EE1C rm_active
@@ -321,7 +321,7 @@ static int rm_FrameCount;
 // 0x6B36AC sf_ScreenHeight
 static int sf_ScreenHeight;
 
-// 0x6B39B8 _mem_alloc
+// 0x6B39B8 mem_alloc
 static MveMallocFunc* mve_malloc_func;
 
 // 0x6B39C0 rm_dx
@@ -339,7 +339,7 @@ static void* io_handle;
 // 0x6B39D0 rm_len
 static int rm_len;
 
-// 0x6B39D4 _mem_free
+// 0x6B39D4 mem_free
 static MveFreeFunc* mve_free_func;
 
 // 0x6B39D8 snd_comp
@@ -360,7 +360,7 @@ static int rm_track_bit;
 // 0x6B3ADC sync_time
 static int sync_time;
 
-// 0x6B3AE0 _io_read
+// 0x6B3AE0 io_read
 static MveReadFunc* mve_read_func;
 
 // 0x6B3AE4
@@ -378,7 +378,7 @@ static int nf_width;
 // 0x6B3D00
 static int dword_6B3D00;
 
-// 0x6B3D0C _pal_tbl
+// 0x6B3D0C pal_tbl
 static unsigned char pal_tbl[768];
 
 // 0x6B4016

--- a/src/nevs.cc
+++ b/src/nevs.cc
@@ -35,7 +35,7 @@ static Nevs* gNevs;
 static int gNevsHits;
 
 // nevs_alloc
-// 0x488340
+// 0x488340 nevs_alloc_
 static Nevs* _nevs_alloc()
 {
     if (gNevs == nullptr) {
@@ -57,14 +57,14 @@ static Nevs* _nevs_alloc()
 
 // NOTE: Inlined.
 //
-// 0x488394
+// 0x488394 nevs_free_
 static void _nevs_reset(Nevs* nevs)
 {
     nevs->used = false;
     memset(nevs, 0, sizeof(*nevs));
 }
 
-// 0x4883AC
+// 0x4883AC nevs_close_
 void _nevs_close()
 {
     if (gNevs != nullptr) {
@@ -73,7 +73,7 @@ void _nevs_close()
     }
 }
 
-// 0x4883D4
+// 0x4883D4 nevs_removeprogramreferences_
 static void _nevs_removeprogramreferences(Program* program)
 {
     if (gNevs != nullptr) {
@@ -88,7 +88,7 @@ static void _nevs_removeprogramreferences(Program* program)
 }
 
 // nevs_initonce
-// 0x488418
+// 0x488418 nevs_initonce_
 void _nevs_initonce()
 {
     intLibRegisterProgramDeleteCallback(_nevs_removeprogramreferences);
@@ -103,7 +103,7 @@ void _nevs_initonce()
 }
 
 // nevs_find
-// 0x48846C
+// 0x48846C nevs_find_
 static Nevs* _nevs_find(const char* name)
 {
     if (gNevs == nullptr) {
@@ -121,7 +121,7 @@ static Nevs* _nevs_find(const char* name)
     return nullptr;
 }
 
-// 0x4884C8
+// 0x4884C8 nevs_addevent_
 int _nevs_addevent(const char* name, Program* program, int proc, int type)
 {
     Nevs* nevs = _nevs_find(name);
@@ -144,7 +144,7 @@ int _nevs_addevent(const char* name, Program* program, int proc, int type)
 }
 
 // nevs_clearevent
-// 0x48859C
+// 0x48859C nevs_clearevent_
 int _nevs_clearevent(const char* name)
 {
     debugPrint("nevs_clearevent( '%s');\n", name);
@@ -160,7 +160,7 @@ int _nevs_clearevent(const char* name)
 }
 
 // nevs_signal
-// 0x48862C
+// 0x48862C nevs_signal_
 int _nevs_signal(const char* name)
 {
     debugPrint("nevs_signal( '%s');\n", name);
@@ -184,7 +184,7 @@ int _nevs_signal(const char* name)
 }
 
 // nevs_update
-// 0x4886AC
+// 0x4886AC nevs_update_
 void _nevs_update()
 {
     if (gNevsHits == 0) {

--- a/src/nevs.cc
+++ b/src/nevs.cc
@@ -28,14 +28,14 @@ static void _nevs_reset(Nevs* nevs);
 static void _nevs_removeprogramreferences(Program* program);
 static Nevs* _nevs_find(const char* name);
 
-// 0x6391C8
+// 0x6391C8 _nevs
 static Nevs* gNevs;
 
-// 0x6391CC
+// 0x6391CC anyhits
 static int gNevsHits;
 
 // nevs_alloc
-// 0x488340 nevs_alloc_
+// 0x488340 nevs_alloc
 static Nevs* _nevs_alloc()
 {
     if (gNevs == nullptr) {
@@ -57,14 +57,14 @@ static Nevs* _nevs_alloc()
 
 // NOTE: Inlined.
 //
-// 0x488394 nevs_free_
+// 0x488394 nevs_free
 static void _nevs_reset(Nevs* nevs)
 {
     nevs->used = false;
     memset(nevs, 0, sizeof(*nevs));
 }
 
-// 0x4883AC nevs_close_
+// 0x4883AC nevs_close
 void _nevs_close()
 {
     if (gNevs != nullptr) {
@@ -73,7 +73,7 @@ void _nevs_close()
     }
 }
 
-// 0x4883D4 nevs_removeprogramreferences_
+// 0x4883D4 nevs_removeprogramreferences
 static void _nevs_removeprogramreferences(Program* program)
 {
     if (gNevs != nullptr) {
@@ -88,7 +88,7 @@ static void _nevs_removeprogramreferences(Program* program)
 }
 
 // nevs_initonce
-// 0x488418 nevs_initonce_
+// 0x488418 nevs_initonce
 void _nevs_initonce()
 {
     intLibRegisterProgramDeleteCallback(_nevs_removeprogramreferences);
@@ -103,7 +103,7 @@ void _nevs_initonce()
 }
 
 // nevs_find
-// 0x48846C nevs_find_
+// 0x48846C nevs_find
 static Nevs* _nevs_find(const char* name)
 {
     if (gNevs == nullptr) {
@@ -121,7 +121,7 @@ static Nevs* _nevs_find(const char* name)
     return nullptr;
 }
 
-// 0x4884C8 nevs_addevent_
+// 0x4884C8 nevs_addevent
 int _nevs_addevent(const char* name, Program* program, int proc, int type)
 {
     Nevs* nevs = _nevs_find(name);
@@ -144,7 +144,7 @@ int _nevs_addevent(const char* name, Program* program, int proc, int type)
 }
 
 // nevs_clearevent
-// 0x48859C nevs_clearevent_
+// 0x48859C nevs_clearevent
 int _nevs_clearevent(const char* name)
 {
     debugPrint("nevs_clearevent( '%s');\n", name);
@@ -160,7 +160,7 @@ int _nevs_clearevent(const char* name)
 }
 
 // nevs_signal
-// 0x48862C nevs_signal_
+// 0x48862C nevs_signal
 int _nevs_signal(const char* name)
 {
     debugPrint("nevs_signal( '%s');\n", name);
@@ -184,7 +184,7 @@ int _nevs_signal(const char* name)
 }
 
 // nevs_update
-// 0x4886AC nevs_update_
+// 0x4886AC nevs_update
 void _nevs_update()
 {
     if (gNevsHits == 0) {

--- a/src/nevs.cc
+++ b/src/nevs.cc
@@ -28,7 +28,7 @@ static void _nevs_reset(Nevs* nevs);
 static void _nevs_removeprogramreferences(Program* program);
 static Nevs* _nevs_find(const char* name);
 
-// 0x6391C8 _nevs
+// 0x6391C8 nevs
 static Nevs* gNevs;
 
 // 0x6391CC anyhits

--- a/src/object.cc
+++ b/src/object.cc
@@ -71,7 +71,7 @@ static int gObjectsUpdateAreaHexHeight = 0;
 // 0x519604 updateHexArea
 static int gObjectsUpdateAreaHexSize = 0;
 
-// 0x519608 _orderTable
+// 0x519608 orderTable
 static int* _orderTable[2] = {
     nullptr,
     nullptr,
@@ -89,7 +89,7 @@ static int* _offsetDivTable = nullptr;
 // 0x51961C offsetModTable
 static int* _offsetModTable = nullptr;
 
-// 0x519620 _renderTable
+// 0x519620 renderTable
 static ObjectListNode** _renderTable = nullptr;
 
 // Number of objects in _outlinedObjects.
@@ -99,7 +99,7 @@ static int _outlineCount = 0;
 
 // Contains objects that are not bounded to tiles.
 //
-// 0x519628 _floatingObjects
+// 0x519628 floatingObjects
 static ObjectListNode* gObjectListHead = nullptr;
 
 // 0x51962C centerToUpperLeft
@@ -114,7 +114,7 @@ static int gObjectFindTile = 0;
 // 0x519638 find_ptr
 static ObjectListNode* gObjectFindLastObjectListNode = nullptr;
 
-// 0x51963C _preload_list
+// 0x51963C preload_list
 static int* gObjectFids = nullptr;
 
 // 0x519640 preload_list_index
@@ -188,7 +188,7 @@ static int _obj_last_elev = -1;
 // 0x51977C obj_last_is_empty
 static bool _obj_last_is_empty = true;
 
-// 0x519780 _wallBlendTable
+// 0x519780 wallBlendTable
 unsigned char* _wallBlendTable = nullptr;
 
 // 0x519784 glassBlendTable
@@ -203,13 +203,13 @@ static unsigned char* _energyBlendTable = nullptr;
 // 0x519790 redBlendTable
 static unsigned char* _redBlendTable = nullptr;
 
-// 0x519794 _moveBlockObj
+// 0x519794 moveBlockObj
 Object* _moveBlockObj = nullptr;
 
 // 0x519798 objItemOutlineState
 static int _objItemOutlineState = 0;
 
-// 0x51979C _cd_order
+// 0x51979C cd_order
 static int _cd_order[9] = {
     1,
     0,
@@ -233,7 +233,7 @@ static Rect gObjectsWindowRect;
 
 // Likely outlined objects on the screen.
 //
-// 0x639C00 _outlinedObjects
+// 0x639C00 outlinedObjects
 static Object* _outlinedObjects[100];
 
 // 0x639D90 updateAreaPixelBounds
@@ -241,7 +241,7 @@ static Rect gObjectsUpdateAreaPixelBounds;
 
 // Contains objects that are bounded to tiles.
 //
-// 0x639DA0 _objectTable
+// 0x639DA0 objectTable
 static ObjectListNode* gObjectListHeadByTile[HEX_GRID_SIZE];
 
 // 0x660EA0 glassGrayTable
@@ -261,7 +261,7 @@ static int gObjectsWindowHeight;
 
 // Translucent "egg" effect around player.
 //
-// 0x6610AC _obj_egg
+// 0x6610AC obj_egg
 Object* gEgg;
 
 // 0x6610B0 back_buf_width
@@ -271,7 +271,7 @@ static int gObjectsWindowPitch;
 static int gObjectsWindowWidth;
 
 // obj_dude
-// 0x6610B8 _obj_dude
+// 0x6610B8 obj_dude
 Object* gDude;
 
 // 0x6610BC obj_seen_check

--- a/src/object.cc
+++ b/src/object.cc
@@ -59,68 +59,68 @@ static void objectDrawOutline(Object* object, Rect* rect);
 static void _obj_render_object(Object* object, Rect* rect, int light);
 static int _obj_preload_sort(const void* a1, const void* a2);
 
-// 0x5195F8
+// 0x5195F8 objInitialized
 static bool gObjectsInitialized = false;
 
-// 0x5195FC
+// 0x5195FC updateHexWidth
 static int gObjectsUpdateAreaHexWidth = 0;
 
-// 0x519600
+// 0x519600 updateHexHeight
 static int gObjectsUpdateAreaHexHeight = 0;
 
-// 0x519604
+// 0x519604 updateHexArea
 static int gObjectsUpdateAreaHexSize = 0;
 
-// 0x519608
+// 0x519608 _orderTable
 static int* _orderTable[2] = {
     nullptr,
     nullptr,
 };
 
-// 0x519610
+// 0x519610 offsetTable
 static int* _offsetTable[2] = {
     nullptr,
     nullptr,
 };
 
-// 0x519618
+// 0x519618 offsetDivTable
 static int* _offsetDivTable = nullptr;
 
-// 0x51961C
+// 0x51961C offsetModTable
 static int* _offsetModTable = nullptr;
 
-// 0x519620
+// 0x519620 _renderTable
 static ObjectListNode** _renderTable = nullptr;
 
 // Number of objects in _outlinedObjects.
 //
-// 0x519624
+// 0x519624 outlineCount
 static int _outlineCount = 0;
 
 // Contains objects that are not bounded to tiles.
 //
-// 0x519628
+// 0x519628 _floatingObjects
 static ObjectListNode* gObjectListHead = nullptr;
 
-// 0x51962C
+// 0x51962C centerToUpperLeft
 static int _centerToUpperLeft = 0;
 
-// 0x519630
+// 0x519630 find_elev
 static int gObjectFindElevation = 0;
 
-// 0x519634
+// 0x519634 find_tile
 static int gObjectFindTile = 0;
 
-// 0x519638
+// 0x519638 find_ptr
 static ObjectListNode* gObjectFindLastObjectListNode = nullptr;
 
-// 0x51963C
+// 0x51963C _preload_list
 static int* gObjectFids = nullptr;
 
-// 0x519640
+// 0x519640 preload_list_index
 static int gObjectFidsLength = 0;
 
-// 0x51964C
+// 0x51964C light_rect
 static Rect _light_rect[9] = {
     { 0, 0, 96, 42 },
     { 0, 0, 160, 74 },
@@ -133,7 +133,7 @@ static Rect _light_rect[9] = {
     { 0, 0, 608, 298 },
 };
 
-// 0x5196DC
+// 0x5196DC light_distance
 static int _light_distance[36] = {
     1,
     2,
@@ -173,43 +173,43 @@ static int _light_distance[36] = {
     8,
 };
 
-// 0x51976C
+// 0x51976C fix_violence_level
 static int gViolenceLevel = -1;
 
-// 0x519770
+// 0x519770 obj_last_roof_x
 static int _obj_last_roof_x = -1;
 
-// 0x519774
+// 0x519774 obj_last_roof_y
 static int _obj_last_roof_y = -1;
 
-// 0x519778
+// 0x519778 obj_last_elev
 static int _obj_last_elev = -1;
 
-// 0x51977C
+// 0x51977C obj_last_is_empty
 static bool _obj_last_is_empty = true;
 
-// 0x519780
+// 0x519780 _wallBlendTable
 unsigned char* _wallBlendTable = nullptr;
 
-// 0x519784
+// 0x519784 glassBlendTable
 static unsigned char* _glassBlendTable = nullptr;
 
-// 0x519788
+// 0x519788 steamBlendTable
 static unsigned char* _steamBlendTable = nullptr;
 
-// 0x51978C
+// 0x51978C energyBlendTable
 static unsigned char* _energyBlendTable = nullptr;
 
-// 0x519790
+// 0x519790 redBlendTable
 static unsigned char* _redBlendTable = nullptr;
 
-// 0x519794
+// 0x519794 _moveBlockObj
 Object* _moveBlockObj = nullptr;
 
-// 0x519798
+// 0x519798 objItemOutlineState
 static int _objItemOutlineState = 0;
 
-// 0x51979C
+// 0x51979C _cd_order
 static int _cd_order[9] = {
     1,
     0,
@@ -222,66 +222,66 @@ static int _cd_order[9] = {
     0,
 };
 
-// 0x6391D0
+// 0x6391D0 light_blocked
 static int _light_blocked[6][36];
 
-// 0x639530
+// 0x639530 light_offsets
 static int _light_offsets[2][6][36];
 
-// 0x639BF0
+// 0x639BF0 buf_rect
 static Rect gObjectsWindowRect;
 
 // Likely outlined objects on the screen.
 //
-// 0x639C00
+// 0x639C00 _outlinedObjects
 static Object* _outlinedObjects[100];
 
-// 0x639D90
+// 0x639D90 updateAreaPixelBounds
 static Rect gObjectsUpdateAreaPixelBounds;
 
 // Contains objects that are bounded to tiles.
 //
-// 0x639DA0
+// 0x639DA0 _objectTable
 static ObjectListNode* gObjectListHeadByTile[HEX_GRID_SIZE];
 
-// 0x660EA0
+// 0x660EA0 glassGrayTable
 static unsigned char _glassGrayTable[256];
 
-// 0x660FA0
+// 0x660FA0 commonGrayTable
 unsigned char _commonGrayTable[256];
 
-// 0x6610A0
+// 0x6610A0 buf_size
 static int gObjectsWindowBufferSize;
 
-// 0x6610A4
+// 0x6610A4 back_buf
 static unsigned char* gObjectsWindowBuffer;
 
-// 0x6610A8
+// 0x6610A8 buf_length
 static int gObjectsWindowHeight;
 
 // Translucent "egg" effect around player.
 //
-// 0x6610AC
+// 0x6610AC _obj_egg
 Object* gEgg;
 
-// 0x6610B0
+// 0x6610B0 back_buf_width
 static int gObjectsWindowPitch;
 
-// 0x6610B4
+// 0x6610B4 buf_width
 static int gObjectsWindowWidth;
 
 // obj_dude
-// 0x6610B8
+// 0x6610B8 _obj_dude
 Object* gDude;
 
-// 0x6610BC
+// 0x6610BC obj_seen_check
 static char _obj_seen_check[5001];
 
-// 0x662445
+// 0x662445 obj_seen
 static char _obj_seen[5001];
 
 // obj_init
-// 0x488780 obj_init_
+// 0x488780 obj_init
 int objectsInit(unsigned char* buf, int width, int height, int pitch)
 {
     int dudeFid;
@@ -372,7 +372,7 @@ err:
     return -1;
 }
 
-// 0x488A00 obj_reset_
+// 0x488A00 obj_reset
 void objectsReset()
 {
     if (gObjectsInitialized) {
@@ -383,7 +383,7 @@ void objectsReset()
     }
 }
 
-// 0x488A30 obj_exit_
+// 0x488A30 obj_exit
 void objectsExit()
 {
     if (gObjectsInitialized) {
@@ -408,7 +408,7 @@ void objectsExit()
     }
 }
 
-// 0x488AF4 obj_read_obj_
+// 0x488AF4 obj_read_obj
 int objectRead(Object* obj, File* stream)
 {
     int field_74;
@@ -460,7 +460,7 @@ int objectRead(Object* obj, File* stream)
     return 0;
 }
 
-// 0x488CE4 obj_load_
+// 0x488CE4 obj_load
 int objectLoadAll(File* stream)
 {
     int rc = objectLoadAllInternal(stream);
@@ -470,7 +470,7 @@ int objectLoadAll(File* stream)
     return rc;
 }
 
-// 0x488CF8 obj_load_func_
+// 0x488CF8 obj_load_func
 static int objectLoadAllInternal(File* stream)
 {
     if (stream == nullptr) {
@@ -597,7 +597,7 @@ static int objectLoadAllInternal(File* stream)
 
 // Fixes ammo pid and number of charges.
 //
-// 0x48911C object_fix_weapon_ammo_
+// 0x48911C object_fix_weapon_ammo
 static void _object_fix_weapon_ammo(Object* obj)
 {
     if (PID_TYPE(obj->pid) != OBJ_TYPE_ITEM) {
@@ -641,7 +641,7 @@ static void _object_fix_weapon_ammo(Object* obj)
     }
 }
 
-// 0x489200 obj_write_obj_
+// 0x489200 obj_write_obj
 static int objectWrite(Object* obj, File* stream)
 {
     if (fileWriteInt32(stream, obj->id) == -1) return -1;
@@ -667,7 +667,7 @@ static int objectWrite(Object* obj, File* stream)
     return 0;
 }
 
-// 0x48935C obj_save_
+// 0x48935C obj_save
 int objectSaveAll(File* stream)
 {
     if (stream == nullptr) {
@@ -757,7 +757,7 @@ int objectSaveAll(File* stream)
     return 0;
 }
 
-// 0x489550 obj_render_pre_roof_
+// 0x489550 obj_render_pre_roof
 void _obj_render_pre_roof(Rect* rect, int elevation)
 {
     if (!gObjectsInitialized) {
@@ -858,7 +858,7 @@ void _obj_render_pre_roof(Rect* rect, int elevation)
     }
 }
 
-// 0x4897EC obj_render_post_roof_
+// 0x4897EC obj_render_post_roof
 void _obj_render_post_roof(Rect* rect, int elevation)
 {
     if (!gObjectsInitialized) {
@@ -886,7 +886,7 @@ void _obj_render_post_roof(Rect* rect, int elevation)
     }
 }
 
-// 0x489A84 obj_new_
+// 0x489A84 obj_new
 int objectCreateWithFidPid(Object** objectPtr, int fid, int pid)
 {
     ObjectListNode* objectListNode;
@@ -977,7 +977,7 @@ int objectCreateWithFidPid(Object** objectPtr, int fid, int pid)
     return 0;
 }
 
-// 0x489C9C obj_pid_new_
+// 0x489C9C obj_pid_new
 int objectCreateWithPid(Object** objectPtr, int pid)
 {
     Proto* proto;
@@ -991,7 +991,7 @@ int objectCreateWithPid(Object** objectPtr, int pid)
     return objectCreateWithFidPid(objectPtr, proto->fid, pid);
 }
 
-// 0x489CCC obj_copy_
+// 0x489CCC obj_copy
 int _obj_copy(Object** a1, Object* a2)
 {
     if (a2 == nullptr) {
@@ -1064,7 +1064,7 @@ int _obj_copy(Object** a1, Object* a2)
     return 0;
 }
 
-// 0x489EC4 obj_connect_
+// 0x489EC4 obj_connect
 int _obj_connect(Object* object, int tile, int elevation, Rect* rect)
 {
     if (object == nullptr) {
@@ -1091,7 +1091,7 @@ int _obj_connect(Object* object, int tile, int elevation, Rect* rect)
     return _obj_connect_to_tile(objectListNode, tile, elevation, rect);
 }
 
-// 0x489F34 obj_disconnect_
+// 0x489F34 obj_disconnect
 int _obj_disconnect(Object* obj, Rect* rect)
 {
     if (obj == nullptr) {
@@ -1130,7 +1130,7 @@ int _obj_disconnect(Object* obj, Rect* rect)
     return 0;
 }
 
-// 0x489FF8 obj_offset_
+// 0x489FF8 obj_offset
 int _obj_offset(Object* obj, int x, int y, Rect* rect)
 {
     if (obj == nullptr) {
@@ -1248,7 +1248,7 @@ int _obj_offset(Object* obj, int x, int y, Rect* rect)
     return 0;
 }
 
-// 0x48A324 obj_move_
+// 0x48A324 obj_move
 int _obj_move(Object* a1, int a2, int a3, int elevation, Rect* a5)
 {
     if (a1 == nullptr) {
@@ -1350,7 +1350,7 @@ int _obj_move(Object* a1, int a2, int a3, int elevation, Rect* a5)
     return 0;
 }
 
-// 0x48A568 obj_move_to_tile_
+// 0x48A568 obj_move_to_tile
 int objectSetLocation(Object* obj, int tile, int elevation, Rect* rect)
 {
     if (obj == nullptr) {
@@ -1500,7 +1500,7 @@ int objectSetLocation(Object* obj, int tile, int elevation, Rect* rect)
     return 0;
 }
 
-// 0x48A9A0 obj_reset_roof_
+// 0x48A9A0 obj_reset_roof
 int _obj_reset_roof()
 {
     int fid = buildFid(OBJ_TYPE_TILE, (_square[gDude->elevation]->field_0[_obj_last_roof_x + 100 * _obj_last_roof_y] >> 16) & 0xFFF, 0, 0, 0);
@@ -1512,7 +1512,7 @@ int _obj_reset_roof()
 
 // Sets object fid.
 //
-// 0x48AA3C obj_change_fid_
+// 0x48AA3C obj_change_fid
 int objectSetFid(Object* obj, int fid, Rect* dirtyRect)
 {
     Rect new_rect;
@@ -1537,7 +1537,7 @@ int objectSetFid(Object* obj, int fid, Rect* dirtyRect)
 
 // Sets object frame.
 //
-// 0x48AA84 obj_set_frame_
+// 0x48AA84 obj_set_frame
 int objectSetFrame(Object* obj, int frame, Rect* rect)
 {
     Rect new_rect;
@@ -1574,7 +1574,7 @@ int objectSetFrame(Object* obj, int frame, Rect* rect)
     return 0;
 }
 
-// 0x48AAF0 obj_inc_frame_
+// 0x48AAF0 obj_inc_frame
 int objectSetNextFrame(Object* obj, Rect* dirtyRect)
 {
     Art* art;
@@ -1616,7 +1616,7 @@ int objectSetNextFrame(Object* obj, Rect* dirtyRect)
     return 0;
 }
 
-// 0x48AB60 obj_dec_frame_
+// 0x48AB60 obj_dec_frame
 //
 int objectSetPrevFrame(Object* obj, Rect* dirtyRect)
 {
@@ -1656,7 +1656,7 @@ int objectSetPrevFrame(Object* obj, Rect* dirtyRect)
     return 0;
 }
 
-// 0x48ABD4 obj_set_rotation_
+// 0x48ABD4 obj_set_rotation
 int objectSetRotation(Object* obj, int direction, Rect* dirtyRect)
 {
     if (obj == nullptr) {
@@ -1681,7 +1681,7 @@ int objectSetRotation(Object* obj, int direction, Rect* dirtyRect)
     return 0;
 }
 
-// 0x48AC20 obj_inc_rotation_
+// 0x48AC20 obj_inc_rotation
 int objectRotateClockwise(Object* obj, Rect* dirtyRect)
 {
     int rotation = obj->rotation + 1;
@@ -1692,7 +1692,7 @@ int objectRotateClockwise(Object* obj, Rect* dirtyRect)
     return objectSetRotation(obj, rotation, dirtyRect);
 }
 
-// 0x48AC38 obj_dec_rotation_
+// 0x48AC38 obj_dec_rotation
 int objectRotateCounterClockwise(Object* obj, Rect* dirtyRect)
 {
     int rotation = obj->rotation - 1;
@@ -1703,7 +1703,7 @@ int objectRotateCounterClockwise(Object* obj, Rect* dirtyRect)
     return objectSetRotation(obj, rotation, dirtyRect);
 }
 
-// 0x48AC54 obj_rebuild_all_light_
+// 0x48AC54 obj_rebuild_all_light
 void _obj_rebuild_all_light()
 {
     lightResetTileIntensity();
@@ -1717,7 +1717,7 @@ void _obj_rebuild_all_light()
     }
 }
 
-// 0x48AC90 obj_set_light_
+// 0x48AC90 obj_set_light
 int objectSetLight(Object* obj, int lightDistance, int lightIntensity, Rect* rect)
 {
     if (obj == nullptr) {
@@ -1744,7 +1744,7 @@ int objectSetLight(Object* obj, int lightDistance, int lightIntensity, Rect* rec
     return rc;
 }
 
-// 0x48AD04 obj_get_visible_light_
+// 0x48AD04 obj_get_visible_light
 int objectGetLightIntensity(Object* obj)
 {
     int ambientIntensity = lightGetAmbientIntensity();
@@ -1765,7 +1765,7 @@ int objectGetLightIntensity(Object* obj)
     return tileIntensity;
 }
 
-// 0x48AD48 obj_turn_on_light_
+// 0x48AD48 obj_turn_on_light
 int _obj_turn_on_light(Object* obj, Rect* rect)
 {
     if (obj == nullptr) {
@@ -1790,7 +1790,7 @@ int _obj_turn_on_light(Object* obj, Rect* rect)
     return 0;
 }
 
-// 0x48AD9C obj_turn_off_light_
+// 0x48AD9C obj_turn_off_light
 int _obj_turn_off_light(Object* obj, Rect* rect)
 {
     if (obj == nullptr) {
@@ -1815,7 +1815,7 @@ int _obj_turn_off_light(Object* obj, Rect* rect)
     return 0;
 }
 
-// 0x48ADF0 obj_turn_on_
+// 0x48ADF0 obj_turn_on
 int objectShow(Object* obj, Rect* rect)
 {
     if (obj == nullptr) {
@@ -1846,7 +1846,7 @@ int objectShow(Object* obj, Rect* rect)
     return 0;
 }
 
-// 0x48AE68 obj_turn_off_
+// 0x48AE68 obj_turn_off
 int objectHide(Object* object, Rect* rect)
 {
     if (object == nullptr) {
@@ -1880,7 +1880,7 @@ int objectHide(Object* object, Rect* rect)
     return 0;
 }
 
-// 0x48AEE4 obj_turn_on_outline_
+// 0x48AEE4 obj_turn_on_outline
 int objectEnableOutline(Object* object, Rect* rect)
 {
     if (object == nullptr) {
@@ -1896,7 +1896,7 @@ int objectEnableOutline(Object* object, Rect* rect)
     return 0;
 }
 
-// 0x48AF00 obj_turn_off_outline_
+// 0x48AF00 obj_turn_off_outline
 int objectDisableOutline(Object* object, Rect* rect)
 {
     if (object == nullptr) {
@@ -1914,7 +1914,7 @@ int objectDisableOutline(Object* object, Rect* rect)
     return 0;
 }
 
-// 0x48AF2C obj_toggle_flat_
+// 0x48AF2C obj_toggle_flat
 int _obj_toggle_flat(Object* object, Rect* rect)
 {
     Rect v1;
@@ -1968,7 +1968,7 @@ int _obj_toggle_flat(Object* object, Rect* rect)
     return 0;
 }
 
-// 0x48B0FC obj_erase_object_
+// 0x48B0FC obj_erase_object
 int objectDestroy(Object* object, Rect* rect)
 {
     if (object == nullptr) {
@@ -2007,7 +2007,7 @@ int objectDestroy(Object* object, Rect* rect)
     return 0;
 }
 
-// 0x48B1B0 obj_inven_free_
+// 0x48B1B0 obj_inven_free
 int _obj_inven_free(Inventory* inventory)
 {
     for (int index = 0; index < inventory->length; index++) {
@@ -2034,7 +2034,7 @@ int _obj_inven_free(Inventory* inventory)
     return 0;
 }
 
-// 0x48B24C obj_action_can_use_
+// 0x48B24C obj_action_can_use
 bool _obj_action_can_use(Object* obj)
 {
     int pid = obj->pid;
@@ -2046,13 +2046,13 @@ bool _obj_action_can_use(Object* obj)
     }
 }
 
-// 0x48B278 obj_action_can_talk_to_
+// 0x48B278 obj_action_can_talk_to
 bool _obj_action_can_talk_to(Object* obj)
 {
     return _proto_action_can_talk_to(obj->pid) && (PID_TYPE(obj->pid) == OBJ_TYPE_CRITTER) && critterIsActive(obj);
 }
 
-// 0x48B2A8 obj_portal_is_walk_thru_
+// 0x48B2A8 obj_portal_is_walk_thru
 bool _obj_portal_is_walk_thru(Object* obj)
 {
     if (PID_TYPE(obj->pid) != OBJ_TYPE_SCENERY) {
@@ -2079,7 +2079,7 @@ bool _obj_portal_is_walk_thru(Object* obj)
     return (proto->scenery.data.generic.genericFlags & 0x04) != 0;
 }
 
-// 0x48B2E8 objFindObjPtrFromID_
+// 0x48B2E8 objFindObjPtrFromID
 Object* objectFindById(int a1)
 {
     Object* obj = objectFindFirst();
@@ -2095,7 +2095,7 @@ Object* objectFindById(int a1)
 
 // Returns root owner of given object.
 //
-// 0x48B304 obj_top_environment_
+// 0x48B304 obj_top_environment
 Object* objectGetOwner(Object* object)
 {
     Object* owner = object->owner;
@@ -2110,7 +2110,7 @@ Object* objectGetOwner(Object* object)
     return owner;
 }
 
-// 0x48B318 obj_remove_all_
+// 0x48B318 obj_remove_all
 void _obj_remove_all()
 {
     ObjectListNode* node;
@@ -2149,7 +2149,7 @@ void _obj_remove_all()
     _obj_last_roof_x = -1;
 }
 
-// 0x48B3A8 obj_find_first_
+// 0x48B3A8 obj_find_first
 Object* objectFindFirst()
 {
     gObjectFindElevation = 0;
@@ -2170,7 +2170,7 @@ Object* objectFindFirst()
     return nullptr;
 }
 
-// 0x48B41C obj_find_next_
+// 0x48B41C obj_find_next
 Object* objectFindNext()
 {
     if (gObjectFindLastObjectListNode == nullptr) {
@@ -2203,7 +2203,7 @@ Object* objectFindNext()
     return nullptr;
 }
 
-// 0x48B48C obj_find_first_at_
+// 0x48B48C obj_find_first_at
 Object* objectFindFirstAtElevation(int elevation)
 {
     gObjectFindElevation = elevation;
@@ -2227,7 +2227,7 @@ Object* objectFindFirstAtElevation(int elevation)
     return nullptr;
 }
 
-// 0x48B510 obj_find_next_at_
+// 0x48B510 obj_find_next_at
 Object* objectFindNextAtElevation()
 {
     if (gObjectFindLastObjectListNode == nullptr) {
@@ -2262,7 +2262,7 @@ Object* objectFindNextAtElevation()
     return nullptr;
 }
 
-// 0x48B5A8 obj_find_first_at_tile_
+// 0x48B5A8 obj_find_first_at_tile
 Object* objectFindFirstAtLocation(int elevation, int tile)
 {
     gObjectFindElevation = elevation;
@@ -2284,7 +2284,7 @@ Object* objectFindFirstAtLocation(int elevation, int tile)
     return nullptr;
 }
 
-// 0x48B608 obj_find_next_at_tile_
+// 0x48B608 obj_find_next_at_tile
 Object* objectFindNextAtLocation()
 {
     if (gObjectFindLastObjectListNode == nullptr) {
@@ -2308,7 +2308,7 @@ Object* objectFindNextAtLocation()
     return nullptr;
 }
 
-// 0x48B66C obj_bound_
+// 0x48B66C obj_bound
 void objectGetRect(Object* obj, Rect* rect)
 {
     if (obj == nullptr) {
@@ -2379,7 +2379,7 @@ void objectGetRect(Object* obj, Rect* rect)
     }
 }
 
-// 0x48B7F8 obj_occupied_
+// 0x48B7F8 obj_occupied
 bool _obj_occupied(int tile, int elevation)
 {
     ObjectListNode* objectListNode = gObjectListHeadByTile[tile];
@@ -2395,7 +2395,7 @@ bool _obj_occupied(int tile, int elevation)
     return false;
 }
 
-// 0x48B848 obj_blocking_at_
+// 0x48B848 obj_blocking_at
 Object* _obj_blocking_at(Object* excludeObj, int tile, int elev)
 {
     ObjectListNode* objectListNode;
@@ -2448,7 +2448,7 @@ Object* _obj_blocking_at(Object* excludeObj, int tile, int elev)
     return nullptr;
 }
 
-// 0x48B930 obj_shoot_blocking_at_
+// 0x48B930 obj_shoot_blocking_at
 Object* _obj_shoot_blocking_at(Object* excludeObj, int tile, int elev)
 {
     if (!hexGridTileIsValid(tile)) {
@@ -2504,7 +2504,7 @@ Object* _obj_shoot_blocking_at(Object* excludeObj, int tile, int elev)
     return nullptr;
 }
 
-// 0x48BA20 obj_ai_blocking_at_
+// 0x48BA20 obj_ai_blocking_at
 Object* _obj_ai_blocking_at(Object* excludeObj, int tile, int elevation)
 {
     if (!hexGridTileIsValid(tile)) {
@@ -2567,7 +2567,7 @@ Object* _obj_ai_blocking_at(Object* excludeObj, int tile, int elevation)
     return nullptr;
 }
 
-// 0x48BB44 obj_scroll_blocking_at_
+// 0x48BB44 obj_scroll_blocking_at
 int _obj_scroll_blocking_at(int tile, int elev)
 {
     // TODO: Might be an error - why tile 0 is excluded?
@@ -2591,7 +2591,7 @@ int _obj_scroll_blocking_at(int tile, int elev)
     return -1;
 }
 
-// 0x48BB88 obj_sight_blocking_at_
+// 0x48BB88 obj_sight_blocking_at
 Object* _obj_sight_blocking_at(Object* excludeObj, int tile, int elevation)
 {
     ObjectListNode* objectListNode = gObjectListHeadByTile[tile];
@@ -2612,7 +2612,7 @@ Object* _obj_sight_blocking_at(Object* excludeObj, int tile, int elevation)
     return nullptr;
 }
 
-// 0x48BBD4 obj_dist_
+// 0x48BBD4 obj_dist
 int objectGetDistanceBetween(Object* object1, Object* object2)
 {
     if (object1 == nullptr || object2 == nullptr) {
@@ -2636,7 +2636,7 @@ int objectGetDistanceBetween(Object* object1, Object* object2)
     return distance;
 }
 
-// 0x48BC08 obj_dist_with_tile_
+// 0x48BC08 obj_dist_with_tile
 int objectGetDistanceBetweenTiles(Object* object1, int tile1, Object* object2, int tile2)
 {
     if (object1 == nullptr || object2 == nullptr) {
@@ -2673,7 +2673,7 @@ bool objectWithinWalkDistance(Object* critter, Object* target)
     return _make_path(critter, critter->tile, target->tile, nullptr, 0) < walkDistance;
 }
 
-// 0x48BC38 obj_create_list_
+// 0x48BC38 obj_create_list
 int objectListCreate(int tile, int elevation, int objectType, Object*** objectListPtr)
 {
     if (objectListPtr == nullptr) {
@@ -2745,7 +2745,7 @@ int objectListCreate(int tile, int elevation, int objectType, Object*** objectLi
     return count;
 }
 
-// 0x48BDCC obj_delete_list_
+// 0x48BDCC obj_delete_list
 void objectListFree(Object** objectList)
 {
     if (objectList != nullptr) {
@@ -2753,7 +2753,7 @@ void objectListFree(Object** objectList)
     }
 }
 
-// 0x48BDD8 translucent_trans_buf_to_buf_
+// 0x48BDD8 translucent_trans_buf_to_buf
 void _translucent_trans_buf_to_buf(unsigned char* src, int srcWidth, int srcHeight, int srcPitch, unsigned char* dest, int destX, int destY, int destPitch, unsigned char* a9, unsigned char* a10)
 {
     dest += destPitch * destY + destX;
@@ -2778,7 +2778,7 @@ void _translucent_trans_buf_to_buf(unsigned char* src, int srcWidth, int srcHeig
     }
 }
 
-// 0x48BEFC dark_trans_buf_to_buf_
+// 0x48BEFC dark_trans_buf_to_buf
 void _dark_trans_buf_to_buf(unsigned char* src, int srcWidth, int srcHeight, int srcPitch, unsigned char* dest, int destX, int destY, int destPitch, int intensity)
 {
     unsigned char* sp = src;
@@ -2808,7 +2808,7 @@ void _dark_trans_buf_to_buf(unsigned char* src, int srcWidth, int srcHeight, int
     }
 }
 
-// 0x48BF88 dark_translucent_trans_buf_to_buf_
+// 0x48BF88 dark_translucent_trans_buf_to_buf
 void _dark_translucent_trans_buf_to_buf(unsigned char* src, int srcWidth, int srcHeight, int srcPitch, unsigned char* dest, int destX, int destY, int destPitch, int intensity, unsigned char* a10, unsigned char* a11)
 {
     int srcStep = srcPitch - srcWidth;
@@ -2836,7 +2836,7 @@ void _dark_translucent_trans_buf_to_buf(unsigned char* src, int srcWidth, int sr
     }
 }
 
-// 0x48C03C intensity_mask_buf_to_buf_
+// 0x48C03C intensity_mask_buf_to_buf
 void _intensity_mask_buf_to_buf(unsigned char* src, int srcWidth, int srcHeight, int srcPitch, unsigned char* dest, int destPitch, unsigned char* mask, int maskPitch, int intensity)
 {
     int srcStep = srcPitch - srcWidth;
@@ -2868,7 +2868,7 @@ void _intensity_mask_buf_to_buf(unsigned char* src, int srcWidth, int srcHeight,
     }
 }
 
-// 0x48C2B4 obj_outline_object_
+// 0x48C2B4 obj_outline_object
 int objectSetOutline(Object* obj, int outlineType, Rect* rect)
 {
     if (obj == nullptr) {
@@ -2896,7 +2896,7 @@ int objectSetOutline(Object* obj, int outlineType, Rect* rect)
     return 0;
 }
 
-// 0x48C2F0 obj_remove_outline_
+// 0x48C2F0 obj_remove_outline
 int objectClearOutline(Object* object, Rect* rect)
 {
     if (object == nullptr) {
@@ -2912,7 +2912,7 @@ int objectClearOutline(Object* object, Rect* rect)
     return 0;
 }
 
-// 0x48C340 obj_intersects_with_
+// 0x48C340 obj_intersects_with
 int _obj_intersects_with(Object* object, int x, int y)
 {
     int flags = 0;
@@ -3003,7 +3003,7 @@ int _obj_intersects_with(Object* object, int x, int y)
     return flags;
 }
 
-// 0x48C5C4 obj_create_intersect_list_
+// 0x48C5C4 obj_create_intersect_list
 int _obj_create_intersect_list(int x, int y, int elevation, int objectType, ObjectWithFlags** entriesPtr)
 {
     int upperLeftTile = tileFromScreenXY(x - 320, y - 240, true);
@@ -3052,7 +3052,7 @@ int _obj_create_intersect_list(int x, int y, int elevation, int objectType, Obje
     return count;
 }
 
-// 0x48C74C obj_delete_intersect_list_
+// 0x48C74C obj_delete_intersect_list
 void _obj_delete_intersect_list(ObjectWithFlags** entriesPtr)
 {
     if (entriesPtr != nullptr && *entriesPtr != nullptr) {
@@ -3063,19 +3063,19 @@ void _obj_delete_intersect_list(ObjectWithFlags** entriesPtr)
 
 // NOTE: Inlined.
 //
-// 0x48C76C obj_set_seen_
+// 0x48C76C obj_set_seen
 void obj_set_seen(int tile)
 {
     _obj_seen[tile >> 3] |= 1 << (tile & 7);
 }
 
-// 0x48C788 obj_clear_seen_
+// 0x48C788 obj_clear_seen
 void _obj_clear_seen()
 {
     memset(_obj_seen, 0, sizeof(_obj_seen));
 }
 
-// 0x48C7A0 obj_process_seen_
+// 0x48C7A0 obj_process_seen
 void _obj_process_seen()
 {
     int i;
@@ -3135,7 +3135,7 @@ void _obj_process_seen()
     memset(_obj_seen, 0, 5001);
 }
 
-// 0x48C8E4 object_name_
+// 0x48C8E4 object_name
 char* objectGetName(Object* obj)
 {
     int objectType = FID_TYPE(obj->fid);
@@ -3149,7 +3149,7 @@ char* objectGetName(Object* obj)
     }
 }
 
-// 0x48C914 object_description_
+// 0x48C914 object_description
 char* objectGetDescription(Object* obj)
 {
     if (FID_TYPE(obj->fid) == OBJ_TYPE_ITEM) {
@@ -3161,7 +3161,7 @@ char* objectGetDescription(Object* obj)
 
 // Warm objects cache?
 //
-// 0x48C938 obj_preload_art_cache_
+// 0x48C938 obj_preload_art_cache
 void _obj_preload_art_cache(int flags)
 {
     if (gObjectFids == nullptr) {
@@ -3246,7 +3246,7 @@ void _obj_preload_art_cache(int flags)
     gObjectFidsLength = 0;
 }
 
-// 0x48CB88 obj_offset_table_init_
+// 0x48CB88 obj_offset_table_init
 static int _obj_offset_table_init()
 {
     int i;
@@ -3333,7 +3333,7 @@ err:
     return -1;
 }
 
-// 0x48CDA0 obj_offset_table_exit_
+// 0x48CDA0 obj_offset_table_exit
 static void _obj_offset_table_exit()
 {
     if (_offsetModTable != nullptr) {
@@ -3357,7 +3357,7 @@ static void _obj_offset_table_exit()
     }
 }
 
-// 0x48CE10 obj_order_table_init_
+// 0x48CE10 obj_order_table_init
 static int _obj_order_table_init()
 {
     if (_orderTable[0] != nullptr || _orderTable[1] != nullptr) {
@@ -3392,7 +3392,7 @@ err:
     return -1;
 }
 
-// 0x48CF20 obj_order_comp_func_even_
+// 0x48CF20 obj_order_comp_func_even
 static int _obj_order_comp_func_even(const void* a1, const void* a2)
 {
     int v1 = *(int*)a1;
@@ -3400,7 +3400,7 @@ static int _obj_order_comp_func_even(const void* a1, const void* a2)
     return _offsetTable[0][v1] - _offsetTable[0][v2];
 }
 
-// 0x48CF38 obj_order_comp_func_odd_
+// 0x48CF38 obj_order_comp_func_odd
 static int _obj_order_comp_func_odd(const void* a1, const void* a2)
 {
     int v1 = *(int*)a1;
@@ -3410,7 +3410,7 @@ static int _obj_order_comp_func_odd(const void* a1, const void* a2)
 
 // NOTE: Inlined.
 //
-// 0x48CF50 obj_order_table_exit_
+// 0x48CF50 obj_order_table_exit
 static void _obj_order_table_exit()
 {
     if (_orderTable[1] != nullptr) {
@@ -3424,7 +3424,7 @@ static void _obj_order_table_exit()
     }
 }
 
-// 0x48CF8C obj_render_table_init_
+// 0x48CF8C obj_render_table_init
 static int _obj_render_table_init()
 {
     if (_renderTable != nullptr) {
@@ -3445,7 +3445,7 @@ static int _obj_render_table_init()
 
 // NOTE: Inlined.
 //
-// 0x48D000 obj_render_table_exit_
+// 0x48D000 obj_render_table_exit
 static void _obj_render_table_exit()
 {
     if (_renderTable != nullptr) {
@@ -3454,7 +3454,7 @@ static void _obj_render_table_exit()
     }
 }
 
-// 0x48D020 obj_light_table_init_
+// 0x48D020 obj_light_table_init
 static void _obj_light_table_init()
 {
     for (int s = 0; s < 2; s++) {
@@ -3475,7 +3475,7 @@ static void _obj_light_table_init()
     }
 }
 
-// 0x48D1E4 obj_blend_table_init_
+// 0x48D1E4 obj_blend_table_init
 static void _obj_blend_table_init()
 {
     for (int index = 0; index < 256; index++) {
@@ -3498,7 +3498,7 @@ static void _obj_blend_table_init()
 
 // NOTE: Inlined.
 //
-// 0x48D2E8 obj_blend_table_exit_
+// 0x48D2E8 obj_blend_table_exit
 static void _obj_blend_table_exit()
 {
     _freeColorBlendTable(_colorTable[25439]);
@@ -3508,7 +3508,7 @@ static void _obj_blend_table_exit()
     _freeColorBlendTable(_colorTable[31744]);
 }
 
-// 0x48D348 obj_save_obj_
+// 0x48D348 obj_save_obj
 static int _obj_save_obj(File* stream, Object* object)
 {
     if ((object->flags & OBJECT_NO_SAVE) != 0) {
@@ -3557,7 +3557,7 @@ static int _obj_save_obj(File* stream, Object* object)
     return 0;
 }
 
-// 0x48D414 obj_load_obj_
+// 0x48D414 obj_load_obj
 static int _obj_load_obj(File* stream, Object** objectPtr, int elevation, Object* owner)
 {
     Object* obj;
@@ -3628,7 +3628,7 @@ static int _obj_load_obj(File* stream, Object** objectPtr, int elevation, Object
 }
 
 // obj_save_dude
-// 0x48D59C obj_save_dude_
+// 0x48D59C obj_save_dude
 int _obj_save_dude(File* stream)
 {
     int field_78 = gDude->sid;
@@ -3650,7 +3650,7 @@ int _obj_save_dude(File* stream)
 }
 
 // obj_load_dude
-// 0x48D600 obj_load_dude_
+// 0x48D600 obj_load_dude
 int _obj_load_dude(File* stream)
 {
     int savedTile = gDude->tile;
@@ -3723,7 +3723,7 @@ int _obj_load_dude(File* stream)
     return rc;
 }
 
-// 0x48D778 obj_create_object_
+// 0x48D778 obj_create_object
 static int objectAllocate(Object** objectPtr)
 {
     if (objectPtr == nullptr) {
@@ -3751,7 +3751,7 @@ static int objectAllocate(Object** objectPtr)
 
 // NOTE: Inlined.
 //
-// 0x48D7F8 obj_destroy_object_
+// 0x48D7F8 obj_destroy_object
 static void objectDeallocate(Object** objectPtr)
 {
     if (objectPtr == nullptr) {
@@ -3769,7 +3769,7 @@ static void objectDeallocate(Object** objectPtr)
 
 // NOTE: Inlined.
 //
-// 0x48D818 obj_create_object_node_
+// 0x48D818 obj_create_object_node
 static int objectListNodeCreate(ObjectListNode** nodePtr)
 {
     if (nodePtr == nullptr) {
@@ -3789,7 +3789,7 @@ static int objectListNodeCreate(ObjectListNode** nodePtr)
 
 // NOTE: Inlined.
 //
-// 0x48D84C obj_destroy_object_node_
+// 0x48D84C obj_destroy_object_node
 static void objectListNodeDestroy(ObjectListNode** nodePtr)
 {
     if (nodePtr == nullptr) {
@@ -3805,7 +3805,7 @@ static void objectListNodeDestroy(ObjectListNode** nodePtr)
     *nodePtr = nullptr;
 }
 
-// 0x48D86C obj_node_ptr_
+// 0x48D86C obj_node_ptr
 static int objectGetListNode(Object* object, ObjectListNode** nodePtr, ObjectListNode** previousNodePtr)
 {
     if (object == nullptr) {
@@ -3851,7 +3851,7 @@ static int objectGetListNode(Object* object, ObjectListNode** nodePtr, ObjectLis
     return -1;
 }
 
-// 0x48D8E8 obj_insert_
+// 0x48D8E8 obj_insert
 static void _obj_insert(ObjectListNode* objectListNode)
 {
     ObjectListNode** objectListNodePtr;
@@ -3912,7 +3912,7 @@ static void _obj_insert(ObjectListNode* objectListNode)
     *objectListNodePtr = objectListNode;
 }
 
-// 0x48DA58 obj_remove_
+// 0x48DA58 obj_remove
 static int _obj_remove(ObjectListNode* a1, ObjectListNode* a2)
 {
     if (a1->obj == nullptr) {
@@ -3952,7 +3952,7 @@ static int _obj_remove(ObjectListNode* a1, ObjectListNode* a2)
     return 0;
 }
 
-// 0x48DB28 obj_connect_to_tile_
+// 0x48DB28 obj_connect_to_tile
 static int _obj_connect_to_tile(ObjectListNode* node, int tile, int elevation, Rect* rect)
 {
     if (node == nullptr) {
@@ -3984,7 +3984,7 @@ static int _obj_connect_to_tile(ObjectListNode* node, int tile, int elevation, R
     return 0;
 }
 
-// 0x48DC28 obj_adjust_light_
+// 0x48DC28 obj_adjust_light
 static int _obj_adjust_light(Object* obj, int a2, Rect* rect)
 {
     if (obj == nullptr) {
@@ -4650,7 +4650,7 @@ static int _obj_adjust_light(Object* obj, int a2, Rect* rect)
     return 0;
 }
 
-// 0x48EABC obj_render_outline_
+// 0x48EABC obj_render_outline
 static void objectDrawOutline(Object* object, Rect* rect)
 {
     CacheEntry* cacheEntry;
@@ -4902,7 +4902,7 @@ static void objectDrawOutline(Object* object, Rect* rect)
     artUnlock(cacheEntry);
 }
 
-// 0x48F1B0 obj_render_object_
+// 0x48F1B0 obj_render_object
 static void _obj_render_object(Object* object, Rect* rect, int light)
 {
     int type = FID_TYPE(object->fid);
@@ -5115,7 +5115,7 @@ static void _obj_render_object(Object* object, Rect* rect, int light)
 
 // Updates fid according to current violence level.
 //
-// 0x48FA14 obj_fix_violence_settings_
+// 0x48FA14 obj_fix_violence_settings
 void _obj_fix_violence_settings(int* fid)
 {
     if (FID_TYPE(*fid) != OBJ_TYPE_CRITTER) {
@@ -5164,7 +5164,7 @@ void _obj_fix_violence_settings(int* fid)
     }
 }
 
-// 0x48FB08 obj_preload_sort_
+// 0x48FB08 obj_preload_sort
 static int _obj_preload_sort(const void* a1, const void* a2)
 {
     int v1 = *(int*)a1;

--- a/src/object.cc
+++ b/src/object.cc
@@ -281,7 +281,7 @@ static char _obj_seen_check[5001];
 static char _obj_seen[5001];
 
 // obj_init
-// 0x488780
+// 0x488780 obj_init_
 int objectsInit(unsigned char* buf, int width, int height, int pitch)
 {
     int dudeFid;
@@ -372,7 +372,7 @@ err:
     return -1;
 }
 
-// 0x488A00
+// 0x488A00 obj_reset_
 void objectsReset()
 {
     if (gObjectsInitialized) {
@@ -383,7 +383,7 @@ void objectsReset()
     }
 }
 
-// 0x488A30
+// 0x488A30 obj_exit_
 void objectsExit()
 {
     if (gObjectsInitialized) {
@@ -408,7 +408,7 @@ void objectsExit()
     }
 }
 
-// 0x488AF4
+// 0x488AF4 obj_read_obj_
 int objectRead(Object* obj, File* stream)
 {
     int field_74;
@@ -460,7 +460,7 @@ int objectRead(Object* obj, File* stream)
     return 0;
 }
 
-// 0x488CE4
+// 0x488CE4 obj_load_
 int objectLoadAll(File* stream)
 {
     int rc = objectLoadAllInternal(stream);
@@ -470,7 +470,7 @@ int objectLoadAll(File* stream)
     return rc;
 }
 
-// 0x488CF8
+// 0x488CF8 obj_load_func_
 static int objectLoadAllInternal(File* stream)
 {
     if (stream == nullptr) {
@@ -597,7 +597,7 @@ static int objectLoadAllInternal(File* stream)
 
 // Fixes ammo pid and number of charges.
 //
-// 0x48911C
+// 0x48911C object_fix_weapon_ammo_
 static void _object_fix_weapon_ammo(Object* obj)
 {
     if (PID_TYPE(obj->pid) != OBJ_TYPE_ITEM) {
@@ -641,7 +641,7 @@ static void _object_fix_weapon_ammo(Object* obj)
     }
 }
 
-// 0x489200
+// 0x489200 obj_write_obj_
 static int objectWrite(Object* obj, File* stream)
 {
     if (fileWriteInt32(stream, obj->id) == -1) return -1;
@@ -667,7 +667,7 @@ static int objectWrite(Object* obj, File* stream)
     return 0;
 }
 
-// 0x48935C
+// 0x48935C obj_save_
 int objectSaveAll(File* stream)
 {
     if (stream == nullptr) {
@@ -757,7 +757,7 @@ int objectSaveAll(File* stream)
     return 0;
 }
 
-// 0x489550
+// 0x489550 obj_render_pre_roof_
 void _obj_render_pre_roof(Rect* rect, int elevation)
 {
     if (!gObjectsInitialized) {
@@ -858,7 +858,7 @@ void _obj_render_pre_roof(Rect* rect, int elevation)
     }
 }
 
-// 0x4897EC
+// 0x4897EC obj_render_post_roof_
 void _obj_render_post_roof(Rect* rect, int elevation)
 {
     if (!gObjectsInitialized) {
@@ -886,7 +886,7 @@ void _obj_render_post_roof(Rect* rect, int elevation)
     }
 }
 
-// 0x489A84
+// 0x489A84 obj_new_
 int objectCreateWithFidPid(Object** objectPtr, int fid, int pid)
 {
     ObjectListNode* objectListNode;
@@ -977,7 +977,7 @@ int objectCreateWithFidPid(Object** objectPtr, int fid, int pid)
     return 0;
 }
 
-// 0x489C9C
+// 0x489C9C obj_pid_new_
 int objectCreateWithPid(Object** objectPtr, int pid)
 {
     Proto* proto;
@@ -991,7 +991,7 @@ int objectCreateWithPid(Object** objectPtr, int pid)
     return objectCreateWithFidPid(objectPtr, proto->fid, pid);
 }
 
-// 0x489CCC
+// 0x489CCC obj_copy_
 int _obj_copy(Object** a1, Object* a2)
 {
     if (a2 == nullptr) {
@@ -1064,7 +1064,7 @@ int _obj_copy(Object** a1, Object* a2)
     return 0;
 }
 
-// 0x489EC4
+// 0x489EC4 obj_connect_
 int _obj_connect(Object* object, int tile, int elevation, Rect* rect)
 {
     if (object == nullptr) {
@@ -1091,7 +1091,7 @@ int _obj_connect(Object* object, int tile, int elevation, Rect* rect)
     return _obj_connect_to_tile(objectListNode, tile, elevation, rect);
 }
 
-// 0x489F34
+// 0x489F34 obj_disconnect_
 int _obj_disconnect(Object* obj, Rect* rect)
 {
     if (obj == nullptr) {
@@ -1130,7 +1130,7 @@ int _obj_disconnect(Object* obj, Rect* rect)
     return 0;
 }
 
-// 0x489FF8
+// 0x489FF8 obj_offset_
 int _obj_offset(Object* obj, int x, int y, Rect* rect)
 {
     if (obj == nullptr) {
@@ -1248,7 +1248,7 @@ int _obj_offset(Object* obj, int x, int y, Rect* rect)
     return 0;
 }
 
-// 0x48A324
+// 0x48A324 obj_move_
 int _obj_move(Object* a1, int a2, int a3, int elevation, Rect* a5)
 {
     if (a1 == nullptr) {
@@ -1350,7 +1350,7 @@ int _obj_move(Object* a1, int a2, int a3, int elevation, Rect* a5)
     return 0;
 }
 
-// 0x48A568
+// 0x48A568 obj_move_to_tile_
 int objectSetLocation(Object* obj, int tile, int elevation, Rect* rect)
 {
     if (obj == nullptr) {
@@ -1500,7 +1500,7 @@ int objectSetLocation(Object* obj, int tile, int elevation, Rect* rect)
     return 0;
 }
 
-// 0x48A9A0
+// 0x48A9A0 obj_reset_roof_
 int _obj_reset_roof()
 {
     int fid = buildFid(OBJ_TYPE_TILE, (_square[gDude->elevation]->field_0[_obj_last_roof_x + 100 * _obj_last_roof_y] >> 16) & 0xFFF, 0, 0, 0);
@@ -1512,7 +1512,7 @@ int _obj_reset_roof()
 
 // Sets object fid.
 //
-// 0x48AA3C
+// 0x48AA3C obj_change_fid_
 int objectSetFid(Object* obj, int fid, Rect* dirtyRect)
 {
     Rect new_rect;
@@ -1537,7 +1537,7 @@ int objectSetFid(Object* obj, int fid, Rect* dirtyRect)
 
 // Sets object frame.
 //
-// 0x48AA84
+// 0x48AA84 obj_set_frame_
 int objectSetFrame(Object* obj, int frame, Rect* rect)
 {
     Rect new_rect;
@@ -1574,7 +1574,7 @@ int objectSetFrame(Object* obj, int frame, Rect* rect)
     return 0;
 }
 
-// 0x48AAF0
+// 0x48AAF0 obj_inc_frame_
 int objectSetNextFrame(Object* obj, Rect* dirtyRect)
 {
     Art* art;
@@ -1616,7 +1616,7 @@ int objectSetNextFrame(Object* obj, Rect* dirtyRect)
     return 0;
 }
 
-// 0x48AB60
+// 0x48AB60 obj_dec_frame_
 //
 int objectSetPrevFrame(Object* obj, Rect* dirtyRect)
 {
@@ -1656,7 +1656,7 @@ int objectSetPrevFrame(Object* obj, Rect* dirtyRect)
     return 0;
 }
 
-// 0x48ABD4
+// 0x48ABD4 obj_set_rotation_
 int objectSetRotation(Object* obj, int direction, Rect* dirtyRect)
 {
     if (obj == nullptr) {
@@ -1681,7 +1681,7 @@ int objectSetRotation(Object* obj, int direction, Rect* dirtyRect)
     return 0;
 }
 
-// 0x48AC20
+// 0x48AC20 obj_inc_rotation_
 int objectRotateClockwise(Object* obj, Rect* dirtyRect)
 {
     int rotation = obj->rotation + 1;
@@ -1692,7 +1692,7 @@ int objectRotateClockwise(Object* obj, Rect* dirtyRect)
     return objectSetRotation(obj, rotation, dirtyRect);
 }
 
-// 0x48AC38
+// 0x48AC38 obj_dec_rotation_
 int objectRotateCounterClockwise(Object* obj, Rect* dirtyRect)
 {
     int rotation = obj->rotation - 1;
@@ -1703,7 +1703,7 @@ int objectRotateCounterClockwise(Object* obj, Rect* dirtyRect)
     return objectSetRotation(obj, rotation, dirtyRect);
 }
 
-// 0x48AC54
+// 0x48AC54 obj_rebuild_all_light_
 void _obj_rebuild_all_light()
 {
     lightResetTileIntensity();
@@ -1717,7 +1717,7 @@ void _obj_rebuild_all_light()
     }
 }
 
-// 0x48AC90
+// 0x48AC90 obj_set_light_
 int objectSetLight(Object* obj, int lightDistance, int lightIntensity, Rect* rect)
 {
     if (obj == nullptr) {
@@ -1744,7 +1744,7 @@ int objectSetLight(Object* obj, int lightDistance, int lightIntensity, Rect* rec
     return rc;
 }
 
-// 0x48AD04
+// 0x48AD04 obj_get_visible_light_
 int objectGetLightIntensity(Object* obj)
 {
     int ambientIntensity = lightGetAmbientIntensity();
@@ -1765,7 +1765,7 @@ int objectGetLightIntensity(Object* obj)
     return tileIntensity;
 }
 
-// 0x48AD48
+// 0x48AD48 obj_turn_on_light_
 int _obj_turn_on_light(Object* obj, Rect* rect)
 {
     if (obj == nullptr) {
@@ -1790,7 +1790,7 @@ int _obj_turn_on_light(Object* obj, Rect* rect)
     return 0;
 }
 
-// 0x48AD9C
+// 0x48AD9C obj_turn_off_light_
 int _obj_turn_off_light(Object* obj, Rect* rect)
 {
     if (obj == nullptr) {
@@ -1815,7 +1815,7 @@ int _obj_turn_off_light(Object* obj, Rect* rect)
     return 0;
 }
 
-// 0x48ADF0
+// 0x48ADF0 obj_turn_on_
 int objectShow(Object* obj, Rect* rect)
 {
     if (obj == nullptr) {
@@ -1846,7 +1846,7 @@ int objectShow(Object* obj, Rect* rect)
     return 0;
 }
 
-// 0x48AE68
+// 0x48AE68 obj_turn_off_
 int objectHide(Object* object, Rect* rect)
 {
     if (object == nullptr) {
@@ -1880,7 +1880,7 @@ int objectHide(Object* object, Rect* rect)
     return 0;
 }
 
-// 0x48AEE4
+// 0x48AEE4 obj_turn_on_outline_
 int objectEnableOutline(Object* object, Rect* rect)
 {
     if (object == nullptr) {
@@ -1896,7 +1896,7 @@ int objectEnableOutline(Object* object, Rect* rect)
     return 0;
 }
 
-// 0x48AF00
+// 0x48AF00 obj_turn_off_outline_
 int objectDisableOutline(Object* object, Rect* rect)
 {
     if (object == nullptr) {
@@ -1914,7 +1914,7 @@ int objectDisableOutline(Object* object, Rect* rect)
     return 0;
 }
 
-// 0x48AF2C
+// 0x48AF2C obj_toggle_flat_
 int _obj_toggle_flat(Object* object, Rect* rect)
 {
     Rect v1;
@@ -1968,7 +1968,7 @@ int _obj_toggle_flat(Object* object, Rect* rect)
     return 0;
 }
 
-// 0x48B0FC
+// 0x48B0FC obj_erase_object_
 int objectDestroy(Object* object, Rect* rect)
 {
     if (object == nullptr) {
@@ -2007,7 +2007,7 @@ int objectDestroy(Object* object, Rect* rect)
     return 0;
 }
 
-// 0x48B1B0
+// 0x48B1B0 obj_inven_free_
 int _obj_inven_free(Inventory* inventory)
 {
     for (int index = 0; index < inventory->length; index++) {
@@ -2034,7 +2034,7 @@ int _obj_inven_free(Inventory* inventory)
     return 0;
 }
 
-// 0x48B24C
+// 0x48B24C obj_action_can_use_
 bool _obj_action_can_use(Object* obj)
 {
     int pid = obj->pid;
@@ -2046,13 +2046,13 @@ bool _obj_action_can_use(Object* obj)
     }
 }
 
-// 0x48B278
+// 0x48B278 obj_action_can_talk_to_
 bool _obj_action_can_talk_to(Object* obj)
 {
     return _proto_action_can_talk_to(obj->pid) && (PID_TYPE(obj->pid) == OBJ_TYPE_CRITTER) && critterIsActive(obj);
 }
 
-// 0x48B2A8
+// 0x48B2A8 obj_portal_is_walk_thru_
 bool _obj_portal_is_walk_thru(Object* obj)
 {
     if (PID_TYPE(obj->pid) != OBJ_TYPE_SCENERY) {
@@ -2079,7 +2079,7 @@ bool _obj_portal_is_walk_thru(Object* obj)
     return (proto->scenery.data.generic.genericFlags & 0x04) != 0;
 }
 
-// 0x48B2E8
+// 0x48B2E8 objFindObjPtrFromID_
 Object* objectFindById(int a1)
 {
     Object* obj = objectFindFirst();
@@ -2095,7 +2095,7 @@ Object* objectFindById(int a1)
 
 // Returns root owner of given object.
 //
-// 0x48B304
+// 0x48B304 obj_top_environment_
 Object* objectGetOwner(Object* object)
 {
     Object* owner = object->owner;
@@ -2110,7 +2110,7 @@ Object* objectGetOwner(Object* object)
     return owner;
 }
 
-// 0x48B318
+// 0x48B318 obj_remove_all_
 void _obj_remove_all()
 {
     ObjectListNode* node;
@@ -2149,7 +2149,7 @@ void _obj_remove_all()
     _obj_last_roof_x = -1;
 }
 
-// 0x48B3A8
+// 0x48B3A8 obj_find_first_
 Object* objectFindFirst()
 {
     gObjectFindElevation = 0;
@@ -2170,7 +2170,7 @@ Object* objectFindFirst()
     return nullptr;
 }
 
-// 0x48B41C
+// 0x48B41C obj_find_next_
 Object* objectFindNext()
 {
     if (gObjectFindLastObjectListNode == nullptr) {
@@ -2203,7 +2203,7 @@ Object* objectFindNext()
     return nullptr;
 }
 
-// 0x48B48C
+// 0x48B48C obj_find_first_at_
 Object* objectFindFirstAtElevation(int elevation)
 {
     gObjectFindElevation = elevation;
@@ -2227,7 +2227,7 @@ Object* objectFindFirstAtElevation(int elevation)
     return nullptr;
 }
 
-// 0x48B510
+// 0x48B510 obj_find_next_at_
 Object* objectFindNextAtElevation()
 {
     if (gObjectFindLastObjectListNode == nullptr) {
@@ -2262,7 +2262,7 @@ Object* objectFindNextAtElevation()
     return nullptr;
 }
 
-// 0x48B5A8
+// 0x48B5A8 obj_find_first_at_tile_
 Object* objectFindFirstAtLocation(int elevation, int tile)
 {
     gObjectFindElevation = elevation;
@@ -2284,7 +2284,7 @@ Object* objectFindFirstAtLocation(int elevation, int tile)
     return nullptr;
 }
 
-// 0x48B608
+// 0x48B608 obj_find_next_at_tile_
 Object* objectFindNextAtLocation()
 {
     if (gObjectFindLastObjectListNode == nullptr) {
@@ -2308,7 +2308,7 @@ Object* objectFindNextAtLocation()
     return nullptr;
 }
 
-// 0x0x48B66C
+// 0x0
 void objectGetRect(Object* obj, Rect* rect)
 {
     if (obj == nullptr) {
@@ -2379,7 +2379,7 @@ void objectGetRect(Object* obj, Rect* rect)
     }
 }
 
-// 0x48B7F8
+// 0x48B7F8 obj_occupied_
 bool _obj_occupied(int tile, int elevation)
 {
     ObjectListNode* objectListNode = gObjectListHeadByTile[tile];
@@ -2395,7 +2395,7 @@ bool _obj_occupied(int tile, int elevation)
     return false;
 }
 
-// 0x48B848
+// 0x48B848 obj_blocking_at_
 Object* _obj_blocking_at(Object* excludeObj, int tile, int elev)
 {
     ObjectListNode* objectListNode;
@@ -2448,7 +2448,7 @@ Object* _obj_blocking_at(Object* excludeObj, int tile, int elev)
     return nullptr;
 }
 
-// 0x48B930
+// 0x48B930 obj_shoot_blocking_at_
 Object* _obj_shoot_blocking_at(Object* excludeObj, int tile, int elev)
 {
     if (!hexGridTileIsValid(tile)) {
@@ -2504,7 +2504,7 @@ Object* _obj_shoot_blocking_at(Object* excludeObj, int tile, int elev)
     return nullptr;
 }
 
-// 0x48BA20
+// 0x48BA20 obj_ai_blocking_at_
 Object* _obj_ai_blocking_at(Object* excludeObj, int tile, int elevation)
 {
     if (!hexGridTileIsValid(tile)) {
@@ -2567,7 +2567,7 @@ Object* _obj_ai_blocking_at(Object* excludeObj, int tile, int elevation)
     return nullptr;
 }
 
-// 0x48BB44
+// 0x48BB44 obj_scroll_blocking_at_
 int _obj_scroll_blocking_at(int tile, int elev)
 {
     // TODO: Might be an error - why tile 0 is excluded?
@@ -2591,7 +2591,7 @@ int _obj_scroll_blocking_at(int tile, int elev)
     return -1;
 }
 
-// 0x48BB88
+// 0x48BB88 obj_sight_blocking_at_
 Object* _obj_sight_blocking_at(Object* excludeObj, int tile, int elevation)
 {
     ObjectListNode* objectListNode = gObjectListHeadByTile[tile];
@@ -2612,7 +2612,7 @@ Object* _obj_sight_blocking_at(Object* excludeObj, int tile, int elevation)
     return nullptr;
 }
 
-// 0x48BBD4
+// 0x48BBD4 obj_dist_
 int objectGetDistanceBetween(Object* object1, Object* object2)
 {
     if (object1 == nullptr || object2 == nullptr) {
@@ -2636,7 +2636,7 @@ int objectGetDistanceBetween(Object* object1, Object* object2)
     return distance;
 }
 
-// 0x48BC08
+// 0x48BC08 obj_dist_with_tile_
 int objectGetDistanceBetweenTiles(Object* object1, int tile1, Object* object2, int tile2)
 {
     if (object1 == nullptr || object2 == nullptr) {
@@ -2673,7 +2673,7 @@ bool objectWithinWalkDistance(Object* critter, Object* target)
     return _make_path(critter, critter->tile, target->tile, nullptr, 0) < walkDistance;
 }
 
-// 0x48BC38
+// 0x48BC38 obj_create_list_
 int objectListCreate(int tile, int elevation, int objectType, Object*** objectListPtr)
 {
     if (objectListPtr == nullptr) {
@@ -2745,7 +2745,7 @@ int objectListCreate(int tile, int elevation, int objectType, Object*** objectLi
     return count;
 }
 
-// 0x48BDCC
+// 0x48BDCC obj_delete_list_
 void objectListFree(Object** objectList)
 {
     if (objectList != nullptr) {
@@ -2753,7 +2753,7 @@ void objectListFree(Object** objectList)
     }
 }
 
-// 0x48BDD8
+// 0x48BDD8 translucent_trans_buf_to_buf_
 void _translucent_trans_buf_to_buf(unsigned char* src, int srcWidth, int srcHeight, int srcPitch, unsigned char* dest, int destX, int destY, int destPitch, unsigned char* a9, unsigned char* a10)
 {
     dest += destPitch * destY + destX;
@@ -2778,7 +2778,7 @@ void _translucent_trans_buf_to_buf(unsigned char* src, int srcWidth, int srcHeig
     }
 }
 
-// 0x48BEFC
+// 0x48BEFC dark_trans_buf_to_buf_
 void _dark_trans_buf_to_buf(unsigned char* src, int srcWidth, int srcHeight, int srcPitch, unsigned char* dest, int destX, int destY, int destPitch, int intensity)
 {
     unsigned char* sp = src;
@@ -2808,7 +2808,7 @@ void _dark_trans_buf_to_buf(unsigned char* src, int srcWidth, int srcHeight, int
     }
 }
 
-// 0x48BF88
+// 0x48BF88 dark_translucent_trans_buf_to_buf_
 void _dark_translucent_trans_buf_to_buf(unsigned char* src, int srcWidth, int srcHeight, int srcPitch, unsigned char* dest, int destX, int destY, int destPitch, int intensity, unsigned char* a10, unsigned char* a11)
 {
     int srcStep = srcPitch - srcWidth;
@@ -2836,7 +2836,7 @@ void _dark_translucent_trans_buf_to_buf(unsigned char* src, int srcWidth, int sr
     }
 }
 
-// 0x48C03C
+// 0x48C03C intensity_mask_buf_to_buf_
 void _intensity_mask_buf_to_buf(unsigned char* src, int srcWidth, int srcHeight, int srcPitch, unsigned char* dest, int destPitch, unsigned char* mask, int maskPitch, int intensity)
 {
     int srcStep = srcPitch - srcWidth;
@@ -2868,7 +2868,7 @@ void _intensity_mask_buf_to_buf(unsigned char* src, int srcWidth, int srcHeight,
     }
 }
 
-// 0x48C2B4
+// 0x48C2B4 obj_outline_object_
 int objectSetOutline(Object* obj, int outlineType, Rect* rect)
 {
     if (obj == nullptr) {
@@ -2896,7 +2896,7 @@ int objectSetOutline(Object* obj, int outlineType, Rect* rect)
     return 0;
 }
 
-// 0x48C2F0
+// 0x48C2F0 obj_remove_outline_
 int objectClearOutline(Object* object, Rect* rect)
 {
     if (object == nullptr) {
@@ -2912,7 +2912,7 @@ int objectClearOutline(Object* object, Rect* rect)
     return 0;
 }
 
-// 0x48C340
+// 0x48C340 obj_intersects_with_
 int _obj_intersects_with(Object* object, int x, int y)
 {
     int flags = 0;
@@ -3003,7 +3003,7 @@ int _obj_intersects_with(Object* object, int x, int y)
     return flags;
 }
 
-// 0x48C5C4
+// 0x48C5C4 obj_create_intersect_list_
 int _obj_create_intersect_list(int x, int y, int elevation, int objectType, ObjectWithFlags** entriesPtr)
 {
     int upperLeftTile = tileFromScreenXY(x - 320, y - 240, true);
@@ -3052,7 +3052,7 @@ int _obj_create_intersect_list(int x, int y, int elevation, int objectType, Obje
     return count;
 }
 
-// 0x48C74C
+// 0x48C74C obj_delete_intersect_list_
 void _obj_delete_intersect_list(ObjectWithFlags** entriesPtr)
 {
     if (entriesPtr != nullptr && *entriesPtr != nullptr) {
@@ -3063,19 +3063,19 @@ void _obj_delete_intersect_list(ObjectWithFlags** entriesPtr)
 
 // NOTE: Inlined.
 //
-// 0x48C76C
+// 0x48C76C obj_set_seen_
 void obj_set_seen(int tile)
 {
     _obj_seen[tile >> 3] |= 1 << (tile & 7);
 }
 
-// 0x48C788
+// 0x48C788 obj_clear_seen_
 void _obj_clear_seen()
 {
     memset(_obj_seen, 0, sizeof(_obj_seen));
 }
 
-// 0x48C7A0
+// 0x48C7A0 obj_process_seen_
 void _obj_process_seen()
 {
     int i;
@@ -3135,7 +3135,7 @@ void _obj_process_seen()
     memset(_obj_seen, 0, 5001);
 }
 
-// 0x48C8E4
+// 0x48C8E4 object_name_
 char* objectGetName(Object* obj)
 {
     int objectType = FID_TYPE(obj->fid);
@@ -3149,7 +3149,7 @@ char* objectGetName(Object* obj)
     }
 }
 
-// 0x48C914
+// 0x48C914 object_description_
 char* objectGetDescription(Object* obj)
 {
     if (FID_TYPE(obj->fid) == OBJ_TYPE_ITEM) {
@@ -3161,7 +3161,7 @@ char* objectGetDescription(Object* obj)
 
 // Warm objects cache?
 //
-// 0x48C938
+// 0x48C938 obj_preload_art_cache_
 void _obj_preload_art_cache(int flags)
 {
     if (gObjectFids == nullptr) {
@@ -3246,7 +3246,7 @@ void _obj_preload_art_cache(int flags)
     gObjectFidsLength = 0;
 }
 
-// 0x48CB88
+// 0x48CB88 obj_offset_table_init_
 static int _obj_offset_table_init()
 {
     int i;
@@ -3333,7 +3333,7 @@ err:
     return -1;
 }
 
-// 0x48CDA0
+// 0x48CDA0 obj_offset_table_exit_
 static void _obj_offset_table_exit()
 {
     if (_offsetModTable != nullptr) {
@@ -3357,7 +3357,7 @@ static void _obj_offset_table_exit()
     }
 }
 
-// 0x48CE10
+// 0x48CE10 obj_order_table_init_
 static int _obj_order_table_init()
 {
     if (_orderTable[0] != nullptr || _orderTable[1] != nullptr) {
@@ -3392,7 +3392,7 @@ err:
     return -1;
 }
 
-// 0x48CF20
+// 0x48CF20 obj_order_comp_func_even_
 static int _obj_order_comp_func_even(const void* a1, const void* a2)
 {
     int v1 = *(int*)a1;
@@ -3400,7 +3400,7 @@ static int _obj_order_comp_func_even(const void* a1, const void* a2)
     return _offsetTable[0][v1] - _offsetTable[0][v2];
 }
 
-// 0x48CF38
+// 0x48CF38 obj_order_comp_func_odd_
 static int _obj_order_comp_func_odd(const void* a1, const void* a2)
 {
     int v1 = *(int*)a1;
@@ -3410,7 +3410,7 @@ static int _obj_order_comp_func_odd(const void* a1, const void* a2)
 
 // NOTE: Inlined.
 //
-// 0x48CF50
+// 0x48CF50 obj_order_table_exit_
 static void _obj_order_table_exit()
 {
     if (_orderTable[1] != nullptr) {
@@ -3424,7 +3424,7 @@ static void _obj_order_table_exit()
     }
 }
 
-// 0x48CF8C
+// 0x48CF8C obj_render_table_init_
 static int _obj_render_table_init()
 {
     if (_renderTable != nullptr) {
@@ -3445,7 +3445,7 @@ static int _obj_render_table_init()
 
 // NOTE: Inlined.
 //
-// 0x48D000
+// 0x48D000 obj_render_table_exit_
 static void _obj_render_table_exit()
 {
     if (_renderTable != nullptr) {
@@ -3454,7 +3454,7 @@ static void _obj_render_table_exit()
     }
 }
 
-// 0x48D020
+// 0x48D020 obj_light_table_init_
 static void _obj_light_table_init()
 {
     for (int s = 0; s < 2; s++) {
@@ -3475,7 +3475,7 @@ static void _obj_light_table_init()
     }
 }
 
-// 0x48D1E4
+// 0x48D1E4 obj_blend_table_init_
 static void _obj_blend_table_init()
 {
     for (int index = 0; index < 256; index++) {
@@ -3498,7 +3498,7 @@ static void _obj_blend_table_init()
 
 // NOTE: Inlined.
 //
-// 0x48D2E8
+// 0x48D2E8 obj_blend_table_exit_
 static void _obj_blend_table_exit()
 {
     _freeColorBlendTable(_colorTable[25439]);
@@ -3508,7 +3508,7 @@ static void _obj_blend_table_exit()
     _freeColorBlendTable(_colorTable[31744]);
 }
 
-// 0x48D348
+// 0x48D348 obj_save_obj_
 static int _obj_save_obj(File* stream, Object* object)
 {
     if ((object->flags & OBJECT_NO_SAVE) != 0) {
@@ -3557,7 +3557,7 @@ static int _obj_save_obj(File* stream, Object* object)
     return 0;
 }
 
-// 0x48D414
+// 0x48D414 obj_load_obj_
 static int _obj_load_obj(File* stream, Object** objectPtr, int elevation, Object* owner)
 {
     Object* obj;
@@ -3628,7 +3628,7 @@ static int _obj_load_obj(File* stream, Object** objectPtr, int elevation, Object
 }
 
 // obj_save_dude
-// 0x48D59C
+// 0x48D59C obj_save_dude_
 int _obj_save_dude(File* stream)
 {
     int field_78 = gDude->sid;
@@ -3650,7 +3650,7 @@ int _obj_save_dude(File* stream)
 }
 
 // obj_load_dude
-// 0x48D600
+// 0x48D600 obj_load_dude_
 int _obj_load_dude(File* stream)
 {
     int savedTile = gDude->tile;
@@ -3723,7 +3723,7 @@ int _obj_load_dude(File* stream)
     return rc;
 }
 
-// 0x48D778
+// 0x48D778 obj_create_object_
 static int objectAllocate(Object** objectPtr)
 {
     if (objectPtr == nullptr) {
@@ -3751,7 +3751,7 @@ static int objectAllocate(Object** objectPtr)
 
 // NOTE: Inlined.
 //
-// 0x48D7F8
+// 0x48D7F8 obj_destroy_object_
 static void objectDeallocate(Object** objectPtr)
 {
     if (objectPtr == nullptr) {
@@ -3769,7 +3769,7 @@ static void objectDeallocate(Object** objectPtr)
 
 // NOTE: Inlined.
 //
-// 0x48D818
+// 0x48D818 obj_create_object_node_
 static int objectListNodeCreate(ObjectListNode** nodePtr)
 {
     if (nodePtr == nullptr) {
@@ -3789,7 +3789,7 @@ static int objectListNodeCreate(ObjectListNode** nodePtr)
 
 // NOTE: Inlined.
 //
-// 0x48D84C
+// 0x48D84C obj_destroy_object_node_
 static void objectListNodeDestroy(ObjectListNode** nodePtr)
 {
     if (nodePtr == nullptr) {
@@ -3805,7 +3805,7 @@ static void objectListNodeDestroy(ObjectListNode** nodePtr)
     *nodePtr = nullptr;
 }
 
-// 0x48D86C
+// 0x48D86C obj_node_ptr_
 static int objectGetListNode(Object* object, ObjectListNode** nodePtr, ObjectListNode** previousNodePtr)
 {
     if (object == nullptr) {
@@ -3851,7 +3851,7 @@ static int objectGetListNode(Object* object, ObjectListNode** nodePtr, ObjectLis
     return -1;
 }
 
-// 0x48D8E8
+// 0x48D8E8 obj_insert_
 static void _obj_insert(ObjectListNode* objectListNode)
 {
     ObjectListNode** objectListNodePtr;
@@ -3912,7 +3912,7 @@ static void _obj_insert(ObjectListNode* objectListNode)
     *objectListNodePtr = objectListNode;
 }
 
-// 0x48DA58
+// 0x48DA58 obj_remove_
 static int _obj_remove(ObjectListNode* a1, ObjectListNode* a2)
 {
     if (a1->obj == nullptr) {
@@ -3952,7 +3952,7 @@ static int _obj_remove(ObjectListNode* a1, ObjectListNode* a2)
     return 0;
 }
 
-// 0x48DB28
+// 0x48DB28 obj_connect_to_tile_
 static int _obj_connect_to_tile(ObjectListNode* node, int tile, int elevation, Rect* rect)
 {
     if (node == nullptr) {
@@ -3984,7 +3984,7 @@ static int _obj_connect_to_tile(ObjectListNode* node, int tile, int elevation, R
     return 0;
 }
 
-// 0x48DC28
+// 0x48DC28 obj_adjust_light_
 static int _obj_adjust_light(Object* obj, int a2, Rect* rect)
 {
     if (obj == nullptr) {
@@ -4650,7 +4650,7 @@ static int _obj_adjust_light(Object* obj, int a2, Rect* rect)
     return 0;
 }
 
-// 0x48EABC
+// 0x48EABC obj_render_outline_
 static void objectDrawOutline(Object* object, Rect* rect)
 {
     CacheEntry* cacheEntry;
@@ -4902,7 +4902,7 @@ static void objectDrawOutline(Object* object, Rect* rect)
     artUnlock(cacheEntry);
 }
 
-// 0x48F1B0
+// 0x48F1B0 obj_render_object_
 static void _obj_render_object(Object* object, Rect* rect, int light)
 {
     int type = FID_TYPE(object->fid);
@@ -5115,7 +5115,7 @@ static void _obj_render_object(Object* object, Rect* rect, int light)
 
 // Updates fid according to current violence level.
 //
-// 0x48FA14
+// 0x48FA14 obj_fix_violence_settings_
 void _obj_fix_violence_settings(int* fid)
 {
     if (FID_TYPE(*fid) != OBJ_TYPE_CRITTER) {
@@ -5164,7 +5164,7 @@ void _obj_fix_violence_settings(int* fid)
     }
 }
 
-// 0x48FB08
+// 0x48FB08 obj_preload_sort_
 static int _obj_preload_sort(const void* a1, const void* a2)
 {
     int v1 = *(int*)a1;

--- a/src/object.cc
+++ b/src/object.cc
@@ -2308,7 +2308,7 @@ Object* objectFindNextAtLocation()
     return nullptr;
 }
 
-// 0x0
+// 0x48B66C obj_bound_
 void objectGetRect(Object* obj, Rect* rect)
 {
     if (obj == nullptr) {

--- a/src/options.cc
+++ b/src/options.cc
@@ -85,7 +85,7 @@ static bool gOptionsWindowIsoWasEnabled;
 
 static FrmImage _optionsFrmImages[OPTIONS_WINDOW_FRM_COUNT];
 
-// 0x48FC50
+// 0x48FC50 do_optionsFunc_
 int showOptions()
 {
     ScopedGameMode gm(GameMode::kOptions);
@@ -168,7 +168,7 @@ int showOptions()
     return rc;
 }
 
-// 0x48FE14
+// 0x48FE14 OptnStart_
 static int optionsWindowInit()
 {
     gOptionsWindowOldFont = fontGetCurrent();
@@ -299,7 +299,7 @@ static int optionsWindowInit()
     return 0;
 }
 
-// 0x490244
+// 0x490244 OptnEnd_
 static int optionsWindowFree()
 {
     windowDestroy(gOptionsWindow);
@@ -327,7 +327,7 @@ static int optionsWindowFree()
     return 0;
 }
 
-// 0x4902B0
+// 0x4902B0 PauseWindow_
 // preserveWorldState is always false
 int showPause(bool preserveWorldState)
 {
@@ -498,7 +498,7 @@ int showPause(bool preserveWorldState)
     return 0;
 }
 
-// 0x490748
+// 0x490748 ShadeScreen_
 static void _ShadeScreen(bool preserveWorldState)
 {
     if (preserveWorldState) {
@@ -519,7 +519,7 @@ static void _ShadeScreen(bool preserveWorldState)
 }
 
 // init_options_menu
-// 0x4928B8
+// 0x4928B8 init_options_menu_
 int _init_options_menu()
 {
     preferencesInit();

--- a/src/options.cc
+++ b/src/options.cc
@@ -52,40 +52,40 @@ static const int gPauseWindowFrmIds[PAUSE_WINDOW_FRM_COUNT] = {
     9, // lilreddn.frm - little red button down
 };
 
-// 0x5197C0
+// 0x5197C0 opgrphs
 static const int gOptionsWindowFrmIds[OPTIONS_WINDOW_FRM_COUNT] = {
     220, // opbase.frm - character editor
     222, // opbtnon.frm - character editor
     221, // opbtnoff.frm - character editor
 };
 
-// 0x6637E8
+// 0x6637E8 optn_msgfl
 static MessageList gPreferencesMessageList;
 
-// 0x663840
+// 0x663840 optnmesg
 static MessageListItem gPreferencesMessageListItem;
 
-// 0x663878
+// 0x663878 opbtns
 static unsigned char* _opbtns[OPTIONS_WINDOW_BUTTONS_COUNT];
 
-// 0x6638FC
+// 0x6638FC mouse_3d_was_on
 static bool gOptionsWindowGameMouseObjectsWasVisible;
 
-// 0x663900
+// 0x663900 optnwin
 static int gOptionsWindow;
 
-// 0x663908
+// 0x663908 winbuf
 static unsigned char* gOptionsWindowBuffer;
 
-// 0x66398C
+// 0x66398C fontsave_3
 static int gOptionsWindowOldFont;
 
-// 0x663994
+// 0x663994 bk_enable_4
 static bool gOptionsWindowIsoWasEnabled;
 
 static FrmImage _optionsFrmImages[OPTIONS_WINDOW_FRM_COUNT];
 
-// 0x48FC50 do_optionsFunc_
+// 0x48FC50 do_optionsFunc
 int showOptions()
 {
     ScopedGameMode gm(GameMode::kOptions);
@@ -168,7 +168,7 @@ int showOptions()
     return rc;
 }
 
-// 0x48FE14 OptnStart_
+// 0x48FE14 OptnStart
 static int optionsWindowInit()
 {
     gOptionsWindowOldFont = fontGetCurrent();
@@ -299,7 +299,7 @@ static int optionsWindowInit()
     return 0;
 }
 
-// 0x490244 OptnEnd_
+// 0x490244 OptnEnd
 static int optionsWindowFree()
 {
     windowDestroy(gOptionsWindow);
@@ -327,7 +327,7 @@ static int optionsWindowFree()
     return 0;
 }
 
-// 0x4902B0 PauseWindow_
+// 0x4902B0 PauseWindow
 // preserveWorldState is always false
 int showPause(bool preserveWorldState)
 {
@@ -498,7 +498,7 @@ int showPause(bool preserveWorldState)
     return 0;
 }
 
-// 0x490748 ShadeScreen_
+// 0x490748 ShadeScreen
 static void _ShadeScreen(bool preserveWorldState)
 {
     if (preserveWorldState) {
@@ -519,7 +519,7 @@ static void _ShadeScreen(bool preserveWorldState)
 }
 
 // init_options_menu
-// 0x4928B8 init_options_menu_
+// 0x4928B8 init_options_menu
 int _init_options_menu()
 {
     preferencesInit();

--- a/src/palette.cc
+++ b/src/palette.cc
@@ -26,7 +26,7 @@ unsigned char gPaletteBlack[256 * 3];
 // 0x6642D0
 static int gPaletteFadeSteps;
 
-// 0x493A00
+// 0x493A00 palette_init_
 void paletteInit()
 {
     memset(gPaletteBlack, 0, 256 * 3);
@@ -75,7 +75,7 @@ void paletteExit()
     _palette_reset_();
 }
 
-// 0x493AD4
+// 0x493AD4 palette_fade_to_
 void paletteFadeTo(unsigned char* palette)
 {
     bool colorCycleWasEnabled = colorCycleEnabled();
@@ -95,14 +95,14 @@ void paletteFadeTo(unsigned char* palette)
     }
 }
 
-// 0x493B48
+// 0x493B48 palette_set_to_
 void paletteSetEntries(unsigned char* palette)
 {
     memcpy(gPalette, palette, sizeof(gPalette));
     _setSystemPalette(palette);
 }
 
-// 0x493B78
+// 0x493B78 palette_set_entries_
 void paletteSetEntriesInRange(unsigned char* palette, int start, int end)
 {
     memcpy(gPalette + 3 * start, palette, 3 * (end - start + 1));

--- a/src/palette.cc
+++ b/src/palette.cc
@@ -14,19 +14,19 @@ namespace fallout {
 
 static void _palette_reset_();
 
-// 0x6639D0
+// 0x6639D0 current_palette
 static unsigned char gPalette[256 * 3];
 
-// 0x663CD0
+// 0x663CD0 white_palette
 unsigned char gPaletteWhite[256 * 3];
 
-// 0x663FD0
+// 0x663FD0 black_palette
 unsigned char gPaletteBlack[256 * 3];
 
-// 0x6642D0
+// 0x6642D0 fade_steps
 static int gPaletteFadeSteps;
 
-// 0x493A00 palette_init_
+// 0x493A00 palette_init
 void paletteInit()
 {
     memset(gPaletteBlack, 0, 256 * 3);
@@ -75,7 +75,7 @@ void paletteExit()
     _palette_reset_();
 }
 
-// 0x493AD4 palette_fade_to_
+// 0x493AD4 palette_fade_to
 void paletteFadeTo(unsigned char* palette)
 {
     bool colorCycleWasEnabled = colorCycleEnabled();
@@ -95,14 +95,14 @@ void paletteFadeTo(unsigned char* palette)
     }
 }
 
-// 0x493B48 palette_set_to_
+// 0x493B48 palette_set_to
 void paletteSetEntries(unsigned char* palette)
 {
     memcpy(gPalette, palette, sizeof(gPalette));
     _setSystemPalette(palette);
 }
 
-// 0x493B78 palette_set_entries_
+// 0x493B78 palette_set_entries
 void paletteSetEntriesInRange(unsigned char* palette, int start, int end)
 {
     memcpy(gPalette + 3 * start, palette, 3 * (end - start + 1));

--- a/src/party_member.cc
+++ b/src/party_member.cc
@@ -119,7 +119,7 @@ static PartyMemberLevelUpInfo* _partyMemberLevelUpInfoList = nullptr;
 static int _curID = 20000;
 
 // partyMember_init
-// 0x493BC0
+// 0x493BC0 partyMember_init_
 int partyMembersInit()
 {
     Config config;
@@ -271,7 +271,7 @@ err:
     return -1;
 }
 
-// 0x4940E4
+// 0x4940E4 partyMember_reset_
 void partyMembersReset()
 {
     for (int index = 0; index < gPartyMemberDescriptionsLength; index++) {
@@ -281,7 +281,7 @@ void partyMembersReset()
     }
 }
 
-// 0x494134
+// 0x494134 partyMember_exit_
 void partyMembersExit()
 {
     for (int index = 0; index < gPartyMemberDescriptionsLength; index++) {
@@ -313,7 +313,7 @@ void partyMembersExit()
     }
 }
 
-// 0x4941F0
+// 0x4941F0 partyMemberGetAIOptions_
 static int partyMemberGetDescription(Object* object, PartyMemberDescription** partyMemberDescriptionPtr)
 {
     for (int index = 1; index < gPartyMemberDescriptionsLength; index++) {
@@ -326,7 +326,7 @@ static int partyMemberGetDescription(Object* object, PartyMemberDescription** pa
     return -1;
 }
 
-// 0x49425C
+// 0x49425C partyMemberAISlotInit_
 static void partyMemberDescriptionInit(PartyMemberDescription* partyMemberDescription)
 {
     for (int index = 0; index < AREA_ATTACK_MODE_COUNT; index++) {
@@ -371,7 +371,7 @@ static void partyMemberDescriptionInit(PartyMemberDescription* partyMemberDescri
 }
 
 // partyMemberAdd
-// 0x494378
+// 0x494378 partyMemberAdd_
 int partyMemberAdd(Object* object)
 {
     if (gPartyMembersLength >= gPartyMemberDescriptionsLength + 20) {
@@ -422,7 +422,7 @@ int partyMemberAdd(Object* object)
 }
 
 // partyMemberRemove
-// 0x4944DC
+// 0x4944DC partyMemberRemove_
 int partyMemberRemove(Object* object)
 {
     if (gPartyMembersLength == 0) {
@@ -474,7 +474,7 @@ int partyMemberRemove(Object* object)
     return 0;
 }
 
-// 0x49460C
+// 0x49460C partyMemberPrepSave_
 int _partyMemberPrepSave()
 {
     _partyStatePrepped = 1;
@@ -495,7 +495,7 @@ int _partyMemberPrepSave()
     return 0;
 }
 
-// 0x49466C
+// 0x49466C partyMemberUnPrepSave_
 int _partyMemberUnPrepSave()
 {
     for (int index = 0; index < gPartyMembersLength; index++) {
@@ -516,7 +516,7 @@ int _partyMemberUnPrepSave()
     return 0;
 }
 
-// 0x4946CC
+// 0x4946CC partyMemberSave_
 int partyMembersSave(File* stream)
 {
     if (fileWriteInt32(stream, gPartyMembersLength) == -1) return -1;
@@ -537,7 +537,7 @@ int partyMembersSave(File* stream)
     return 0;
 }
 
-// 0x4947AC
+// 0x4947AC partyMemberPrepLoad_
 int _partyMemberPrepLoad()
 {
     if (_partyStatePrepped) {
@@ -557,7 +557,7 @@ int _partyMemberPrepLoad()
 }
 
 // partyMemberPrepLoadInstance
-// 0x49480C
+// 0x49480C partyMemberPrepLoadInstance_
 static int _partyMemberPrepLoadInstance(PartyMemberListItem* a1)
 {
     Object* obj = a1->object;
@@ -625,7 +625,7 @@ static int _partyMemberPrepLoadInstance(PartyMemberListItem* a1)
 }
 
 // partyMemberRecoverLoad
-// 0x4949C4
+// 0x4949C4 partyMemberRecoverLoad_
 int _partyMemberRecoverLoad()
 {
     if (_partyStatePrepped != 1) {
@@ -663,7 +663,7 @@ int _partyMemberRecoverLoad()
 }
 
 // partyMemberRecoverLoadInstance
-// 0x494A88
+// 0x494A88 partyMemberRecoverLoadInstance_
 static int _partyMemberRecoverLoadInstance(PartyMemberListItem* a1)
 {
     if (a1->script == nullptr) {
@@ -709,7 +709,7 @@ static int _partyMemberRecoverLoadInstance(PartyMemberListItem* a1)
     return 0;
 }
 
-// 0x494BBC
+// 0x494BBC partyMemberLoad_
 int partyMembersLoad(File* stream)
 {
     int* partyMemberObjectIds = (int*)internal_malloc(sizeof(*partyMemberObjectIds) * (gPartyMemberDescriptionsLength + 20));
@@ -773,7 +773,7 @@ int partyMembersLoad(File* stream)
     return 0;
 }
 
-// 0x494D7C
+// 0x494D7C partyMemberClear_
 void _partyMemberClear()
 {
     if (_partyStatePrepped) {
@@ -792,7 +792,7 @@ void _partyMemberClear()
     _partyStatePrepped = 0;
 }
 
-// 0x494DD0
+// 0x494DD0 partyMemberSyncPosition_
 int _partyMemberSyncPosition()
 {
     int clockwiseRotation = (gDude->rotation + 2) % ROTATION_COUNT;
@@ -824,7 +824,7 @@ int _partyMemberSyncPosition()
 
 // Heals party members according to their healing rate.
 //
-// 0x494EB8
+// 0x494EB8 partyMemberRestingHeal_
 int _partyMemberRestingHeal(int hours)
 {
     int healingTicks = hours / 3;
@@ -843,7 +843,7 @@ int _partyMemberRestingHeal(int hours)
     return 1;
 }
 
-// 0x494F24
+// 0x494F24 partyMemberFindObjFromPid_
 Object* partyMemberFindByPid(int pid)
 {
     for (int index = 0; index < gPartyMembersLength; index++) {
@@ -856,7 +856,7 @@ Object* partyMemberFindByPid(int pid)
     return nullptr;
 }
 
-// 0x494F64
+// 0x494F64 isPotentialPartyMember_
 bool _isPotentialPartyMember(Object* object)
 {
     for (int index = 0; index < gPartyMembersLength; index++) {
@@ -871,7 +871,7 @@ bool _isPotentialPartyMember(Object* object)
 
 // Returns `true` if specified object is a party member.
 //
-// 0x494FC4
+// 0x494FC4 isPartyMember_
 bool objectIsPartyMember(Object* object)
 {
     if (object == nullptr) {
@@ -896,7 +896,7 @@ bool objectIsPartyMember(Object* object)
 
 // Returns number of active critters in the party.
 //
-// 0x495010
+// 0x495010 getPartyMemberCount_
 int _getPartyMemberCount()
 {
     int count = gPartyMembersLength;
@@ -912,7 +912,7 @@ int _getPartyMemberCount()
     return count;
 }
 
-// 0x495070
+// 0x495070 partyMemberNewObjID_
 static int _partyMemberNewObjID()
 {
     Object* object;
@@ -954,7 +954,7 @@ static int _partyMemberNewObjID()
     return _curID;
 }
 
-// 0x4950F4
+// 0x4950F4 partyMemberNewObjIDRecurseFind_
 static int _partyMemberNewObjIDRecurseFind(Object* obj, int objectId)
 {
     Inventory* inventory = &(obj->data.inventory);
@@ -972,7 +972,7 @@ static int _partyMemberNewObjIDRecurseFind(Object* obj, int objectId)
     return 0;
 }
 
-// 0x495140
+// 0x495140 partyMemberPrepItemSaveAll_
 int _partyMemberPrepItemSaveAll()
 {
     for (int partyMemberIndex = 0; partyMemberIndex < gPartyMembersLength; partyMemberIndex++) {
@@ -1010,7 +1010,7 @@ static int _partyMemberPrepItemSave(Object* object)
     return 0;
 }
 
-// 0x495234
+// 0x495234 partyMemberItemSave_
 static int _partyMemberItemSave(Object* object)
 {
     if (object->sid != -1) {
@@ -1068,7 +1068,7 @@ static int _partyMemberItemSave(Object* object)
 }
 
 // partyMemberItemRecover
-// 0x495388
+// 0x495388 partyMemberItemRecover_
 static int _partyMemberItemRecover(PartyMemberListItem* a1)
 {
     int sid = -1;
@@ -1104,7 +1104,7 @@ static int _partyMemberItemRecover(PartyMemberListItem* a1)
     return 0;
 }
 
-// 0x4954C4
+// 0x4954C4 partyMemberClearItemList_
 static int _partyMemberClearItemList()
 {
     while (_itemSaveListHead != nullptr) {
@@ -1129,7 +1129,7 @@ static int _partyMemberClearItemList()
 
 // Returns best skill of the specified party member.
 //
-// 0x495520
+// 0x495520 partyMemberSkill_
 int partyMemberGetBestSkill(Object* object)
 {
     int bestSkill = SKILL_SMALL_GUNS;
@@ -1156,7 +1156,7 @@ int partyMemberGetBestSkill(Object* object)
 
 // Returns party member with highest skill level.
 //
-// 0x495560
+// 0x495560 partyMemberWithHighestSkill_
 Object* partyMemberGetBestInSkill(int skill)
 {
     int bestValue = 0;
@@ -1178,7 +1178,7 @@ Object* partyMemberGetBestInSkill(int skill)
 
 // Returns highest skill level in party.
 //
-// 0x4955C8
+// 0x4955C8 partyMemberHighestSkillLevel_
 int partyGetBestSkillValue(int skill)
 {
     int bestValue = 0;
@@ -1196,7 +1196,7 @@ int partyGetBestSkillValue(int skill)
     return bestValue;
 }
 
-// 0x495620
+// 0x495620 partyFixMultipleMembers_
 static int partyFixMultipleMembers()
 {
     debugPrint("\n\n\n[Party Members]:");
@@ -1277,7 +1277,7 @@ static int partyFixMultipleMembers()
     return 0;
 }
 
-// 0x495870
+// 0x495870 partyMemberSaveProtos_
 void _partyMemberSaveProtos()
 {
     for (int index = 1; index < gPartyMemberDescriptionsLength; index++) {
@@ -1288,7 +1288,7 @@ void _partyMemberSaveProtos()
     }
 }
 
-// 0x4958B0
+// 0x4958B0 partyMemberHasAIDisposition_
 bool partyMemberSupportsDisposition(Object* critter, int disposition)
 {
     if (critter == nullptr) {
@@ -1311,7 +1311,7 @@ bool partyMemberSupportsDisposition(Object* critter, int disposition)
     return partyMemberDescription->disposition[disposition + 1];
 }
 
-// 0x495920
+// 0x495920 partyMemberHasAIBurstValue_
 bool partyMemberSupportsAreaAttackMode(Object* object, int areaAttackMode)
 {
     if (object == nullptr) {
@@ -1334,7 +1334,7 @@ bool partyMemberSupportsAreaAttackMode(Object* object, int areaAttackMode)
     return partyMemberDescription->areaAttackMode[areaAttackMode];
 }
 
-// 0x495980
+// 0x495980 partyMemberHasAIRunAwayValue_
 bool partyMemberSupportsRunAwayMode(Object* object, int runAwayMode)
 {
     if (object == nullptr) {
@@ -1357,7 +1357,7 @@ bool partyMemberSupportsRunAwayMode(Object* object, int runAwayMode)
     return partyMemberDescription->runAwayMode[runAwayMode + 1];
 }
 
-// 0x4959E0
+// 0x4959E0 partyMemberHasAIWeaponPrefValue_
 bool partyMemberSupportsBestWeapon(Object* object, int bestWeapon)
 {
     if (object == nullptr) {
@@ -1380,7 +1380,7 @@ bool partyMemberSupportsBestWeapon(Object* object, int bestWeapon)
     return partyMemberDescription->bestWeapon[bestWeapon];
 }
 
-// 0x495A40
+// 0x495A40 partyMemberHasAIDistancePrefValue_
 bool partyMemberSupportsDistance(Object* object, int distanceMode)
 {
     if (object == nullptr) {
@@ -1403,7 +1403,7 @@ bool partyMemberSupportsDistance(Object* object, int distanceMode)
     return partyMemberDescription->distanceMode[distanceMode];
 }
 
-// 0x495AA0
+// 0x495AA0 partyMemberHasAIAttackWhoValue_
 bool partyMemberSupportsAttackWho(Object* object, int attackWho)
 {
     if (object == nullptr) {
@@ -1426,7 +1426,7 @@ bool partyMemberSupportsAttackWho(Object* object, int attackWho)
     return partyMemberDescription->attackWho[attackWho];
 }
 
-// 0x495B00
+// 0x495B00 partyMemberHasAIChemUseValue_
 bool partyMemberSupportsChemUse(Object* object, int chemUse)
 {
     if (object == nullptr) {
@@ -1450,7 +1450,7 @@ bool partyMemberSupportsChemUse(Object* object, int chemUse)
 }
 
 // partyMemberIncLevels
-// 0x495B60
+// 0x495B60 partyMemberIncLevels_
 int _partyMemberIncLevels()
 {
     int i;
@@ -1559,7 +1559,7 @@ int _partyMemberIncLevels()
     return 0;
 }
 
-// 0x495EA8
+// 0x495EA8 partyMemberCopyLevelInfo_
 static int _partyMemberCopyLevelInfo(Object* critter, int stagePid)
 {
     if (critter == nullptr) {
@@ -1626,7 +1626,7 @@ static int _partyMemberCopyLevelInfo(Object* critter, int stagePid)
 // (they cannot be healed by resting) and dude (he/she has it's own "Rest
 // until healed" option).
 //
-// 0x496058
+// 0x496058 partyMemberNeedsHealing_
 bool partyIsAnyoneCanBeHealedByRest()
 {
     for (int index = 1; index < gPartyMembersLength; index++) {
@@ -1651,7 +1651,7 @@ bool partyIsAnyoneCanBeHealedByRest()
 // Returns maximum amount of damage of any party member that can be healed thru
 // the rest.
 //
-// 0x4960DC
+// 0x4960DC partyMemberMaxHealingNeeded_
 int partyGetMaxWoundToHealByRest()
 {
     int maxWound = 0;

--- a/src/party_member.cc
+++ b/src/party_member.cc
@@ -87,7 +87,7 @@ static int _partyMemberCopyLevelInfo(Object* object, int a2);
 // 0x519D9C partyMemberMaxCount
 int gPartyMemberDescriptionsLength = 0;
 
-// 0x519DA0 _partyMemberPidList
+// 0x519DA0 partyMemberPidList
 int* gPartyMemberPids = nullptr;
 
 //
@@ -95,7 +95,7 @@ static PartyMemberListItem* _itemSaveListHead = nullptr;
 
 // List of party members, it's length is [gPartyMemberDescriptionsLength] + 20.
 //
-// 0x519DA8 _partyMemberList
+// 0x519DA8 partyMemberList
 PartyMemberListItem* gPartyMembers = nullptr;
 
 // Number of critters added to party.
@@ -109,7 +109,7 @@ static int _partyMemberItemCount = 20000;
 // 0x519DB4 partyStatePrepped
 static int _partyStatePrepped = 0;
 
-// 0x519DB8 _partyMemberAIOptions
+// 0x519DB8 partyMemberAIOptions
 static PartyMemberDescription* gPartyMemberDescriptions = nullptr;
 
 // 0x519DBC partyMemberLevelUpInfoList

--- a/src/party_member.cc
+++ b/src/party_member.cc
@@ -84,10 +84,10 @@ static int _partyMemberClearItemList();
 static int partyFixMultipleMembers();
 static int _partyMemberCopyLevelInfo(Object* object, int a2);
 
-// 0x519D9C
+// 0x519D9C partyMemberMaxCount
 int gPartyMemberDescriptionsLength = 0;
 
-// 0x519DA0
+// 0x519DA0 _partyMemberPidList
 int* gPartyMemberPids = nullptr;
 
 //
@@ -95,31 +95,31 @@ static PartyMemberListItem* _itemSaveListHead = nullptr;
 
 // List of party members, it's length is [gPartyMemberDescriptionsLength] + 20.
 //
-// 0x519DA8
+// 0x519DA8 _partyMemberList
 PartyMemberListItem* gPartyMembers = nullptr;
 
 // Number of critters added to party.
 //
-// 0x519DAC
+// 0x519DAC partyMemberCount
 static int gPartyMembersLength = 0;
 
-// 0x519DB0
+// 0x519DB0 partyMemberItemCount
 static int _partyMemberItemCount = 20000;
 
-// 0x519DB4
+// 0x519DB4 partyStatePrepped
 static int _partyStatePrepped = 0;
 
-// 0x519DB8
+// 0x519DB8 _partyMemberAIOptions
 static PartyMemberDescription* gPartyMemberDescriptions = nullptr;
 
-// 0x519DBC
+// 0x519DBC partyMemberLevelUpInfoList
 static PartyMemberLevelUpInfo* _partyMemberLevelUpInfoList = nullptr;
 
-// 0x519DC0
+// 0x519DC0 curID
 static int _curID = 20000;
 
 // partyMember_init
-// 0x493BC0 partyMember_init_
+// 0x493BC0 partyMember_init
 int partyMembersInit()
 {
     Config config;
@@ -271,7 +271,7 @@ err:
     return -1;
 }
 
-// 0x4940E4 partyMember_reset_
+// 0x4940E4 partyMember_reset
 void partyMembersReset()
 {
     for (int index = 0; index < gPartyMemberDescriptionsLength; index++) {
@@ -281,7 +281,7 @@ void partyMembersReset()
     }
 }
 
-// 0x494134 partyMember_exit_
+// 0x494134 partyMember_exit
 void partyMembersExit()
 {
     for (int index = 0; index < gPartyMemberDescriptionsLength; index++) {
@@ -313,7 +313,7 @@ void partyMembersExit()
     }
 }
 
-// 0x4941F0 partyMemberGetAIOptions_
+// 0x4941F0 partyMemberGetAIOptions
 static int partyMemberGetDescription(Object* object, PartyMemberDescription** partyMemberDescriptionPtr)
 {
     for (int index = 1; index < gPartyMemberDescriptionsLength; index++) {
@@ -326,7 +326,7 @@ static int partyMemberGetDescription(Object* object, PartyMemberDescription** pa
     return -1;
 }
 
-// 0x49425C partyMemberAISlotInit_
+// 0x49425C partyMemberAISlotInit
 static void partyMemberDescriptionInit(PartyMemberDescription* partyMemberDescription)
 {
     for (int index = 0; index < AREA_ATTACK_MODE_COUNT; index++) {
@@ -371,7 +371,7 @@ static void partyMemberDescriptionInit(PartyMemberDescription* partyMemberDescri
 }
 
 // partyMemberAdd
-// 0x494378 partyMemberAdd_
+// 0x494378 partyMemberAdd
 int partyMemberAdd(Object* object)
 {
     if (gPartyMembersLength >= gPartyMemberDescriptionsLength + 20) {
@@ -422,7 +422,7 @@ int partyMemberAdd(Object* object)
 }
 
 // partyMemberRemove
-// 0x4944DC partyMemberRemove_
+// 0x4944DC partyMemberRemove
 int partyMemberRemove(Object* object)
 {
     if (gPartyMembersLength == 0) {
@@ -474,7 +474,7 @@ int partyMemberRemove(Object* object)
     return 0;
 }
 
-// 0x49460C partyMemberPrepSave_
+// 0x49460C partyMemberPrepSave
 int _partyMemberPrepSave()
 {
     _partyStatePrepped = 1;
@@ -495,7 +495,7 @@ int _partyMemberPrepSave()
     return 0;
 }
 
-// 0x49466C partyMemberUnPrepSave_
+// 0x49466C partyMemberUnPrepSave
 int _partyMemberUnPrepSave()
 {
     for (int index = 0; index < gPartyMembersLength; index++) {
@@ -516,7 +516,7 @@ int _partyMemberUnPrepSave()
     return 0;
 }
 
-// 0x4946CC partyMemberSave_
+// 0x4946CC partyMemberSave
 int partyMembersSave(File* stream)
 {
     if (fileWriteInt32(stream, gPartyMembersLength) == -1) return -1;
@@ -537,7 +537,7 @@ int partyMembersSave(File* stream)
     return 0;
 }
 
-// 0x4947AC partyMemberPrepLoad_
+// 0x4947AC partyMemberPrepLoad
 int _partyMemberPrepLoad()
 {
     if (_partyStatePrepped) {
@@ -557,7 +557,7 @@ int _partyMemberPrepLoad()
 }
 
 // partyMemberPrepLoadInstance
-// 0x49480C partyMemberPrepLoadInstance_
+// 0x49480C partyMemberPrepLoadInstance
 static int _partyMemberPrepLoadInstance(PartyMemberListItem* a1)
 {
     Object* obj = a1->object;
@@ -625,7 +625,7 @@ static int _partyMemberPrepLoadInstance(PartyMemberListItem* a1)
 }
 
 // partyMemberRecoverLoad
-// 0x4949C4 partyMemberRecoverLoad_
+// 0x4949C4 partyMemberRecoverLoad
 int _partyMemberRecoverLoad()
 {
     if (_partyStatePrepped != 1) {
@@ -663,7 +663,7 @@ int _partyMemberRecoverLoad()
 }
 
 // partyMemberRecoverLoadInstance
-// 0x494A88 partyMemberRecoverLoadInstance_
+// 0x494A88 partyMemberRecoverLoadInstance
 static int _partyMemberRecoverLoadInstance(PartyMemberListItem* a1)
 {
     if (a1->script == nullptr) {
@@ -709,7 +709,7 @@ static int _partyMemberRecoverLoadInstance(PartyMemberListItem* a1)
     return 0;
 }
 
-// 0x494BBC partyMemberLoad_
+// 0x494BBC partyMemberLoad
 int partyMembersLoad(File* stream)
 {
     int* partyMemberObjectIds = (int*)internal_malloc(sizeof(*partyMemberObjectIds) * (gPartyMemberDescriptionsLength + 20));
@@ -773,7 +773,7 @@ int partyMembersLoad(File* stream)
     return 0;
 }
 
-// 0x494D7C partyMemberClear_
+// 0x494D7C partyMemberClear
 void _partyMemberClear()
 {
     if (_partyStatePrepped) {
@@ -792,7 +792,7 @@ void _partyMemberClear()
     _partyStatePrepped = 0;
 }
 
-// 0x494DD0 partyMemberSyncPosition_
+// 0x494DD0 partyMemberSyncPosition
 int _partyMemberSyncPosition()
 {
     int clockwiseRotation = (gDude->rotation + 2) % ROTATION_COUNT;
@@ -824,7 +824,7 @@ int _partyMemberSyncPosition()
 
 // Heals party members according to their healing rate.
 //
-// 0x494EB8 partyMemberRestingHeal_
+// 0x494EB8 partyMemberRestingHeal
 int _partyMemberRestingHeal(int hours)
 {
     int healingTicks = hours / 3;
@@ -843,7 +843,7 @@ int _partyMemberRestingHeal(int hours)
     return 1;
 }
 
-// 0x494F24 partyMemberFindObjFromPid_
+// 0x494F24 partyMemberFindObjFromPid
 Object* partyMemberFindByPid(int pid)
 {
     for (int index = 0; index < gPartyMembersLength; index++) {
@@ -856,7 +856,7 @@ Object* partyMemberFindByPid(int pid)
     return nullptr;
 }
 
-// 0x494F64 isPotentialPartyMember_
+// 0x494F64 isPotentialPartyMember
 bool _isPotentialPartyMember(Object* object)
 {
     for (int index = 0; index < gPartyMembersLength; index++) {
@@ -871,7 +871,7 @@ bool _isPotentialPartyMember(Object* object)
 
 // Returns `true` if specified object is a party member.
 //
-// 0x494FC4 isPartyMember_
+// 0x494FC4 isPartyMember
 bool objectIsPartyMember(Object* object)
 {
     if (object == nullptr) {
@@ -896,7 +896,7 @@ bool objectIsPartyMember(Object* object)
 
 // Returns number of active critters in the party.
 //
-// 0x495010 getPartyMemberCount_
+// 0x495010 getPartyMemberCount
 int _getPartyMemberCount()
 {
     int count = gPartyMembersLength;
@@ -912,7 +912,7 @@ int _getPartyMemberCount()
     return count;
 }
 
-// 0x495070 partyMemberNewObjID_
+// 0x495070 partyMemberNewObjID
 static int _partyMemberNewObjID()
 {
     Object* object;
@@ -954,7 +954,7 @@ static int _partyMemberNewObjID()
     return _curID;
 }
 
-// 0x4950F4 partyMemberNewObjIDRecurseFind_
+// 0x4950F4 partyMemberNewObjIDRecurseFind
 static int _partyMemberNewObjIDRecurseFind(Object* obj, int objectId)
 {
     Inventory* inventory = &(obj->data.inventory);
@@ -972,7 +972,7 @@ static int _partyMemberNewObjIDRecurseFind(Object* obj, int objectId)
     return 0;
 }
 
-// 0x495140 partyMemberPrepItemSaveAll_
+// 0x495140 partyMemberPrepItemSaveAll
 int _partyMemberPrepItemSaveAll()
 {
     for (int partyMemberIndex = 0; partyMemberIndex < gPartyMembersLength; partyMemberIndex++) {
@@ -1010,7 +1010,7 @@ static int _partyMemberPrepItemSave(Object* object)
     return 0;
 }
 
-// 0x495234 partyMemberItemSave_
+// 0x495234 partyMemberItemSave
 static int _partyMemberItemSave(Object* object)
 {
     if (object->sid != -1) {
@@ -1068,7 +1068,7 @@ static int _partyMemberItemSave(Object* object)
 }
 
 // partyMemberItemRecover
-// 0x495388 partyMemberItemRecover_
+// 0x495388 partyMemberItemRecover
 static int _partyMemberItemRecover(PartyMemberListItem* a1)
 {
     int sid = -1;
@@ -1104,7 +1104,7 @@ static int _partyMemberItemRecover(PartyMemberListItem* a1)
     return 0;
 }
 
-// 0x4954C4 partyMemberClearItemList_
+// 0x4954C4 partyMemberClearItemList
 static int _partyMemberClearItemList()
 {
     while (_itemSaveListHead != nullptr) {
@@ -1129,7 +1129,7 @@ static int _partyMemberClearItemList()
 
 // Returns best skill of the specified party member.
 //
-// 0x495520 partyMemberSkill_
+// 0x495520 partyMemberSkill
 int partyMemberGetBestSkill(Object* object)
 {
     int bestSkill = SKILL_SMALL_GUNS;
@@ -1156,7 +1156,7 @@ int partyMemberGetBestSkill(Object* object)
 
 // Returns party member with highest skill level.
 //
-// 0x495560 partyMemberWithHighestSkill_
+// 0x495560 partyMemberWithHighestSkill
 Object* partyMemberGetBestInSkill(int skill)
 {
     int bestValue = 0;
@@ -1178,7 +1178,7 @@ Object* partyMemberGetBestInSkill(int skill)
 
 // Returns highest skill level in party.
 //
-// 0x4955C8 partyMemberHighestSkillLevel_
+// 0x4955C8 partyMemberHighestSkillLevel
 int partyGetBestSkillValue(int skill)
 {
     int bestValue = 0;
@@ -1196,7 +1196,7 @@ int partyGetBestSkillValue(int skill)
     return bestValue;
 }
 
-// 0x495620 partyFixMultipleMembers_
+// 0x495620 partyFixMultipleMembers
 static int partyFixMultipleMembers()
 {
     debugPrint("\n\n\n[Party Members]:");
@@ -1277,7 +1277,7 @@ static int partyFixMultipleMembers()
     return 0;
 }
 
-// 0x495870 partyMemberSaveProtos_
+// 0x495870 partyMemberSaveProtos
 void _partyMemberSaveProtos()
 {
     for (int index = 1; index < gPartyMemberDescriptionsLength; index++) {
@@ -1288,7 +1288,7 @@ void _partyMemberSaveProtos()
     }
 }
 
-// 0x4958B0 partyMemberHasAIDisposition_
+// 0x4958B0 partyMemberHasAIDisposition
 bool partyMemberSupportsDisposition(Object* critter, int disposition)
 {
     if (critter == nullptr) {
@@ -1311,7 +1311,7 @@ bool partyMemberSupportsDisposition(Object* critter, int disposition)
     return partyMemberDescription->disposition[disposition + 1];
 }
 
-// 0x495920 partyMemberHasAIBurstValue_
+// 0x495920 partyMemberHasAIBurstValue
 bool partyMemberSupportsAreaAttackMode(Object* object, int areaAttackMode)
 {
     if (object == nullptr) {
@@ -1334,7 +1334,7 @@ bool partyMemberSupportsAreaAttackMode(Object* object, int areaAttackMode)
     return partyMemberDescription->areaAttackMode[areaAttackMode];
 }
 
-// 0x495980 partyMemberHasAIRunAwayValue_
+// 0x495980 partyMemberHasAIRunAwayValue
 bool partyMemberSupportsRunAwayMode(Object* object, int runAwayMode)
 {
     if (object == nullptr) {
@@ -1357,7 +1357,7 @@ bool partyMemberSupportsRunAwayMode(Object* object, int runAwayMode)
     return partyMemberDescription->runAwayMode[runAwayMode + 1];
 }
 
-// 0x4959E0 partyMemberHasAIWeaponPrefValue_
+// 0x4959E0 partyMemberHasAIWeaponPrefValue
 bool partyMemberSupportsBestWeapon(Object* object, int bestWeapon)
 {
     if (object == nullptr) {
@@ -1380,7 +1380,7 @@ bool partyMemberSupportsBestWeapon(Object* object, int bestWeapon)
     return partyMemberDescription->bestWeapon[bestWeapon];
 }
 
-// 0x495A40 partyMemberHasAIDistancePrefValue_
+// 0x495A40 partyMemberHasAIDistancePrefValue
 bool partyMemberSupportsDistance(Object* object, int distanceMode)
 {
     if (object == nullptr) {
@@ -1403,7 +1403,7 @@ bool partyMemberSupportsDistance(Object* object, int distanceMode)
     return partyMemberDescription->distanceMode[distanceMode];
 }
 
-// 0x495AA0 partyMemberHasAIAttackWhoValue_
+// 0x495AA0 partyMemberHasAIAttackWhoValue
 bool partyMemberSupportsAttackWho(Object* object, int attackWho)
 {
     if (object == nullptr) {
@@ -1426,7 +1426,7 @@ bool partyMemberSupportsAttackWho(Object* object, int attackWho)
     return partyMemberDescription->attackWho[attackWho];
 }
 
-// 0x495B00 partyMemberHasAIChemUseValue_
+// 0x495B00 partyMemberHasAIChemUseValue
 bool partyMemberSupportsChemUse(Object* object, int chemUse)
 {
     if (object == nullptr) {
@@ -1450,7 +1450,7 @@ bool partyMemberSupportsChemUse(Object* object, int chemUse)
 }
 
 // partyMemberIncLevels
-// 0x495B60 partyMemberIncLevels_
+// 0x495B60 partyMemberIncLevels
 int _partyMemberIncLevels()
 {
     int i;
@@ -1559,7 +1559,7 @@ int _partyMemberIncLevels()
     return 0;
 }
 
-// 0x495EA8 partyMemberCopyLevelInfo_
+// 0x495EA8 partyMemberCopyLevelInfo
 static int _partyMemberCopyLevelInfo(Object* critter, int stagePid)
 {
     if (critter == nullptr) {
@@ -1626,7 +1626,7 @@ static int _partyMemberCopyLevelInfo(Object* critter, int stagePid)
 // (they cannot be healed by resting) and dude (he/she has it's own "Rest
 // until healed" option).
 //
-// 0x496058 partyMemberNeedsHealing_
+// 0x496058 partyMemberNeedsHealing
 bool partyIsAnyoneCanBeHealedByRest()
 {
     for (int index = 1; index < gPartyMembersLength; index++) {
@@ -1651,7 +1651,7 @@ bool partyIsAnyoneCanBeHealedByRest()
 // Returns maximum amount of damage of any party member that can be healed thru
 // the rest.
 //
-// 0x4960DC partyMemberMaxHealingNeeded_
+// 0x4960DC partyMemberMaxHealingNeeded
 int partyGetMaxWoundToHealByRest()
 {
     int maxWound = 0;

--- a/src/pcx.cc
+++ b/src/pcx.cc
@@ -14,7 +14,7 @@ unsigned char gPcxLastValue = 0;
 // use high level reading functions, which can read right into struct. Instead
 // they read everything into temporary variables. There are no error checks.
 //
-// 0x4961D4
+// 0x4961D4 readPcxHeader_
 void pcxReadHeader(PcxHeader* pcxHeader, File* stream)
 {
     pcxHeader->identifier = fileReadChar(stream);
@@ -74,7 +74,7 @@ void pcxReadHeader(PcxHeader* pcxHeader, File* stream)
     }
 }
 
-// 0x49636C
+// 0x49636C pcxDecodeScanline_
 int pcxReadLine(unsigned char* data, int size, File* stream)
 {
     unsigned char runLength = gPcxLastRunLength;
@@ -114,7 +114,7 @@ int pcxReadLine(unsigned char* data, int size, File* stream)
     return uncompressedSize;
 }
 
-// 0x49641C
+// 0x49641C readPcxVgaPalette_
 int pcxReadPalette(PcxHeader* pcxHeader, unsigned char* palette, File* stream)
 {
     if (pcxHeader->version != 5) {
@@ -138,7 +138,7 @@ int pcxReadPalette(PcxHeader* pcxHeader, unsigned char* palette, File* stream)
     return 1;
 }
 
-// 0x496494
+// 0x496494 loadPCX_
 unsigned char* pcxRead(const char* path, int* widthPtr, int* heightPtr, unsigned char* palette)
 {
     File* stream = fileOpen(path, "rb");

--- a/src/pcx.cc
+++ b/src/pcx.cc
@@ -4,17 +4,17 @@
 
 namespace fallout {
 
-// 0x519DC8
+// 0x519DC8 runcount
 unsigned char gPcxLastRunLength = 0;
 
-// 0x519DC9
+// 0x519DC9 runvalue
 unsigned char gPcxLastValue = 0;
 
 // NOTE: The reading method in this function is a little bit odd. It does not
 // use high level reading functions, which can read right into struct. Instead
 // they read everything into temporary variables. There are no error checks.
 //
-// 0x4961D4 readPcxHeader_
+// 0x4961D4 readPcxHeader
 void pcxReadHeader(PcxHeader* pcxHeader, File* stream)
 {
     pcxHeader->identifier = fileReadChar(stream);
@@ -74,7 +74,7 @@ void pcxReadHeader(PcxHeader* pcxHeader, File* stream)
     }
 }
 
-// 0x49636C pcxDecodeScanline_
+// 0x49636C pcxDecodeScanline
 int pcxReadLine(unsigned char* data, int size, File* stream)
 {
     unsigned char runLength = gPcxLastRunLength;
@@ -114,7 +114,7 @@ int pcxReadLine(unsigned char* data, int size, File* stream)
     return uncompressedSize;
 }
 
-// 0x49641C readPcxVgaPalette_
+// 0x49641C readPcxVgaPalette
 int pcxReadPalette(PcxHeader* pcxHeader, unsigned char* palette, File* stream)
 {
     if (pcxHeader->version != 5) {
@@ -138,7 +138,7 @@ int pcxReadPalette(PcxHeader* pcxHeader, unsigned char* palette, File* stream)
     return 1;
 }
 
-// 0x496494 loadPCX_
+// 0x496494 loadPCX
 unsigned char* pcxRead(const char* path, int* widthPtr, int* heightPtr, unsigned char* palette)
 {
     File* stream = fileOpen(path, "rb");

--- a/src/perk.cc
+++ b/src/perk.cc
@@ -191,7 +191,7 @@ static int gHereAndNowBonusExperience = 0;
 // 0x6642D4
 static MessageList gPerksMessageList;
 
-// 0x4965A0
+// 0x4965A0 perk_init_
 int perksInit()
 {
     gPartyMemberPerkRanks = (PerkRankData*)internal_malloc(sizeof(*gPartyMemberPerkRanks) * gPartyMemberDescriptionsLength);
@@ -231,13 +231,13 @@ int perksInit()
     return 0;
 }
 
-// 0x4966B0
+// 0x4966B0 perk_reset_
 void perksReset()
 {
     perkResetRanks();
 }
 
-// 0x4966B8
+// 0x4966B8 perk_exit_
 void perksExit()
 {
     messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_PERK, nullptr);
@@ -249,7 +249,7 @@ void perksExit()
     }
 }
 
-// 0x4966E4
+// 0x4966E4 perk_load_
 int perksLoad(File* stream)
 {
     for (int index = 0; index < gPartyMemberDescriptionsLength; index++) {
@@ -264,7 +264,7 @@ int perksLoad(File* stream)
     return 0;
 }
 
-// 0x496738
+// 0x496738 perk_save_
 int perksSave(File* stream)
 {
     for (int index = 0; index < gPartyMemberDescriptionsLength; index++) {
@@ -280,7 +280,7 @@ int perksSave(File* stream)
 }
 
 // perkGetLevelData
-// 0x49678C
+// 0x49678C perkGetLevelData_
 static PerkRankData* perkGetRankData(Object* critter)
 {
     if (critter == gDude) {
@@ -298,7 +298,7 @@ static PerkRankData* perkGetRankData(Object* critter)
     return gPartyMemberPerkRanks;
 }
 
-// 0x49680C
+// 0x49680C perk_can_add_
 static bool perkCanAdd(Object* critter, int perk)
 {
     if (!perkIsValid(perk)) {
@@ -419,7 +419,7 @@ static bool perkCanAdd(Object* critter, int perk)
 
 // Resets party member perks.
 //
-// 0x496A0C
+// 0x496A0C perk_defaults_
 static void perkResetRanks()
 {
     for (int index = 0; index < gPartyMemberDescriptionsLength; index++) {
@@ -430,7 +430,7 @@ static void perkResetRanks()
     }
 }
 
-// 0x496A5C
+// 0x496A5C perk_add_
 int perkAdd(Object* critter, int perk)
 {
     if (!perkIsValid(perk)) {
@@ -450,7 +450,7 @@ int perkAdd(Object* critter, int perk)
 }
 
 // perk_add_force
-// 0x496A9C
+// 0x496A9C perk_add_force_
 int perkAddForce(Object* critter, int perk)
 {
     if (!perkIsValid(perk)) {
@@ -474,7 +474,7 @@ int perkAddForce(Object* critter, int perk)
 }
 
 // perk_sub
-// 0x496AFC
+// 0x496AFC perk_sub_
 int perkRemove(Object* critter, int perk)
 {
     if (!perkIsValid(perk)) {
@@ -497,7 +497,7 @@ int perkRemove(Object* critter, int perk)
 
 // Returns perks available to pick.
 //
-// 0x496B44
+// 0x496B44 perk_make_list_
 int perkGetAvailablePerks(Object* critter, int* perks)
 {
     int count = 0;
@@ -511,7 +511,7 @@ int perkGetAvailablePerks(Object* critter, int* perks)
 }
 
 // has_perk
-// 0x496B78
+// 0x496B78 perk_level_
 int perkGetRank(Object* critter, int perk)
 {
     if (!perkIsValid(perk)) {
@@ -522,7 +522,7 @@ int perkGetRank(Object* critter, int perk)
     return ranksData->ranks[perk];
 }
 
-// 0x496B90
+// 0x496B90 perk_name_
 char* perkGetName(int perk)
 {
     if (!perkIsValid(perk)) {
@@ -531,7 +531,7 @@ char* perkGetName(int perk)
     return gPerkDescriptions[perk].name;
 }
 
-// 0x496BB4
+// 0x496BB4 perk_description_
 char* perkGetDescription(int perk)
 {
     if (!perkIsValid(perk)) {
@@ -540,7 +540,7 @@ char* perkGetDescription(int perk)
     return gPerkDescriptions[perk].description;
 }
 
-// 0x496BD8
+// 0x496BD8 perk_skilldex_fid_
 int perkGetFrmId(int perk)
 {
     if (!perkIsValid(perk)) {
@@ -550,7 +550,7 @@ int perkGetFrmId(int perk)
 }
 
 // perk_add_effect
-// 0x496BFC
+// 0x496BFC perk_add_effect_
 void perkAddEffect(Object* critter, int perk)
 {
     if (PID_TYPE(critter->pid) != OBJ_TYPE_CRITTER) {
@@ -590,7 +590,7 @@ void perkAddEffect(Object* critter, int perk)
 }
 
 // perk_remove_effect
-// 0x496CE0
+// 0x496CE0 perk_remove_effect_
 void perkRemoveEffect(Object* critter, int perk)
 {
     if (PID_TYPE(critter->pid) != OBJ_TYPE_CRITTER) {
@@ -624,7 +624,7 @@ void perkRemoveEffect(Object* critter, int perk)
 
 // Returns modifier to specified skill accounting for perks.
 //
-// 0x496DD0
+// 0x496DD0 perk_adjust_skill_
 int perkGetSkillModifier(Object* critter, int skill)
 {
     int modifier = 0;

--- a/src/perk.cc
+++ b/src/perk.cc
@@ -52,7 +52,7 @@ static PerkRankData* perkGetRankData(Object* critter);
 static bool perkCanAdd(Object* critter, int perk);
 static void perkResetRanks();
 
-// 0x519DCC
+// 0x519DCC perk_data
 static PerkDescription gPerkDescriptions[PERK_COUNT] = {
     { nullptr, nullptr, 72, 1, 3, -1, 0, -1, 0, 0, -1, 0, 0, 5, 0, 0, 0, 0, 0 },
     { nullptr, nullptr, 73, 1, 15, -1, 0, -1, 0, 0, -1, 0, 0, 0, 0, 0, 0, 6, 0 },
@@ -177,21 +177,21 @@ static PerkDescription gPerkDescriptions[PERK_COUNT] = {
 
 // An array of perk ranks for each party member.
 //
-// 0x51C120
+// 0x51C120 perkLevelDataList
 static PerkRankData* gPartyMemberPerkRanks = nullptr;
 
 // Amount of experience points granted when player selected "Here and now"
 // perk.
 //
-// 0x51C124
+// 0x51C124 hereAndNowExps
 static int gHereAndNowBonusExperience = 0;
 
 // perk.msg
 //
-// 0x6642D4
+// 0x6642D4 perk_message_file
 static MessageList gPerksMessageList;
 
-// 0x4965A0 perk_init_
+// 0x4965A0 perk_init
 int perksInit()
 {
     gPartyMemberPerkRanks = (PerkRankData*)internal_malloc(sizeof(*gPartyMemberPerkRanks) * gPartyMemberDescriptionsLength);
@@ -231,13 +231,13 @@ int perksInit()
     return 0;
 }
 
-// 0x4966B0 perk_reset_
+// 0x4966B0 perk_reset
 void perksReset()
 {
     perkResetRanks();
 }
 
-// 0x4966B8 perk_exit_
+// 0x4966B8 perk_exit
 void perksExit()
 {
     messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_PERK, nullptr);
@@ -249,7 +249,7 @@ void perksExit()
     }
 }
 
-// 0x4966E4 perk_load_
+// 0x4966E4 perk_load
 int perksLoad(File* stream)
 {
     for (int index = 0; index < gPartyMemberDescriptionsLength; index++) {
@@ -264,7 +264,7 @@ int perksLoad(File* stream)
     return 0;
 }
 
-// 0x496738 perk_save_
+// 0x496738 perk_save
 int perksSave(File* stream)
 {
     for (int index = 0; index < gPartyMemberDescriptionsLength; index++) {
@@ -280,7 +280,7 @@ int perksSave(File* stream)
 }
 
 // perkGetLevelData
-// 0x49678C perkGetLevelData_
+// 0x49678C perkGetLevelData
 static PerkRankData* perkGetRankData(Object* critter)
 {
     if (critter == gDude) {
@@ -298,7 +298,7 @@ static PerkRankData* perkGetRankData(Object* critter)
     return gPartyMemberPerkRanks;
 }
 
-// 0x49680C perk_can_add_
+// 0x49680C perk_can_add
 static bool perkCanAdd(Object* critter, int perk)
 {
     if (!perkIsValid(perk)) {
@@ -419,7 +419,7 @@ static bool perkCanAdd(Object* critter, int perk)
 
 // Resets party member perks.
 //
-// 0x496A0C perk_defaults_
+// 0x496A0C perk_defaults
 static void perkResetRanks()
 {
     for (int index = 0; index < gPartyMemberDescriptionsLength; index++) {
@@ -430,7 +430,7 @@ static void perkResetRanks()
     }
 }
 
-// 0x496A5C perk_add_
+// 0x496A5C perk_add
 int perkAdd(Object* critter, int perk)
 {
     if (!perkIsValid(perk)) {
@@ -450,7 +450,7 @@ int perkAdd(Object* critter, int perk)
 }
 
 // perk_add_force
-// 0x496A9C perk_add_force_
+// 0x496A9C perk_add_force
 int perkAddForce(Object* critter, int perk)
 {
     if (!perkIsValid(perk)) {
@@ -474,7 +474,7 @@ int perkAddForce(Object* critter, int perk)
 }
 
 // perk_sub
-// 0x496AFC perk_sub_
+// 0x496AFC perk_sub
 int perkRemove(Object* critter, int perk)
 {
     if (!perkIsValid(perk)) {
@@ -497,7 +497,7 @@ int perkRemove(Object* critter, int perk)
 
 // Returns perks available to pick.
 //
-// 0x496B44 perk_make_list_
+// 0x496B44 perk_make_list
 int perkGetAvailablePerks(Object* critter, int* perks)
 {
     int count = 0;
@@ -511,7 +511,7 @@ int perkGetAvailablePerks(Object* critter, int* perks)
 }
 
 // has_perk
-// 0x496B78 perk_level_
+// 0x496B78 perk_level
 int perkGetRank(Object* critter, int perk)
 {
     if (!perkIsValid(perk)) {
@@ -522,7 +522,7 @@ int perkGetRank(Object* critter, int perk)
     return ranksData->ranks[perk];
 }
 
-// 0x496B90 perk_name_
+// 0x496B90 perk_name
 char* perkGetName(int perk)
 {
     if (!perkIsValid(perk)) {
@@ -531,7 +531,7 @@ char* perkGetName(int perk)
     return gPerkDescriptions[perk].name;
 }
 
-// 0x496BB4 perk_description_
+// 0x496BB4 perk_description
 char* perkGetDescription(int perk)
 {
     if (!perkIsValid(perk)) {
@@ -540,7 +540,7 @@ char* perkGetDescription(int perk)
     return gPerkDescriptions[perk].description;
 }
 
-// 0x496BD8 perk_skilldex_fid_
+// 0x496BD8 perk_skilldex_fid
 int perkGetFrmId(int perk)
 {
     if (!perkIsValid(perk)) {
@@ -550,7 +550,7 @@ int perkGetFrmId(int perk)
 }
 
 // perk_add_effect
-// 0x496BFC perk_add_effect_
+// 0x496BFC perk_add_effect
 void perkAddEffect(Object* critter, int perk)
 {
     if (PID_TYPE(critter->pid) != OBJ_TYPE_CRITTER) {
@@ -590,7 +590,7 @@ void perkAddEffect(Object* critter, int perk)
 }
 
 // perk_remove_effect
-// 0x496CE0 perk_remove_effect_
+// 0x496CE0 perk_remove_effect
 void perkRemoveEffect(Object* critter, int perk)
 {
     if (PID_TYPE(critter->pid) != OBJ_TYPE_CRITTER) {
@@ -624,7 +624,7 @@ void perkRemoveEffect(Object* critter, int perk)
 
 // Returns modifier to specified skill accounting for perks.
 //
-// 0x496DD0 perk_adjust_skill_
+// 0x496DD0 perk_adjust_skill
 int perkGetSkillModifier(Object* critter, int skill)
 {
     int modifier = 0;

--- a/src/pipboy.cc
+++ b/src/pipboy.cc
@@ -261,13 +261,13 @@ const int gPipboyFrmIds[PIPBOY_FRM_COUNT] = {
     226,
 };
 
-// 0x51C128 _quests
+// 0x51C128 quests
 QuestDescription* gQuestDescriptions = nullptr;
 
 // 0x51C12C quest_count
 int gQuestsCount = 0;
 
-// 0x51C130 _holodisks
+// 0x51C130 holodisks
 HolodiskDescription* gHolodiskDescriptions = nullptr;
 
 // 0x51C134 holodisks_count
@@ -293,7 +293,7 @@ const HolidayDescription gHolidayDescriptions[HOLIDAY_COUNT] = {
     { 12, 25, 107 },
 };
 
-// 0x51C170 _PipFnctn
+// 0x51C170 PipFnctn
 PipboyRenderProc* _PipFnctn[5] = {
     pipboyWindowHandleStatus,
     pipboyWindowHandleAutomaps,
@@ -310,7 +310,7 @@ MessageListItem gPipboyMessageListItem;
 // 0x664348 pipboy_message_file
 MessageList gPipboyMessageList = { 0, nullptr };
 
-// 0x664350 _sortlist
+// 0x664350 sortlist
 STRUCT_664350 _sortlist[24];
 
 // quests.msg
@@ -341,7 +341,7 @@ unsigned int gPipboyLastEventTimestamp;
 // 0x66445C holopages
 int gPipboyHolodiskLastPage;
 
-// 0x664460 _HotLines
+// 0x664460 HotLines
 int _HotLines[22];
 
 // 0x6644B8 button

--- a/src/pipboy.cc
+++ b/src/pipboy.cc
@@ -238,7 +238,7 @@ static int questDescriptionCompare(const void* a1, const void* a2);
 static int holodiskInit();
 static void holodiskFree();
 
-// 0x496FC0
+// 0x496FC0 pip_rect
 const Rect gPipboyWindowContentRect = {
     PIPBOY_WINDOW_CONTENT_VIEW_X,
     PIPBOY_WINDOW_CONTENT_VIEW_Y,
@@ -246,7 +246,7 @@ const Rect gPipboyWindowContentRect = {
     PIPBOY_WINDOW_CONTENT_VIEW_Y + PIPBOY_WINDOW_CONTENT_VIEW_HEIGHT,
 };
 
-// 0x496FD0
+// 0x496FD0 pipgrphs
 const int gPipboyFrmIds[PIPBOY_FRM_COUNT] = {
     8,
     9,
@@ -261,27 +261,27 @@ const int gPipboyFrmIds[PIPBOY_FRM_COUNT] = {
     226,
 };
 
-// 0x51C128
+// 0x51C128 _quests
 QuestDescription* gQuestDescriptions = nullptr;
 
-// 0x51C12C
+// 0x51C12C quest_count
 int gQuestsCount = 0;
 
-// 0x51C130
+// 0x51C130 _holodisks
 HolodiskDescription* gHolodiskDescriptions = nullptr;
 
-// 0x51C134
+// 0x51C134 holodisks_count
 int gHolodisksCount = 0;
 
 // Number of rest options available.
 //
-// 0x51C138
+// 0x51C138 currentAlarmTypeCount
 int gPipboyRestOptionsCount = PIPBOY_REST_DURATION_COUNT;
 
-// 0x51C13C
+// 0x51C13C bk_enable_5
 bool gPipboyWindowIsoWasEnabled = false;
 
-// 0x51C140
+// 0x51C140 SpclDate
 const HolidayDescription gHolidayDescriptions[HOLIDAY_COUNT] = {
     { 1, 1, 100 },
     { 2, 14, 101 },
@@ -293,7 +293,7 @@ const HolidayDescription gHolidayDescriptions[HOLIDAY_COUNT] = {
     { 12, 25, 107 },
 };
 
-// 0x51C170
+// 0x51C170 _PipFnctn
 PipboyRenderProc* _PipFnctn[5] = {
     pipboyWindowHandleStatus,
     pipboyWindowHandleAutomaps,
@@ -302,76 +302,76 @@ PipboyRenderProc* _PipFnctn[5] = {
     pipboyHandleAlarmClock,
 };
 
-// 0x664338
+// 0x664338 pipmesg
 MessageListItem gPipboyMessageListItem;
 
 // pipboy.msg
 //
-// 0x664348
+// 0x664348 pipboy_message_file
 MessageList gPipboyMessageList = { 0, nullptr };
 
-// 0x664350
+// 0x664350 _sortlist
 STRUCT_664350 _sortlist[24];
 
 // quests.msg
 //
-// 0x664410
+// 0x664410 quest_message_file
 MessageList gQuestsMessageList;
 
-// 0x664418
+// 0x664418 statcount
 int gPipboyQuestLocationsCount;
 
-// 0x66441C
+// 0x66441C scrn_buf
 unsigned char* gPipboyWindowBuffer;
 
-// 0x66444C
+// 0x66444C holocount
 int gPipboyWindowHolodisksCount;
 
-// 0x664450
+// 0x664450 mouse_y
 int gPipboyMouseY;
 
-// 0x664454
+// 0x664454 mouse_x
 int gPipboyMouseX;
 
-// 0x664458
+// 0x664458 wait_time
 unsigned int gPipboyLastEventTimestamp;
 
 // Index of the last page when rendering holodisk content.
 //
-// 0x66445C
+// 0x66445C holopages
 int gPipboyHolodiskLastPage;
 
-// 0x664460
+// 0x664460 _HotLines
 int _HotLines[22];
 
-// 0x6644B8
+// 0x6644B8 button
 int _button;
 
-// 0x6644BC
+// 0x6644BC old_mouse_x
 int gPipboyPreviousMouseX;
 
-// 0x6644C0
+// 0x6644C0 old_mouse_y
 int gPipboyPreviousMouseY;
 
-// 0x6644C4
+// 0x6644C4 pip_win
 int gPipboyWindow;
 
-// 0x6644F4
+// 0x6644F4 holodisk
 int _holodisk;
 
-// 0x6644F8
+// 0x6644F8 hot_line_count
 int gPipboyWindowButtonCount;
 
-// 0x6644FC
+// 0x6644FC savefont
 int gPipboyWindowOldFont;
 
-// 0x664500
+// 0x664500 proc_bail_flag
 bool _proc_bail_flag;
 
-// 0x664504
+// 0x664504 amlst_mode
 int main_sub_mode;
 
-// 0x664508
+// 0x664508 crnt_func
 int gPipboyTab;
 
 // automap location count
@@ -383,16 +383,16 @@ int _map_count;
 // adjusted index for pagination
 int realIndex;
 
-// 0x664510
+// 0x664510 hot_line_start
 int gPipboyWindowButtonStart;
 
-// 0x664514
+// 0x664514 cursor_line
 int gPipboyCurrentLine;
 
-// 0x664518
+// 0x664518 rest_time
 int _rest_time;
 
-// 0x66451C
+// 0x66451C amcty_indx
 int _amcty_indx;
 
 // current page for holodisk entry pagination
@@ -413,16 +413,16 @@ int _view_page_questlist;
 // current page for main holodisk pagination
 int _view_page_holodisk;
 
-// 0x664524
+// 0x664524 bottom_line
 int gPipboyLinesCount;
 
-// 0x664528
+// 0x664528 hot_back_line
 unsigned char _hot_back_line;
 
-// 0x664529
+// 0x664529 holo_flag
 unsigned char _holo_flag;
 
-// 0x66452A
+// 0x66452A stat_flag
 unsigned char _stat_flag;
 
 void handlePipboyPageNavigation(

--- a/src/preferences.cc
+++ b/src/preferences.cc
@@ -116,7 +116,7 @@ static int preferencesWindowInit();
 static int preferencesWindowFree();
 static void _DoThing(int eventCode);
 
-// 0x48FBD0
+// 0x48FBD0 row1Ytab
 static const int _row1Ytab[PRIMARY_PREF_COUNT] = {
     48,
     125,
@@ -125,7 +125,7 @@ static const int _row1Ytab[PRIMARY_PREF_COUNT] = {
     363,
 };
 
-// 0x48FBDA
+// 0x48FBDA row2Ytab
 static const int _row2Ytab[SECONDARY_PREF_COUNT] = {
     49,
     116,
@@ -135,7 +135,7 @@ static const int _row2Ytab[SECONDARY_PREF_COUNT] = {
     380,
 };
 
-// 0x48FBE6
+// 0x48FBE6 row3Ytab
 static const int _row3Ytab[RANGE_PREF_COUNT] = {
     19,
     94,
@@ -148,7 +148,7 @@ static const int _row3Ytab[RANGE_PREF_COUNT] = {
 };
 
 // x offsets for primary preferences from the knob position
-// 0x48FBF6
+// 0x48FBF6 _bglbx
 static const short kPrimaryOptionLabelXOffsetByValue[PRIMARY_OPTION_VALUE_COUNT] = {
     2,
     25,
@@ -157,7 +157,7 @@ static const short kPrimaryOptionLabelXOffsetByValue[PRIMARY_OPTION_VALUE_COUNT]
 };
 
 // y offsets for primary preference option values from the knob position
-// 0x48FBFE
+// 0x48FBFE _bglby
 static const short kPrimaryOptionLabelYOffsetByValue[PRIMARY_OPTION_VALUE_COUNT] = {
     10,
     -4,
@@ -166,7 +166,7 @@ static const short kPrimaryOptionLabelYOffsetByValue[PRIMARY_OPTION_VALUE_COUNT]
 };
 
 // x offsets for secondary prefrence option values from the knob position
-// 0x48FC06
+// 0x48FC06 _smlbx
 static const short word_48FC06[SECONDARY_OPTION_VALUE_COUNT] = {
     4,
     21,
@@ -211,7 +211,7 @@ static const double kTextLineDelayScale = 0.2;
 // 0x50C2E0
 static const double kTextLineDelayRange = 2.0;
 
-// 0x5197CC
+// 0x5197CC prfgrphs
 static const int gPreferencesWindowFrmIds[PREFERENCES_WINDOW_FRM_COUNT] = {
     240, // prefscrn.frm - options screen
     241, // prfsldof.frm - options screen
@@ -225,37 +225,37 @@ static const int gPreferencesWindowFrmIds[PREFERENCES_WINDOW_FRM_COUNT] = {
     9, // lilreddn.frm - little red button down
 };
 
-// 0x6637E8
+// 0x6637E8 optn_msgfl
 static MessageList gPreferencesMessageList;
 
-// 0x663840
+// 0x663840 optnmesg
 static MessageListItem gPreferencesMessageListItem;
 
-// 0x6638C8
+// 0x6638C8 _text_delay_back
 static double gPreferencesTextBaseDelay2;
 
-// 0x6638D0
+// 0x6638D0 gamma_value
 static double gPreferencesBrightness1;
 
-// 0x6638D8
+// 0x6638D8 _gamma_value_back
 static double gPreferencesBrightness2;
 
-// 0x6638E0
+// 0x6638E0 text_delay
 static double gPreferencesTextBaseDelay1;
 
-// 0x6638E8
+// 0x6638E8 mouse_sens
 static double gPreferencesMouseSensitivity1;
 
-// 0x6638F0
+// 0x6638F0 _mouse_sens_back
 static double gPreferencesMouseSensitivity2;
 
-// 0x6638F8
+// 0x6638F8 prefbuf
 static unsigned char* gPreferencesWindowBuffer;
 
-// 0x663904
+// 0x663904 prfwin
 static int gPreferencesWindow = -1;
 
-// 0x663924
+// 0x663924 _settings_backup
 static int gPreferencesGameDifficulty2;
 
 // 0x663928
@@ -306,43 +306,43 @@ static int gPreferencesSoundEffectsVolume2;
 // 0x663964
 static int gPreferencesSpeechVolume2;
 
-// 0x663970
+// 0x663970 sndfx_volume_2
 static int gPreferencesSoundEffectsVolume1;
 
-// 0x663974
+// 0x663974 subtitles
 static int gPreferencesSubtitles1;
 
-// 0x663978
+// 0x663978 language_filter
 static int gPreferencesLanguageFilter1;
 
-// 0x66397C
+// 0x66397C speech_volume_2
 static int gPreferencesSpeechVolume1;
 
-// 0x663980
+// 0x663980 master_volume_2
 static int gPreferencesMasterVolume1;
 
-// 0x663984
+// 0x663984 player_speedup
 static int gPreferencesPlayerSpeedup1;
 
-// 0x663988
+// 0x663988 combat_taunts
 static int gPreferencesCombatTaunts1;
 
-// 0x663990
+// 0x663990 music_volume
 static int gPreferencesMusicVolume1;
 
-// 0x663998
+// 0x663998 prf_running
 static int gPreferencesRunning1;
 
-// 0x66399C
+// 0x66399C combat_speed
 static int gPreferencesCombatSpeed1;
 
-// 0x6639A0
+// 0x6639A0 plyrspdbid
 static int _plyrspdbid;
 
-// 0x6639A4
+// 0x6639A4 item_highlight
 static int gPreferencesItemHighlight1;
 
-// 0x6639A8
+// 0x6639A8 changed
 static bool _changed;
 
 static void preferencesRefreshBrightnessSlider()
@@ -351,25 +351,25 @@ static void preferencesRefreshBrightnessSlider()
     windowRefresh(gPreferencesWindow);
 }
 
-// 0x6639AC
+// 0x6639AC combat_messages
 static int gPreferencesCombatMessages1;
 
-// 0x6639B0
+// 0x6639B0 target_highlight
 static int gPreferencesTargetHighlight1;
 
-// 0x6639B4
+// 0x6639B4 combat_difficulty
 static int gPreferencesCombatDifficulty1;
 
-// 0x6639B8
+// 0x6639B8 violence_level
 static int gPreferencesViolenceLevel1;
 
-// 0x6639BC
+// 0x6639BC game_difficulty
 static int gPreferencesGameDifficulty1;
 
-// 0x6639C0
+// 0x6639C0 combatLookValue
 static int gPreferencesCombatLooks1;
 
-// 0x5197F8
+// 0x5197F8 btndat
 static PreferenceDescription gPreferenceDescriptions[PREF_COUNT] = {
     { 3, 0, 76, 71, 0, 0, { 203, 204, 205, 0 }, 0, 0, 0, &gPreferencesGameDifficulty1 },
     { 3, 0, 76, 149, 0, 0, { 206, 204, 208, 0 }, 0, 0, 0, &gPreferencesCombatDifficulty1 },
@@ -406,7 +406,7 @@ int preferencesInit()
     return 0;
 }
 
-// 0x492AA8 SetSystemPrefs_
+// 0x492AA8 SetSystemPrefs
 static void _SetSystemPrefs()
 {
     preferencesSetDefaults(false);
@@ -435,7 +435,7 @@ static void _SetSystemPrefs()
     _JustUpdate_();
 }
 
-// 0x493054 SaveSettings_
+// 0x493054 SaveSettings
 static void _SaveSettings()
 {
     gPreferencesGameDifficulty2 = gPreferencesGameDifficulty1;
@@ -460,7 +460,7 @@ static void _SaveSettings()
     gPreferencesSpeechVolume2 = gPreferencesSpeechVolume1;
 }
 
-// 0x493128 RestoreSettings_
+// 0x493128 RestoreSettings
 static void _RestoreSettings()
 {
     gPreferencesGameDifficulty1 = gPreferencesGameDifficulty2;
@@ -487,7 +487,7 @@ static void _RestoreSettings()
     _JustUpdate_();
 }
 
-// 0x492F60 SetDefaults_
+// 0x492F60 SetDefaults
 static void preferencesSetDefaults(bool updateUi)
 {
     gPreferencesCombatDifficulty1 = COMBAT_DIFFICULTY_NORMAL;
@@ -562,7 +562,7 @@ static void _JustUpdate_()
     colorSetBrightness(gPreferencesBrightness1);
 }
 
-// 0x491A68 UpdateThing_
+// 0x491A68 UpdateThing
 static void _UpdateThing(int index)
 {
     fontSetCurrent(101);
@@ -778,7 +778,7 @@ static void _UpdateThing(int index)
     // return true;
 }
 
-// 0x492CB0 SavePrefs_
+// 0x492CB0 SavePrefs
 int _SavePrefs(bool save)
 {
     settings.preferences.game_difficulty = gPreferencesGameDifficulty1;
@@ -909,7 +909,7 @@ err:
     return -1;
 }
 
-// 0x4928E4 IncGamma_
+// 0x4928E4 IncGamma
 // Note: this can be called from many different contexts, not just the preferences window.
 void brightnessIncrease()
 {
@@ -939,7 +939,7 @@ void brightnessIncrease()
     }
 }
 
-// 0x4929C8 DecGamma_
+// 0x4929C8 DecGamma
 void brightnessDecrease()
 {
     if (!GameMode::isInGameMode(GameMode::kPreferences)) {
@@ -968,7 +968,7 @@ void brightnessDecrease()
     }
 }
 
-// 0x4908A0 PrefStart_
+// 0x4908A0 PrefStart
 static int preferencesWindowInit()
 {
     int i;
@@ -1191,7 +1191,7 @@ static int preferencesWindowInit()
     return 0;
 }
 
-// 0x492870 PrefEnd_
+// 0x492870 PrefEnd
 static int preferencesWindowFree()
 {
     if (_changed) {
@@ -1216,7 +1216,7 @@ static int preferencesWindowFree()
     return 0;
 }
 
-// 0x490798 do_prefscreen_
+// 0x490798 do_prefscreen
 int doPreferences(bool animated)
 {
     ScopedGameMode gm(GameMode::kPreferences);
@@ -1299,7 +1299,7 @@ int doPreferences(bool animated)
     return rc;
 }
 
-// 0x490E8C DoThing_
+// 0x490E8C DoThing
 static void _DoThing(int eventCode)
 {
     int x;

--- a/src/preferences.cc
+++ b/src/preferences.cc
@@ -148,7 +148,7 @@ static const int _row3Ytab[RANGE_PREF_COUNT] = {
 };
 
 // x offsets for primary preferences from the knob position
-// 0x48FBF6 _bglbx
+// 0x48FBF6 bglbx
 static const short kPrimaryOptionLabelXOffsetByValue[PRIMARY_OPTION_VALUE_COUNT] = {
     2,
     25,
@@ -157,7 +157,7 @@ static const short kPrimaryOptionLabelXOffsetByValue[PRIMARY_OPTION_VALUE_COUNT]
 };
 
 // y offsets for primary preference option values from the knob position
-// 0x48FBFE _bglby
+// 0x48FBFE bglby
 static const short kPrimaryOptionLabelYOffsetByValue[PRIMARY_OPTION_VALUE_COUNT] = {
     10,
     -4,
@@ -166,7 +166,7 @@ static const short kPrimaryOptionLabelYOffsetByValue[PRIMARY_OPTION_VALUE_COUNT]
 };
 
 // x offsets for secondary prefrence option values from the knob position
-// 0x48FC06 _smlbx
+// 0x48FC06 smlbx
 static const short word_48FC06[SECONDARY_OPTION_VALUE_COUNT] = {
     4,
     21,
@@ -231,13 +231,13 @@ static MessageList gPreferencesMessageList;
 // 0x663840 optnmesg
 static MessageListItem gPreferencesMessageListItem;
 
-// 0x6638C8 _text_delay_back
+// 0x6638C8 text_delay_back
 static double gPreferencesTextBaseDelay2;
 
 // 0x6638D0 gamma_value
 static double gPreferencesBrightness1;
 
-// 0x6638D8 _gamma_value_back
+// 0x6638D8 gamma_value_back
 static double gPreferencesBrightness2;
 
 // 0x6638E0 text_delay
@@ -246,7 +246,7 @@ static double gPreferencesTextBaseDelay1;
 // 0x6638E8 mouse_sens
 static double gPreferencesMouseSensitivity1;
 
-// 0x6638F0 _mouse_sens_back
+// 0x6638F0 mouse_sens_back
 static double gPreferencesMouseSensitivity2;
 
 // 0x6638F8 prefbuf
@@ -255,7 +255,7 @@ static unsigned char* gPreferencesWindowBuffer;
 // 0x663904 prfwin
 static int gPreferencesWindow = -1;
 
-// 0x663924 _settings_backup
+// 0x663924 settings_backup
 static int gPreferencesGameDifficulty2;
 
 // 0x663928

--- a/src/preferences.cc
+++ b/src/preferences.cc
@@ -406,7 +406,7 @@ int preferencesInit()
     return 0;
 }
 
-// 0x492AA8
+// 0x492AA8 SetSystemPrefs_
 static void _SetSystemPrefs()
 {
     preferencesSetDefaults(false);
@@ -435,7 +435,7 @@ static void _SetSystemPrefs()
     _JustUpdate_();
 }
 
-// 0x493054
+// 0x493054 SaveSettings_
 static void _SaveSettings()
 {
     gPreferencesGameDifficulty2 = gPreferencesGameDifficulty1;
@@ -460,7 +460,7 @@ static void _SaveSettings()
     gPreferencesSpeechVolume2 = gPreferencesSpeechVolume1;
 }
 
-// 0x493128
+// 0x493128 RestoreSettings_
 static void _RestoreSettings()
 {
     gPreferencesGameDifficulty1 = gPreferencesGameDifficulty2;
@@ -487,7 +487,7 @@ static void _RestoreSettings()
     _JustUpdate_();
 }
 
-// 0x492F60
+// 0x492F60 SetDefaults_
 static void preferencesSetDefaults(bool updateUi)
 {
     gPreferencesCombatDifficulty1 = COMBAT_DIFFICULTY_NORMAL;
@@ -562,7 +562,7 @@ static void _JustUpdate_()
     colorSetBrightness(gPreferencesBrightness1);
 }
 
-// 0x491A68
+// 0x491A68 UpdateThing_
 static void _UpdateThing(int index)
 {
     fontSetCurrent(101);
@@ -778,7 +778,7 @@ static void _UpdateThing(int index)
     // return true;
 }
 
-// 0x492CB0
+// 0x492CB0 SavePrefs_
 int _SavePrefs(bool save)
 {
     settings.preferences.game_difficulty = gPreferencesGameDifficulty1;
@@ -909,7 +909,7 @@ err:
     return -1;
 }
 
-// 0x4928E4
+// 0x4928E4 IncGamma_
 // Note: this can be called from many different contexts, not just the preferences window.
 void brightnessIncrease()
 {
@@ -939,7 +939,7 @@ void brightnessIncrease()
     }
 }
 
-// 0x4929C8
+// 0x4929C8 DecGamma_
 void brightnessDecrease()
 {
     if (!GameMode::isInGameMode(GameMode::kPreferences)) {
@@ -968,7 +968,7 @@ void brightnessDecrease()
     }
 }
 
-// 0x4908A0
+// 0x4908A0 PrefStart_
 static int preferencesWindowInit()
 {
     int i;
@@ -1191,7 +1191,7 @@ static int preferencesWindowInit()
     return 0;
 }
 
-// 0x492870
+// 0x492870 PrefEnd_
 static int preferencesWindowFree()
 {
     if (_changed) {
@@ -1216,7 +1216,7 @@ static int preferencesWindowFree()
     return 0;
 }
 
-// 0x490798
+// 0x490798 do_prefscreen_
 int doPreferences(bool animated)
 {
     ScopedGameMode gm(GameMode::kPreferences);
@@ -1299,7 +1299,7 @@ int doPreferences(bool animated)
     return rc;
 }
 
-// 0x490E8C
+// 0x490E8C DoThing_
 static void _DoThing(int eventCode)
 {
     int x;

--- a/src/proto.cc
+++ b/src/proto.cc
@@ -185,7 +185,7 @@ static char** _perk_code_strs;
 // 0x6648BC
 static char** _critter_stats_list;
 
-// 0x49E270
+// 0x49E270 proto_make_path_
 void proto_make_path(char* path, int pid)
 {
     strcpy(path, _cd_path_base);
@@ -197,7 +197,7 @@ void proto_make_path(char* path, int pid)
 
 // Append proto file name to proto_path from proto.lst.
 //
-// 0x49E758
+// 0x49E758 proto_list_str_
 int _proto_list_str(int pid, char* proto_path)
 {
     if (pid == -1) {
@@ -247,13 +247,13 @@ int _proto_list_str(int pid, char* proto_path)
     return 0;
 }
 
-// 0x49E984
+// 0x49E984 proto_size_
 size_t proto_size(int type)
 {
     return type >= 0 && type < OBJ_TYPE_COUNT ? _proto_sizes[type] : 0;
 }
 
-// 0x49E99C
+// 0x49E99C proto_action_can_use_
 bool _proto_action_can_use(int pid)
 {
     Proto* proto;
@@ -272,7 +272,7 @@ bool _proto_action_can_use(int pid)
     return false;
 }
 
-// 0x49E9DC
+// 0x49E9DC proto_action_can_use_on_
 bool _proto_action_can_use_on(int pid)
 {
     Proto* proto;
@@ -291,7 +291,7 @@ bool _proto_action_can_use_on(int pid)
     return false;
 }
 
-// 0x49EA24
+// 0x49EA24 proto_action_can_talk_to_
 bool _proto_action_can_talk_to(int pid)
 {
     Proto* proto;
@@ -312,7 +312,7 @@ bool _proto_action_can_talk_to(int pid)
 
 // Likely returns true if item with given pid can be picked up.
 //
-// 0x49EA5C
+// 0x49EA5C proto_action_can_pickup_
 int _proto_action_can_pickup(int pid)
 {
     if (PID_TYPE(pid) != OBJ_TYPE_ITEM) {
@@ -331,7 +331,7 @@ int _proto_action_can_pickup(int pid)
     return true;
 }
 
-// 0x49EAA4
+// 0x49EAA4 proto_get_msg_info_
 char* protoGetMessage(int pid, int message)
 {
     char* messageText = _proto_none_str;
@@ -352,7 +352,7 @@ char* protoGetMessage(int pid, int message)
     return messageText;
 }
 
-// 0x49EAFC
+// 0x49EAFC proto_name_
 char* protoGetName(int pid)
 {
     if (pid == 0x1000000) {
@@ -362,13 +362,13 @@ char* protoGetName(int pid)
     return protoGetMessage(pid, PROTOTYPE_MESSAGE_NAME);
 }
 
-// 0x49EB1C
+// 0x49EB1C proto_description_
 char* protoGetDescription(int pid)
 {
     return protoGetMessage(pid, PROTOTYPE_MESSAGE_DESCRIPTION);
 }
 
-// 0x49EB2C
+// 0x49EB2C proto_item_init_
 int proto_item_init(Proto* proto, int pid)
 {
     int protoNum = pid & 0xFFFFFF;
@@ -396,7 +396,7 @@ int proto_item_init(Proto* proto, int pid)
     return 0;
 }
 
-// 0x49EBFC
+// 0x49EBFC proto_item_subdata_init_
 int proto_item_subdata_init(Proto* proto, int type)
 {
     int index;
@@ -479,7 +479,7 @@ int proto_item_subdata_init(Proto* proto, int type)
     return 0;
 }
 
-// 0x49EDB4
+// 0x49EDB4 proto_critter_init_
 int proto_critter_init(Proto* proto, int pid)
 {
     if (!_protos_been_initialized) {
@@ -514,7 +514,7 @@ int proto_critter_init(Proto* proto, int pid)
     return 0;
 }
 
-// 0x49EEA4
+// 0x49EEA4 clear_pupdate_data_
 void objectDataReset(Object* obj)
 {
     // NOTE: Original code is slightly different. It uses loop to zero object
@@ -522,7 +522,7 @@ void objectDataReset(Object* obj)
     memset(&(obj->data), 0, sizeof(obj->data));
 }
 
-// 0x49EEB8
+// 0x49EEB8 proto_read_CombatData_
 static int objectCritterCombatDataRead(CritterCombatData* data, File* stream)
 {
     if (fileReadInt32(stream, &(data->damageLastTurn)) == -1) return -1;
@@ -536,7 +536,7 @@ static int objectCritterCombatDataRead(CritterCombatData* data, File* stream)
     return 0;
 }
 
-// 0x49EF40
+// 0x49EF40 proto_write_CombatData_
 static int objectCritterCombatDataWrite(CritterCombatData* data, File* stream)
 {
     if (fileWriteInt32(stream, data->damageLastTurn) == -1) return -1;
@@ -550,7 +550,7 @@ static int objectCritterCombatDataWrite(CritterCombatData* data, File* stream)
     return 0;
 }
 
-// 0x49F004
+// 0x49F004 proto_read_protoUpdateData_
 int objectDataRead(Object* obj, File* stream)
 {
     Proto* proto;
@@ -647,7 +647,7 @@ int objectDataRead(Object* obj, File* stream)
     return 0;
 }
 
-// 0x49F428
+// 0x49F428 proto_write_protoUpdateData_
 int objectDataWrite(Object* obj, File* stream)
 {
     Proto* proto;
@@ -730,7 +730,7 @@ int objectDataWrite(Object* obj, File* stream)
     return 0;
 }
 
-// 0x49F73C
+// 0x49F73C proto_update_gen_
 static int _proto_update_gen(Object* obj)
 {
     Proto* proto;
@@ -803,7 +803,7 @@ static int _proto_update_gen(Object* obj)
     return 0;
 }
 
-// 0x49F8A0
+// 0x49F8A0 proto_update_init_
 int _proto_update_init(Object* obj)
 {
     if (!_protos_been_initialized) {
@@ -843,7 +843,7 @@ int _proto_update_init(Object* obj)
     return 0;
 }
 
-// 0x49F984
+// 0x49F984 proto_dude_update_gender_
 int _proto_dude_update_gender()
 {
     Proto* proto;
@@ -881,7 +881,7 @@ int _proto_dude_update_gender()
 }
 
 // proto_dude_init
-// 0x49FA64
+// 0x49FA64 proto_dude_init_
 int _proto_dude_init(const char* path)
 {
     gDudeProto.fid = buildFid(OBJ_TYPE_CRITTER, _art_vault_guy_num, 0, 0, 0);
@@ -935,7 +935,7 @@ int _proto_dude_init(const char* path)
     return 0;
 }
 
-// 0x49FBBC
+// 0x49FBBC proto_scenery_init_
 int proto_scenery_init(Proto* proto, int pid)
 {
     int num = pid & 0xFFFFFF;
@@ -959,7 +959,7 @@ int proto_scenery_init(Proto* proto, int pid)
     return 0;
 }
 
-// 0x49FC74
+// 0x49FC74 proto_scenery_subdata_init_
 int proto_scenery_subdata_init(Proto* proto, int type)
 {
     switch (type) {
@@ -990,7 +990,7 @@ int proto_scenery_subdata_init(Proto* proto, int type)
     return 0;
 }
 
-// 0x49FCFC
+// 0x49FCFC proto_wall_init_
 int proto_wall_init(Proto* proto, int pid)
 {
     int num = pid & 0xFFFFFF;
@@ -1011,7 +1011,7 @@ int proto_wall_init(Proto* proto, int pid)
     return 0;
 }
 
-// 0x49FD84
+// 0x49FD84 proto_tile_init_
 int proto_tile_init(Proto* proto, int pid)
 {
     int num = pid & 0xFFFFFF;
@@ -1030,7 +1030,7 @@ int proto_tile_init(Proto* proto, int pid)
     return 0;
 }
 
-// 0x49FDFC
+// 0x49FDFC proto_misc_init_
 int proto_misc_init(Proto* proto, int pid)
 {
     int num = pid & 0xFFFFFF;
@@ -1049,7 +1049,7 @@ int proto_misc_init(Proto* proto, int pid)
     return 0;
 }
 
-// 0x49FE74
+// 0x49FE74 proto_copy_proto_
 int proto_copy_proto(int srcPid, int dstPid)
 {
     int srcType;
@@ -1077,7 +1077,7 @@ int proto_copy_proto(int srcPid, int dstPid)
     return 0;
 }
 
-// 0x49FEDC
+// 0x49FEDC proto_is_subtype_
 bool proto_is_subtype(Proto* proto, int subtype)
 {
     if (subtype == -1) {
@@ -1095,7 +1095,7 @@ bool proto_is_subtype(Proto* proto, int subtype)
 }
 
 // proto_data_member
-// 0x49FFD8
+// 0x49FFD8 proto_data_member_
 int protoGetDataMember(int pid, int member, ProtoDataMemberValue* value)
 {
     Proto* proto;
@@ -1329,7 +1329,7 @@ int protoGetDataMember(int pid, int member, ProtoDataMemberValue* value)
 }
 
 // proto_init
-// 0x4A0390
+// 0x4A0390 proto_init_
 int protoInit()
 {
     size_t len;
@@ -1462,7 +1462,7 @@ int protoInit()
     return 0;
 }
 
-// 0x4A0814
+// 0x4A0814 proto_reset_
 void protoReset()
 {
     int i;
@@ -1486,7 +1486,7 @@ void protoReset()
     _proto_dude_init("premade\\player.gcd");
 }
 
-// 0x4A0898
+// 0x4A0898 proto_exit_
 void protoExit()
 {
     int i;
@@ -1506,7 +1506,7 @@ void protoExit()
 
 // Count .pro lines in .lst files.
 //
-// 0x4A08E0
+// 0x4A08E0 proto_header_load_
 static int _proto_header_load()
 {
     for (int index = 0; index < 6; index++) {
@@ -1549,7 +1549,7 @@ static int _proto_header_load()
     return 0;
 }
 
-// 0x4A0AEC
+// 0x4A0AEC proto_read_item_data_
 static int protoItemDataRead(ItemProtoData* item_data, int type, File* stream)
 {
     switch (type) {
@@ -1625,7 +1625,7 @@ static int protoItemDataRead(ItemProtoData* item_data, int type, File* stream)
     return 0;
 }
 
-// 0x4A0ED0
+// 0x4A0ED0 proto_read_scenery_data_
 static int protoSceneryDataRead(SceneryProtoData* scenery_data, int type, File* stream)
 {
     switch (type) {
@@ -1659,7 +1659,7 @@ static int protoSceneryDataRead(SceneryProtoData* scenery_data, int type, File* 
 }
 
 // read .pro file
-// 0x4A0FA0
+// 0x4A0FA0 proto_read_protoSubNode_
 static int protoRead(Proto* proto, File* stream)
 {
     if (fileReadInt32(stream, &(proto->pid)) == -1) return -1;
@@ -1735,7 +1735,7 @@ static int protoRead(Proto* proto, File* stream)
     return -1;
 }
 
-// 0x4A1390
+// 0x4A1390 proto_write_item_data_
 static int protoItemDataWrite(ItemProtoData* item_data, int type, File* stream)
 {
     switch (type) {
@@ -1811,7 +1811,7 @@ static int protoItemDataWrite(ItemProtoData* item_data, int type, File* stream)
     return 0;
 }
 
-// 0x4A16E4
+// 0x4A16E4 proto_write_scenery_data_
 static int protoSceneryDataWrite(SceneryProtoData* scenery_data, int type, File* stream)
 {
     switch (type) {
@@ -1844,7 +1844,7 @@ static int protoSceneryDataWrite(SceneryProtoData* scenery_data, int type, File*
     return 0;
 }
 
-// 0x4A17B4
+// 0x4A17B4 proto_write_protoSubNode_
 static int protoWrite(Proto* proto, File* stream)
 {
     if (fileWriteInt32(stream, proto->pid) == -1) return -1;
@@ -1918,7 +1918,7 @@ static int protoWrite(Proto* proto, File* stream)
     return -1;
 }
 
-// 0x4A1B30
+// 0x4A1B30 proto_save_pid_
 int _proto_save_pid(int pid)
 {
     Proto* proto;
@@ -1944,7 +1944,7 @@ int _proto_save_pid(int pid)
     return rc;
 }
 
-// 0x4A1C3C
+// 0x4A1C3C proto_load_pid_
 static int _proto_load_pid(int pid, Proto** protoPtr)
 {
     char path[COMPAT_MAX_PATH];
@@ -1976,7 +1976,7 @@ static int _proto_load_pid(int pid, Proto** protoPtr)
     return 0;
 }
 
-// 0x4A1D98
+// 0x4A1D98 proto_find_free_subnode_
 static int _proto_find_free_subnode(int type, Proto** protoPtr)
 {
     Proto* proto = (Proto*)internal_malloc(proto_size(type));
@@ -2027,7 +2027,7 @@ static int _proto_find_free_subnode(int type, Proto** protoPtr)
     return 0;
 }
 
-// 0x4A1E90
+// 0x4A1E90 proto_new_
 int proto_new(int* pid, int type)
 {
     Proto* proto;
@@ -2071,7 +2071,7 @@ int proto_new(int* pid, int type)
 
 // Evict top most proto cache block.
 //
-// 0x4A2040
+// 0x4A2040 proto_remove_some_list_
 static void _proto_remove_some_list(int type)
 {
     ProtoList* protoList = &(_protoLists[type]);
@@ -2090,7 +2090,7 @@ static void _proto_remove_some_list(int type)
 
 // Clear proto cache of given type.
 //
-// 0x4A2094
+// 0x4A2094 proto_remove_list_
 static void _proto_remove_list(int type)
 {
     ProtoList* protoList = &(_protoLists[type]);
@@ -2112,7 +2112,7 @@ static void _proto_remove_list(int type)
 
 // Clear all proto cache.
 //
-// 0x4A20F4
+// 0x4A20F4 proto_remove_all_
 void _proto_remove_all()
 {
     for (int index = 0; index < 6; index++) {
@@ -2121,7 +2121,7 @@ void _proto_remove_all()
 }
 
 // proto_ptr
-// 0x4A2108
+// 0x4A2108 proto_ptr_
 int protoGetProto(int pid, Proto** protoPtr)
 {
     *protoPtr = nullptr;
@@ -2157,7 +2157,7 @@ int protoGetProto(int pid, Proto** protoPtr)
     return _proto_load_pid(pid, protoPtr);
 }
 
-// 0x4A21DC
+// 0x4A21DC proto_new_id_
 static int _proto_new_id(int type)
 {
     int result = _protoLists[type].max_entries_num;
@@ -2166,13 +2166,13 @@ static int _proto_new_id(int type)
     return result;
 }
 
-// 0x4A2214
+// 0x4A2214 proto_max_id_
 int proto_max_id(int type)
 {
     return _protoLists[type].max_entries_num;
 }
 
-// 0x4A22C0
+// 0x4A22C0 ResetPlayer_
 int _ResetPlayer()
 {
     Proto* proto;

--- a/src/proto.cc
+++ b/src/proto.cc
@@ -109,7 +109,7 @@ static CritterProto gDudeProto = {
     0,
 };
 
-// 0x51C534 _proto_path_base
+// 0x51C534 proto_path_base
 static char* _proto_path_base = _aProto_0;
 
 // 0x51C538 init_true
@@ -147,7 +147,7 @@ static MessageList _proto_msg_files[6];
 // 0x6647DC race_type_strs
 static char* gRaceTypeNames[RACE_TYPE_COUNT];
 
-// 0x6647E4 _scenery_pro_type
+// 0x6647E4 scenery_pro_type
 static char* gSceneryTypeNames[SCENERY_TYPE_COUNT];
 
 // proto.msg
@@ -155,12 +155,12 @@ static char* gSceneryTypeNames[SCENERY_TYPE_COUNT];
 // 0x6647FC proto_main_msg_file
 MessageList gProtoMessageList;
 
-// 0x664804 _item_pro_material
+// 0x664804 item_pro_material
 static char* gMaterialTypeNames[MATERIAL_TYPE_COUNT];
 
 // "<None>" from proto.msg
 //
-// 0x664824 _proto_none_str
+// 0x664824 proto_none_str
 char* _proto_none_str;
 
 // 0x664828 body_type_strs
@@ -172,7 +172,7 @@ char* gItemTypeNames[ITEM_TYPE_COUNT];
 // 0x66484C
 static char* gDamageTypeNames[DAMAGE_TYPE_COUNT];
 
-// 0x66486C _cal_type_strs
+// 0x66486C cal_type_strs
 static char* gCaliberTypeNames[CALIBER_TYPE_COUNT];
 
 // Perk names.

--- a/src/proto.cc
+++ b/src/proto.cc
@@ -40,19 +40,19 @@ static void _proto_remove_some_list(int type);
 static void _proto_remove_list(int type);
 static int _proto_new_id(int type);
 
-// 0x50CF3C
+// 0x50CF3C aProto_0
 static char _aProto_0[] = "proto\\";
 
-// 0x50D1B0
+// 0x50D1B0 aDrugStatSpecia
 static char _aDrugStatSpecia[] = "Drug Stat (Special)";
 
-// 0x50D1C4
+// 0x50D1C4 aNone_1
 static char _aNone_1[] = "None";
 
-// 0x51C18C
+// 0x51C18C cd_path_base
 char _cd_path_base[COMPAT_MAX_PATH];
 
-// 0x51C290
+// 0x51C290 protoLists
 static ProtoList _protoLists[11] = {
     { nullptr, nullptr, 0, 1 },
     { nullptr, nullptr, 0, 1 },
@@ -67,7 +67,7 @@ static ProtoList _protoLists[11] = {
     { nullptr, nullptr, 0, 0 },
 };
 
-// 0x51C340
+// 0x51C340 proto_sizes
 static const size_t _proto_sizes[11] = {
     sizeof(ItemProto), // 0x84
     sizeof(CritterProto), // 0x1A0
@@ -82,11 +82,11 @@ static const size_t _proto_sizes[11] = {
     0,
 };
 
-// 0x51C36C
+// 0x51C36C protos_been_initialized
 static int _protos_been_initialized = 0;
 
 // obj_dude_proto
-// 0x51C370
+// 0x51C370 pc_proto
 static CritterProto gDudeProto = {
     0x1000000,
     -1,
@@ -109,28 +109,28 @@ static CritterProto gDudeProto = {
     0,
 };
 
-// 0x51C534
+// 0x51C534 _proto_path_base
 static char* _proto_path_base = _aProto_0;
 
-// 0x51C538
+// 0x51C538 init_true
 static int _init_true = 0;
 
-// 0x51C53C
+// 0x51C53C retval
 static int _retval = 0;
 
-// 0x66452C
+// 0x66452C mp_perk_code_None
 static char* _mp_perk_code_None;
 
-// 0x664530
+// 0x664530 mp_perk_code_strs
 static char* _mp_perk_code_strs[PERK_COUNT];
 
-// 0x66470C
+// 0x66470C mp_critter_stats_list
 static char* _mp_critter_stats_list;
 
-// 0x664710
+// 0x664710 critter_stats_list_None
 static char* _critter_stats_list_None;
 
-// 0x664714
+// 0x664714 critter_stats_list_strs
 static char* _critter_stats_list_strs[STAT_COUNT];
 
 // Message list by object type
@@ -141,51 +141,51 @@ static char* _critter_stats_list_strs[STAT_COUNT];
 // 4 - pro_tile.msg
 // 5 - pro_misc.msg
 //
-// 0x6647AC
+// 0x6647AC proto_msg_files
 static MessageList _proto_msg_files[6];
 
-// 0x6647DC
+// 0x6647DC race_type_strs
 static char* gRaceTypeNames[RACE_TYPE_COUNT];
 
-// 0x6647E4
+// 0x6647E4 _scenery_pro_type
 static char* gSceneryTypeNames[SCENERY_TYPE_COUNT];
 
 // proto.msg
 //
-// 0x6647FC
+// 0x6647FC proto_main_msg_file
 MessageList gProtoMessageList;
 
-// 0x664804
+// 0x664804 _item_pro_material
 static char* gMaterialTypeNames[MATERIAL_TYPE_COUNT];
 
 // "<None>" from proto.msg
 //
-// 0x664824
+// 0x664824 _proto_none_str
 char* _proto_none_str;
 
-// 0x664828
+// 0x664828 body_type_strs
 static char* gBodyTypeNames[BODY_TYPE_COUNT];
 
-// 0x664834
+// 0x664834 item_pro_type
 char* gItemTypeNames[ITEM_TYPE_COUNT];
 
 // 0x66484C
 static char* gDamageTypeNames[DAMAGE_TYPE_COUNT];
 
-// 0x66486C
+// 0x66486C _cal_type_strs
 static char* gCaliberTypeNames[CALIBER_TYPE_COUNT];
 
 // Perk names.
 //
-// 0x6648B8
+// 0x6648B8 perk_code_strs
 static char** _perk_code_strs;
 
 // Stat names.
 //
-// 0x6648BC
+// 0x6648BC critter_stats_list
 static char** _critter_stats_list;
 
-// 0x49E270 proto_make_path_
+// 0x49E270 proto_make_path
 void proto_make_path(char* path, int pid)
 {
     strcpy(path, _cd_path_base);
@@ -197,7 +197,7 @@ void proto_make_path(char* path, int pid)
 
 // Append proto file name to proto_path from proto.lst.
 //
-// 0x49E758 proto_list_str_
+// 0x49E758 proto_list_str
 int _proto_list_str(int pid, char* proto_path)
 {
     if (pid == -1) {
@@ -247,13 +247,13 @@ int _proto_list_str(int pid, char* proto_path)
     return 0;
 }
 
-// 0x49E984 proto_size_
+// 0x49E984 proto_size
 size_t proto_size(int type)
 {
     return type >= 0 && type < OBJ_TYPE_COUNT ? _proto_sizes[type] : 0;
 }
 
-// 0x49E99C proto_action_can_use_
+// 0x49E99C proto_action_can_use
 bool _proto_action_can_use(int pid)
 {
     Proto* proto;
@@ -272,7 +272,7 @@ bool _proto_action_can_use(int pid)
     return false;
 }
 
-// 0x49E9DC proto_action_can_use_on_
+// 0x49E9DC proto_action_can_use_on
 bool _proto_action_can_use_on(int pid)
 {
     Proto* proto;
@@ -291,7 +291,7 @@ bool _proto_action_can_use_on(int pid)
     return false;
 }
 
-// 0x49EA24 proto_action_can_talk_to_
+// 0x49EA24 proto_action_can_talk_to
 bool _proto_action_can_talk_to(int pid)
 {
     Proto* proto;
@@ -312,7 +312,7 @@ bool _proto_action_can_talk_to(int pid)
 
 // Likely returns true if item with given pid can be picked up.
 //
-// 0x49EA5C proto_action_can_pickup_
+// 0x49EA5C proto_action_can_pickup
 int _proto_action_can_pickup(int pid)
 {
     if (PID_TYPE(pid) != OBJ_TYPE_ITEM) {
@@ -331,7 +331,7 @@ int _proto_action_can_pickup(int pid)
     return true;
 }
 
-// 0x49EAA4 proto_get_msg_info_
+// 0x49EAA4 proto_get_msg_info
 char* protoGetMessage(int pid, int message)
 {
     char* messageText = _proto_none_str;
@@ -352,7 +352,7 @@ char* protoGetMessage(int pid, int message)
     return messageText;
 }
 
-// 0x49EAFC proto_name_
+// 0x49EAFC proto_name
 char* protoGetName(int pid)
 {
     if (pid == 0x1000000) {
@@ -362,13 +362,13 @@ char* protoGetName(int pid)
     return protoGetMessage(pid, PROTOTYPE_MESSAGE_NAME);
 }
 
-// 0x49EB1C proto_description_
+// 0x49EB1C proto_description
 char* protoGetDescription(int pid)
 {
     return protoGetMessage(pid, PROTOTYPE_MESSAGE_DESCRIPTION);
 }
 
-// 0x49EB2C proto_item_init_
+// 0x49EB2C proto_item_init
 int proto_item_init(Proto* proto, int pid)
 {
     int protoNum = pid & 0xFFFFFF;
@@ -396,7 +396,7 @@ int proto_item_init(Proto* proto, int pid)
     return 0;
 }
 
-// 0x49EBFC proto_item_subdata_init_
+// 0x49EBFC proto_item_subdata_init
 int proto_item_subdata_init(Proto* proto, int type)
 {
     int index;
@@ -479,7 +479,7 @@ int proto_item_subdata_init(Proto* proto, int type)
     return 0;
 }
 
-// 0x49EDB4 proto_critter_init_
+// 0x49EDB4 proto_critter_init
 int proto_critter_init(Proto* proto, int pid)
 {
     if (!_protos_been_initialized) {
@@ -514,7 +514,7 @@ int proto_critter_init(Proto* proto, int pid)
     return 0;
 }
 
-// 0x49EEA4 clear_pupdate_data_
+// 0x49EEA4 clear_pupdate_data
 void objectDataReset(Object* obj)
 {
     // NOTE: Original code is slightly different. It uses loop to zero object
@@ -522,7 +522,7 @@ void objectDataReset(Object* obj)
     memset(&(obj->data), 0, sizeof(obj->data));
 }
 
-// 0x49EEB8 proto_read_CombatData_
+// 0x49EEB8 proto_read_CombatData
 static int objectCritterCombatDataRead(CritterCombatData* data, File* stream)
 {
     if (fileReadInt32(stream, &(data->damageLastTurn)) == -1) return -1;
@@ -536,7 +536,7 @@ static int objectCritterCombatDataRead(CritterCombatData* data, File* stream)
     return 0;
 }
 
-// 0x49EF40 proto_write_CombatData_
+// 0x49EF40 proto_write_CombatData
 static int objectCritterCombatDataWrite(CritterCombatData* data, File* stream)
 {
     if (fileWriteInt32(stream, data->damageLastTurn) == -1) return -1;
@@ -550,7 +550,7 @@ static int objectCritterCombatDataWrite(CritterCombatData* data, File* stream)
     return 0;
 }
 
-// 0x49F004 proto_read_protoUpdateData_
+// 0x49F004 proto_read_protoUpdateData
 int objectDataRead(Object* obj, File* stream)
 {
     Proto* proto;
@@ -647,7 +647,7 @@ int objectDataRead(Object* obj, File* stream)
     return 0;
 }
 
-// 0x49F428 proto_write_protoUpdateData_
+// 0x49F428 proto_write_protoUpdateData
 int objectDataWrite(Object* obj, File* stream)
 {
     Proto* proto;
@@ -730,7 +730,7 @@ int objectDataWrite(Object* obj, File* stream)
     return 0;
 }
 
-// 0x49F73C proto_update_gen_
+// 0x49F73C proto_update_gen
 static int _proto_update_gen(Object* obj)
 {
     Proto* proto;
@@ -803,7 +803,7 @@ static int _proto_update_gen(Object* obj)
     return 0;
 }
 
-// 0x49F8A0 proto_update_init_
+// 0x49F8A0 proto_update_init
 int _proto_update_init(Object* obj)
 {
     if (!_protos_been_initialized) {
@@ -843,7 +843,7 @@ int _proto_update_init(Object* obj)
     return 0;
 }
 
-// 0x49F984 proto_dude_update_gender_
+// 0x49F984 proto_dude_update_gender
 int _proto_dude_update_gender()
 {
     Proto* proto;
@@ -881,7 +881,7 @@ int _proto_dude_update_gender()
 }
 
 // proto_dude_init
-// 0x49FA64 proto_dude_init_
+// 0x49FA64 proto_dude_init
 int _proto_dude_init(const char* path)
 {
     gDudeProto.fid = buildFid(OBJ_TYPE_CRITTER, _art_vault_guy_num, 0, 0, 0);
@@ -935,7 +935,7 @@ int _proto_dude_init(const char* path)
     return 0;
 }
 
-// 0x49FBBC proto_scenery_init_
+// 0x49FBBC proto_scenery_init
 int proto_scenery_init(Proto* proto, int pid)
 {
     int num = pid & 0xFFFFFF;
@@ -959,7 +959,7 @@ int proto_scenery_init(Proto* proto, int pid)
     return 0;
 }
 
-// 0x49FC74 proto_scenery_subdata_init_
+// 0x49FC74 proto_scenery_subdata_init
 int proto_scenery_subdata_init(Proto* proto, int type)
 {
     switch (type) {
@@ -990,7 +990,7 @@ int proto_scenery_subdata_init(Proto* proto, int type)
     return 0;
 }
 
-// 0x49FCFC proto_wall_init_
+// 0x49FCFC proto_wall_init
 int proto_wall_init(Proto* proto, int pid)
 {
     int num = pid & 0xFFFFFF;
@@ -1011,7 +1011,7 @@ int proto_wall_init(Proto* proto, int pid)
     return 0;
 }
 
-// 0x49FD84 proto_tile_init_
+// 0x49FD84 proto_tile_init
 int proto_tile_init(Proto* proto, int pid)
 {
     int num = pid & 0xFFFFFF;
@@ -1030,7 +1030,7 @@ int proto_tile_init(Proto* proto, int pid)
     return 0;
 }
 
-// 0x49FDFC proto_misc_init_
+// 0x49FDFC proto_misc_init
 int proto_misc_init(Proto* proto, int pid)
 {
     int num = pid & 0xFFFFFF;
@@ -1049,7 +1049,7 @@ int proto_misc_init(Proto* proto, int pid)
     return 0;
 }
 
-// 0x49FE74 proto_copy_proto_
+// 0x49FE74 proto_copy_proto
 int proto_copy_proto(int srcPid, int dstPid)
 {
     int srcType;
@@ -1077,7 +1077,7 @@ int proto_copy_proto(int srcPid, int dstPid)
     return 0;
 }
 
-// 0x49FEDC proto_is_subtype_
+// 0x49FEDC proto_is_subtype
 bool proto_is_subtype(Proto* proto, int subtype)
 {
     if (subtype == -1) {
@@ -1095,7 +1095,7 @@ bool proto_is_subtype(Proto* proto, int subtype)
 }
 
 // proto_data_member
-// 0x49FFD8 proto_data_member_
+// 0x49FFD8 proto_data_member
 int protoGetDataMember(int pid, int member, ProtoDataMemberValue* value)
 {
     Proto* proto;
@@ -1329,7 +1329,7 @@ int protoGetDataMember(int pid, int member, ProtoDataMemberValue* value)
 }
 
 // proto_init
-// 0x4A0390 proto_init_
+// 0x4A0390 proto_init
 int protoInit()
 {
     size_t len;
@@ -1462,7 +1462,7 @@ int protoInit()
     return 0;
 }
 
-// 0x4A0814 proto_reset_
+// 0x4A0814 proto_reset
 void protoReset()
 {
     int i;
@@ -1486,7 +1486,7 @@ void protoReset()
     _proto_dude_init("premade\\player.gcd");
 }
 
-// 0x4A0898 proto_exit_
+// 0x4A0898 proto_exit
 void protoExit()
 {
     int i;
@@ -1506,7 +1506,7 @@ void protoExit()
 
 // Count .pro lines in .lst files.
 //
-// 0x4A08E0 proto_header_load_
+// 0x4A08E0 proto_header_load
 static int _proto_header_load()
 {
     for (int index = 0; index < 6; index++) {
@@ -1549,7 +1549,7 @@ static int _proto_header_load()
     return 0;
 }
 
-// 0x4A0AEC proto_read_item_data_
+// 0x4A0AEC proto_read_item_data
 static int protoItemDataRead(ItemProtoData* item_data, int type, File* stream)
 {
     switch (type) {
@@ -1625,7 +1625,7 @@ static int protoItemDataRead(ItemProtoData* item_data, int type, File* stream)
     return 0;
 }
 
-// 0x4A0ED0 proto_read_scenery_data_
+// 0x4A0ED0 proto_read_scenery_data
 static int protoSceneryDataRead(SceneryProtoData* scenery_data, int type, File* stream)
 {
     switch (type) {
@@ -1659,7 +1659,7 @@ static int protoSceneryDataRead(SceneryProtoData* scenery_data, int type, File* 
 }
 
 // read .pro file
-// 0x4A0FA0 proto_read_protoSubNode_
+// 0x4A0FA0 proto_read_protoSubNode
 static int protoRead(Proto* proto, File* stream)
 {
     if (fileReadInt32(stream, &(proto->pid)) == -1) return -1;
@@ -1735,7 +1735,7 @@ static int protoRead(Proto* proto, File* stream)
     return -1;
 }
 
-// 0x4A1390 proto_write_item_data_
+// 0x4A1390 proto_write_item_data
 static int protoItemDataWrite(ItemProtoData* item_data, int type, File* stream)
 {
     switch (type) {
@@ -1811,7 +1811,7 @@ static int protoItemDataWrite(ItemProtoData* item_data, int type, File* stream)
     return 0;
 }
 
-// 0x4A16E4 proto_write_scenery_data_
+// 0x4A16E4 proto_write_scenery_data
 static int protoSceneryDataWrite(SceneryProtoData* scenery_data, int type, File* stream)
 {
     switch (type) {
@@ -1844,7 +1844,7 @@ static int protoSceneryDataWrite(SceneryProtoData* scenery_data, int type, File*
     return 0;
 }
 
-// 0x4A17B4 proto_write_protoSubNode_
+// 0x4A17B4 proto_write_protoSubNode
 static int protoWrite(Proto* proto, File* stream)
 {
     if (fileWriteInt32(stream, proto->pid) == -1) return -1;
@@ -1918,7 +1918,7 @@ static int protoWrite(Proto* proto, File* stream)
     return -1;
 }
 
-// 0x4A1B30 proto_save_pid_
+// 0x4A1B30 proto_save_pid
 int _proto_save_pid(int pid)
 {
     Proto* proto;
@@ -1944,7 +1944,7 @@ int _proto_save_pid(int pid)
     return rc;
 }
 
-// 0x4A1C3C proto_load_pid_
+// 0x4A1C3C proto_load_pid
 static int _proto_load_pid(int pid, Proto** protoPtr)
 {
     char path[COMPAT_MAX_PATH];
@@ -1976,7 +1976,7 @@ static int _proto_load_pid(int pid, Proto** protoPtr)
     return 0;
 }
 
-// 0x4A1D98 proto_find_free_subnode_
+// 0x4A1D98 proto_find_free_subnode
 static int _proto_find_free_subnode(int type, Proto** protoPtr)
 {
     Proto* proto = (Proto*)internal_malloc(proto_size(type));
@@ -2027,7 +2027,7 @@ static int _proto_find_free_subnode(int type, Proto** protoPtr)
     return 0;
 }
 
-// 0x4A1E90 proto_new_
+// 0x4A1E90 proto_new
 int proto_new(int* pid, int type)
 {
     Proto* proto;
@@ -2071,7 +2071,7 @@ int proto_new(int* pid, int type)
 
 // Evict top most proto cache block.
 //
-// 0x4A2040 proto_remove_some_list_
+// 0x4A2040 proto_remove_some_list
 static void _proto_remove_some_list(int type)
 {
     ProtoList* protoList = &(_protoLists[type]);
@@ -2090,7 +2090,7 @@ static void _proto_remove_some_list(int type)
 
 // Clear proto cache of given type.
 //
-// 0x4A2094 proto_remove_list_
+// 0x4A2094 proto_remove_list
 static void _proto_remove_list(int type)
 {
     ProtoList* protoList = &(_protoLists[type]);
@@ -2112,7 +2112,7 @@ static void _proto_remove_list(int type)
 
 // Clear all proto cache.
 //
-// 0x4A20F4 proto_remove_all_
+// 0x4A20F4 proto_remove_all
 void _proto_remove_all()
 {
     for (int index = 0; index < 6; index++) {
@@ -2121,7 +2121,7 @@ void _proto_remove_all()
 }
 
 // proto_ptr
-// 0x4A2108 proto_ptr_
+// 0x4A2108 proto_ptr
 int protoGetProto(int pid, Proto** protoPtr)
 {
     *protoPtr = nullptr;
@@ -2157,7 +2157,7 @@ int protoGetProto(int pid, Proto** protoPtr)
     return _proto_load_pid(pid, protoPtr);
 }
 
-// 0x4A21DC proto_new_id_
+// 0x4A21DC proto_new_id
 static int _proto_new_id(int type)
 {
     int result = _protoLists[type].max_entries_num;
@@ -2166,13 +2166,13 @@ static int _proto_new_id(int type)
     return result;
 }
 
-// 0x4A2214 proto_max_id_
+// 0x4A2214 proto_max_id
 int proto_max_id(int type)
 {
     return _protoLists[type].max_entries_num;
 }
 
-// 0x4A22C0 ResetPlayer_
+// 0x4A22C0 ResetPlayer
 int _ResetPlayer()
 {
     Proto* proto;

--- a/src/queue.cc
+++ b/src/queue.cc
@@ -81,20 +81,20 @@ static EventTypeDescription gEventTypeDescriptions[EVENT_TYPE_COUNT] = {
     { ambientSoundEffectEventProcess, internal_free, nullptr, nullptr, true, nullptr },
 };
 
-// 0x4A2320
+// 0x4A2320 queue_init_
 void queueInit()
 {
     gQueueListHead = nullptr;
 }
 
-// 0x4A2330
+// 0x4A2330 queue_reset_
 int queueExit()
 {
     queueClear();
     return 0;
 }
 
-// 0x4A2338
+// 0x4A2338 queue_load_
 int queueLoad(File* stream)
 {
     int count;
@@ -201,7 +201,7 @@ int queueLoad(File* stream)
     return rc;
 }
 
-// 0x4A24E0
+// 0x4A24E0 queue_save_
 int queueSave(File* stream)
 {
     QueueListNode* queueListNode;
@@ -248,7 +248,7 @@ int queueSave(File* stream)
     return 0;
 }
 
-// 0x4A258C
+// 0x4A258C queue_add_
 int queueAddEvent(int delay, Object* obj, void* data, int eventType)
 {
     QueueListNode* newQueueListNode = (QueueListNode*)internal_malloc(sizeof(QueueListNode));
@@ -281,7 +281,7 @@ int queueAddEvent(int delay, Object* obj, void* data, int eventType)
     return 0;
 }
 
-// 0x4A25F4
+// 0x4A25F4 queue_remove_
 int queueRemoveEvents(Object* owner)
 {
     QueueListNode* queueListNode = gQueueListHead;
@@ -309,7 +309,7 @@ int queueRemoveEvents(Object* owner)
     return 0;
 }
 
-// 0x4A264C
+// 0x4A264C queue_remove_this_
 int queueRemoveEventsByType(Object* owner, int eventType)
 {
     QueueListNode* queueListNode = gQueueListHead;
@@ -339,7 +339,7 @@ int queueRemoveEventsByType(Object* owner, int eventType)
 
 // Returns true if there is at least one event of given type scheduled.
 //
-// 0x4A26A8
+// 0x4A26A8 queue_find_
 bool queueHasEvent(Object* owner, int eventType)
 {
     QueueListNode* queueListEvent = gQueueListHead;
@@ -354,7 +354,7 @@ bool queueHasEvent(Object* owner, int eventType)
     return false;
 }
 
-// 0x4A26D0
+// 0x4A26D0 queue_process_
 int queueProcessEvents()
 {
     unsigned int time = gameTimeGetTime();
@@ -382,7 +382,7 @@ int queueProcessEvents()
     return stopProcess;
 }
 
-// 0x4A2748
+// 0x4A2748 queue_clear_
 void queueClear()
 {
     QueueListNode* queueListNode = gQueueListHead;
@@ -402,7 +402,7 @@ void queueClear()
     gQueueListHead = nullptr;
 }
 
-// 0x4A2790
+// 0x4A2790 queue_clear_type_
 void queueClearByEventType(int eventType, QueueEventHandler* fn)
 {
     QueueListNode** ptr = &gQueueListHead;
@@ -438,7 +438,7 @@ void queueClearByEventType(int eventType, QueueEventHandler* fn)
     }
 }
 
-// 0x4A2808
+// 0x4A2808 queue_next_time_
 unsigned int queueGetNextEventTime()
 {
     if (gQueueListHead == nullptr) {
@@ -448,20 +448,20 @@ unsigned int queueGetNextEventTime()
     return gQueueListHead->time;
 }
 
-// 0x4A281C
+// 0x4A281C queue_destroy_
 static int flareEventProcess(Object* obj, void* data)
 {
     objectDestroy(obj);
     return 1;
 }
 
-// 0x4A2828
+// 0x4A2828 queue_explode_
 static int explosionEventProcess(Object* obj, void* data)
 {
     return explosionProcess(obj, true);
 }
 
-// 0x4A2830
+// 0x4A2830 queue_explode_exit_
 static int explosionExit(Object* obj, void* data)
 {
     return explosionProcess(obj, false);
@@ -506,7 +506,7 @@ static int explosionProcess(Object* explosive, bool animate)
     return 1;
 }
 
-// 0x4A28E4
+// 0x4A28E4 queue_premature_
 static int explosionFailureEventProcess(Object* obj, void* data)
 {
     MessageListItem msg;
@@ -520,7 +520,7 @@ static int explosionFailureEventProcess(Object* obj, void* data)
     return explosionProcess(obj, true);
 }
 
-// 0x4A2920
+// 0x4A2920 queue_leaving_map_
 void _queue_leaving_map()
 {
     for (int eventType = 0; eventType < EVENT_TYPE_COUNT; eventType++) {
@@ -531,13 +531,13 @@ void _queue_leaving_map()
     }
 }
 
-// 0x4A294C
+// 0x4A294C queue_is_empty_
 bool queueIsEmpty()
 {
     return gQueueListHead == nullptr;
 }
 
-// 0x4A295C
+// 0x4A295C queue_find_first_
 void* queueFindFirstEvent(Object* owner, int eventType)
 {
     QueueListNode* queueListNode = gQueueListHead;
@@ -553,7 +553,7 @@ void* queueFindFirstEvent(Object* owner, int eventType)
     return nullptr;
 }
 
-// 0x4A2994
+// 0x4A2994 queue_find_next_
 void* queueFindNextEvent(Object* owner, int eventType)
 {
     if (gLastFoundQueueListNode != nullptr) {

--- a/src/queue.cc
+++ b/src/queue.cc
@@ -46,7 +46,7 @@ static int explosionFailureEventProcess(Object* obj, void* data);
 // 0x51C690 tmpQNode
 static QueueListNode* gLastFoundQueueListNode = nullptr;
 
-// 0x6648C0 _queue
+// 0x6648C0 queue
 static QueueListNode* gQueueListHead;
 
 // 0x51C540 q_func

--- a/src/queue.cc
+++ b/src/queue.cc
@@ -43,13 +43,13 @@ static int explosionFailureEventProcess(Object* obj, void* data);
 // Last queue list node found during [queueFindFirstEvent] and
 // [queueFindNextEvent] calls.
 //
-// 0x51C690
+// 0x51C690 tmpQNode
 static QueueListNode* gLastFoundQueueListNode = nullptr;
 
-// 0x6648C0
+// 0x6648C0 _queue
 static QueueListNode* gQueueListHead;
 
-// 0x51C540
+// 0x51C540 q_func
 static EventTypeDescription gEventTypeDescriptions[EVENT_TYPE_COUNT] = {
     // EVENT_TYPE_DRUG
     { drugEffectEventProcess, internal_free, drugEffectEventRead, drugEffectEventWrite, true, drugItemClear },
@@ -81,20 +81,20 @@ static EventTypeDescription gEventTypeDescriptions[EVENT_TYPE_COUNT] = {
     { ambientSoundEffectEventProcess, internal_free, nullptr, nullptr, true, nullptr },
 };
 
-// 0x4A2320 queue_init_
+// 0x4A2320 queue_init
 void queueInit()
 {
     gQueueListHead = nullptr;
 }
 
-// 0x4A2330 queue_reset_
+// 0x4A2330 queue_reset
 int queueExit()
 {
     queueClear();
     return 0;
 }
 
-// 0x4A2338 queue_load_
+// 0x4A2338 queue_load
 int queueLoad(File* stream)
 {
     int count;
@@ -201,7 +201,7 @@ int queueLoad(File* stream)
     return rc;
 }
 
-// 0x4A24E0 queue_save_
+// 0x4A24E0 queue_save
 int queueSave(File* stream)
 {
     QueueListNode* queueListNode;
@@ -248,7 +248,7 @@ int queueSave(File* stream)
     return 0;
 }
 
-// 0x4A258C queue_add_
+// 0x4A258C queue_add
 int queueAddEvent(int delay, Object* obj, void* data, int eventType)
 {
     QueueListNode* newQueueListNode = (QueueListNode*)internal_malloc(sizeof(QueueListNode));
@@ -281,7 +281,7 @@ int queueAddEvent(int delay, Object* obj, void* data, int eventType)
     return 0;
 }
 
-// 0x4A25F4 queue_remove_
+// 0x4A25F4 queue_remove
 int queueRemoveEvents(Object* owner)
 {
     QueueListNode* queueListNode = gQueueListHead;
@@ -309,7 +309,7 @@ int queueRemoveEvents(Object* owner)
     return 0;
 }
 
-// 0x4A264C queue_remove_this_
+// 0x4A264C queue_remove_this
 int queueRemoveEventsByType(Object* owner, int eventType)
 {
     QueueListNode* queueListNode = gQueueListHead;
@@ -339,7 +339,7 @@ int queueRemoveEventsByType(Object* owner, int eventType)
 
 // Returns true if there is at least one event of given type scheduled.
 //
-// 0x4A26A8 queue_find_
+// 0x4A26A8 queue_find
 bool queueHasEvent(Object* owner, int eventType)
 {
     QueueListNode* queueListEvent = gQueueListHead;
@@ -354,7 +354,7 @@ bool queueHasEvent(Object* owner, int eventType)
     return false;
 }
 
-// 0x4A26D0 queue_process_
+// 0x4A26D0 queue_process
 int queueProcessEvents()
 {
     unsigned int time = gameTimeGetTime();
@@ -382,7 +382,7 @@ int queueProcessEvents()
     return stopProcess;
 }
 
-// 0x4A2748 queue_clear_
+// 0x4A2748 queue_clear
 void queueClear()
 {
     QueueListNode* queueListNode = gQueueListHead;
@@ -402,7 +402,7 @@ void queueClear()
     gQueueListHead = nullptr;
 }
 
-// 0x4A2790 queue_clear_type_
+// 0x4A2790 queue_clear_type
 void queueClearByEventType(int eventType, QueueEventHandler* fn)
 {
     QueueListNode** ptr = &gQueueListHead;
@@ -438,7 +438,7 @@ void queueClearByEventType(int eventType, QueueEventHandler* fn)
     }
 }
 
-// 0x4A2808 queue_next_time_
+// 0x4A2808 queue_next_time
 unsigned int queueGetNextEventTime()
 {
     if (gQueueListHead == nullptr) {
@@ -448,20 +448,20 @@ unsigned int queueGetNextEventTime()
     return gQueueListHead->time;
 }
 
-// 0x4A281C queue_destroy_
+// 0x4A281C queue_destroy
 static int flareEventProcess(Object* obj, void* data)
 {
     objectDestroy(obj);
     return 1;
 }
 
-// 0x4A2828 queue_explode_
+// 0x4A2828 queue_explode
 static int explosionEventProcess(Object* obj, void* data)
 {
     return explosionProcess(obj, true);
 }
 
-// 0x4A2830 queue_explode_exit_
+// 0x4A2830 queue_explode_exit
 static int explosionExit(Object* obj, void* data)
 {
     return explosionProcess(obj, false);
@@ -506,7 +506,7 @@ static int explosionProcess(Object* explosive, bool animate)
     return 1;
 }
 
-// 0x4A28E4 queue_premature_
+// 0x4A28E4 queue_premature
 static int explosionFailureEventProcess(Object* obj, void* data)
 {
     MessageListItem msg;
@@ -520,7 +520,7 @@ static int explosionFailureEventProcess(Object* obj, void* data)
     return explosionProcess(obj, true);
 }
 
-// 0x4A2920 queue_leaving_map_
+// 0x4A2920 queue_leaving_map
 void _queue_leaving_map()
 {
     for (int eventType = 0; eventType < EVENT_TYPE_COUNT; eventType++) {
@@ -531,13 +531,13 @@ void _queue_leaving_map()
     }
 }
 
-// 0x4A294C queue_is_empty_
+// 0x4A294C queue_is_empty
 bool queueIsEmpty()
 {
     return gQueueListHead == nullptr;
 }
 
-// 0x4A295C queue_find_first_
+// 0x4A295C queue_find_first
 void* queueFindFirstEvent(Object* owner, int eventType)
 {
     QueueListNode* queueListNode = gQueueListHead;
@@ -553,7 +553,7 @@ void* queueFindFirstEvent(Object* owner, int eventType)
     return nullptr;
 }
 
-// 0x4A2994 queue_find_next_
+// 0x4A2994 queue_find_next
 void* queueFindNextEvent(Object* owner, int eventType)
 {
     if (gLastFoundQueueListNode != nullptr) {

--- a/src/random.cc
+++ b/src/random.cc
@@ -36,7 +36,7 @@ static int _iv[32];
 // 0x664950
 static int _idum;
 
-// 0x4A2FE0
+// 0x4A2FE0 roll_init_
 void randomInit()
 {
     unsigned int randomSeed = randomGetSeed();
@@ -82,7 +82,7 @@ int randomLoad(File* stream)
 
 // Rolls d% against [difficulty].
 //
-// 0x4A3000
+// 0x4A3000 roll_check_
 int randomRoll(int difficulty, int criticalSuccessModifier, int* howMuchPtr)
 {
     int delta = difficulty - randomBetween(1, 100);
@@ -98,7 +98,7 @@ int randomRoll(int difficulty, int criticalSuccessModifier, int* howMuchPtr)
 // Translates raw d% result into [Roll] constants, possibly upgrading to
 // criticals (starting from day 2).
 //
-// 0x4A3030
+// 0x4A3030 roll_check_critical_
 static int randomTranslateRoll(int delta, int criticalSuccessModifier)
 {
     unsigned int gameTime = gameTimeGetTime();
@@ -127,7 +127,7 @@ static int randomTranslateRoll(int delta, int criticalSuccessModifier)
     return roll;
 }
 
-// 0x4A30C0
+// 0x4A30C0 roll_random_
 int randomBetween(int min, int max)
 {
     int result;
@@ -146,7 +146,7 @@ int randomBetween(int min, int max)
     return result;
 }
 
-// 0x4A30FC
+// 0x4A30FC ran1_
 static int getRandom(int max)
 {
     int seed = 16807 * (_idum % 127773) - 2836 * (_idum / 127773);
@@ -168,7 +168,7 @@ static int getRandom(int max)
     return value % max;
 }
 
-// 0x4A31A0
+// 0x4A31A0 roll_set_seed_
 void randomSeedPrerandom(int seed)
 {
     if (seed == -1) {
@@ -179,13 +179,13 @@ void randomSeedPrerandom(int seed)
     randomSeedPrerandomInternal(seed);
 }
 
-// 0x4A31C4
+// 0x4A31C4 random_seed_
 static int randomInt32()
 {
     return std::rand();
 }
 
-// 0x4A31E0
+// 0x4A31E0 seed_generator_
 static void randomSeedPrerandomInternal(int seed)
 {
     int num = seed;
@@ -211,13 +211,13 @@ static void randomSeedPrerandomInternal(int seed)
 
 // Provides seed for random number generator.
 //
-// 0x4A3258
+// 0x4A3258 timer_read_
 static unsigned int randomGetSeed()
 {
     return compat_timeGetTime();
 }
 
-// 0x4A3264
+// 0x4A3264 check_chi_squared_
 static void randomValidatePrerandom()
 {
     int results[25];

--- a/src/random.cc
+++ b/src/random.cc
@@ -27,16 +27,16 @@ static const double kChiSquared95Threshold = 36.42;
 // 0x50D4C2
 static const double kExpectedBucketHits = 4000;
 
-// 0x51C694
+// 0x51C694 iy
 static int _iy = 0;
 
-// 0x6648D0
+// 0x6648D0 iv
 static int _iv[32];
 
-// 0x664950
+// 0x664950 idum
 static int _idum;
 
-// 0x4A2FE0 roll_init_
+// 0x4A2FE0 roll_init
 void randomInit()
 {
     unsigned int randomSeed = randomGetSeed();
@@ -82,7 +82,7 @@ int randomLoad(File* stream)
 
 // Rolls d% against [difficulty].
 //
-// 0x4A3000 roll_check_
+// 0x4A3000 roll_check
 int randomRoll(int difficulty, int criticalSuccessModifier, int* howMuchPtr)
 {
     int delta = difficulty - randomBetween(1, 100);
@@ -98,7 +98,7 @@ int randomRoll(int difficulty, int criticalSuccessModifier, int* howMuchPtr)
 // Translates raw d% result into [Roll] constants, possibly upgrading to
 // criticals (starting from day 2).
 //
-// 0x4A3030 roll_check_critical_
+// 0x4A3030 roll_check_critical
 static int randomTranslateRoll(int delta, int criticalSuccessModifier)
 {
     unsigned int gameTime = gameTimeGetTime();
@@ -127,7 +127,7 @@ static int randomTranslateRoll(int delta, int criticalSuccessModifier)
     return roll;
 }
 
-// 0x4A30C0 roll_random_
+// 0x4A30C0 roll_random
 int randomBetween(int min, int max)
 {
     int result;
@@ -146,7 +146,7 @@ int randomBetween(int min, int max)
     return result;
 }
 
-// 0x4A30FC ran1_
+// 0x4A30FC ran1
 static int getRandom(int max)
 {
     int seed = 16807 * (_idum % 127773) - 2836 * (_idum / 127773);
@@ -168,7 +168,7 @@ static int getRandom(int max)
     return value % max;
 }
 
-// 0x4A31A0 roll_set_seed_
+// 0x4A31A0 roll_set_seed
 void randomSeedPrerandom(int seed)
 {
     if (seed == -1) {
@@ -179,13 +179,13 @@ void randomSeedPrerandom(int seed)
     randomSeedPrerandomInternal(seed);
 }
 
-// 0x4A31C4 random_seed_
+// 0x4A31C4 random_seed
 static int randomInt32()
 {
     return std::rand();
 }
 
-// 0x4A31E0 seed_generator_
+// 0x4A31E0 seed_generator
 static void randomSeedPrerandomInternal(int seed)
 {
     int num = seed;
@@ -211,13 +211,13 @@ static void randomSeedPrerandomInternal(int seed)
 
 // Provides seed for random number generator.
 //
-// 0x4A3258 timer_read_
+// 0x4A3258 timer_read
 static unsigned int randomGetSeed()
 {
     return compat_timeGetTime();
 }
 
-// 0x4A3264 check_chi_squared_
+// 0x4A3264 check_chi_squared
 static void randomValidatePrerandom()
 {
     int results[25];

--- a/src/reaction.cc
+++ b/src/reaction.cc
@@ -4,7 +4,7 @@
 
 namespace fallout {
 
-// 0x4A29D0
+// 0x4A29D0 reaction_set_
 int reactionSetValue(Object* critter, int value)
 {
     ProgramValue programValue;
@@ -14,7 +14,7 @@ int reactionSetValue(Object* critter, int value)
     return 0;
 }
 
-// 0x4A29E8
+// 0x4A29E8 reaction_to_level_
 int reactionTranslateValue(int value)
 {
     if (value > 10) {
@@ -38,7 +38,7 @@ int _reaction_influence_()
     return 0;
 }
 
-// 0x4A2B28
+// 0x4A2B28 reaction_get_
 int reactionGetValue(Object* critter)
 {
     ProgramValue programValue;

--- a/src/reaction.cc
+++ b/src/reaction.cc
@@ -4,7 +4,7 @@
 
 namespace fallout {
 
-// 0x4A29D0 reaction_set_
+// 0x4A29D0 reaction_set
 int reactionSetValue(Object* critter, int value)
 {
     ProgramValue programValue;
@@ -14,7 +14,7 @@ int reactionSetValue(Object* critter, int value)
     return 0;
 }
 
-// 0x4A29E8 reaction_to_level_
+// 0x4A29E8 reaction_to_level
 int reactionTranslateValue(int value)
 {
     if (value > 10) {
@@ -38,7 +38,7 @@ int _reaction_influence_()
     return 0;
 }
 
-// 0x4A2B28 reaction_get_
+// 0x4A2B28 reaction_get
 int reactionGetValue(Object* critter)
 {
     ProgramValue programValue;

--- a/src/region.cc
+++ b/src/region.cc
@@ -13,7 +13,7 @@ static char _aNull[] = "<null>";
 
 // Probably recalculates bounding box of the region.
 //
-// 0x4A2B50
+// 0x4A2B50 regionSetBound_
 void _regionSetBound(Region* region)
 {
     int minX = INT_MAX;
@@ -46,7 +46,7 @@ void _regionSetBound(Region* region)
     }
 }
 
-// 0x4A2C14
+// 0x4A2C14 pointInRegion_
 bool regionContainsPoint(Region* region, int x, int y)
 {
     if (region == nullptr) {
@@ -122,7 +122,7 @@ bool regionContainsPoint(Region* region, int x, int y)
     return false;
 }
 
-// 0x4A2D78
+// 0x4A2D78 allocateRegion_
 Region* regionCreate(int initialCapacity)
 {
     Region* region = (Region*)internal_malloc_safe(sizeof(*region), __FILE__, __LINE__); // "..\int\REGION.C", 142
@@ -163,7 +163,7 @@ Region* regionCreate(int initialCapacity)
 }
 
 // regionAddPoint
-// 0x4A2E68
+// 0x4A2E68 regionAddPoint_
 void regionAddPoint(Region* region, int x, int y)
 {
     if (region == nullptr) {
@@ -195,7 +195,7 @@ void regionAddPoint(Region* region, int x, int y)
 }
 
 // regionDelete
-// 0x4A2F0C
+// 0x4A2F0C regionDelete_
 void regionDelete(Region* region)
 {
     if (region == nullptr) {
@@ -211,7 +211,7 @@ void regionDelete(Region* region)
 }
 
 // regionAddName
-// 0x4A2F54
+// 0x4A2F54 regionAddName_
 void regionSetName(Region* region, const char* name)
 {
     if (region == nullptr) {
@@ -228,7 +228,7 @@ void regionSetName(Region* region, const char* name)
 }
 
 // regionGetName
-// 0x4A2F80
+// 0x4A2F80 regionGetName_
 char* regionGetName(Region* region)
 {
     if (region == nullptr) {
@@ -240,7 +240,7 @@ char* regionGetName(Region* region)
 }
 
 // regionGetUserData
-// 0x4A2F98
+// 0x4A2F98 regionGetUserData_
 void* regionGetUserData(Region* region)
 {
     if (region == nullptr) {
@@ -252,7 +252,7 @@ void* regionGetUserData(Region* region)
 }
 
 // regionSetUserData
-// 0x4A2FB4
+// 0x4A2FB4 regionSetUserData_
 void regionSetUserData(Region* region, void* data)
 {
     if (region == nullptr) {
@@ -263,7 +263,7 @@ void regionSetUserData(Region* region, void* data)
     region->userData = data;
 }
 
-// 0x4A2FD0
+// 0x4A2FD0 regionSetFlag_
 void regionAddFlag(Region* region, int value)
 {
     region->flags |= value;

--- a/src/region.cc
+++ b/src/region.cc
@@ -8,12 +8,12 @@
 
 namespace fallout {
 
-// 0x50D394
+// 0x50D394 aNull
 static char _aNull[] = "<null>";
 
 // Probably recalculates bounding box of the region.
 //
-// 0x4A2B50 regionSetBound_
+// 0x4A2B50 regionSetBound
 void _regionSetBound(Region* region)
 {
     int minX = INT_MAX;
@@ -46,7 +46,7 @@ void _regionSetBound(Region* region)
     }
 }
 
-// 0x4A2C14 pointInRegion_
+// 0x4A2C14 pointInRegion
 bool regionContainsPoint(Region* region, int x, int y)
 {
     if (region == nullptr) {
@@ -122,7 +122,7 @@ bool regionContainsPoint(Region* region, int x, int y)
     return false;
 }
 
-// 0x4A2D78 allocateRegion_
+// 0x4A2D78 allocateRegion
 Region* regionCreate(int initialCapacity)
 {
     Region* region = (Region*)internal_malloc_safe(sizeof(*region), __FILE__, __LINE__); // "..\int\REGION.C", 142
@@ -163,7 +163,7 @@ Region* regionCreate(int initialCapacity)
 }
 
 // regionAddPoint
-// 0x4A2E68 regionAddPoint_
+// 0x4A2E68 regionAddPoint
 void regionAddPoint(Region* region, int x, int y)
 {
     if (region == nullptr) {
@@ -195,7 +195,7 @@ void regionAddPoint(Region* region, int x, int y)
 }
 
 // regionDelete
-// 0x4A2F0C regionDelete_
+// 0x4A2F0C regionDelete
 void regionDelete(Region* region)
 {
     if (region == nullptr) {
@@ -211,7 +211,7 @@ void regionDelete(Region* region)
 }
 
 // regionAddName
-// 0x4A2F54 regionAddName_
+// 0x4A2F54 regionAddName
 void regionSetName(Region* region, const char* name)
 {
     if (region == nullptr) {
@@ -228,7 +228,7 @@ void regionSetName(Region* region, const char* name)
 }
 
 // regionGetName
-// 0x4A2F80 regionGetName_
+// 0x4A2F80 regionGetName
 char* regionGetName(Region* region)
 {
     if (region == nullptr) {
@@ -240,7 +240,7 @@ char* regionGetName(Region* region)
 }
 
 // regionGetUserData
-// 0x4A2F98 regionGetUserData_
+// 0x4A2F98 regionGetUserData
 void* regionGetUserData(Region* region)
 {
     if (region == nullptr) {
@@ -252,7 +252,7 @@ void* regionGetUserData(Region* region)
 }
 
 // regionSetUserData
-// 0x4A2FB4 regionSetUserData_
+// 0x4A2FB4 regionSetUserData
 void regionSetUserData(Region* region, void* data)
 {
     if (region == nullptr) {
@@ -263,7 +263,7 @@ void regionSetUserData(Region* region, void* data)
     region->userData = data;
 }
 
-// 0x4A2FD0 regionSetFlag_
+// 0x4A2FD0 regionSetFlag
 void regionAddFlag(Region* region, int value)
 {
     region->flags |= value;

--- a/src/scan_unimplemented_sfall.h
+++ b/src/scan_unimplemented_sfall.h
@@ -236,14 +236,14 @@ static struct SfallOpcodeInfo opcodeInfoArray[] = {
     { 0x24f, "strlen" },
     { 0x250, "sprintf" },
     { 0x251, "charcode" },
-    // 0x252 // RESERVE
+    // 0x25
     { 0x253, "typeof" },
     { 0x254, "save_array" },
     { 0x255, "load_array" },
     { 0x256, "array_key" },
     { 0x257, "arrayexpr" },
-    // 0x258 // RESERVED for array
-    // 0x259 // RESERVED for array
+    // 0x25
+    // 0x25
     { 0x25a, "reg_anim_destroy" },
     { 0x25b, "reg_anim_animate_and_hide" },
     { 0x25c, "reg_anim_combat_check" },
@@ -258,9 +258,9 @@ static struct SfallOpcodeInfo opcodeInfoArray[] = {
     { 0x265, "exponent" },
     { 0x266, "ceil" },
     { 0x267, "round" },
-    // 0x268 RESERVE
-    // 0x269 RESERVE
-    // 0x26a RESERVE
+    // 0x26
+    // 0x26
+    // 0x26
     { 0x26b, "message_str_game" },
     { 0x26c, "sneak_success" },
     { 0x26d, "tile_light" },

--- a/src/scripts.cc
+++ b/src/scripts.cc
@@ -92,7 +92,7 @@ static int scriptGetNewId(int scriptType);
 static int scriptsRemoveLocalVars(Script* script);
 static int scriptsGetMessageList(int messageListId, MessageList** outMessageList);
 
-// 0x50D6B8
+// 0x50D6B8 Error_2
 static char gScriptsErrorText[] = "Error";
 
 // 0x50D6C0
@@ -100,42 +100,42 @@ static char gScriptsEmptyText[] = "";
 
 // Number of lines in scripts.lst
 //
-// 0x51C6AC
+// 0x51C6AC num_script_indexes
 static int _num_script_indexes = 0;
 
-// 0x51C6B0
+// 0x51C6B0 scr_find_first_idx
 static int gScriptsEnumerationScriptIndex = 0;
 
-// 0x51C6B4
+// 0x51C6B4 scr_find_first_ptr
 static ScriptListExtent* gScriptsEnumerationScriptListExtent = nullptr;
 
-// 0x51C6B8
+// 0x51C6B8 scr_find_first_elev
 static int gScriptsEnumerationElevation = 0;
 
-// 0x51C6BC
+// 0x51C6BC scrSpatialsEnabled
 static bool gSpatialsEnabled = true;
 
-// 0x51C6C0
+// 0x51C6C0 scriptlists
 static ScriptList gScriptLists[SCRIPT_TYPE_COUNT];
 
-// 0x51C710
+// 0x51C710 _script_path_base
 static const char* gScriptsBasePath = "scripts\\";
 
-// 0x51C714
+// 0x51C714 script_engine_running
 static bool gScriptsEnabled = false;
 
-// 0x51C718
+// 0x51C718 script_engine_run_critters
 static int gCritterProcessingEnabled = 0;
 
-// 0x51C71C
+// 0x51C71C script_engine_game_mode
 static int gGameModeEnabled = 0;
 
 // Game time in ticks (1/10 second).
 //
-// 0x51C720
+// 0x51C720 fallout_game_time
 static unsigned int gGameTime = 302400;
 
-// 0x51C724
+// 0x51C724 days_in_month
 static const int gGameTimeDaysPerMonth[12] = {
     31, // Jan
     28, // Feb
@@ -151,7 +151,7 @@ static const int gGameTimeDaysPerMonth[12] = {
     31, // Dec
 };
 
-// 0x51C758
+// 0x51C758 _procTableStrs
 const char* gScriptProcNames[SCRIPT_PROC_COUNT] = {
     "no_p_proc",
     "start",
@@ -185,93 +185,93 @@ const char* gScriptProcNames[SCRIPT_PROC_COUNT] = {
 
 // scripts.lst
 //
-// 0x51C7C8
+// 0x51C7C8 _scriptListInfo
 static ScriptsListEntry* gScriptsListEntries = nullptr;
 
-// 0x51C7CC
+// 0x51C7CC maxScriptNum
 static int gScriptsListEntriesLength = 0;
 
-// 0x51C7D4
+// 0x51C7D4 cur_id
 static int gObjectIdCounter = 4;
 
-// 0x51C7DC
+// 0x51C7DC count
 static int gCritterProcessingIndex = 0;
 
-// 0x51C7E0
+// 0x51C7E0 last_time_
 static int gLastQueueProcessingTime = 0;
 
-// 0x51C7E4
+// 0x51C7E4 last_light_time
 static int gLastMapUpdateTime = 0;
 
-// 0x51C7E8
+// 0x51C7E8 scrQueueTestObj
 static Object* _scrQueueTestObj = nullptr;
 
-// 0x51C7EC
+// 0x51C7EC scrQueueTestValue
 static int _scrQueueTestValue = 0;
 
-// 0x51C7F0
+// 0x51C7F0 _err_str
 static char* gErrorString = gScriptsErrorText;
 
-// 0x51C7F4
+// 0x51C7F4 _blank_str
 static char* gEmptyString = gScriptsEmptyText;
 
-// 0x664954
+// 0x664954 scriptState
 static unsigned int gScriptsRequests;
 
-// 0x664958
+// 0x664958 gcsd_requests
 static CombatStartData gScriptsRequestedCSD;
 
-// 0x664980
+// 0x664980 gcsd_copy
 static CombatStartData gScriptsCSD;
 
-// 0x6649A8
+// 0x6649A8 elevType
 static int gScriptsRequestedElevatorType;
 
-// 0x6649AC
+// 0x6649AC elevLevel
 static int gScriptsRequestedElevatorLevel;
 
-// 0x6649B0
+// 0x6649B0 tile_num
 static int gScriptsRequestedExplosionTile;
 
-// 0x6649B4
+// 0x6649B4 elev
 static int gScriptsRequestedExplosionElevation;
 
-// 0x6649B8
+// 0x6649B8 min_dmg
 static int gScriptsRequestedExplosionMinDamage;
 
-// 0x6649BC
+// 0x6649BC max_dmg
 static int gScriptsRequestedExplosionMaxDamage;
 
-// 0x6649C0
+// 0x6649C0 _dialogTarget
 static Object* gScriptsRequestedDialogWith;
 
-// 0x6649C4
+// 0x6649C4 _lootSource
 static Object* gScriptsRequestedLootingBy;
 
-// 0x6649C8
+// 0x6649C8 _lootTarget
 static Object* gScriptsRequestedLootingFrom;
 
-// 0x6649CC
+// 0x6649CC stealSource
 static Object* gScriptsRequestedStealingBy;
 
-// 0x6649D0
+// 0x6649D0 stealTarget
 static Object* gScriptsRequestedStealingFrom;
 
-// 0x6649D4
+// 0x6649D4 script_dialog_msgs
 static MessageList gScriptDialogMessageLists[SCRIPT_DIALOG_MESSAGE_LIST_CAPACITY];
 
 // scr.msg
 //
-// 0x667724
+// 0x667724 script_message_file
 static MessageList gScrMessageList;
 
-// 0x667748
+// 0x667748 lasttime
 static int gLastBackgroundProcessTime;
 
-// 0x66774C
+// 0x66774C last_is_set
 static bool gBackgroundProcessTimeInitialized;
 
-// 0x667750
+// 0x667750 tempStr1
 static char gDebugScriptFileName[20];
 
 static int gStartYear;

--- a/src/scripts.cc
+++ b/src/scripts.cc
@@ -118,7 +118,7 @@ static bool gSpatialsEnabled = true;
 // 0x51C6C0 scriptlists
 static ScriptList gScriptLists[SCRIPT_TYPE_COUNT];
 
-// 0x51C710 _script_path_base
+// 0x51C710 script_path_base
 static const char* gScriptsBasePath = "scripts\\";
 
 // 0x51C714 script_engine_running
@@ -151,7 +151,7 @@ static const int gGameTimeDaysPerMonth[12] = {
     31, // Dec
 };
 
-// 0x51C758 _procTableStrs
+// 0x51C758 procTableStrs
 const char* gScriptProcNames[SCRIPT_PROC_COUNT] = {
     "no_p_proc",
     "start",
@@ -185,7 +185,7 @@ const char* gScriptProcNames[SCRIPT_PROC_COUNT] = {
 
 // scripts.lst
 //
-// 0x51C7C8 _scriptListInfo
+// 0x51C7C8 scriptListInfo
 static ScriptsListEntry* gScriptsListEntries = nullptr;
 
 // 0x51C7CC maxScriptNum
@@ -209,10 +209,10 @@ static Object* _scrQueueTestObj = nullptr;
 // 0x51C7EC scrQueueTestValue
 static int _scrQueueTestValue = 0;
 
-// 0x51C7F0 _err_str
+// 0x51C7F0 err_str
 static char* gErrorString = gScriptsErrorText;
 
-// 0x51C7F4 _blank_str
+// 0x51C7F4 blank_str
 static char* gEmptyString = gScriptsEmptyText;
 
 // 0x664954 scriptState
@@ -242,13 +242,13 @@ static int gScriptsRequestedExplosionMinDamage;
 // 0x6649BC max_dmg
 static int gScriptsRequestedExplosionMaxDamage;
 
-// 0x6649C0 _dialogTarget
+// 0x6649C0 dialogTarget
 static Object* gScriptsRequestedDialogWith;
 
-// 0x6649C4 _lootSource
+// 0x6649C4 lootSource
 static Object* gScriptsRequestedLootingBy;
 
-// 0x6649C8 _lootTarget
+// 0x6649C8 lootTarget
 static Object* gScriptsRequestedLootingFrom;
 
 // 0x6649CC stealSource

--- a/src/select_file_list.cc
+++ b/src/select_file_list.cc
@@ -7,7 +7,7 @@
 
 namespace fallout {
 
-// 0x4AA250
+// 0x4AA250 compare_
 int _compare(const void* a, const void* b)
 {
     const char* c1 = *(const char**)a;
@@ -15,7 +15,7 @@ int _compare(const void* a, const void* b)
     return strcmp(c1, c2);
 }
 
-// 0x4AA2A4
+// 0x4AA2A4 getFileList_
 char** _getFileList(const char* pattern, int* fileNameListLengthPtr)
 {
     char** fileNameList;
@@ -30,7 +30,7 @@ char** _getFileList(const char* pattern, int* fileNameListLengthPtr)
     return fileNameList;
 }
 
-// 0x4AA2DC
+// 0x4AA2DC freeFileList_
 void _freeFileList(char** fileList)
 {
     fileNameListFree(&fileList, 0);

--- a/src/select_file_list.cc
+++ b/src/select_file_list.cc
@@ -7,7 +7,7 @@
 
 namespace fallout {
 
-// 0x4AA250 compare_
+// 0x4AA250 compare
 int _compare(const void* a, const void* b)
 {
     const char* c1 = *(const char**)a;
@@ -15,7 +15,7 @@ int _compare(const void* a, const void* b)
     return strcmp(c1, c2);
 }
 
-// 0x4AA2A4 getFileList_
+// 0x4AA2A4 getFileList
 char** _getFileList(const char* pattern, int* fileNameListLengthPtr)
 {
     char** fileNameList;
@@ -30,7 +30,7 @@ char** _getFileList(const char* pattern, int* fileNameListLengthPtr)
     return fileNameList;
 }
 
-// 0x4AA2DC freeFileList_
+// 0x4AA2DC freeFileList
 void _freeFileList(char** fileList)
 {
     fileNameListFree(&fileList, 0);

--- a/src/skill.cc
+++ b/src/skill.cc
@@ -77,7 +77,7 @@ static const int gHealableDamageFlags[HEALABLE_DAMAGE_FLAGS_LENGTH] = {
     DAM_CRIP_LEG_LEFT,
 };
 
-// 0x51D118
+// 0x51D118 skill_data
 static SkillDescription gSkillDescriptions[SKILL_COUNT] = {
     { nullptr, nullptr, nullptr, 28, 5, 4, STAT_AGILITY, STAT_INVALID, 1, 0, 0 },
     { nullptr, nullptr, nullptr, 29, 0, 2, STAT_AGILITY, STAT_INVALID, 1, 0, 0 },
@@ -99,26 +99,26 @@ static SkillDescription gSkillDescriptions[SKILL_COUNT] = {
     { nullptr, nullptr, nullptr, 45, 0, 2, STAT_ENDURANCE, STAT_INTELLIGENCE, 1, 100, 0 },
 };
 
-// 0x51D430
+// 0x51D430 gIsSteal
 int _gIsSteal = 0;
 
 // Something about stealing, base value?
 //
-// 0x51D434
+// 0x51D434 gStealCount
 int _gStealCount = 0;
 
-// 0x51D438
+// 0x51D438 gStealSize
 int _gStealSize = 0;
 
-// 0x667F98
+// 0x667F98 timesSkillUsed
 static int _timesSkillUsed[SKILL_COUNT][SKILLS_MAX_USES_PER_DAY];
 
-// 0x668070
+// 0x668070 tag_skill
 static int gTaggedSkills[NUM_TAGGED_SKILLS];
 
 // skill.msg
 //
-// 0x668080
+// 0x668080 skill_message_file
 static MessageList gSkillsMessageList;
 
 // 0x4AA318

--- a/src/skilldex.cc
+++ b/src/skilldex.cc
@@ -106,7 +106,7 @@ static int gSkilldexWindowOldFont;
 static FrmImage _skilldexFrmImages[SKILLDEX_FRM_COUNT];
 
 // skilldex_select
-// 0x4ABFD0
+// 0x4ABFD0 skilldex_select_
 int skilldexOpen()
 {
     ScopedGameMode gm(GameMode::kSkilldex);
@@ -147,7 +147,7 @@ int skilldexOpen()
     return rc;
 }
 
-// 0x4AC054
+// 0x4AC054 skilldex_start_
 static int skilldexWindowInit()
 {
     gSkilldexWindowOldFont = fontGetCurrent();
@@ -390,7 +390,7 @@ static int skilldexWindowInit()
     return 0;
 }
 
-// 0x4AC67C
+// 0x4AC67C skilldex_end_
 static void skilldexWindowFree()
 {
     windowDestroy(gSkilldexWindow);

--- a/src/skilldex.cc
+++ b/src/skilldex.cc
@@ -57,10 +57,10 @@ typedef enum SkilldexSkill {
 static int skilldexWindowInit();
 static void skilldexWindowFree();
 
-// 0x51D43C
+// 0x51D43C bk_enable_6
 static bool gSkilldexWindowIsoWasEnabled = false;
 
-// 0x51D440
+// 0x51D440 grphfid
 static const int gSkilldexFrmIds[SKILLDEX_FRM_COUNT] = {
     121,
     119,
@@ -72,7 +72,7 @@ static const int gSkilldexFrmIds[SKILLDEX_FRM_COUNT] = {
 
 // Maps Skilldex options into skills.
 //
-// 0x51D458
+// 0x51D458 sklxref
 static const int gSkilldexSkills[SKILLDEX_SKILL_COUNT] = {
     SKILL_SNEAK,
     SKILL_LOCKPICK,
@@ -84,29 +84,29 @@ static const int gSkilldexSkills[SKILLDEX_SKILL_COUNT] = {
     SKILL_REPAIR,
 };
 
-// 0x6680B8
+// 0x6680B8 skldxbtn
 static unsigned char* gSkilldexButtonsData[SKILLDEX_SKILL_BUTTON_BUFFER_COUNT];
 
 // skilldex.msg
-// 0x6680F8
+// 0x6680F8 skldxmsg
 static MessageList gSkilldexMessageList;
 
-// 0x668100
+// 0x668100 mesg_2
 static MessageListItem gSkilldexMessageListItem;
 
-// 0x668140
+// 0x668140 skldxwin
 static int gSkilldexWindow;
 
-// 0x668144
+// 0x668144 winbuf_2
 static unsigned char* gSkilldexWindowBuffer;
 
-// 0x668148
+// 0x668148 fontsave_4
 static int gSkilldexWindowOldFont;
 
 static FrmImage _skilldexFrmImages[SKILLDEX_FRM_COUNT];
 
 // skilldex_select
-// 0x4ABFD0 skilldex_select_
+// 0x4ABFD0 skilldex_select
 int skilldexOpen()
 {
     ScopedGameMode gm(GameMode::kSkilldex);
@@ -147,7 +147,7 @@ int skilldexOpen()
     return rc;
 }
 
-// 0x4AC054 skilldex_start_
+// 0x4AC054 skilldex_start
 static int skilldexWindowInit()
 {
     gSkilldexWindowOldFont = fontGetCurrent();
@@ -390,7 +390,7 @@ static int skilldexWindowInit()
     return 0;
 }
 
-// 0x4AC67C skilldex_end_
+// 0x4AC67C skilldex_end
 static void skilldexWindowFree()
 {
     windowDestroy(gSkilldexWindow);

--- a/src/sound.cc
+++ b/src/sound.cc
@@ -68,22 +68,22 @@ static void _removeFadeSound(FadeSound* fadeSound);
 static void _fadeSounds();
 static int _internalSoundFade(Sound* sound, int duration, int targetVolume, bool pause);
 
-// 0x51D478 _fadeHead
+// 0x51D478 fadeHead
 static FadeSound* _fadeHead = nullptr;
 
-// 0x51D47C _fadeFreeList
+// 0x51D47C fadeFreeList
 static FadeSound* _fadeFreeList = nullptr;
 
-// 0x51D488 _mallocPtr_2
+// 0x51D488 mallocPtr_2
 static MallocProc* gSoundMallocProc = soundMallocProcDefaultImpl;
 
-// 0x51D48C _reallocPtr_2
+// 0x51D48C reallocPtr_2
 static ReallocProc* gSoundReallocProc = soundReallocProcDefaultImpl;
 
-// 0x51D490 _freePtr_2
+// 0x51D490 freePtr_2
 static FreeProc* gSoundFreeProc = soundFreeProcDefaultImpl;
 
-// 0x51D494 _defaultStream
+// 0x51D494 defaultStream
 static SoundFileIO gSoundDefaultFileIO = {
     soundOpenData,
     soundCloseData,
@@ -95,10 +95,10 @@ static SoundFileIO gSoundDefaultFileIO = {
     -1,
 };
 
-// 0x51D4B4 _nameMangler
+// 0x51D4B4 nameMangler
 static SoundFileNameMangler* gSoundFileNameMangler = soundFileManglerDefaultImpl;
 
-// 0x51D4B8 _errorMsgs
+// 0x51D4B8 errorMsgs
 static const char* gSoundErrorDescriptions[SOUND_ERR_COUNT] = {
     "sound.c: No error",
     "sound.c: SOS driver not loaded",
@@ -161,7 +161,7 @@ static int _numBuffers;
 // 0x668170 shouldUseSound
 static bool gSoundInitialized;
 
-// 0x668174 _soundMgrList
+// 0x668174 soundMgrList
 static Sound* gSoundListHead;
 
 static SDL_TimerID gFadeSoundsTimerId = 0;

--- a/src/sound.cc
+++ b/src/sound.cc
@@ -68,22 +68,22 @@ static void _removeFadeSound(FadeSound* fadeSound);
 static void _fadeSounds();
 static int _internalSoundFade(Sound* sound, int duration, int targetVolume, bool pause);
 
-// 0x51D478
+// 0x51D478 _fadeHead
 static FadeSound* _fadeHead = nullptr;
 
-// 0x51D47C
+// 0x51D47C _fadeFreeList
 static FadeSound* _fadeFreeList = nullptr;
 
-// 0x51D488
+// 0x51D488 _mallocPtr_2
 static MallocProc* gSoundMallocProc = soundMallocProcDefaultImpl;
 
-// 0x51D48C
+// 0x51D48C _reallocPtr_2
 static ReallocProc* gSoundReallocProc = soundReallocProcDefaultImpl;
 
-// 0x51D490
+// 0x51D490 _freePtr_2
 static FreeProc* gSoundFreeProc = soundFreeProcDefaultImpl;
 
-// 0x51D494
+// 0x51D494 _defaultStream
 static SoundFileIO gSoundDefaultFileIO = {
     soundOpenData,
     soundCloseData,
@@ -95,10 +95,10 @@ static SoundFileIO gSoundDefaultFileIO = {
     -1,
 };
 
-// 0x51D4B4
+// 0x51D4B4 _nameMangler
 static SoundFileNameMangler* gSoundFileNameMangler = soundFileManglerDefaultImpl;
 
-// 0x51D4B8
+// 0x51D4B8 _errorMsgs
 static const char* gSoundErrorDescriptions[SOUND_ERR_COUNT] = {
     "sound.c: No error",
     "sound.c: SOS driver not loaded",
@@ -135,33 +135,33 @@ static const char* gSoundErrorDescriptions[SOUND_ERR_COUNT] = {
     "sound.c: unknown error",
 };
 
-// 0x668150
+// 0x668150 soundErrorno
 static int gSoundLastError;
 
-// 0x668154
+// 0x668154 masterVol
 static int _masterVol;
 
-// 0x66815C
+// 0x66815C sampleRate
 static int _sampleRate;
 
 // Number of sounds currently playing.
 //
-// 0x668160
+// 0x668160 numSounds
 static int _numSounds;
 
-// 0x668164
+// 0x668164 deviceInit
 static int _deviceInit;
 
-// 0x668168
+// 0x668168 dataSize
 static int _dataSize;
 
-// 0x66816C
+// 0x66816C numBuffers
 static int _numBuffers;
 
-// 0x668170
+// 0x668170 shouldUseSound
 static bool gSoundInitialized;
 
-// 0x668174
+// 0x668174 _soundMgrList
 static Sound* gSoundListHead;
 
 static SDL_TimerID gFadeSoundsTimerId = 0;

--- a/src/sound_decoder.cc
+++ b/src/sound_decoder.cc
@@ -98,7 +98,7 @@ static unsigned char* _AudioDecoder_scale0;
 // 0x6ADB04
 static unsigned char* _AudioDecoder_scale_tbl;
 
-// 0x4D3BB0
+// 0x4D3BB0 bytes_init_
 static bool soundDecoderPrepare(SoundDecoder* soundDecoder, SoundDecoderReadProc* readProc, void* data)
 {
     soundDecoder->readProc = readProc;
@@ -115,7 +115,7 @@ static bool soundDecoderPrepare(SoundDecoder* soundDecoder, SoundDecoderReadProc
     return true;
 }
 
-// 0x4D3BE0
+// 0x4D3BE0 ByteReaderFill_
 static unsigned char soundDecoderReadNextChunk(SoundDecoder* soundDecoder)
 {
     soundDecoder->remainingInSize = soundDecoder->readProc(soundDecoder->data, soundDecoder->bufferIn, soundDecoder->bufferInSize);
@@ -129,7 +129,7 @@ static unsigned char soundDecoderReadNextChunk(SoundDecoder* soundDecoder)
     return *soundDecoder->nextIn++;
 }
 
-// 0x4D3C78
+// 0x4D3C78 init_pack_tables_
 static void init_pack_tables()
 {
     // 0x51E32C
@@ -805,7 +805,7 @@ static bool ReadBands(SoundDecoder* soundDecoder)
     return true;
 }
 
-// 0x4D4ADC
+// 0x4D4ADC untransform_subband0_
 static void untransform_subband0(unsigned char* a1, unsigned char* a2, int a3, int a4)
 {
     short* p;
@@ -903,7 +903,7 @@ static void untransform_subband0(unsigned char* a1, unsigned char* a2, int a3, i
     }
 }
 
-// 0x4D4D1C
+// 0x4D4D1C untransform_subband_
 static void untransform_subband(unsigned char* a1, unsigned char* a2, int a3, int a4)
 {
     int v13;
@@ -994,7 +994,7 @@ static void untransform_subband(unsigned char* a1, unsigned char* a2, int a3, in
     }
 }
 
-// 0x4D4E80
+// 0x4D4E80 untransform_all_
 static void untransform_all(SoundDecoder* soundDecoder)
 {
     int v8;
@@ -1047,7 +1047,7 @@ static void untransform_all(SoundDecoder* soundDecoder)
 
 // NOTE: Inlined.
 //
-// 0x4D4F58
+// 0x4D4F58 AudioDecoder_fill_
 static bool soundDecoderFill(SoundDecoder* soundDecoder)
 {
     // CE: Implementation is slightly different. `ReadBands` now handles new
@@ -1071,7 +1071,7 @@ static bool soundDecoderFill(SoundDecoder* soundDecoder)
     return true;
 }
 
-// 0x4D4FA0
+// 0x4D4FA0 AudioDecoder_Read_
 size_t soundDecoderDecode(SoundDecoder* soundDecoder, void* buffer, size_t size)
 {
     unsigned char* dest;
@@ -1110,7 +1110,7 @@ size_t soundDecoderDecode(SoundDecoder* soundDecoder, void* buffer, size_t size)
     return bytesRead;
 }
 
-// 0x4D5048
+// 0x4D5048 AudioDecoder_Close_
 void soundDecoderFree(SoundDecoder* soundDecoder)
 {
     if (soundDecoder->bufferIn != nullptr) {
@@ -1137,7 +1137,7 @@ void soundDecoderFree(SoundDecoder* soundDecoder)
     }
 }
 
-// 0x4D50A8
+// 0x4D50A8 Create_AudioDecoder_
 SoundDecoder* soundDecoderInit(SoundDecoderReadProc* readProc, void* data, int* channelsPtr, int* sampleRatePtr, int* sampleCountPtr)
 {
     int v14;

--- a/src/sound_decoder.cc
+++ b/src/sound_decoder.cc
@@ -44,10 +44,10 @@ static inline void soundDecoderRequireBits(SoundDecoder* soundDecoder, int bits)
 static inline void soundDecoderDropBits(SoundDecoder* soundDecoder, int bits);
 static int ReadBand_Fmt31(SoundDecoder* soundDecoder, int offset, int bits);
 
-// 0x51E328
+// 0x51E328 AudioDecoder_cnt
 static int gSoundDecodersCount = 0;
 
-// 0x51E330
+// 0x51E330 _ReadBand_tbl
 static ReadBandFunc _ReadBand_tbl[32] = {
     ReadBand_Fmt0,
     ReadBand_Fail,
@@ -83,22 +83,22 @@ static ReadBandFunc _ReadBand_tbl[32] = {
     ReadBand_Fmt31,
 };
 
-// 0x6AD960
+// 0x6AD960 _pack11_2
 static unsigned char pack11_2[128];
 
-// 0x6AD9E0
+// 0x6AD9E0 _pack3_3
 static unsigned char pack3_3[32];
 
-// 0x6ADA00
+// 0x6ADA00 _pack5_3
 static unsigned short pack5_3[128];
 
-// 0x6ADB00
+// 0x6ADB00 AudioDecoder_scale0
 static unsigned char* _AudioDecoder_scale0;
 
-// 0x6ADB04
+// 0x6ADB04 AudioDecoder_scale_tbl
 static unsigned char* _AudioDecoder_scale_tbl;
 
-// 0x4D3BB0 bytes_init_
+// 0x4D3BB0 bytes_init
 static bool soundDecoderPrepare(SoundDecoder* soundDecoder, SoundDecoderReadProc* readProc, void* data)
 {
     soundDecoder->readProc = readProc;
@@ -115,7 +115,7 @@ static bool soundDecoderPrepare(SoundDecoder* soundDecoder, SoundDecoderReadProc
     return true;
 }
 
-// 0x4D3BE0 ByteReaderFill_
+// 0x4D3BE0 ByteReaderFill
 static unsigned char soundDecoderReadNextChunk(SoundDecoder* soundDecoder)
 {
     soundDecoder->remainingInSize = soundDecoder->readProc(soundDecoder->data, soundDecoder->bufferIn, soundDecoder->bufferInSize);
@@ -129,7 +129,7 @@ static unsigned char soundDecoderReadNextChunk(SoundDecoder* soundDecoder)
     return *soundDecoder->nextIn++;
 }
 
-// 0x4D3C78 init_pack_tables_
+// 0x4D3C78 init_pack_tables
 static void init_pack_tables()
 {
     // 0x51E32C
@@ -805,7 +805,7 @@ static bool ReadBands(SoundDecoder* soundDecoder)
     return true;
 }
 
-// 0x4D4ADC untransform_subband0_
+// 0x4D4ADC untransform_subband0
 static void untransform_subband0(unsigned char* a1, unsigned char* a2, int a3, int a4)
 {
     short* p;
@@ -903,7 +903,7 @@ static void untransform_subband0(unsigned char* a1, unsigned char* a2, int a3, i
     }
 }
 
-// 0x4D4D1C untransform_subband_
+// 0x4D4D1C untransform_subband
 static void untransform_subband(unsigned char* a1, unsigned char* a2, int a3, int a4)
 {
     int v13;
@@ -994,7 +994,7 @@ static void untransform_subband(unsigned char* a1, unsigned char* a2, int a3, in
     }
 }
 
-// 0x4D4E80 untransform_all_
+// 0x4D4E80 untransform_all
 static void untransform_all(SoundDecoder* soundDecoder)
 {
     int v8;
@@ -1047,7 +1047,7 @@ static void untransform_all(SoundDecoder* soundDecoder)
 
 // NOTE: Inlined.
 //
-// 0x4D4F58 AudioDecoder_fill_
+// 0x4D4F58 AudioDecoder_fill
 static bool soundDecoderFill(SoundDecoder* soundDecoder)
 {
     // CE: Implementation is slightly different. `ReadBands` now handles new
@@ -1071,7 +1071,7 @@ static bool soundDecoderFill(SoundDecoder* soundDecoder)
     return true;
 }
 
-// 0x4D4FA0 AudioDecoder_Read_
+// 0x4D4FA0 AudioDecoder_Read
 size_t soundDecoderDecode(SoundDecoder* soundDecoder, void* buffer, size_t size)
 {
     unsigned char* dest;
@@ -1110,7 +1110,7 @@ size_t soundDecoderDecode(SoundDecoder* soundDecoder, void* buffer, size_t size)
     return bytesRead;
 }
 
-// 0x4D5048 AudioDecoder_Close_
+// 0x4D5048 AudioDecoder_Close
 void soundDecoderFree(SoundDecoder* soundDecoder)
 {
     if (soundDecoder->bufferIn != nullptr) {
@@ -1137,7 +1137,7 @@ void soundDecoderFree(SoundDecoder* soundDecoder)
     }
 }
 
-// 0x4D50A8 Create_AudioDecoder_
+// 0x4D50A8 Create_AudioDecoder
 SoundDecoder* soundDecoderInit(SoundDecoderReadProc* readProc, void* data, int* channelsPtr, int* sampleRatePtr, int* sampleCountPtr)
 {
     int v14;

--- a/src/sound_decoder.cc
+++ b/src/sound_decoder.cc
@@ -47,7 +47,7 @@ static int ReadBand_Fmt31(SoundDecoder* soundDecoder, int offset, int bits);
 // 0x51E328 AudioDecoder_cnt
 static int gSoundDecodersCount = 0;
 
-// 0x51E330 _ReadBand_tbl
+// 0x51E330 ReadBand_tbl
 static ReadBandFunc _ReadBand_tbl[32] = {
     ReadBand_Fmt0,
     ReadBand_Fail,
@@ -83,13 +83,13 @@ static ReadBandFunc _ReadBand_tbl[32] = {
     ReadBand_Fmt31,
 };
 
-// 0x6AD960 _pack11_2
+// 0x6AD960 pack11_2
 static unsigned char pack11_2[128];
 
-// 0x6AD9E0 _pack3_3
+// 0x6AD9E0 pack3_3
 static unsigned char pack3_3[32];
 
-// 0x6ADA00 _pack5_3
+// 0x6ADA00 pack5_3
 static unsigned short pack5_3[128];
 
 // 0x6ADB00 AudioDecoder_scale0

--- a/src/sound_effects_cache.cc
+++ b/src/sound_effects_cache.cc
@@ -53,14 +53,14 @@ static bool gSoundEffectsCacheInitialized = false;
 static int _sfxc_cmpr = 1;
 
 // sfxc_pcache
-// 0x51C8EC _sfxc_pcache
+// 0x51C8EC sfxc_pcache
 static Cache* gSoundEffectsCache = nullptr;
 
 // sfxc_dlevel
 // 0x51C8DC sfxc_dlevel
 static int gSoundEffectsCacheDebugLevel = INT_MAX;
 
-// 0x51C8E0 _sfxc_effect_path
+// 0x51C8E0 sfxc_effect_path
 static char* gSoundEffectsCacheEffectsPath = nullptr;
 
 // 0x51C8E4 sfxc_handle_list

--- a/src/sound_effects_cache.cc
+++ b/src/sound_effects_cache.cc
@@ -46,27 +46,27 @@ static int soundEffectsCacheSoundDecoderReadHandler(void* data, void* buf, unsig
 static const char* off_50DE04 = "";
 
 // sfxc_initialized
-// 0x51C8F0
+// 0x51C8F0 sfxc_initialized
 static bool gSoundEffectsCacheInitialized = false;
 
-// 0x51C8F4
+// 0x51C8F4 sfxc_cmpr
 static int _sfxc_cmpr = 1;
 
 // sfxc_pcache
-// 0x51C8EC
+// 0x51C8EC _sfxc_pcache
 static Cache* gSoundEffectsCache = nullptr;
 
 // sfxc_dlevel
-// 0x51C8DC
+// 0x51C8DC sfxc_dlevel
 static int gSoundEffectsCacheDebugLevel = INT_MAX;
 
-// 0x51C8E0
+// 0x51C8E0 _sfxc_effect_path
 static char* gSoundEffectsCacheEffectsPath = nullptr;
 
-// 0x51C8E4
+// 0x51C8E4 sfxc_handle_list
 static SoundEffect* gSoundEffects = nullptr;
 
-// 0x51C8E8
+// 0x51C8E8 sfxc_files_open
 static int _sfxc_files_open = 0;
 
 // sfxc_init

--- a/src/sound_effects_list.cc
+++ b/src/sound_effects_list.cc
@@ -58,14 +58,14 @@ static int gSoundEffectsListEntriesLength = 0;
 static int _sfxl_compression;
 
 // sfxl_tag_is_legal
-// 0x4A98E0
+// 0x4A98E0 sfxl_tag_is_legal_
 bool soundEffectsListIsValidTag(int tag)
 {
     return soundEffectsListTagToIndex(tag, nullptr) == SFXL_OK;
 }
 
 // sfxl_init
-// 0x4A98F4
+// 0x4A98F4 sfxl_init_
 int soundEffectsListInit(const char* soundEffectsPath, int compression, int debugLevel)
 {
     char path[COMPAT_MAX_PATH];
@@ -169,7 +169,7 @@ int soundEffectsListInit(const char* soundEffectsPath, int compression, int debu
     return SFXL_OK;
 }
 
-// 0x4A9C04
+// 0x4A9C04 sfxl_exit_
 void soundEffectsListExit()
 {
     if (gSoundEffectsListInitialized) {
@@ -180,7 +180,7 @@ void soundEffectsListExit()
 }
 
 // sfxl_name_to_tag
-// 0x4A9C28
+// 0x4A9C28 sfxl_name_to_tag_
 int soundEffectsListGetTag(char* name, int* tagPtr)
 {
     if (compat_strnicmp(gSoundEffectsListPath, name, gSoundEffectsListPathLength) != 0) {
@@ -206,7 +206,7 @@ int soundEffectsListGetTag(char* name, int* tagPtr)
 }
 
 // sfxl_name
-// 0x4A9CD8
+// 0x4A9CD8 sfxl_name_
 int soundEffectsListGetFilePath(int tag, char** pathPtr)
 {
     int index;
@@ -230,7 +230,7 @@ int soundEffectsListGetFilePath(int tag, char** pathPtr)
     return SFXL_OK;
 }
 
-// 0x4A9D90
+// 0x4A9D90 sfxl_size_full_
 int soundEffectsListGetDataSize(int tag, int* sizePtr)
 {
     int index;
@@ -245,7 +245,7 @@ int soundEffectsListGetDataSize(int tag, int* sizePtr)
     return SFXL_OK;
 }
 
-// 0x4A9DBC
+// 0x4A9DBC sfxl_size_cached_
 int soundEffectsListGetFileSize(int tag, int* sizePtr)
 {
     int index;
@@ -261,7 +261,7 @@ int soundEffectsListGetFileSize(int tag, int* sizePtr)
 }
 
 // sfxl_tag_to_index
-// 0x4A9DE8
+// 0x4A9DE8 sfxl_index_
 static int soundEffectsListTagToIndex(int tag, int* indexPtr)
 {
     if (tag <= 0) {
@@ -284,7 +284,7 @@ static int soundEffectsListTagToIndex(int tag, int* indexPtr)
     return SFXL_OK;
 }
 
-// 0x4A9E44
+// 0x4A9E44 sfxl_destroy_
 static void soundEffectsListClear()
 {
     if (gSoundEffectsListEntriesLength < 0) {
@@ -309,7 +309,7 @@ static void soundEffectsListClear()
 }
 
 // sfxl_get_names
-// 0x4A9EA0
+// 0x4A9EA0 sfxl_get_names_
 static int soundEffectsListPopulateFileNames()
 {
     const char* extension;
@@ -366,7 +366,7 @@ static int soundEffectsListPopulateFileNames()
 }
 
 // sfxl_copy_names
-// 0x4AA000
+// 0x4AA000 sfxl_copy_names_
 static int soundEffectsListCopyFileNames(char** fileNameList)
 {
     for (int index = 0; index < gSoundEffectsListEntriesLength; index++) {
@@ -381,7 +381,7 @@ static int soundEffectsListCopyFileNames(char** fileNameList)
     return SFXL_OK;
 }
 
-// 0x4AA050
+// 0x4AA050 sfxl_get_sizes_
 static int soundEffectsListPopulateFileSizes()
 {
 
@@ -445,7 +445,7 @@ static int soundEffectsListPopulateFileSizes()
 
 // NOTE: Inlined.
 //
-// 0x4AA200
+// 0x4AA200 sfxl_sort_by_name_
 static int soundEffectsListSort()
 {
     if (gSoundEffectsListEntriesLength != 1) {
@@ -454,7 +454,7 @@ static int soundEffectsListSort()
     return 0;
 }
 
-// 0x4AA228
+// 0x4AA228 sfxl_compare_by_name_
 static int soundEffectsListCompareByName(const void* a, const void* b)
 {
     SoundEffectsListEntry* lhs = (SoundEffectsListEntry*)a;

--- a/src/sound_effects_list.cc
+++ b/src/sound_effects_list.cc
@@ -29,43 +29,43 @@ static int soundEffectsListSort();
 static int soundEffectsListCompareByName(const void* a, const void* b);
 static int soundEffectsListSoundDecoderReadHandler(void* data, void* buf, unsigned int size);
 
-// 0x51C8F8
+// 0x51C8F8 sfxl_initialized
 static bool gSoundEffectsListInitialized = false;
 
-// 0x51C8FC
+// 0x51C8FC sfxl_dlevel
 static int gSoundEffectsListDebugLevel = INT_MAX;
 
 // sfxl_effect_path
-// 0x51C900
+// 0x51C900 sfxl_effect_path
 static char* gSoundEffectsListPath = nullptr;
 
 // sfxl_effect_path_len
-// 0x51C904
+// 0x51C904 sfxl_effect_path_len
 static int gSoundEffectsListPathLength = 0;
 
 // sndlist.lst
 //
 // sfxl_list
-// 0x51C908
+// 0x51C908 _sfxl_list
 static SoundEffectsListEntry* gSoundEffectsListEntries = nullptr;
 
 // The length of [gSoundEffectsListEntries] array.
 //
-// 0x51C90C
+// 0x51C90C sfxl_files_total
 static int gSoundEffectsListEntriesLength = 0;
 
-// 0x667F94
+// 0x667F94 sfxl_compression
 static int _sfxl_compression;
 
 // sfxl_tag_is_legal
-// 0x4A98E0 sfxl_tag_is_legal_
+// 0x4A98E0 sfxl_tag_is_legal
 bool soundEffectsListIsValidTag(int tag)
 {
     return soundEffectsListTagToIndex(tag, nullptr) == SFXL_OK;
 }
 
 // sfxl_init
-// 0x4A98F4 sfxl_init_
+// 0x4A98F4 sfxl_init
 int soundEffectsListInit(const char* soundEffectsPath, int compression, int debugLevel)
 {
     char path[COMPAT_MAX_PATH];
@@ -169,7 +169,7 @@ int soundEffectsListInit(const char* soundEffectsPath, int compression, int debu
     return SFXL_OK;
 }
 
-// 0x4A9C04 sfxl_exit_
+// 0x4A9C04 sfxl_exit
 void soundEffectsListExit()
 {
     if (gSoundEffectsListInitialized) {
@@ -180,7 +180,7 @@ void soundEffectsListExit()
 }
 
 // sfxl_name_to_tag
-// 0x4A9C28 sfxl_name_to_tag_
+// 0x4A9C28 sfxl_name_to_tag
 int soundEffectsListGetTag(char* name, int* tagPtr)
 {
     if (compat_strnicmp(gSoundEffectsListPath, name, gSoundEffectsListPathLength) != 0) {
@@ -206,7 +206,7 @@ int soundEffectsListGetTag(char* name, int* tagPtr)
 }
 
 // sfxl_name
-// 0x4A9CD8 sfxl_name_
+// 0x4A9CD8 sfxl_name
 int soundEffectsListGetFilePath(int tag, char** pathPtr)
 {
     int index;
@@ -230,7 +230,7 @@ int soundEffectsListGetFilePath(int tag, char** pathPtr)
     return SFXL_OK;
 }
 
-// 0x4A9D90 sfxl_size_full_
+// 0x4A9D90 sfxl_size_full
 int soundEffectsListGetDataSize(int tag, int* sizePtr)
 {
     int index;
@@ -245,7 +245,7 @@ int soundEffectsListGetDataSize(int tag, int* sizePtr)
     return SFXL_OK;
 }
 
-// 0x4A9DBC sfxl_size_cached_
+// 0x4A9DBC sfxl_size_cached
 int soundEffectsListGetFileSize(int tag, int* sizePtr)
 {
     int index;
@@ -261,7 +261,7 @@ int soundEffectsListGetFileSize(int tag, int* sizePtr)
 }
 
 // sfxl_tag_to_index
-// 0x4A9DE8 sfxl_index_
+// 0x4A9DE8 sfxl_index
 static int soundEffectsListTagToIndex(int tag, int* indexPtr)
 {
     if (tag <= 0) {
@@ -284,7 +284,7 @@ static int soundEffectsListTagToIndex(int tag, int* indexPtr)
     return SFXL_OK;
 }
 
-// 0x4A9E44 sfxl_destroy_
+// 0x4A9E44 sfxl_destroy
 static void soundEffectsListClear()
 {
     if (gSoundEffectsListEntriesLength < 0) {
@@ -309,7 +309,7 @@ static void soundEffectsListClear()
 }
 
 // sfxl_get_names
-// 0x4A9EA0 sfxl_get_names_
+// 0x4A9EA0 sfxl_get_names
 static int soundEffectsListPopulateFileNames()
 {
     const char* extension;
@@ -366,7 +366,7 @@ static int soundEffectsListPopulateFileNames()
 }
 
 // sfxl_copy_names
-// 0x4AA000 sfxl_copy_names_
+// 0x4AA000 sfxl_copy_names
 static int soundEffectsListCopyFileNames(char** fileNameList)
 {
     for (int index = 0; index < gSoundEffectsListEntriesLength; index++) {
@@ -381,7 +381,7 @@ static int soundEffectsListCopyFileNames(char** fileNameList)
     return SFXL_OK;
 }
 
-// 0x4AA050 sfxl_get_sizes_
+// 0x4AA050 sfxl_get_sizes
 static int soundEffectsListPopulateFileSizes()
 {
 
@@ -445,7 +445,7 @@ static int soundEffectsListPopulateFileSizes()
 
 // NOTE: Inlined.
 //
-// 0x4AA200 sfxl_sort_by_name_
+// 0x4AA200 sfxl_sort_by_name
 static int soundEffectsListSort()
 {
     if (gSoundEffectsListEntriesLength != 1) {
@@ -454,7 +454,7 @@ static int soundEffectsListSort()
     return 0;
 }
 
-// 0x4AA228 sfxl_compare_by_name_
+// 0x4AA228 sfxl_compare_by_name
 static int soundEffectsListCompareByName(const void* a, const void* b)
 {
     SoundEffectsListEntry* lhs = (SoundEffectsListEntry*)a;

--- a/src/sound_effects_list.cc
+++ b/src/sound_effects_list.cc
@@ -46,7 +46,7 @@ static int gSoundEffectsListPathLength = 0;
 // sndlist.lst
 //
 // sfxl_list
-// 0x51C908 _sfxl_list
+// 0x51C908 sfxl_list
 static SoundEffectsListEntry* gSoundEffectsListEntries = nullptr;
 
 // The length of [gSoundEffectsListEntries] array.

--- a/src/stat.cc
+++ b/src/stat.cc
@@ -38,7 +38,7 @@ typedef struct StatDescription {
     int defaultValue;
 } StatDescription;
 
-// 0x51D53C
+// 0x51D53C stat_data
 static StatDescription gStatDescriptions[STAT_COUNT] = {
     { nullptr, nullptr, 0, PRIMARY_STAT_MIN, PRIMARY_STAT_MAX, 5 },
     { nullptr, nullptr, 1, PRIMARY_STAT_MIN, PRIMARY_STAT_MAX, 5 },
@@ -80,7 +80,7 @@ static StatDescription gStatDescriptions[STAT_COUNT] = {
     { nullptr, nullptr, 12, 0, 2000, 0 },
 };
 
-// 0x51D8CC
+// 0x51D8CC pc_stat_data
 static StatDescription gPcStatDescriptions[PC_STAT_COUNT] = {
     { nullptr, nullptr, 0, 0, INT_MAX, 0 },
     { nullptr, nullptr, 0, 1, PC_LEVEL_MAX, 1 },
@@ -89,13 +89,13 @@ static StatDescription gPcStatDescriptions[PC_STAT_COUNT] = {
     { nullptr, nullptr, 0, 0, INT_MAX, 0 },
 };
 
-// 0x66817C
+// 0x66817C stat_message_file
 static MessageList gStatsMessageList;
 
 // 0x668184
 static char* gStatValueDescriptions[PRIMARY_STAT_RANGE];
 
-// 0x6681AC
+// 0x6681AC curr_pc_stat
 static int gPcStatValues[PC_STAT_COUNT];
 
 static int unspentApBonus = 4;

--- a/src/string_parsers.cc
+++ b/src/string_parsers.cc
@@ -9,7 +9,7 @@
 namespace fallout {
 
 // strParseInt
-// 0x4AFD10
+// 0x4AFD10 strParseValue_
 int strParseInt(char** stringPtr, int* valuePtr)
 {
     char *str, *remaining_str;
@@ -52,7 +52,7 @@ int strParseInt(char** stringPtr, int* valuePtr)
 }
 
 // strParseStrFromList
-// 0x4AFE08
+// 0x4AFE08 strParseStrFromList_
 int strParseStrFromList(char** stringPtr, int* valuePtr, const char** stringList, int stringListLength)
 {
     int i;
@@ -108,7 +108,7 @@ int strParseStrFromList(char** stringPtr, int* valuePtr, const char** stringList
 }
 
 // strParseStrFromFunc
-// 0x4AFEDC
+// 0x4AFEDC strParseStrFromFunc_
 int strParseStrFromFunc(char** stringPtr, int* valuePtr, StringParserCallback* callback)
 {
     char *str, *remaining_str;
@@ -157,7 +157,7 @@ int strParseStrFromFunc(char** stringPtr, int* valuePtr, StringParserCallback* c
     return 0;
 }
 
-// 0x4AFF7C
+// 0x4AFF7C strParseStrSepVal_
 int strParseIntWithKey(char** stringPtr, const char* key, int* valuePtr, const char* delimeter)
 {
     char* str;
@@ -214,7 +214,7 @@ int strParseIntWithKey(char** stringPtr, const char* key, int* valuePtr, const c
     return result;
 }
 
-// 0x4B005C
+// 0x4B005C strParseStrAndSepVal_
 int strParseKeyValue(char** stringPtr, char* key, int* valuePtr, const char* delimiter)
 {
     char* str;

--- a/src/string_parsers.cc
+++ b/src/string_parsers.cc
@@ -9,7 +9,7 @@
 namespace fallout {
 
 // strParseInt
-// 0x4AFD10 strParseValue_
+// 0x4AFD10 strParseValue
 int strParseInt(char** stringPtr, int* valuePtr)
 {
     char *str, *remaining_str;
@@ -52,7 +52,7 @@ int strParseInt(char** stringPtr, int* valuePtr)
 }
 
 // strParseStrFromList
-// 0x4AFE08 strParseStrFromList_
+// 0x4AFE08 strParseStrFromList
 int strParseStrFromList(char** stringPtr, int* valuePtr, const char** stringList, int stringListLength)
 {
     int i;
@@ -108,7 +108,7 @@ int strParseStrFromList(char** stringPtr, int* valuePtr, const char** stringList
 }
 
 // strParseStrFromFunc
-// 0x4AFEDC strParseStrFromFunc_
+// 0x4AFEDC strParseStrFromFunc
 int strParseStrFromFunc(char** stringPtr, int* valuePtr, StringParserCallback* callback)
 {
     char *str, *remaining_str;
@@ -157,7 +157,7 @@ int strParseStrFromFunc(char** stringPtr, int* valuePtr, StringParserCallback* c
     return 0;
 }
 
-// 0x4AFF7C strParseStrSepVal_
+// 0x4AFF7C strParseStrSepVal
 int strParseIntWithKey(char** stringPtr, const char* key, int* valuePtr, const char* delimeter)
 {
     char* str;
@@ -214,7 +214,7 @@ int strParseIntWithKey(char** stringPtr, const char* key, int* valuePtr, const c
     return result;
 }
 
-// 0x4B005C strParseStrAndSepVal_
+// 0x4B005C strParseStrAndSepVal
 int strParseKeyValue(char** stringPtr, char* key, int* valuePtr, const char* delimiter)
 {
     char* str;

--- a/src/svga.cc
+++ b/src/svga.cc
@@ -27,10 +27,10 @@ static void destroyRenderer();
 // screen rect
 Rect _scr_size;
 
-// 0x6ACA18 _scr_blit
+// 0x6ACA18 scr_blit
 void (*_scr_blit)(unsigned char* src, int src_pitch, int unused, int src_x, int src_y, int src_width, int src_height, int dest_x, int dest_y) = _GNW95_ShowRect;
 
-// 0x6ACA1C _zero_mem
+// 0x6ACA1C zero_mem
 void (*_zero_mem)() = nullptr;
 
 SDL_Window* gSdlWindow = nullptr;

--- a/src/svga.cc
+++ b/src/svga.cc
@@ -42,49 +42,49 @@ SDL_Surface* gSdlTextureSurface = nullptr;
 // TODO: Remove once migration to update-render cycle is completed.
 FpsLimiter sharedFpsLimiter;
 
-// 0x4CAD08
+// 0x4CAD08 init_mode_320_200_
 int _init_mode_320_200()
 {
     return _GNW95_init_mode_ex(320, 200, 8);
 }
 
-// 0x4CAD40
+// 0x4CAD40 init_mode_320_400_
 int _init_mode_320_400()
 {
     return _GNW95_init_mode_ex(320, 400, 8);
 }
 
-// 0x4CAD5C
+// 0x4CAD5C init_mode_640_480_16_
 int _init_mode_640_480_16()
 {
     return -1;
 }
 
-// 0x4CAD64
+// 0x4CAD64 init_mode_640_480_
 int _init_mode_640_480()
 {
     return _init_vesa_mode(640, 480);
 }
 
-// 0x4CAD94
+// 0x4CAD94 init_mode_640_400_
 int _init_mode_640_400()
 {
     return _init_vesa_mode(640, 400);
 }
 
-// 0x4CADA8
+// 0x4CADA8 init_mode_800_600_
 int _init_mode_800_600()
 {
     return _init_vesa_mode(800, 600);
 }
 
-// 0x4CADBC
+// 0x4CADBC init_mode_1024_768_
 int _init_mode_1024_768()
 {
     return _init_vesa_mode(1024, 768);
 }
 
-// 0x4CADD0
+// 0x4CADD0 init_mode_1280_1024_
 int _init_mode_1280_1024()
 {
     return _init_vesa_mode(1280, 1024);
@@ -95,7 +95,7 @@ void _get_start_mode_()
 {
 }
 
-// 0x4CADFC
+// 0x4CADFC zero_vid_mem_
 void _zero_vid_mem()
 {
     if (_zero_mem) {
@@ -103,7 +103,7 @@ void _zero_vid_mem()
     }
 }
 
-// 0x4CAE1C
+// 0x4CAE1C GNW95_init_mode_ex_
 int _GNW95_init_mode_ex(int width, int height, int bpp)
 {
     width = settings.screen.resolution_x;
@@ -148,13 +148,13 @@ int _GNW95_init_mode_ex(int width, int height, int bpp)
     return 0;
 }
 
-// 0x4CAECC
+// 0x4CAECC init_vesa_mode_
 int _init_vesa_mode(int width, int height)
 {
     return _GNW95_init_mode_ex(width, height, 8);
 }
 
-// 0x4CAEDC
+// 0x4CAEDC GNW95_init_window_
 int _GNW95_init_window(int width, int height, bool fullscreen, int scale)
 {
     if (gSdlWindow == nullptr) {
@@ -184,7 +184,7 @@ int _GNW95_init_window(int width, int height, bool fullscreen, int scale)
     return 0;
 }
 
-// 0x4CAF9C
+// 0x4CAF9C GNW95_init_DirectDraw_
 int directDrawInit(int width, int height, int bpp)
 {
     if (gSdlSurface != nullptr) {
@@ -215,7 +215,7 @@ int directDrawInit(int width, int height, int bpp)
     return 0;
 }
 
-// 0x4CB1B0
+// 0x4CB1B0 GNW95_reset_mode_
 void directDrawFree()
 {
     if (gSdlSurface != nullptr) {
@@ -224,7 +224,7 @@ void directDrawFree()
     }
 }
 
-// 0x4CB310
+// 0x4CB310 GNW95_SetPaletteEntries_
 void directDrawSetPaletteInRange(unsigned char* palette, int start, int count)
 {
     if (gSdlSurface != nullptr && gSdlSurface->format->palette != nullptr) {
@@ -244,7 +244,7 @@ void directDrawSetPaletteInRange(unsigned char* palette, int start, int count)
     }
 }
 
-// 0x4CB568
+// 0x4CB568 GNW95_SetPalette_
 void directDrawSetPalette(unsigned char* palette)
 {
     if (gSdlSurface != nullptr && gSdlSurface->format->palette != nullptr) {
@@ -262,7 +262,7 @@ void directDrawSetPalette(unsigned char* palette)
     }
 }
 
-// 0x4CB68C
+// 0x4CB68C GNW95_GetPalette_
 unsigned char* directDrawGetPalette()
 {
     // 0x6ACA24
@@ -282,7 +282,7 @@ unsigned char* directDrawGetPalette()
     return palette;
 }
 
-// 0x4CB850
+// 0x4CB850 GNW95_ShowRect_
 void _GNW95_ShowRect(unsigned char* src, int srcPitch, int unused, int srcX, int srcY, int srcWidth, int srcHeight, int destX, int destY)
 {
     (void)unused;
@@ -303,7 +303,7 @@ void _GNW95_ShowRect(unsigned char* src, int srcPitch, int unused, int srcX, int
 
 // Clears drawing surface.
 //
-// 0x4CBBC8
+// 0x4CBBC8 GNW95_zero_vid_mem_
 void _GNW95_zero_vid_mem()
 {
     if (!gProgramIsActive) {

--- a/src/svga.cc
+++ b/src/svga.cc
@@ -27,10 +27,10 @@ static void destroyRenderer();
 // screen rect
 Rect _scr_size;
 
-// 0x6ACA18
+// 0x6ACA18 _scr_blit
 void (*_scr_blit)(unsigned char* src, int src_pitch, int unused, int src_x, int src_y, int src_width, int src_height, int dest_x, int dest_y) = _GNW95_ShowRect;
 
-// 0x6ACA1C
+// 0x6ACA1C _zero_mem
 void (*_zero_mem)() = nullptr;
 
 SDL_Window* gSdlWindow = nullptr;
@@ -42,49 +42,49 @@ SDL_Surface* gSdlTextureSurface = nullptr;
 // TODO: Remove once migration to update-render cycle is completed.
 FpsLimiter sharedFpsLimiter;
 
-// 0x4CAD08 init_mode_320_200_
+// 0x4CAD08 init_mode_320_200
 int _init_mode_320_200()
 {
     return _GNW95_init_mode_ex(320, 200, 8);
 }
 
-// 0x4CAD40 init_mode_320_400_
+// 0x4CAD40 init_mode_320_400
 int _init_mode_320_400()
 {
     return _GNW95_init_mode_ex(320, 400, 8);
 }
 
-// 0x4CAD5C init_mode_640_480_16_
+// 0x4CAD5C init_mode_640_480_16
 int _init_mode_640_480_16()
 {
     return -1;
 }
 
-// 0x4CAD64 init_mode_640_480_
+// 0x4CAD64 init_mode_640_480
 int _init_mode_640_480()
 {
     return _init_vesa_mode(640, 480);
 }
 
-// 0x4CAD94 init_mode_640_400_
+// 0x4CAD94 init_mode_640_400
 int _init_mode_640_400()
 {
     return _init_vesa_mode(640, 400);
 }
 
-// 0x4CADA8 init_mode_800_600_
+// 0x4CADA8 init_mode_800_600
 int _init_mode_800_600()
 {
     return _init_vesa_mode(800, 600);
 }
 
-// 0x4CADBC init_mode_1024_768_
+// 0x4CADBC init_mode_1024_768
 int _init_mode_1024_768()
 {
     return _init_vesa_mode(1024, 768);
 }
 
-// 0x4CADD0 init_mode_1280_1024_
+// 0x4CADD0 init_mode_1280_1024
 int _init_mode_1280_1024()
 {
     return _init_vesa_mode(1280, 1024);
@@ -95,7 +95,7 @@ void _get_start_mode_()
 {
 }
 
-// 0x4CADFC zero_vid_mem_
+// 0x4CADFC zero_vid_mem
 void _zero_vid_mem()
 {
     if (_zero_mem) {
@@ -103,7 +103,7 @@ void _zero_vid_mem()
     }
 }
 
-// 0x4CAE1C GNW95_init_mode_ex_
+// 0x4CAE1C GNW95_init_mode_ex
 int _GNW95_init_mode_ex(int width, int height, int bpp)
 {
     width = settings.screen.resolution_x;
@@ -148,13 +148,13 @@ int _GNW95_init_mode_ex(int width, int height, int bpp)
     return 0;
 }
 
-// 0x4CAECC init_vesa_mode_
+// 0x4CAECC init_vesa_mode
 int _init_vesa_mode(int width, int height)
 {
     return _GNW95_init_mode_ex(width, height, 8);
 }
 
-// 0x4CAEDC GNW95_init_window_
+// 0x4CAEDC GNW95_init_window
 int _GNW95_init_window(int width, int height, bool fullscreen, int scale)
 {
     if (gSdlWindow == nullptr) {
@@ -184,7 +184,7 @@ int _GNW95_init_window(int width, int height, bool fullscreen, int scale)
     return 0;
 }
 
-// 0x4CAF9C GNW95_init_DirectDraw_
+// 0x4CAF9C GNW95_init_DirectDraw
 int directDrawInit(int width, int height, int bpp)
 {
     if (gSdlSurface != nullptr) {
@@ -215,7 +215,7 @@ int directDrawInit(int width, int height, int bpp)
     return 0;
 }
 
-// 0x4CB1B0 GNW95_reset_mode_
+// 0x4CB1B0 GNW95_reset_mode
 void directDrawFree()
 {
     if (gSdlSurface != nullptr) {
@@ -224,7 +224,7 @@ void directDrawFree()
     }
 }
 
-// 0x4CB310 GNW95_SetPaletteEntries_
+// 0x4CB310 GNW95_SetPaletteEntries
 void directDrawSetPaletteInRange(unsigned char* palette, int start, int count)
 {
     if (gSdlSurface != nullptr && gSdlSurface->format->palette != nullptr) {
@@ -244,7 +244,7 @@ void directDrawSetPaletteInRange(unsigned char* palette, int start, int count)
     }
 }
 
-// 0x4CB568 GNW95_SetPalette_
+// 0x4CB568 GNW95_SetPalette
 void directDrawSetPalette(unsigned char* palette)
 {
     if (gSdlSurface != nullptr && gSdlSurface->format->palette != nullptr) {
@@ -262,7 +262,7 @@ void directDrawSetPalette(unsigned char* palette)
     }
 }
 
-// 0x4CB68C GNW95_GetPalette_
+// 0x4CB68C GNW95_GetPalette
 unsigned char* directDrawGetPalette()
 {
     // 0x6ACA24
@@ -282,7 +282,7 @@ unsigned char* directDrawGetPalette()
     return palette;
 }
 
-// 0x4CB850 GNW95_ShowRect_
+// 0x4CB850 GNW95_ShowRect
 void _GNW95_ShowRect(unsigned char* src, int srcPitch, int unused, int srcX, int srcY, int srcWidth, int srcHeight, int destX, int destY)
 {
     (void)unused;
@@ -303,7 +303,7 @@ void _GNW95_ShowRect(unsigned char* src, int srcPitch, int unused, int srcX, int
 
 // Clears drawing surface.
 //
-// 0x4CBBC8 GNW95_zero_vid_mem_
+// 0x4CBBC8 GNW95_zero_vid_mem
 void _GNW95_zero_vid_mem()
 {
     if (!gProgramIsActive) {

--- a/src/text_font.cc
+++ b/src/text_font.cc
@@ -106,7 +106,7 @@ static FontManager gFontManagers[FONT_MANAGER_MAX];
 // 0x6ADD88
 static TextFontDescriptor* gCurrentTextFontDescriptor;
 
-// 0x4D555C
+// 0x4D555C GNW_text_init_
 int textFontsInit()
 {
     int currentFont = -1;
@@ -137,7 +137,7 @@ int textFontsInit()
     return 0;
 }
 
-// 0x4D55CC
+// 0x4D55CC GNW_text_exit_
 void textFontsExit()
 {
     for (int index = 0; index < TEXT_FONT_MAX; index++) {
@@ -149,7 +149,7 @@ void textFontsExit()
     }
 }
 
-// 0x4D55FC
+// 0x4D55FC load_font_
 int textFontLoad(int font)
 {
     int rc = -1;
@@ -237,7 +237,7 @@ out:
     return rc;
 }
 
-// 0x4D5780
+// 0x4D5780 text_add_manager_
 int fontManagerAdd(FontManager* fontManager)
 {
     if (fontManager == nullptr) {
@@ -262,7 +262,7 @@ int fontManagerAdd(FontManager* fontManager)
     return 0;
 }
 
-// 0x4D58AC
+// 0x4D58AC GNW_text_font_
 static void textFontSetCurrentImpl(int font)
 {
     if (font >= TEXT_FONT_MAX) {
@@ -277,13 +277,13 @@ static void textFontSetCurrentImpl(int font)
     gCurrentTextFontDescriptor = textFontDescriptor;
 }
 
-// 0x4D58D4
+// 0x4D58D4 text_curr_
 int fontGetCurrent()
 {
     return gCurrentFont;
 }
 
-// 0x4D58DC
+// 0x4D58DC text_font_
 void fontSetCurrent(int font)
 {
     FontManager* fontManager;
@@ -304,7 +304,7 @@ void fontSetCurrent(int font)
     }
 }
 
-// 0x4D595C
+// 0x4D595C text_font_exists_
 static bool fontManagerFind(int font, FontManager** fontManagerPtr)
 {
     for (int index = 0; index < gFontManagersCount; index++) {
@@ -318,7 +318,7 @@ static bool fontManagerFind(int font, FontManager** fontManagerPtr)
     return false;
 }
 
-// 0x4D59B0
+// 0x4D59B0 GNW_text_to_buf_
 static void textFontDrawImpl(unsigned char* buf, const char* string, int length, int pitch, int color)
 {
     if ((color & FONT_SHADOW) != 0) {
@@ -383,13 +383,13 @@ static void textFontDrawImpl(unsigned char* buf, const char* string, int length,
     }
 }
 
-// 0x4D5B54
+// 0x4D5B54 GNW_text_height_
 static int textFontGetLineHeightImpl()
 {
     return gCurrentTextFontDescriptor->lineHeight;
 }
 
-// 0x4D5B60
+// 0x4D5B60 GNW_text_width_
 static int textFontGeStringWidthImpl(const char* string)
 {
     int width = 0;
@@ -405,31 +405,31 @@ static int textFontGeStringWidthImpl(const char* string)
     return width;
 }
 
-// 0x4D5BA4
+// 0x4D5BA4 GNW_text_char_width_
 static int textFontGetCharacterWidthImpl(int ch)
 {
     return gCurrentTextFontDescriptor->glyphs[ch & 0xFF].width;
 }
 
-// 0x4D5BB8
+// 0x4D5BB8 GNW_text_mono_width_
 static int textFontGetMonospacedStringWidthImpl(const char* string)
 {
     return fontGetMonospacedCharacterWidth() * strlen(string);
 }
 
-// 0x4D5BD8
+// 0x4D5BD8 GNW_text_spacing_
 static int textFontGetLetterSpacingImpl()
 {
     return gCurrentTextFontDescriptor->letterSpacing;
 }
 
-// 0x4D5BE4
+// 0x4D5BE4 GNW_text_size_
 static int textFontGetBufferSizeImpl(const char* string)
 {
     return fontGetStringWidth(string) * fontGetLineHeight();
 }
 
-// 0x4D5BF8
+// 0x4D5BF8 GNW_text_max_
 static int textFontGetMonospacedCharacterWidthImpl()
 {
     int width = 0;

--- a/src/text_font.cc
+++ b/src/text_font.cc
@@ -52,7 +52,7 @@ static int textFontGetLetterSpacingImpl();
 static int textFontGetBufferSizeImpl(const char* string);
 static int textFontGetMonospacedCharacterWidthImpl();
 
-// 0x4D5530
+// 0x4D5530 GNW_text_functions
 FontManager gTextFontManager = {
     0,
     9,
@@ -67,46 +67,46 @@ FontManager gTextFontManager = {
     textFontGetMonospacedCharacterWidthImpl,
 };
 
-// 0x51E3B0
+// 0x51E3B0 curr_font_num
 int gCurrentFont = -1;
 
-// 0x51E3B4
+// 0x51E3B4 total_managers
 int gFontManagersCount = 0;
 
-// 0x51E3B8
+// 0x51E3B8 _text_to_buf
 FontManagerDrawTextProc* fontDrawText = nullptr;
 
-// 0x51E3BC
+// 0x51E3BC _text_height
 FontManagerGetLineHeightProc* fontGetLineHeight = nullptr;
 
-// 0x51E3C0
+// 0x51E3C0 _text_width
 FontManagerGetStringWidthProc* fontGetStringWidth = nullptr;
 
-// 0x51E3C4
+// 0x51E3C4 _text_char_width
 FontManagerGetCharacterWidthProc* fontGetCharacterWidth = nullptr;
 
-// 0x51E3C8
+// 0x51E3C8 _text_mono_width
 FontManagerGetMonospacedStringWidthProc* fontGetMonospacedStringWidth = nullptr;
 
-// 0x51E3CC
+// 0x51E3CC _text_spacing
 FontManagerGetLetterSpacingProc* fontGetLetterSpacing = nullptr;
 
-// 0x51E3D0
+// 0x51E3D0 text_size
 FontManagerGetBufferSizeProc* fontGetBufferSize = nullptr;
 
-// 0x51E3D4
+// 0x51E3D4 _text_max
 FontManagerGetMonospacedCharacterWidth* fontGetMonospacedCharacterWidth = nullptr;
 
-// 0x6ADB08
+// 0x6ADB08 font
 static TextFontDescriptor gTextFontDescriptors[TEXT_FONT_MAX];
 
-// 0x6ADBD0
+// 0x6ADBD0 font_managers
 static FontManager gFontManagers[FONT_MANAGER_MAX];
 
-// 0x6ADD88
+// 0x6ADD88 curr_font
 static TextFontDescriptor* gCurrentTextFontDescriptor;
 
-// 0x4D555C GNW_text_init_
+// 0x4D555C GNW_text_init
 int textFontsInit()
 {
     int currentFont = -1;
@@ -137,7 +137,7 @@ int textFontsInit()
     return 0;
 }
 
-// 0x4D55CC GNW_text_exit_
+// 0x4D55CC GNW_text_exit
 void textFontsExit()
 {
     for (int index = 0; index < TEXT_FONT_MAX; index++) {
@@ -149,7 +149,7 @@ void textFontsExit()
     }
 }
 
-// 0x4D55FC load_font_
+// 0x4D55FC load_font
 int textFontLoad(int font)
 {
     int rc = -1;
@@ -237,7 +237,7 @@ out:
     return rc;
 }
 
-// 0x4D5780 text_add_manager_
+// 0x4D5780 text_add_manager
 int fontManagerAdd(FontManager* fontManager)
 {
     if (fontManager == nullptr) {
@@ -262,7 +262,7 @@ int fontManagerAdd(FontManager* fontManager)
     return 0;
 }
 
-// 0x4D58AC GNW_text_font_
+// 0x4D58AC GNW_text_font
 static void textFontSetCurrentImpl(int font)
 {
     if (font >= TEXT_FONT_MAX) {
@@ -277,13 +277,13 @@ static void textFontSetCurrentImpl(int font)
     gCurrentTextFontDescriptor = textFontDescriptor;
 }
 
-// 0x4D58D4 text_curr_
+// 0x4D58D4 text_curr
 int fontGetCurrent()
 {
     return gCurrentFont;
 }
 
-// 0x4D58DC text_font_
+// 0x4D58DC text_font
 void fontSetCurrent(int font)
 {
     FontManager* fontManager;
@@ -304,7 +304,7 @@ void fontSetCurrent(int font)
     }
 }
 
-// 0x4D595C text_font_exists_
+// 0x4D595C text_font_exists
 static bool fontManagerFind(int font, FontManager** fontManagerPtr)
 {
     for (int index = 0; index < gFontManagersCount; index++) {
@@ -318,7 +318,7 @@ static bool fontManagerFind(int font, FontManager** fontManagerPtr)
     return false;
 }
 
-// 0x4D59B0 GNW_text_to_buf_
+// 0x4D59B0 GNW_text_to_buf
 static void textFontDrawImpl(unsigned char* buf, const char* string, int length, int pitch, int color)
 {
     if ((color & FONT_SHADOW) != 0) {
@@ -383,13 +383,13 @@ static void textFontDrawImpl(unsigned char* buf, const char* string, int length,
     }
 }
 
-// 0x4D5B54 GNW_text_height_
+// 0x4D5B54 GNW_text_height
 static int textFontGetLineHeightImpl()
 {
     return gCurrentTextFontDescriptor->lineHeight;
 }
 
-// 0x4D5B60 GNW_text_width_
+// 0x4D5B60 GNW_text_width
 static int textFontGeStringWidthImpl(const char* string)
 {
     int width = 0;
@@ -405,31 +405,31 @@ static int textFontGeStringWidthImpl(const char* string)
     return width;
 }
 
-// 0x4D5BA4 GNW_text_char_width_
+// 0x4D5BA4 GNW_text_char_width
 static int textFontGetCharacterWidthImpl(int ch)
 {
     return gCurrentTextFontDescriptor->glyphs[ch & 0xFF].width;
 }
 
-// 0x4D5BB8 GNW_text_mono_width_
+// 0x4D5BB8 GNW_text_mono_width
 static int textFontGetMonospacedStringWidthImpl(const char* string)
 {
     return fontGetMonospacedCharacterWidth() * strlen(string);
 }
 
-// 0x4D5BD8 GNW_text_spacing_
+// 0x4D5BD8 GNW_text_spacing
 static int textFontGetLetterSpacingImpl()
 {
     return gCurrentTextFontDescriptor->letterSpacing;
 }
 
-// 0x4D5BE4 GNW_text_size_
+// 0x4D5BE4 GNW_text_size
 static int textFontGetBufferSizeImpl(const char* string)
 {
     return fontGetStringWidth(string) * fontGetLineHeight();
 }
 
-// 0x4D5BF8 GNW_text_max_
+// 0x4D5BF8 GNW_text_max
 static int textFontGetMonospacedCharacterWidthImpl()
 {
     int width = 0;

--- a/src/text_font.cc
+++ b/src/text_font.cc
@@ -73,28 +73,28 @@ int gCurrentFont = -1;
 // 0x51E3B4 total_managers
 int gFontManagersCount = 0;
 
-// 0x51E3B8 _text_to_buf
+// 0x51E3B8 text_to_buf
 FontManagerDrawTextProc* fontDrawText = nullptr;
 
-// 0x51E3BC _text_height
+// 0x51E3BC text_height
 FontManagerGetLineHeightProc* fontGetLineHeight = nullptr;
 
-// 0x51E3C0 _text_width
+// 0x51E3C0 text_width
 FontManagerGetStringWidthProc* fontGetStringWidth = nullptr;
 
-// 0x51E3C4 _text_char_width
+// 0x51E3C4 text_char_width
 FontManagerGetCharacterWidthProc* fontGetCharacterWidth = nullptr;
 
-// 0x51E3C8 _text_mono_width
+// 0x51E3C8 text_mono_width
 FontManagerGetMonospacedStringWidthProc* fontGetMonospacedStringWidth = nullptr;
 
-// 0x51E3CC _text_spacing
+// 0x51E3CC text_spacing
 FontManagerGetLetterSpacingProc* fontGetLetterSpacing = nullptr;
 
 // 0x51E3D0 text_size
 FontManagerGetBufferSizeProc* fontGetBufferSize = nullptr;
 
-// 0x51E3D4 _text_max
+// 0x51E3D4 text_max
 FontManagerGetMonospacedCharacterWidth* fontGetMonospacedCharacterWidth = nullptr;
 
 // 0x6ADB08 font

--- a/src/text_object.cc
+++ b/src/text_object.cc
@@ -69,7 +69,7 @@ static bool gTextObjectsEnabled;
 // 0x668220
 static bool gTextObjectsInitialized;
 
-// 0x4B0130
+// 0x4B0130 text_object_init_
 int textObjectsInit(unsigned char* windowBuffer, int width, int height)
 {
     if (gTextObjectsInitialized) {
@@ -92,7 +92,7 @@ int textObjectsInit(unsigned char* windowBuffer, int width, int height)
     return 0;
 }
 
-// 0x4B021C
+// 0x4B021C text_object_reset_
 int textObjectsReset()
 {
     if (!gTextObjectsInitialized) {
@@ -110,7 +110,7 @@ int textObjectsReset()
     return 0;
 }
 
-// 0x4B0280
+// 0x4B0280 text_object_exit_
 void textObjectsFree()
 {
     if (gTextObjectsInitialized) {
@@ -120,19 +120,19 @@ void textObjectsFree()
     }
 }
 
-// 0x4B02A4
+// 0x4B02A4 text_object_disable_
 void textObjectsDisable()
 {
     gTextObjectsEnabled = false;
 }
 
-// 0x4B02B0
+// 0x4B02B0 text_object_enable_
 void textObjectsEnable()
 {
     gTextObjectsEnabled = true;
 }
 
-// 0x4B02C4
+// 0x4B02C4 text_object_set_base_delay_
 void textObjectsSetBaseDelay(double value)
 {
     if (value < 1.0) {
@@ -142,7 +142,7 @@ void textObjectsSetBaseDelay(double value)
     gTextObjectsBaseDelay = (int)(value * 1000.0);
 }
 
-// 0x4B031C
+// 0x4B031C text_object_set_line_delay_
 void textObjectsSetLineDelay(double value)
 {
     if (value < 0.0) {
@@ -153,7 +153,7 @@ void textObjectsSetLineDelay(double value)
 }
 
 // text_object_create
-// 0x4B036C
+// 0x4B036C text_object_create_
 int textObjectAdd(Object* object, char* string, int font, int color, int outlineColor, Rect* rect)
 {
     if (!gTextObjectsInitialized) {
@@ -287,7 +287,7 @@ int textObjectAdd(Object* object, char* string, int font, int color, int outline
     return 0;
 }
 
-// 0x4B06E8
+// 0x4B06E8 text_object_render_
 void textObjectsRenderInRect(Rect* rect)
 {
     if (!gTextObjectsInitialized) {
@@ -316,13 +316,13 @@ void textObjectsRenderInRect(Rect* rect)
     }
 }
 
-// 0x4B07F0
+// 0x4B07F0 text_object_count_
 int textObjectsGetCount()
 {
     return gTextObjectsCount;
 }
 
-// 0x4B07F8
+// 0x4B07F8 text_object_bk_
 static void textObjectsTicker()
 {
     if (!gTextObjectsEnabled) {
@@ -371,7 +371,7 @@ static void textObjectsTicker()
 
 // Finds best position for placing text object.
 //
-// 0x4B0954
+// 0x4B0954 text_object_get_offset_
 static void textObjectFindPlacement(TextObject* textObject)
 {
     int tileScreenX;
@@ -457,7 +457,7 @@ static void textObjectFindPlacement(TextObject* textObject)
 
 // Marks text objects attached to [object] for removal.
 //
-// 0x4B0C00
+// 0x4B0C00 text_object_remove_
 void textObjectsRemoveByOwner(Object* object)
 {
     for (int index = 0; index < gTextObjectsCount; index++) {

--- a/src/text_object.cc
+++ b/src/text_object.cc
@@ -51,7 +51,7 @@ static unsigned int gTextObjectsBaseDelay = 3500;
 // 0x51D94C text_object_line_delay
 static unsigned int gTextObjectsLineDelay = 1399;
 
-// 0x6681C0 _text_object_list
+// 0x6681C0 text_object_list
 static TextObject* gTextObjects[TEXT_OBJECTS_MAX_COUNT];
 
 // 0x668210 display_width

--- a/src/text_object.cc
+++ b/src/text_object.cc
@@ -42,34 +42,34 @@ typedef struct TextObject {
 static void textObjectsTicker();
 static void textObjectFindPlacement(TextObject* textObject);
 
-// 0x51D944
+// 0x51D944 text_object_index
 static int gTextObjectsCount = 0;
 
-// 0x51D948
+// 0x51D948 text_object_base_delay
 static unsigned int gTextObjectsBaseDelay = 3500;
 
-// 0x51D94C
+// 0x51D94C text_object_line_delay
 static unsigned int gTextObjectsLineDelay = 1399;
 
-// 0x6681C0
+// 0x6681C0 _text_object_list
 static TextObject* gTextObjects[TEXT_OBJECTS_MAX_COUNT];
 
-// 0x668210
+// 0x668210 display_width
 static int gTextObjectsWindowWidth;
 
-// 0x668214
+// 0x668214 display_height
 static int gTextObjectsWindowHeight;
 
-// 0x668218
+// 0x668218 display_buffer
 static unsigned char* gTextObjectsWindowBuffer;
 
-// 0x66821C
+// 0x66821C text_object_enabled
 static bool gTextObjectsEnabled;
 
-// 0x668220
+// 0x668220 text_object_initialized
 static bool gTextObjectsInitialized;
 
-// 0x4B0130 text_object_init_
+// 0x4B0130 text_object_init
 int textObjectsInit(unsigned char* windowBuffer, int width, int height)
 {
     if (gTextObjectsInitialized) {
@@ -92,7 +92,7 @@ int textObjectsInit(unsigned char* windowBuffer, int width, int height)
     return 0;
 }
 
-// 0x4B021C text_object_reset_
+// 0x4B021C text_object_reset
 int textObjectsReset()
 {
     if (!gTextObjectsInitialized) {
@@ -110,7 +110,7 @@ int textObjectsReset()
     return 0;
 }
 
-// 0x4B0280 text_object_exit_
+// 0x4B0280 text_object_exit
 void textObjectsFree()
 {
     if (gTextObjectsInitialized) {
@@ -120,19 +120,19 @@ void textObjectsFree()
     }
 }
 
-// 0x4B02A4 text_object_disable_
+// 0x4B02A4 text_object_disable
 void textObjectsDisable()
 {
     gTextObjectsEnabled = false;
 }
 
-// 0x4B02B0 text_object_enable_
+// 0x4B02B0 text_object_enable
 void textObjectsEnable()
 {
     gTextObjectsEnabled = true;
 }
 
-// 0x4B02C4 text_object_set_base_delay_
+// 0x4B02C4 text_object_set_base_delay
 void textObjectsSetBaseDelay(double value)
 {
     if (value < 1.0) {
@@ -142,7 +142,7 @@ void textObjectsSetBaseDelay(double value)
     gTextObjectsBaseDelay = (int)(value * 1000.0);
 }
 
-// 0x4B031C text_object_set_line_delay_
+// 0x4B031C text_object_set_line_delay
 void textObjectsSetLineDelay(double value)
 {
     if (value < 0.0) {
@@ -153,7 +153,7 @@ void textObjectsSetLineDelay(double value)
 }
 
 // text_object_create
-// 0x4B036C text_object_create_
+// 0x4B036C text_object_create
 int textObjectAdd(Object* object, char* string, int font, int color, int outlineColor, Rect* rect)
 {
     if (!gTextObjectsInitialized) {
@@ -287,7 +287,7 @@ int textObjectAdd(Object* object, char* string, int font, int color, int outline
     return 0;
 }
 
-// 0x4B06E8 text_object_render_
+// 0x4B06E8 text_object_render
 void textObjectsRenderInRect(Rect* rect)
 {
     if (!gTextObjectsInitialized) {
@@ -316,13 +316,13 @@ void textObjectsRenderInRect(Rect* rect)
     }
 }
 
-// 0x4B07F0 text_object_count_
+// 0x4B07F0 text_object_count
 int textObjectsGetCount()
 {
     return gTextObjectsCount;
 }
 
-// 0x4B07F8 text_object_bk_
+// 0x4B07F8 text_object_bk
 static void textObjectsTicker()
 {
     if (!gTextObjectsEnabled) {
@@ -371,7 +371,7 @@ static void textObjectsTicker()
 
 // Finds best position for placing text object.
 //
-// 0x4B0954 text_object_get_offset_
+// 0x4B0954 text_object_get_offset
 static void textObjectFindPlacement(TextObject* textObject)
 {
     int tileScreenX;
@@ -457,7 +457,7 @@ static void textObjectFindPlacement(TextObject* textObject)
 
 // Marks text objects attached to [object] for removal.
 //
-// 0x4B0C00 text_object_remove_
+// 0x4B0C00 text_object_remove
 void textObjectsRemoveByOwner(Object* object)
 {
     for (int index = 0; index < gTextObjectsCount; index++) {

--- a/src/tile.cc
+++ b/src/tile.cc
@@ -83,13 +83,13 @@ static bool gTileRoofIsVisible = true;
 // 0x51D960 show_grid
 static bool gTileGridIsVisible = false;
 
-// 0x51D964 _tile_refresh
+// 0x51D964 tile_refresh
 static TileWindowRefreshElevationProc* gTileWindowRefreshElevationProc = tileRefreshGame;
 
 // 0x51D968 refresh_enabled
 static bool gTileEnabled = true;
 
-// 0x51D96C _off_tile
+// 0x51D96C off_tile
 const int _off_tile[6] = {
     16,
     32,
@@ -225,7 +225,7 @@ static int _square_offx;
 // 0x66BDF0 square_offy
 static int _square_offy;
 
-// 0x66BDF4 _blit
+// 0x66BDF4 blit
 static TileWindowRefreshProc* gTileWindowRefreshProc;
 
 // 0x66BDF8 tile_offy
@@ -244,7 +244,7 @@ static int gSquareGridSize;
 // 0x66BE04 grid_width
 static int gHexGridWidth;
 
-// 0x66BE08 _squares
+// 0x66BE08 squares
 static TileData** gTileSquares;
 
 // 0x66BE0C tile_back_buf

--- a/src/tile.cc
+++ b/src/tile.cc
@@ -286,7 +286,7 @@ static int gTileWindowWidth;
 // 0x66BE34
 int gCenterTile;
 
-// 0x4B0C40
+// 0x4B0C40 tile_init_
 int tileInit(TileData** squareGrid, int squareGridWidth, int squareGridHeight, int hexGridWidth, int hexGridHeight, unsigned char* buf, int windowWidth, int windowHeight, int windowPitch, TileWindowRefreshProc* windowRefreshProc)
 {
     int v11;
@@ -458,7 +458,7 @@ int tileInit(TileData** squareGrid, int squareGridWidth, int squareGridHeight, i
     return 0;
 }
 
-// 0x4B11E4
+// 0x4B11E4 tile_set_border_
 static void tileSetBorder(int windowWidth, int windowHeight, int hexGridWidth, int hexGridHeight)
 {
     // TODO: Borders, scroll blockers and tile system overall were designed
@@ -503,19 +503,19 @@ void tileExit()
     _tile_reset_();
 }
 
-// 0x4B12A8
+// 0x4B12A8 tile_disable_refresh_
 void tileDisable()
 {
     gTileEnabled = false;
 }
 
-// 0x4B12B4
+// 0x4B12B4 tile_enable_refresh_
 void tileEnable()
 {
     gTileEnabled = true;
 }
 
-// 0x4B12C0
+// 0x4B12C0 tile_refresh_rect_
 void tileWindowRefreshRect(Rect* rect, int elevation)
 {
     if (gTileEnabled) {
@@ -525,7 +525,7 @@ void tileWindowRefreshRect(Rect* rect, int elevation)
     }
 }
 
-// 0x4B12D8
+// 0x4B12D8 tile_refresh_display_
 void tileWindowRefresh()
 {
     if (gTileEnabled) {
@@ -533,7 +533,7 @@ void tileWindowRefresh()
     }
 }
 
-// 0x4B12F8
+// 0x4B12F8 tile_set_center_
 int tileSetCenter(int tile, int flags)
 {
     if (!tileIsValid(tile)) {
@@ -609,7 +609,7 @@ int tileSetCenter(int tile, int flags)
     return 0;
 }
 
-// 0x4B1554
+// 0x4B1554 refresh_mapper_
 static void tileRefreshMapper(Rect* rect, int elevation)
 {
     Rect rectToUpdate;
@@ -635,7 +635,7 @@ static void tileRefreshMapper(Rect* rect, int elevation)
     gTileWindowRefreshProc(&rectToUpdate);
 }
 
-// 0x4B15E8
+// 0x4B15E8 refresh_game_
 static void tileRefreshGame(Rect* rect, int elevation)
 {
     Rect rectToUpdate;
@@ -662,7 +662,7 @@ static void tileRefreshGame(Rect* rect, int elevation)
     gTileWindowRefreshProc(&rectToUpdate);
 }
 
-// 0x4B1634
+// 0x4B1634 tile_toggle_roof_
 void tile_toggle_roof(bool refresh)
 {
     gTileRoofIsVisible = !gTileRoofIsVisible;
@@ -673,13 +673,13 @@ void tile_toggle_roof(bool refresh)
     }
 }
 
-// 0x4B166C
+// 0x4B166C tile_roof_visible_
 int tileRoofIsVisible()
 {
     return gTileRoofIsVisible;
 }
 
-// 0x4B1674
+// 0x4B1674 tile_coord_
 int tileToScreenXY(int tile, int* screenX, int* screenY)
 {
     int v3;
@@ -721,7 +721,7 @@ int tileToScreenXY(int tile, int* screenX, int* screenY)
 // validating hex grid bounds. The resulting invalid tile number serves as an
 // origin for calculations using prepared offsets table during objects
 // rendering.
-// 0x4B1754
+// 0x4B1754 tile_num_
 int tileFromScreenXY(int screenX, int screenY, bool ignoreBounds)
 {
     int x, y;
@@ -802,7 +802,7 @@ int squareTileFromTile(int tile)
 }
 
 // tile_distance
-// 0x4B185C
+// 0x4B185C tile_dist_
 int tileDistanceBetween(int tile1, int tile2)
 {
     if (tile1 == -1 || tile2 == -1) {
@@ -820,7 +820,7 @@ int tileDistanceBetween(int tile1, int tile2)
     return step;
 }
 
-// 0x4B1994
+// 0x4B1994 tile_in_front_of_
 bool tileIsInFrontOf(int tile1, int tile2)
 {
     int x1, y1;
@@ -835,7 +835,7 @@ bool tileIsInFrontOf(int tile1, int tile2)
     return (double)dx <= (double)dy * dbl_50E7C7;
 }
 
-// 0x4B1A00
+// 0x4B1A00 tile_to_right_of_
 bool tileIsToRightOf(int tile1, int tile2)
 {
     int x1, y1;
@@ -855,7 +855,7 @@ bool tileIsToRightOf(int tile1, int tile2)
 }
 
 // tile_num_in_direction
-// 0x4B1A6C
+// 0x4B1A6C tile_num_in_direction_
 int tileGetTileInDirection(int tile, int rotation, int distance)
 {
     int newTile = tile;
@@ -872,7 +872,7 @@ int tileGetTileInDirection(int tile, int rotation, int distance)
 }
 
 // rotation_to_tile
-// 0x4B1ABC
+// 0x4B1ABC tile_dir_
 int tileGetRotationTo(int tile1, int tile2)
 {
     int x1, y1;
@@ -902,7 +902,7 @@ int tileGetRotationTo(int tile1, int tile2)
     return dy < 0 ? ROTATION_NE : ROTATION_SE;
 }
 
-// 0x4B1B84
+// 0x4B1B84 tile_num_beyond_
 int _tile_num_beyond(int from, int to, int distance)
 {
     if (distance <= 0 || from == to) {
@@ -991,7 +991,7 @@ int _tile_num_beyond(int from, int to, int distance)
     assert(false && "Should be unreachable");
 }
 
-// 0x4B1D20
+// 0x4B1D20 tile_on_edge_
 bool tileIsEdge(int tile)
 {
     if (!tileIsValid(tile)) {
@@ -1017,43 +1017,43 @@ bool tileIsEdge(int tile)
     return false;
 }
 
-// 0x4B1D80
+// 0x4B1D80 tile_enable_scroll_blocking_
 void tileScrollBlockingEnable()
 {
     gTileScrollBlockingEnabled = true;
 }
 
-// 0x4B1D8C
+// 0x4B1D8C tile_disable_scroll_blocking_
 void tileScrollBlockingDisable()
 {
     gTileScrollBlockingEnabled = false;
 }
 
-// 0x4B1D98
+// 0x4B1D98 tile_get_scroll_blocking_
 bool tileScrollBlockingIsEnabled()
 {
     return gTileScrollBlockingEnabled;
 }
 
-// 0x4B1DA0
+// 0x4B1DA0 tile_enable_scroll_limiting_
 void tileScrollLimitingEnable()
 {
     gTileScrollLimitingEnabled = true;
 }
 
-// 0x4B1DAC
+// 0x4B1DAC tile_disable_scroll_limiting_
 void tileScrollLimitingDisable()
 {
     gTileScrollLimitingEnabled = false;
 }
 
-// 0x4B1DB8
+// 0x4B1DB8 tile_get_scroll_limiting_
 bool tileScrollLimitingIsEnabled()
 {
     return gTileScrollLimitingEnabled;
 }
 
-// 0x4B1DC0
+// 0x4B1DC0 square_coord_
 int squareTileToScreenXY(int squareTile, int* coordX, int* coordY, int elevation)
 {
     if (squareTile < 0 || squareTile >= gSquareGridSize) {
@@ -1077,7 +1077,7 @@ int squareTileToScreenXY(int squareTile, int* coordX, int* coordY, int elevation
     return 0;
 }
 
-// 0x4B1E60
+// 0x4B1E60 square_coord_roof_
 int squareTileToRoofScreenXY(int squareTile, int* screenX, int* screenY, int elevation)
 {
     int v5;
@@ -1110,7 +1110,7 @@ int squareTileToRoofScreenXY(int squareTile, int* screenX, int* screenY, int ele
     return 0;
 }
 
-// 0x4B1F04
+// 0x4B1F04 square_num_
 int squareTileFromScreenXY(int screenX, int screenY, int elevation)
 {
     int coordY;
@@ -1125,7 +1125,7 @@ int squareTileFromScreenXY(int screenX, int screenY, int elevation)
     return -1;
 }
 
-// 0x4B1F94
+// 0x4B1F94 square_xy_
 void squareTileScreenToCoord(int screenX, int screenY, int elevation, int* coordX, int* coordY)
 {
     int v4;
@@ -1147,7 +1147,7 @@ void squareTileScreenToCoord(int screenX, int screenY, int elevation, int* coord
     *coordX = gSquareGridWidth - 1 - *coordX;
 }
 
-// 0x4B203C
+// 0x4B203C square_xy_roof_
 void squareTileScreenToCoordRoof(int screenX, int screenY, int elevation, int* coordX, int* coordY)
 {
     int v4;
@@ -1170,7 +1170,7 @@ void squareTileScreenToCoordRoof(int screenX, int screenY, int elevation, int* c
     *coordX = gSquareGridWidth - 1 - *coordX;
 }
 
-// 0x4B20E8
+// 0x4B20E8 square_render_roof_
 void tileRenderRoofsInRect(Rect* rect, int elevation)
 {
     if (!gTileRoofIsVisible) {
@@ -1265,7 +1265,7 @@ static void roof_fill_off_process_task(std::stack<roof_fill_task>& tasks_stack, 
     }
 }
 
-// 0x4B23D4
+// 0x4B23D4 tile_fill_roof_
 void tile_fill_roof(int x, int y, int elevation, bool on)
 {
     std::stack<roof_fill_task> tasks_stack;
@@ -1277,7 +1277,7 @@ void tile_fill_roof(int x, int y, int elevation, bool on)
     }
 }
 
-// 0x4B24E0
+// 0x4B24E0 roof_draw_
 static void tileRenderRoof(int fid, int x, int y, Rect* rect, int light)
 {
     CacheEntry* tileFrmHandle;
@@ -1387,7 +1387,7 @@ static void tileRenderRoof(int fid, int x, int y, Rect* rect, int light)
     artUnlock(tileFrmHandle);
 }
 
-// 0x4B2944
+// 0x4B2944 square_render_floor_
 void tileRenderFloorsInRect(Rect* rect, int elevation)
 {
     int minY;
@@ -1437,7 +1437,7 @@ void tileRenderFloorsInRect(Rect* rect, int elevation)
     }
 }
 
-// 0x4B2B10
+// 0x4B2B10 square_roof_intersect_
 bool _square_roof_intersect(int x, int y, int elevation)
 {
     if (!gTileRoofIsVisible) {
@@ -1479,7 +1479,7 @@ bool _square_roof_intersect(int x, int y, int elevation)
     return result;
 }
 
-// 0x4B2E98
+// 0x4B2E98 grid_render_
 void _grid_render(Rect* rect, int elevation)
 {
     if (!gTileGridIsVisible) {
@@ -1494,7 +1494,7 @@ void _grid_render(Rect* rect, int elevation)
     }
 }
 
-// 0x4B2F4C
+// 0x4B2F4C draw_grid_
 static void _draw_grid(int tile, int elevation, Rect* rect)
 {
     if (tile == -1) {
@@ -1547,7 +1547,7 @@ static void _draw_grid(int tile, int elevation, Rect* rect)
         _commonGrayTable);
 }
 
-// 0x4B30C4
+// 0x4B30C4 floor_draw_
 static void tileRenderFloor(int fid, int x, int y, Rect* rect)
 {
     if (artIsObjectTypeHidden(FID_TYPE(fid)) != 0) {
@@ -1784,7 +1784,7 @@ out:
     artUnlock(cacheEntry);
 }
 
-// 0x4B372C
+// 0x4B372C tile_make_line_
 static int _tile_make_line(int from, int to, int* tiles, int tilesCapacity)
 {
     if (tilesCapacity <= 1) {
@@ -1896,7 +1896,7 @@ static int _tile_make_line(int from, int to, int* tiles, int tilesCapacity)
     return count;
 }
 
-// 0x4B3924
+// 0x4B3924 tile_scroll_to_
 int _tile_scroll_to(int tile, int flags)
 {
     if (tile == gCenterTile) {

--- a/src/tile.cc
+++ b/src/tile.cc
@@ -65,31 +65,31 @@ static void _draw_grid(int tile, int elevation, Rect* rect);
 static void tileRenderFloor(int fid, int x, int y, Rect* rect);
 static int _tile_make_line(int currentCenterTile, int newCenterTile, int* tiles, int tilesCapacity);
 
-// 0x50E7C7
+// 0x50E7C7 minus_4_0f
 static double const dbl_50E7C7 = -4.0;
 
-// 0x51D950
+// 0x51D950 borderInitialized
 bool gTileBorderInitialized = false;
 
-// 0x51D954
+// 0x51D954 scroll_blocking_on
 static bool gTileScrollBlockingEnabled = true;
 
-// 0x51D958
+// 0x51D958 scroll_limiting_on
 static bool gTileScrollLimitingEnabled = true;
 
-// 0x51D95C
+// 0x51D95C show_roof
 static bool gTileRoofIsVisible = true;
 
-// 0x51D960
+// 0x51D960 show_grid
 static bool gTileGridIsVisible = false;
 
-// 0x51D964
+// 0x51D964 _tile_refresh
 static TileWindowRefreshElevationProc* gTileWindowRefreshElevationProc = tileRefreshGame;
 
-// 0x51D968
+// 0x51D968 refresh_enabled
 static bool gTileEnabled = true;
 
-// 0x51D96C
+// 0x51D96C _off_tile
 const int _off_tile[6] = {
     16,
     32,
@@ -109,7 +109,7 @@ const int dword_51D984[6] = {
     -12,
 };
 
-// 0x51D99C
+// 0x51D99C rightside_up_table
 static RightsideUpTableEntry _rightside_up_table[13] = {
     { -1, 2 },
     { 78, 2 },
@@ -126,7 +126,7 @@ static RightsideUpTableEntry _rightside_up_table[13] = {
     { 50, 32 },
 };
 
-// 0x51DA04
+// 0x51DA04 upside_down_table
 static UpsideDownTableEntry _upside_down_table[13] = {
     { 0, 32 },
     { 48, 32 },
@@ -143,7 +143,7 @@ static UpsideDownTableEntry _upside_down_table[13] = {
     { 75, 4 },
 };
 
-// 0x51DA6C
+// 0x51DA6C verticies
 static STRUCT_51DA6C _verticies[10] = {
     { 16, -1, -201, 0 },
     { 48, -2, -2, 0 },
@@ -157,7 +157,7 @@ static STRUCT_51DA6C _verticies[10] = {
     { 2944, 599, 399, 0 },
 };
 
-// 0x51DB0C
+// 0x51DB0C rightside_up_triangles
 static RightsideUpTriangle _rightside_up_triangles[5] = {
     { 2, 3, 0 },
     { 3, 4, 1 },
@@ -166,7 +166,7 @@ static RightsideUpTriangle _rightside_up_triangles[5] = {
     { 8, 9, 6 },
 };
 
-// 0x51DB48
+// 0x51DB48 upside_down_triangles
 static UpsideDownTriangle _upside_down_triangles[5] = {
     { 0, 3, 1 },
     { 2, 5, 3 },
@@ -175,27 +175,27 @@ static UpsideDownTriangle _upside_down_triangles[5] = {
     { 6, 9, 7 },
 };
 
-// 0x668224
+// 0x668224 intensity_map
 static int _intensity_map[3280];
 
-// 0x66B564
+// 0x66B564 dir_tile2
 static int _dir_tile2[2][6];
 
 // Deltas to perform tile calculations in given direction.
 //
-// 0x66B594
+// 0x66B594 dir_tile
 static int _dir_tile[2][6];
 
-// 0x66B5C4
+// 0x66B5C4 tile_grid_blocked
 static unsigned char _tile_grid_blocked[512];
 
-// 0x66B7C4
+// 0x66B7C4 tile_grid_occupied
 static unsigned char _tile_grid_occupied[512];
 
-// 0x66B9C4
+// 0x66B9C4 tile_mask
 static unsigned char _tile_mask[512];
 
-// 0x66BBC4
+// 0x66BBC4 tile_border
 int gTileBorderMinX = 0;
 
 // 0x66BBC8
@@ -207,86 +207,86 @@ int gTileBorderMaxX = 0;
 // 0x66BBD0
 int gTileBorderMaxY = 0;
 
-// 0x66BBD4
+// 0x66BBD4 buf_rect_2
 static Rect gTileWindowRect;
 
-// 0x66BBE4
+// 0x66BBE4 tile_grid
 static unsigned char _tile_grid[32 * 16];
 
-// 0x66BDE4
+// 0x66BDE4 square_y
 static int _square_y;
 
-// 0x66BDE8
+// 0x66BDE8 square_x
 static int _square_x;
 
-// 0x66BDEC
+// 0x66BDEC square_offx
 static int _square_offx;
 
-// 0x66BDF0
+// 0x66BDF0 square_offy
 static int _square_offy;
 
-// 0x66BDF4
+// 0x66BDF4 _blit
 static TileWindowRefreshProc* gTileWindowRefreshProc;
 
-// 0x66BDF8
+// 0x66BDF8 tile_offy
 static int _tile_offy;
 
-// 0x66BDFC
+// 0x66BDFC tile_offx
 static int _tile_offx;
 
-// 0x66BE00
+// 0x66BE00 square_size
 static int gSquareGridSize;
 
 // Number of tiles horizontally.
 //
 // Currently this value is always 200.
 //
-// 0x66BE04
+// 0x66BE04 grid_width
 static int gHexGridWidth;
 
-// 0x66BE08
+// 0x66BE08 _squares
 static TileData** gTileSquares;
 
-// 0x66BE0C
+// 0x66BE0C tile_back_buf
 static unsigned char* gTileWindowBuffer;
 
 // Number of tiles vertically.
 //
 // Currently this value is always 200.
 //
-// 0x66BE10
+// 0x66BE10 grid_length
 static int gHexGridHeight;
 
-// 0x66BE14
+// 0x66BE14 buf_length_2
 static int gTileWindowHeight;
 
-// 0x66BE18
+// 0x66BE18 tile_x
 static int _tile_x;
 
-// 0x66BE1C
+// 0x66BE1C tile_y
 static int _tile_y;
 
 // The number of tiles in the hex grid.
 //
-// 0x66BE20
+// 0x66BE20 grid_size
 int gHexGridSize;
 
-// 0x66BE24
+// 0x66BE24 square_length
 static int gSquareGridHeight;
 
-// 0x66BE28
+// 0x66BE28 buf_to_width
 static int gTileWindowPitch;
 
-// 0x66BE2C
+// 0x66BE2C square_width
 static int gSquareGridWidth;
 
-// 0x66BE30
+// 0x66BE30 buf_width_2
 static int gTileWindowWidth;
 
-// 0x66BE34
+// 0x66BE34 tile_center_tile
 int gCenterTile;
 
-// 0x4B0C40 tile_init_
+// 0x4B0C40 tile_init
 int tileInit(TileData** squareGrid, int squareGridWidth, int squareGridHeight, int hexGridWidth, int hexGridHeight, unsigned char* buf, int windowWidth, int windowHeight, int windowPitch, TileWindowRefreshProc* windowRefreshProc)
 {
     int v11;
@@ -458,7 +458,7 @@ int tileInit(TileData** squareGrid, int squareGridWidth, int squareGridHeight, i
     return 0;
 }
 
-// 0x4B11E4 tile_set_border_
+// 0x4B11E4 tile_set_border
 static void tileSetBorder(int windowWidth, int windowHeight, int hexGridWidth, int hexGridHeight)
 {
     // TODO: Borders, scroll blockers and tile system overall were designed
@@ -503,19 +503,19 @@ void tileExit()
     _tile_reset_();
 }
 
-// 0x4B12A8 tile_disable_refresh_
+// 0x4B12A8 tile_disable_refresh
 void tileDisable()
 {
     gTileEnabled = false;
 }
 
-// 0x4B12B4 tile_enable_refresh_
+// 0x4B12B4 tile_enable_refresh
 void tileEnable()
 {
     gTileEnabled = true;
 }
 
-// 0x4B12C0 tile_refresh_rect_
+// 0x4B12C0 tile_refresh_rect
 void tileWindowRefreshRect(Rect* rect, int elevation)
 {
     if (gTileEnabled) {
@@ -525,7 +525,7 @@ void tileWindowRefreshRect(Rect* rect, int elevation)
     }
 }
 
-// 0x4B12D8 tile_refresh_display_
+// 0x4B12D8 tile_refresh_display
 void tileWindowRefresh()
 {
     if (gTileEnabled) {
@@ -533,7 +533,7 @@ void tileWindowRefresh()
     }
 }
 
-// 0x4B12F8 tile_set_center_
+// 0x4B12F8 tile_set_center
 int tileSetCenter(int tile, int flags)
 {
     if (!tileIsValid(tile)) {
@@ -609,7 +609,7 @@ int tileSetCenter(int tile, int flags)
     return 0;
 }
 
-// 0x4B1554 refresh_mapper_
+// 0x4B1554 refresh_mapper
 static void tileRefreshMapper(Rect* rect, int elevation)
 {
     Rect rectToUpdate;
@@ -635,7 +635,7 @@ static void tileRefreshMapper(Rect* rect, int elevation)
     gTileWindowRefreshProc(&rectToUpdate);
 }
 
-// 0x4B15E8 refresh_game_
+// 0x4B15E8 refresh_game
 static void tileRefreshGame(Rect* rect, int elevation)
 {
     Rect rectToUpdate;
@@ -662,7 +662,7 @@ static void tileRefreshGame(Rect* rect, int elevation)
     gTileWindowRefreshProc(&rectToUpdate);
 }
 
-// 0x4B1634 tile_toggle_roof_
+// 0x4B1634 tile_toggle_roof
 void tile_toggle_roof(bool refresh)
 {
     gTileRoofIsVisible = !gTileRoofIsVisible;
@@ -673,13 +673,13 @@ void tile_toggle_roof(bool refresh)
     }
 }
 
-// 0x4B166C tile_roof_visible_
+// 0x4B166C tile_roof_visible
 int tileRoofIsVisible()
 {
     return gTileRoofIsVisible;
 }
 
-// 0x4B1674 tile_coord_
+// 0x4B1674 tile_coord
 int tileToScreenXY(int tile, int* screenX, int* screenY)
 {
     int v3;
@@ -721,7 +721,7 @@ int tileToScreenXY(int tile, int* screenX, int* screenY)
 // validating hex grid bounds. The resulting invalid tile number serves as an
 // origin for calculations using prepared offsets table during objects
 // rendering.
-// 0x4B1754 tile_num_
+// 0x4B1754 tile_num
 int tileFromScreenXY(int screenX, int screenY, bool ignoreBounds)
 {
     int x, y;
@@ -802,7 +802,7 @@ int squareTileFromTile(int tile)
 }
 
 // tile_distance
-// 0x4B185C tile_dist_
+// 0x4B185C tile_dist
 int tileDistanceBetween(int tile1, int tile2)
 {
     if (tile1 == -1 || tile2 == -1) {
@@ -820,7 +820,7 @@ int tileDistanceBetween(int tile1, int tile2)
     return step;
 }
 
-// 0x4B1994 tile_in_front_of_
+// 0x4B1994 tile_in_front_of
 bool tileIsInFrontOf(int tile1, int tile2)
 {
     int x1, y1;
@@ -835,7 +835,7 @@ bool tileIsInFrontOf(int tile1, int tile2)
     return (double)dx <= (double)dy * dbl_50E7C7;
 }
 
-// 0x4B1A00 tile_to_right_of_
+// 0x4B1A00 tile_to_right_of
 bool tileIsToRightOf(int tile1, int tile2)
 {
     int x1, y1;
@@ -855,7 +855,7 @@ bool tileIsToRightOf(int tile1, int tile2)
 }
 
 // tile_num_in_direction
-// 0x4B1A6C tile_num_in_direction_
+// 0x4B1A6C tile_num_in_direction
 int tileGetTileInDirection(int tile, int rotation, int distance)
 {
     int newTile = tile;
@@ -872,7 +872,7 @@ int tileGetTileInDirection(int tile, int rotation, int distance)
 }
 
 // rotation_to_tile
-// 0x4B1ABC tile_dir_
+// 0x4B1ABC tile_dir
 int tileGetRotationTo(int tile1, int tile2)
 {
     int x1, y1;
@@ -902,7 +902,7 @@ int tileGetRotationTo(int tile1, int tile2)
     return dy < 0 ? ROTATION_NE : ROTATION_SE;
 }
 
-// 0x4B1B84 tile_num_beyond_
+// 0x4B1B84 tile_num_beyond
 int _tile_num_beyond(int from, int to, int distance)
 {
     if (distance <= 0 || from == to) {
@@ -991,7 +991,7 @@ int _tile_num_beyond(int from, int to, int distance)
     assert(false && "Should be unreachable");
 }
 
-// 0x4B1D20 tile_on_edge_
+// 0x4B1D20 tile_on_edge
 bool tileIsEdge(int tile)
 {
     if (!tileIsValid(tile)) {
@@ -1017,43 +1017,43 @@ bool tileIsEdge(int tile)
     return false;
 }
 
-// 0x4B1D80 tile_enable_scroll_blocking_
+// 0x4B1D80 tile_enable_scroll_blocking
 void tileScrollBlockingEnable()
 {
     gTileScrollBlockingEnabled = true;
 }
 
-// 0x4B1D8C tile_disable_scroll_blocking_
+// 0x4B1D8C tile_disable_scroll_blocking
 void tileScrollBlockingDisable()
 {
     gTileScrollBlockingEnabled = false;
 }
 
-// 0x4B1D98 tile_get_scroll_blocking_
+// 0x4B1D98 tile_get_scroll_blocking
 bool tileScrollBlockingIsEnabled()
 {
     return gTileScrollBlockingEnabled;
 }
 
-// 0x4B1DA0 tile_enable_scroll_limiting_
+// 0x4B1DA0 tile_enable_scroll_limiting
 void tileScrollLimitingEnable()
 {
     gTileScrollLimitingEnabled = true;
 }
 
-// 0x4B1DAC tile_disable_scroll_limiting_
+// 0x4B1DAC tile_disable_scroll_limiting
 void tileScrollLimitingDisable()
 {
     gTileScrollLimitingEnabled = false;
 }
 
-// 0x4B1DB8 tile_get_scroll_limiting_
+// 0x4B1DB8 tile_get_scroll_limiting
 bool tileScrollLimitingIsEnabled()
 {
     return gTileScrollLimitingEnabled;
 }
 
-// 0x4B1DC0 square_coord_
+// 0x4B1DC0 square_coord
 int squareTileToScreenXY(int squareTile, int* coordX, int* coordY, int elevation)
 {
     if (squareTile < 0 || squareTile >= gSquareGridSize) {
@@ -1077,7 +1077,7 @@ int squareTileToScreenXY(int squareTile, int* coordX, int* coordY, int elevation
     return 0;
 }
 
-// 0x4B1E60 square_coord_roof_
+// 0x4B1E60 square_coord_roof
 int squareTileToRoofScreenXY(int squareTile, int* screenX, int* screenY, int elevation)
 {
     int v5;
@@ -1110,7 +1110,7 @@ int squareTileToRoofScreenXY(int squareTile, int* screenX, int* screenY, int ele
     return 0;
 }
 
-// 0x4B1F04 square_num_
+// 0x4B1F04 square_num
 int squareTileFromScreenXY(int screenX, int screenY, int elevation)
 {
     int coordY;
@@ -1125,7 +1125,7 @@ int squareTileFromScreenXY(int screenX, int screenY, int elevation)
     return -1;
 }
 
-// 0x4B1F94 square_xy_
+// 0x4B1F94 square_xy
 void squareTileScreenToCoord(int screenX, int screenY, int elevation, int* coordX, int* coordY)
 {
     int v4;
@@ -1147,7 +1147,7 @@ void squareTileScreenToCoord(int screenX, int screenY, int elevation, int* coord
     *coordX = gSquareGridWidth - 1 - *coordX;
 }
 
-// 0x4B203C square_xy_roof_
+// 0x4B203C square_xy_roof
 void squareTileScreenToCoordRoof(int screenX, int screenY, int elevation, int* coordX, int* coordY)
 {
     int v4;
@@ -1170,7 +1170,7 @@ void squareTileScreenToCoordRoof(int screenX, int screenY, int elevation, int* c
     *coordX = gSquareGridWidth - 1 - *coordX;
 }
 
-// 0x4B20E8 square_render_roof_
+// 0x4B20E8 square_render_roof
 void tileRenderRoofsInRect(Rect* rect, int elevation)
 {
     if (!gTileRoofIsVisible) {
@@ -1265,7 +1265,7 @@ static void roof_fill_off_process_task(std::stack<roof_fill_task>& tasks_stack, 
     }
 }
 
-// 0x4B23D4 tile_fill_roof_
+// 0x4B23D4 tile_fill_roof
 void tile_fill_roof(int x, int y, int elevation, bool on)
 {
     std::stack<roof_fill_task> tasks_stack;
@@ -1277,7 +1277,7 @@ void tile_fill_roof(int x, int y, int elevation, bool on)
     }
 }
 
-// 0x4B24E0 roof_draw_
+// 0x4B24E0 roof_draw
 static void tileRenderRoof(int fid, int x, int y, Rect* rect, int light)
 {
     CacheEntry* tileFrmHandle;
@@ -1387,7 +1387,7 @@ static void tileRenderRoof(int fid, int x, int y, Rect* rect, int light)
     artUnlock(tileFrmHandle);
 }
 
-// 0x4B2944 square_render_floor_
+// 0x4B2944 square_render_floor
 void tileRenderFloorsInRect(Rect* rect, int elevation)
 {
     int minY;
@@ -1437,7 +1437,7 @@ void tileRenderFloorsInRect(Rect* rect, int elevation)
     }
 }
 
-// 0x4B2B10 square_roof_intersect_
+// 0x4B2B10 square_roof_intersect
 bool _square_roof_intersect(int x, int y, int elevation)
 {
     if (!gTileRoofIsVisible) {
@@ -1479,7 +1479,7 @@ bool _square_roof_intersect(int x, int y, int elevation)
     return result;
 }
 
-// 0x4B2E98 grid_render_
+// 0x4B2E98 grid_render
 void _grid_render(Rect* rect, int elevation)
 {
     if (!gTileGridIsVisible) {
@@ -1494,7 +1494,7 @@ void _grid_render(Rect* rect, int elevation)
     }
 }
 
-// 0x4B2F4C draw_grid_
+// 0x4B2F4C draw_grid
 static void _draw_grid(int tile, int elevation, Rect* rect)
 {
     if (tile == -1) {
@@ -1547,7 +1547,7 @@ static void _draw_grid(int tile, int elevation, Rect* rect)
         _commonGrayTable);
 }
 
-// 0x4B30C4 floor_draw_
+// 0x4B30C4 floor_draw
 static void tileRenderFloor(int fid, int x, int y, Rect* rect)
 {
     if (artIsObjectTypeHidden(FID_TYPE(fid)) != 0) {
@@ -1784,7 +1784,7 @@ out:
     artUnlock(cacheEntry);
 }
 
-// 0x4B372C tile_make_line_
+// 0x4B372C tile_make_line
 static int _tile_make_line(int from, int to, int* tiles, int tilesCapacity)
 {
     if (tilesCapacity <= 1) {
@@ -1896,7 +1896,7 @@ static int _tile_make_line(int from, int to, int* tiles, int tilesCapacity)
     return count;
 }
 
-// 0x4B3924 tile_scroll_to_
+// 0x4B3924 tile_scroll_to
 int _tile_scroll_to(int tile, int flags)
 {
     if (tile == gCenterTile) {

--- a/src/trait.cc
+++ b/src/trait.cc
@@ -54,7 +54,7 @@ static TraitDescription gTraitDescriptions[TRAIT_COUNT] = {
     { nullptr, nullptr, 70 },
 };
 
-// 0x4B39F0
+// 0x4B39F0 trait_init_
 int traitsInit()
 {
     if (!messageListInit(&gTraitsMessageList)) {
@@ -90,7 +90,7 @@ int traitsInit()
     return true;
 }
 
-// 0x4B3ADC
+// 0x4B3ADC trait_reset_
 void traitsReset()
 {
     for (int index = 0; index < TRAITS_MAX_SELECTED_COUNT; index++) {
@@ -98,7 +98,7 @@ void traitsReset()
     }
 }
 
-// 0x4B3AF8
+// 0x4B3AF8 trait_exit_
 void traitsExit()
 {
     messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_TRAIT, nullptr);
@@ -107,7 +107,7 @@ void traitsExit()
 
 // Loads trait system state from save game.
 //
-// 0x4B3B08
+// 0x4B3B08 trait_load_
 int traitsLoad(File* stream)
 {
     return fileReadInt32List(stream, gSelectedTraits, TRAITS_MAX_SELECTED_COUNT);
@@ -115,7 +115,7 @@ int traitsLoad(File* stream)
 
 // Saves trait system state to save game.
 //
-// 0x4B3B28
+// 0x4B3B28 trait_save_
 int traitsSave(File* stream)
 {
     return fileWriteInt32List(stream, gSelectedTraits, TRAITS_MAX_SELECTED_COUNT);
@@ -123,7 +123,7 @@ int traitsSave(File* stream)
 
 // Sets selected traits.
 //
-// 0x4B3B48
+// 0x4B3B48 trait_set_
 void traitsSetSelected(int trait1, int trait2)
 {
     gSelectedTraits[0] = trait1;
@@ -132,7 +132,7 @@ void traitsSetSelected(int trait1, int trait2)
 
 // Returns selected traits.
 //
-// 0x4B3B54
+// 0x4B3B54 trait_get_
 void traitsGetSelected(int* trait1, int* trait2)
 {
     *trait1 = gSelectedTraits[0];
@@ -142,7 +142,7 @@ void traitsGetSelected(int* trait1, int* trait2)
 // Returns a name of the specified trait, or `NULL` if the specified trait is
 // out of range.
 //
-// 0x4B3B68
+// 0x4B3B68 trait_name_
 char* traitGetName(int trait)
 {
     return trait >= 0 && trait < TRAIT_COUNT ? gTraitDescriptions[trait].name : nullptr;
@@ -151,7 +151,7 @@ char* traitGetName(int trait)
 // Returns a description of the specified trait, or `NULL` if the specified
 // trait is out of range.
 //
-// 0x4B3B88
+// 0x4B3B88 trait_description_
 char* traitGetDescription(int trait)
 {
     return trait >= 0 && trait < TRAIT_COUNT ? gTraitDescriptions[trait].description : nullptr;
@@ -160,7 +160,7 @@ char* traitGetDescription(int trait)
 // Return an art ID of the specified trait, or `0` if the specified trait is
 // out of range.
 //
-// 0x4B3BA8
+// 0x4B3BA8 trait_pic_
 int traitGetFrmId(int trait)
 {
     return trait >= 0 && trait < TRAIT_COUNT ? gTraitDescriptions[trait].frmId : 0;
@@ -168,7 +168,7 @@ int traitGetFrmId(int trait)
 
 // Returns `true` if the specified trait is selected.
 //
-// 0x4B3BC8
+// 0x4B3BC8 trait_level_
 bool traitIsSelected(int trait)
 {
     return gSelectedTraits[0] == trait || gSelectedTraits[1] == trait;
@@ -176,7 +176,7 @@ bool traitIsSelected(int trait)
 
 // Returns stat modifier depending on selected traits.
 //
-// 0x4B3C7C
+// 0x4B3C7C trait_adjust_stat_
 int traitGetStatModifier(int stat)
 {
     int modifier = 0;
@@ -280,7 +280,7 @@ int traitGetStatModifier(int stat)
 
 // Returns skill modifier depending on selected traits.
 //
-// 0x4B40FC
+// 0x4B40FC trait_adjust_skill_
 int traitGetSkillModifier(int skill)
 {
     int modifier = 0;

--- a/src/trait.cc
+++ b/src/trait.cc
@@ -26,15 +26,15 @@ typedef struct TraitDescription {
     int frmId;
 } TraitDescription;
 
-// 0x66BE38
+// 0x66BE38 trait_message_file
 static MessageList gTraitsMessageList;
 
 // List of selected traits.
 //
-// 0x66BE40
+// 0x66BE40 pc_trait
 static int gSelectedTraits[TRAITS_MAX_SELECTED_COUNT];
 
-// 0x51DB84
+// 0x51DB84 trait_data
 static TraitDescription gTraitDescriptions[TRAIT_COUNT] = {
     { nullptr, nullptr, 55 },
     { nullptr, nullptr, 56 },
@@ -54,7 +54,7 @@ static TraitDescription gTraitDescriptions[TRAIT_COUNT] = {
     { nullptr, nullptr, 70 },
 };
 
-// 0x4B39F0 trait_init_
+// 0x4B39F0 trait_init
 int traitsInit()
 {
     if (!messageListInit(&gTraitsMessageList)) {
@@ -90,7 +90,7 @@ int traitsInit()
     return true;
 }
 
-// 0x4B3ADC trait_reset_
+// 0x4B3ADC trait_reset
 void traitsReset()
 {
     for (int index = 0; index < TRAITS_MAX_SELECTED_COUNT; index++) {
@@ -98,7 +98,7 @@ void traitsReset()
     }
 }
 
-// 0x4B3AF8 trait_exit_
+// 0x4B3AF8 trait_exit
 void traitsExit()
 {
     messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_TRAIT, nullptr);
@@ -107,7 +107,7 @@ void traitsExit()
 
 // Loads trait system state from save game.
 //
-// 0x4B3B08 trait_load_
+// 0x4B3B08 trait_load
 int traitsLoad(File* stream)
 {
     return fileReadInt32List(stream, gSelectedTraits, TRAITS_MAX_SELECTED_COUNT);
@@ -115,7 +115,7 @@ int traitsLoad(File* stream)
 
 // Saves trait system state to save game.
 //
-// 0x4B3B28 trait_save_
+// 0x4B3B28 trait_save
 int traitsSave(File* stream)
 {
     return fileWriteInt32List(stream, gSelectedTraits, TRAITS_MAX_SELECTED_COUNT);
@@ -123,7 +123,7 @@ int traitsSave(File* stream)
 
 // Sets selected traits.
 //
-// 0x4B3B48 trait_set_
+// 0x4B3B48 trait_set
 void traitsSetSelected(int trait1, int trait2)
 {
     gSelectedTraits[0] = trait1;
@@ -132,7 +132,7 @@ void traitsSetSelected(int trait1, int trait2)
 
 // Returns selected traits.
 //
-// 0x4B3B54 trait_get_
+// 0x4B3B54 trait_get
 void traitsGetSelected(int* trait1, int* trait2)
 {
     *trait1 = gSelectedTraits[0];
@@ -142,7 +142,7 @@ void traitsGetSelected(int* trait1, int* trait2)
 // Returns a name of the specified trait, or `NULL` if the specified trait is
 // out of range.
 //
-// 0x4B3B68 trait_name_
+// 0x4B3B68 trait_name
 char* traitGetName(int trait)
 {
     return trait >= 0 && trait < TRAIT_COUNT ? gTraitDescriptions[trait].name : nullptr;
@@ -151,7 +151,7 @@ char* traitGetName(int trait)
 // Returns a description of the specified trait, or `NULL` if the specified
 // trait is out of range.
 //
-// 0x4B3B88 trait_description_
+// 0x4B3B88 trait_description
 char* traitGetDescription(int trait)
 {
     return trait >= 0 && trait < TRAIT_COUNT ? gTraitDescriptions[trait].description : nullptr;
@@ -160,7 +160,7 @@ char* traitGetDescription(int trait)
 // Return an art ID of the specified trait, or `0` if the specified trait is
 // out of range.
 //
-// 0x4B3BA8 trait_pic_
+// 0x4B3BA8 trait_pic
 int traitGetFrmId(int trait)
 {
     return trait >= 0 && trait < TRAIT_COUNT ? gTraitDescriptions[trait].frmId : 0;
@@ -168,7 +168,7 @@ int traitGetFrmId(int trait)
 
 // Returns `true` if the specified trait is selected.
 //
-// 0x4B3BC8 trait_level_
+// 0x4B3BC8 trait_level
 bool traitIsSelected(int trait)
 {
     return gSelectedTraits[0] == trait || gSelectedTraits[1] == trait;
@@ -176,7 +176,7 @@ bool traitIsSelected(int trait)
 
 // Returns stat modifier depending on selected traits.
 //
-// 0x4B3C7C trait_adjust_stat_
+// 0x4B3C7C trait_adjust_stat
 int traitGetStatModifier(int stat)
 {
     int modifier = 0;
@@ -280,7 +280,7 @@ int traitGetStatModifier(int stat)
 
 // Returns skill modifier depending on selected traits.
 //
-// 0x4B40FC trait_adjust_skill_
+// 0x4B40FC trait_adjust_skill
 int traitGetSkillModifier(int skill)
 {
     int modifier = 0;

--- a/src/version.cc
+++ b/src/version.cc
@@ -5,7 +5,7 @@
 
 namespace fallout {
 
-// 0x4B4580
+// 0x4B4580 getverstr_
 void versionGetVersion(char* dest, size_t size)
 {
     // SFALL: custom version string.

--- a/src/version.cc
+++ b/src/version.cc
@@ -5,7 +5,7 @@
 
 namespace fallout {
 
-// 0x4B4580 getverstr_
+// 0x4B4580 getverstr
 void versionGetVersion(char* dest, size_t size)
 {
     // SFALL: custom version string.

--- a/src/widget.cc
+++ b/src/widget.cc
@@ -5,13 +5,13 @@ namespace fallout {
 // 0x66E6A0
 static int _updateRegions[32];
 
-// 0x4B5A64
+// 0x4B5A64 showRegion_
 static void _showRegion(int region)
 {
     // TODO: Incomplete.
 }
 
-// 0x4B5C24
+// 0x4B5C24 update_widgets_
 int windowUpdateWidgets()
 {
     for (int index = 0; index < 32; index++) {
@@ -23,7 +23,7 @@ int windowUpdateWidgets()
     return 1;
 }
 
-// 0x4B5998
+// 0x4B5998 win_delete_widgets_
 void windowDeleteWidgets(int win)
 {
     // TODO: Incomplete.

--- a/src/widget.cc
+++ b/src/widget.cc
@@ -2,16 +2,16 @@
 
 namespace fallout {
 
-// 0x66E6A0
+// 0x66E6A0 updateRegions
 static int _updateRegions[32];
 
-// 0x4B5A64 showRegion_
+// 0x4B5A64 showRegion
 static void _showRegion(int region)
 {
     // TODO: Incomplete.
 }
 
-// 0x4B5C24 update_widgets_
+// 0x4B5C24 update_widgets
 int windowUpdateWidgets()
 {
     for (int index = 0; index < 32; index++) {
@@ -23,7 +23,7 @@ int windowUpdateWidgets()
     return 1;
 }
 
-// 0x4B5998 win_delete_widgets_
+// 0x4B5998 win_delete_widgets
 void windowDeleteWidgets(int win)
 {
     // TODO: Incomplete.

--- a/src/win32.cc
+++ b/src/win32.cc
@@ -32,7 +32,7 @@
 
 namespace fallout {
 
-// 0x51E444
+// 0x51E444 GNW95_isActive
 bool gProgramIsActive = false;
 
 #if __APPLE__ && TARGET_OS_OSX

--- a/src/window.cc
+++ b/src/window.cc
@@ -92,20 +92,20 @@ typedef int (*INITVIDEOFN)();
 
 static void redrawButton(ManagedButton* managedButton);
 
-// 0x51DCAC
+// 0x51DCAC holdTime
 static int _holdTime = 250;
 
-// 0x51DCB0
+// 0x51DCB0 checkRegionEnable
 static int _checkRegionEnable = 1;
 
-// 0x51DCB4
+// 0x51DCB4 winTOS
 static int _winTOS = -1;
 
 // 051DCB8
 static int gCurrentManagedWindowIndex = -1;
 
 // TODO: this is probably not needed: FO always used mode 1
-// 0x51DCBC
+// 0x51DCBC _gfx_init
 static INITVIDEOFN _gfx_init[12] = {
     _init_mode_320_200,
     _init_mode_640_480,
@@ -121,7 +121,7 @@ static INITVIDEOFN _gfx_init[12] = {
     _init_mode_1280_1024,
 };
 
-// 0x51DD1C
+// 0x51DD1C sizes_x
 static Size _sizes_x[12] = {
     { 320, 200 },
     { 640, 480 },
@@ -137,87 +137,87 @@ static Size _sizes_x[12] = {
     { 1280, 1024 },
 };
 
-// 0x51DD7C
+// 0x51DD7C numInputFunc
 static int gWindowInputHandlersLength = 0;
 
-// 0x51DD80
+// 0x51DD80 lastWin
 static int _lastWin = -1;
 
-// 0x51DD84
+// 0x51DD84 _said_quit
 static int _said_quit = 1;
 
-// 0x66E770
+// 0x66E770 winStack
 static int _winStack[MANAGED_WINDOW_COUNT];
 
-// 0x66E7B0
+// 0x66E7B0 alphaBlendTable
 static char _alphaBlendTable[64 * 256];
 
-// 0x6727B0
+// 0x6727B0 sWindows
 static ManagedWindow gManagedWindows[MANAGED_WINDOW_COUNT];
 
-// 0x672D70
+// 0x672D70 inputFunc
 static WindowInputHandler** gWindowInputHandlers;
 
-// 0x672D74
+// 0x672D74 _createWindowFunc
 static ManagedWindowCreateCallback* off_672D74;
 
 // NOTE: This value is never set.
 //
-// 0x672D78
+// 0x672D78 _selectWindowFunc
 static void (*_selectWindowFunc)(int, ManagedWindow*);
 
-// 0x672D7C
+// 0x672D7C xres
 static int _xres;
 
-// 0x672D80
+// 0x672D80 _displayFunc
 static DisplayInWindowCallback* gDisplayInWindowCallback;
 
-// 0x672D84
+// 0x672D84 _deleteWindowFunc
 static WindowDeleteCallback* gWindowDeleteCallback;
 
-// 0x672D88
+// 0x672D88 yres
 static int _yres;
 
 // Highlight color (maybe r).
 //
-// 0x672D8C
+// 0x672D8C currentHighlightColorR
 static int _currentHighlightColorR;
 
-// 0x672D90
+// 0x672D90 currentFont
 static int gWidgetFont;
 
-// 0x672D98
+// 0x672D98 _soundPressFunc
 ButtonCallback* off_672D98;
 
-// 0x672D9C
+// 0x672D9C _soundReleaseFunc
 ButtonCallback* off_672D9C;
 
 // Text color (maybe g).
 //
-// 0x672DA0
+// 0x672DA0 currentTextColorG
 static int _currentTextColorG;
 
 // text color (maybe b).
 //
-// 0x672DA4
+// 0x672DA4 currentTextColorB
 static int _currentTextColorB;
 
-// 0x672DA8
+// 0x672DA8 currentTextFlags
 static int gWidgetTextFlags;
 
 // Text color (maybe r)
 //
-// 0x672DAC
+// 0x672DAC currentTextColorR
 static int _currentTextColorR;
 
 // highlight color (maybe g)
 //
-// 0x672DB0
+// 0x672DB0 currentHighlightColorG
 static int _currentHighlightColorG;
 
 // Highlight color (maybe b).
 //
-// 0x672DB4
+// 0x672DB4 currentHighlightColorB
 static int _currentHighlightColorB;
 
 // 0x4B6120

--- a/src/window.cc
+++ b/src/window.cc
@@ -105,7 +105,7 @@ static int _winTOS = -1;
 static int gCurrentManagedWindowIndex = -1;
 
 // TODO: this is probably not needed: FO always used mode 1
-// 0x51DCBC _gfx_init
+// 0x51DCBC gfx_init
 static INITVIDEOFN _gfx_init[12] = {
     _init_mode_320_200,
     _init_mode_640_480,
@@ -143,7 +143,7 @@ static int gWindowInputHandlersLength = 0;
 // 0x51DD80 lastWin
 static int _lastWin = -1;
 
-// 0x51DD84 _said_quit
+// 0x51DD84 said_quit
 static int _said_quit = 1;
 
 // 0x66E770 winStack
@@ -158,21 +158,21 @@ static ManagedWindow gManagedWindows[MANAGED_WINDOW_COUNT];
 // 0x672D70 inputFunc
 static WindowInputHandler** gWindowInputHandlers;
 
-// 0x672D74 _createWindowFunc
+// 0x672D74 createWindowFunc
 static ManagedWindowCreateCallback* off_672D74;
 
 // NOTE: This value is never set.
 //
-// 0x672D78 _selectWindowFunc
+// 0x672D78 selectWindowFunc
 static void (*_selectWindowFunc)(int, ManagedWindow*);
 
 // 0x672D7C xres
 static int _xres;
 
-// 0x672D80 _displayFunc
+// 0x672D80 displayFunc
 static DisplayInWindowCallback* gDisplayInWindowCallback;
 
-// 0x672D84 _deleteWindowFunc
+// 0x672D84 deleteWindowFunc
 static WindowDeleteCallback* gWindowDeleteCallback;
 
 // 0x672D88 yres
@@ -186,10 +186,10 @@ static int _currentHighlightColorR;
 // 0x672D90 currentFont
 static int gWidgetFont;
 
-// 0x672D98 _soundPressFunc
+// 0x672D98 soundPressFunc
 ButtonCallback* off_672D98;
 
-// 0x672D9C _soundReleaseFunc
+// 0x672D9C soundReleaseFunc
 ButtonCallback* off_672D9C;
 
 // Text color (maybe g).

--- a/src/window_manager.cc
+++ b/src/window_manager.cc
@@ -67,7 +67,7 @@ int _GNW_wcolor[6] = {
     0,
 };
 
-// 0x51E3FC _screen_buffer
+// 0x51E3FC screen_buffer
 static unsigned char* _screen_buffer = nullptr;
 
 // 0x51E400 insideWinExit
@@ -79,10 +79,10 @@ static int _last_button_winID = -1;
 // 0x6ADD90 window_index
 static int gWindowIndexes[MAX_WINDOW_COUNT];
 
-// 0x6ADE58 _window
+// 0x6ADE58 window
 static Window* gWindows[MAX_WINDOW_COUNT];
 
-// 0x6ADF20 _video_reset
+// 0x6ADF20 video_reset
 static VideoSystemExitProc* gVideoSystemExitProc;
 
 // 0x6ADF24 num_windows
@@ -97,7 +97,7 @@ static bool _buffering = false;
 // 0x6ADF30 bk_color
 static int _bk_color;
 
-// 0x6ADF34 _video_set
+// 0x6ADF34 video_set
 static VideoSystemInitProc* gVideoSystemInitProc;
 
 // 0x6ADF38 doing_refresh_all
@@ -106,7 +106,7 @@ static int _doing_refresh_all;
 // 0x6ADF3C GNW_texture
 static void* _GNW_texture;
 
-// 0x6ADF40 _btn_grp
+// 0x6ADF40 btn_grp
 static ButtonGroup gButtonGroups[BUTTON_GROUP_LIST_CAPACITY];
 
 // 0x4D5C30

--- a/src/window_manager.cc
+++ b/src/window_manager.cc
@@ -43,21 +43,21 @@ static int _button_check_group(Button* button);
 static void _button_draw(Button* button, Window* window, unsigned char* data, bool draw, Rect* bound, bool sound);
 static void _GNW_button_refresh(Window* window, Rect* rect);
 
-// 0x50FA30
+// 0x50FA30 path_patches
 static char _path_patches[] = "";
 
-// 0x51E3D8
+// 0x51E3D8 GNW95_already_running
 static bool _GNW95_already_running = false;
 
 #ifdef _WIN32
-// 0x51E3DC
+// 0x51E3DC GNW95_title_mutex
 static HANDLE _GNW95_title_mutex = INVALID_HANDLE_VALUE;
 #endif
 
-// 0x51E3E0
+// 0x51E3E0 GNW_win_init_flag
 bool gWindowSystemInitialized = false;
 
-// 0x51E3E4
+// 0x51E3E4 GNW_wcolor
 int _GNW_wcolor[6] = {
     0,
     0,
@@ -67,46 +67,46 @@ int _GNW_wcolor[6] = {
     0,
 };
 
-// 0x51E3FC
+// 0x51E3FC _screen_buffer
 static unsigned char* _screen_buffer = nullptr;
 
-// 0x51E400
+// 0x51E400 insideWinExit
 static bool _insideWinExit = false;
 
-// 0x51E404
+// 0x51E404 last_button_winID
 static int _last_button_winID = -1;
 
-// 0x6ADD90
+// 0x6ADD90 window_index
 static int gWindowIndexes[MAX_WINDOW_COUNT];
 
-// 0x6ADE58
+// 0x6ADE58 _window
 static Window* gWindows[MAX_WINDOW_COUNT];
 
-// 0x6ADF20
+// 0x6ADF20 _video_reset
 static VideoSystemExitProc* gVideoSystemExitProc;
 
-// 0x6ADF24
+// 0x6ADF24 num_windows
 static int gWindowsLength;
 
-// 0x6ADF28
+// 0x6ADF28 window_flags
 static int _window_flags;
 
-// 0x6ADF2C
+// 0x6ADF2C buffering
 static bool _buffering = false;
 
-// 0x6ADF30
+// 0x6ADF30 bk_color
 static int _bk_color;
 
-// 0x6ADF34
+// 0x6ADF34 _video_set
 static VideoSystemInitProc* gVideoSystemInitProc;
 
-// 0x6ADF38
+// 0x6ADF38 doing_refresh_all
 static int _doing_refresh_all;
 
-// 0x6ADF3C
+// 0x6ADF3C GNW_texture
 static void* _GNW_texture;
 
-// 0x6ADF40
+// 0x6ADF40 _btn_grp
 static ButtonGroup gButtonGroups[BUTTON_GROUP_LIST_CAPACITY];
 
 // 0x4D5C30

--- a/src/window_manager_private.cc
+++ b/src/window_manager_private.cc
@@ -28,64 +28,64 @@ static void tm_kill_out_of_order(int queueIndex);
 static void tm_click_response(int btn, int keyCode);
 static bool tm_index_active(int queueIndex);
 
-// 0x51E414
+// 0x51E414 wd
 static int _wd = -1;
 
-// 0x51E418
+// 0x51E418 curr_menu
 static MenuBar* _curr_menu = nullptr;
 
-// 0x51E41C
+// 0x51E41C _tm_watch_active
 static bool tm_watch_active = false;
 
 // NOTE: Also anonymous in the original code.
 //
-// 0x6B2340
+// 0x6B2340 tm_location
 static struct {
     bool taken;
     int y;
 } tm_location[kTimedMsgs];
 
-// 0x6B2368
+// 0x6B2368 tm_text_x
 static int tm_text_x;
 
-// 0x6B236C
+// 0x6B236C tm_h
 static int tm_h;
 
 // NOTE: Also anonymous in the original code.
 //
-// 0x6B2370
+// 0x6B2370 tm_queue
 static struct {
     unsigned int created;
     int id;
     int location;
 } tm_queue[kTimedMsgs];
 
-// 0x6B23AC
+// 0x6B23AC tm_persistence
 static unsigned int tm_persistence;
 
-// 0x6B23B0
+// 0x6B23B0 scr_center_x
 static int scr_center_x;
 
-// 0x6B23B4
+// 0x6B23B4 tm_text_y
 static int tm_text_y;
 
-// 0x6B23B8
+// 0x6B23B8 tm_kill
 static int tm_kill;
 
-// 0x6B23BC
+// 0x6B23BC tm_add
 static int tm_add;
 
 // x
 //
-// 0x6B23C0
+// 0x6B23C0 curry
 static int _curry;
 
 // y
 //
-// 0x6B23C4
+// 0x6B23C4 currx
 static int _currx;
 
-// 0x6B23D0
+// 0x6B23D0 GNW95_title
 char gProgramWindowTitle[256];
 
 // 0x4DA6C0

--- a/src/window_manager_private.cc
+++ b/src/window_manager_private.cc
@@ -34,7 +34,7 @@ static int _wd = -1;
 // 0x51E418 curr_menu
 static MenuBar* _curr_menu = nullptr;
 
-// 0x51E41C _tm_watch_active
+// 0x51E41C tm_watch_active
 static bool tm_watch_active = false;
 
 // NOTE: Also anonymous in the original code.

--- a/src/word_wrap.cc
+++ b/src/word_wrap.cc
@@ -8,7 +8,7 @@
 
 namespace fallout {
 
-// 0x4BC6F0
+// 0x4BC6F0 _word_wrap_
 int wordWrap(const char* string, int width, short* breakpoints, short* breakpointsLengthPtr)
 {
     breakpoints[0] = 0;

--- a/src/word_wrap.cc
+++ b/src/word_wrap.cc
@@ -8,7 +8,7 @@
 
 namespace fallout {
 
-// 0x4BC6F0 _word_wrap
+// 0x4BC6F0 word_wrap
 int wordWrap(const char* string, int width, short* breakpoints, short* breakpointsLengthPtr)
 {
     breakpoints[0] = 0;

--- a/src/word_wrap.cc
+++ b/src/word_wrap.cc
@@ -8,7 +8,7 @@
 
 namespace fallout {
 
-// 0x4BC6F0 _word_wrap_
+// 0x4BC6F0 _word_wrap
 int wordWrap(const char* string, int width, short* breakpoints, short* breakpointsLengthPtr)
 {
     breakpoints[0] = 0;

--- a/src/worldmap.cc
+++ b/src/worldmap.cc
@@ -613,7 +613,7 @@ static const char* wmYesNoStrs[2] = {
     "yes",
 };
 
-// 0x51DD98 _wmFreqStrs
+// 0x51DD98 wmFreqStrs
 static const char* wmFreqStrs[ENCOUNTER_FREQUENCY_TYPE_COUNT] = {
     "none",
     "rare",
@@ -647,10 +647,10 @@ static const char* wmSceneryStrs[ENCOUNTER_SCENERY_TYPE_COUNT] = {
 // 0x51DDE4 wmTerrainTypeList
 static Terrain* wmTerrainTypeList = nullptr;
 
-// 0x51DDE8 _wmMaxTerrainTypes
+// 0x51DDE8 wmMaxTerrainTypes
 static int wmMaxTerrainTypes = 0;
 
-// 0x51DDEC _wmTileInfoList
+// 0x51DDEC wmTileInfoList
 static TileInfo* wmTileInfoList = nullptr;
 
 // 0x51DDF0 wmMaxTileNum
@@ -665,7 +665,7 @@ static int wmMaxTileNum = 0;
 // 0x51DDF4 wmNumHorizontalTiles
 static int wmNumHorizontalTiles = 0;
 
-// 0x51DDF8 _wmAreaInfoList
+// 0x51DDF8 wmAreaInfoList
 static CityInfo* wmAreaInfoList = nullptr;
 
 // 0x51DDFC wmMaxAreaNum
@@ -678,7 +678,7 @@ static const char* wmAreaSizeStrs[CITY_SIZE_COUNT] = {
     "large",
 };
 
-// 0x51DE0C _wmMapInfoList
+// 0x51DE0C wmMapInfoList
 static MapInfo* wmMapInfoList = nullptr;
 
 // 0x51DE10 wmMaxMapNum
@@ -714,7 +714,7 @@ static const char* wmEncOpStrs[ENCOUNTER_SITUATION_COUNT] = {
     "and",
 };
 
-// 0x51DE4C _wmConditionalOpStrs
+// 0x51DE4C wmConditionalOpStrs
 static const char* wmConditionalOpStrs[ENCOUNTER_CONDITIONAL_OPERATOR_COUNT] = {
     "_",
     "==",
@@ -828,13 +828,13 @@ static Config* pConfigCfg;
 // 0x672FD8 wmTownMapSubButtonIds
 static int wmTownMapSubButtonIds[WM_TOWN_LIST_VISIBLE_SLOT_COUNT];
 
-// 0x672FF4 _wmEncBaseTypeList
+// 0x672FF4 wmEncBaseTypeList
 static Encounter* wmEncBaseTypeList;
 
 // 0x672FF8 wmSphereData
 static CitySizeDescription wmSphereData[CITY_SIZE_COUNT];
 
-// 0x673034 _wmEncounterTableList
+// 0x673034 wmEncounterTableList
 static EncounterTable* wmEncounterTableList;
 
 // Number of enc_base_types.

--- a/src/worldmap.cc
+++ b/src/worldmap.cc
@@ -859,7 +859,7 @@ static inline bool cityIsValid(int city)
     return city >= 0 && city < wmMaxAreaNum;
 }
 
-// 0x4BC890
+// 0x4BC890 wmSetFlags_
 static void wmSetFlags(int* flagsPtr, int flag, int value)
 {
     if (value) {
@@ -869,7 +869,7 @@ static void wmSetFlags(int* flagsPtr, int flag, int value)
     }
 }
 
-// 0x4BC89C
+// 0x4BC89C wmWorldMap_init_
 int wmWorldMap_init()
 {
     char path[COMPAT_MAX_PATH];
@@ -917,7 +917,7 @@ int wmWorldMap_init()
     return 0;
 }
 
-// 0x4BC984
+// 0x4BC984 wmGenDataInit_
 static int wmGenDataInit()
 {
     gDidMeetFrankHorrigan = false;
@@ -971,7 +971,7 @@ static int wmGenDataInit()
     return 0;
 }
 
-// 0x4BCBFC
+// 0x4BCBFC wmGenDataReset_
 static int wmGenDataReset()
 {
     gDidMeetFrankHorrigan = false;
@@ -1024,7 +1024,7 @@ static int wmGenDataReset()
     return 0;
 }
 
-// 0x4BCE00
+// 0x4BCE00 wmWorldMap_exit_
 void wmWorldMap_exit()
 {
     if (wmTerrainTypeList != nullptr) {
@@ -1076,7 +1076,7 @@ void wmWorldMap_exit()
     messageListFree(&wmMsgFile);
 }
 
-// 0x4BCEF8
+// 0x4BCEF8 wmWorldMap_reset_
 int wmWorldMap_reset()
 {
     wmWorldOffsetX = 0;
@@ -1091,7 +1091,7 @@ int wmWorldMap_reset()
     return wmGenDataReset();
 }
 
-// 0x4BCF28
+// 0x4BCF28 wmWorldMap_save_
 int wmWorldMap_save(File* stream)
 {
     int i;
@@ -1174,7 +1174,7 @@ int wmWorldMap_save(File* stream)
     return 0;
 }
 
-// 0x4BD28C
+// 0x4BD28C wmWorldMap_load_
 int wmWorldMap_load(File* stream)
 {
     if (fileReadBool(stream, &gDidMeetFrankHorrigan) == -1) return -1;
@@ -1259,7 +1259,7 @@ int wmWorldMap_load(File* stream)
     return 0;
 }
 
-// 0x4BD678
+// 0x4BD678 wmWorldMapSaveTempData_
 static int wmWorldMapSaveTempData()
 {
     File* stream = fileOpen("worldmap.dat", "wb");
@@ -1277,7 +1277,7 @@ static int wmWorldMapSaveTempData()
     return rc;
 }
 
-// 0x4BD6B4
+// 0x4BD6B4 wmWorldMapLoadTempData_
 static int wmWorldMapLoadTempData()
 {
     File* stream = fileOpen("worldmap.dat", "rb");
@@ -1295,7 +1295,7 @@ static int wmWorldMapLoadTempData()
     return rc;
 }
 
-// 0x4BD6F0
+// 0x4BD6F0 wmConfigInit_
 static int wmConfigInit()
 {
     if (wmAreaInit() == -1) {
@@ -1398,7 +1398,7 @@ static int wmConfigInit()
     return 0;
 }
 
-// 0x4BD9F0
+// 0x4BD9F0 wmReadEncounterType_
 static int wmReadEncounterType(Config* config, char* lookupName, char* sectionKey)
 {
     wmMaxEncounterInfoTables++;
@@ -1460,7 +1460,7 @@ static int wmReadEncounterType(Config* config, char* lookupName, char* sectionKe
     return 0;
 }
 
-// 0x4BDB64
+// 0x4BDB64 wmParseEncounterTableIndex_
 static int wmParseEncounterTableIndex(EncounterTableEntry* encounterTableEntry, char* string)
 {
     // NOTE: Uninline.
@@ -1513,7 +1513,7 @@ static int wmParseEncounterTableIndex(EncounterTableEntry* encounterTableEntry, 
     return 0;
 }
 
-// 0x4BDCA8
+// 0x4BDCA8 wmParseEncounterSubEncStr_
 static int wmParseEncounterSubEncStr(EncounterTableEntry* encounterTableEntry, char** stringPtr)
 {
     char* string = *stringPtr;
@@ -1617,7 +1617,7 @@ static int wmParseEncounterSubEncStr(EncounterTableEntry* encounterTableEntry, c
     return 0;
 }
 
-// 0x4BDE94
+// 0x4BDE94 wmParseFindSubEncTypeMatch_
 static int wmParseFindSubEncTypeMatch(char* str, int* valuePtr)
 {
     *valuePtr = 0;
@@ -1638,7 +1638,7 @@ static int wmParseFindSubEncTypeMatch(char* str, int* valuePtr)
     return -1;
 }
 
-// 0x4BDED8
+// 0x4BDED8 wmFindEncBaseTypeMatch_
 static int wmFindEncBaseTypeMatch(char* str, int* valuePtr)
 {
     for (int index = 0; index < wmMaxEncBaseTypes; index++) {
@@ -1652,7 +1652,7 @@ static int wmFindEncBaseTypeMatch(char* str, int* valuePtr)
     return -1;
 }
 
-// 0x4BDF34
+// 0x4BDF34 wmReadEncBaseType_
 static int wmReadEncBaseType(char* name, int* valuePtr)
 {
     char section[40];
@@ -1718,7 +1718,7 @@ static int wmReadEncBaseType(char* name, int* valuePtr)
     return -1;
 }
 
-// 0x4BE140
+// 0x4BE140 wmParseEncBaseSubTypeStr_
 static int wmParseEncBaseSubTypeStr(EncounterEntry* encounterEntry, char** stringPtr)
 {
     char* string = *stringPtr;
@@ -1761,7 +1761,7 @@ static int wmParseEncBaseSubTypeStr(EncounterEntry* encounterEntry, char** strin
 
 // NOTE: Inlined.
 //
-// 0x4BE2A0
+// 0x4BE2A0 wmEncBaseTypeSlotInit_
 static int wmEncBaseTypeSlotInit(Encounter* encounter)
 {
     encounter->name[0] = '\0';
@@ -1775,7 +1775,7 @@ static int wmEncBaseTypeSlotInit(Encounter* encounter)
 
 // NOTE: Inlined.
 //
-// 0x4BE2C4
+// 0x4BE2C4 wmEncBaseSubTypeSlotInit_
 static int wmEncBaseSubTypeSlotInit(EncounterEntry* encounterEntry)
 {
     encounterEntry->field_28 = -1;
@@ -1794,7 +1794,7 @@ static int wmEncBaseSubTypeSlotInit(EncounterEntry* encounterEntry)
 
 // NOTE: Inlined.
 //
-// 0x4BE32C
+// 0x4BE32C wmEncounterSubEncSlotInit_
 static int wmEncounterSubEncSlotInit(EncounterTableSubEntry* encounterTableSubEntry)
 {
     encounterTableSubEntry->minimumCount = 1;
@@ -1807,7 +1807,7 @@ static int wmEncounterSubEncSlotInit(EncounterTableSubEntry* encounterTableSubEn
 
 // NOTE: Inlined.
 //
-// 0x4BE34C
+// 0x4BE34C wmEncounterTypeSlotInit_
 static int wmEncounterTypeSlotInit(EncounterTableEntry* encounterTableEntry)
 {
     encounterTableEntry->flags = 0;
@@ -1822,7 +1822,7 @@ static int wmEncounterTypeSlotInit(EncounterTableEntry* encounterTableEntry)
 
 // NOTE: Inlined.
 //
-// 0x4BE3B8
+// 0x4BE3B8 wmEncounterTableSlotInit_
 static int wmEncounterTableSlotInit(EncounterTable* encounterTable)
 {
     encounterTable->lookupName[0] = '\0';
@@ -1835,7 +1835,7 @@ static int wmEncounterTableSlotInit(EncounterTable* encounterTable)
 
 // NOTE: Inlined.
 //
-// 0x4BE3D4
+// 0x4BE3D4 wmTileSlotInit_
 static int wmTileSlotInit(TileInfo* tile)
 {
     tile->fid = -1;
@@ -1850,7 +1850,7 @@ static int wmTileSlotInit(TileInfo* tile)
 
 // NOTE: Inlined.
 //
-// 0x4BE400
+// 0x4BE400 wmTerrainTypeSlotInit_
 static int wmTerrainTypeSlotInit(Terrain* terrain)
 {
     terrain->lookupName[0] = '\0';
@@ -1880,7 +1880,7 @@ static int wmConditionalDataInit(EncounterCondition* condition)
     return 0;
 }
 
-// 0x4BE414
+// 0x4BE414 wmParseTerrainTypes_
 static int wmParseTerrainTypes(Config* config, char* string)
 {
     if (*string == '\0') {
@@ -1945,7 +1945,7 @@ static int wmParseTerrainTypes(Config* config, char* string)
     return 0;
 }
 
-// 0x4BE598
+// 0x4BE598 wmParseTerrainRndMaps_
 static int wmParseTerrainRndMaps(Config* config, Terrain* terrain)
 {
     char section[40];
@@ -1974,7 +1974,7 @@ static int wmParseTerrainRndMaps(Config* config, Terrain* terrain)
     return 0;
 }
 
-// 0x4BE61C
+// 0x4BE61C wmParseSubTileInfo_
 static int wmParseSubTileInfo(TileInfo* tile, int row, int column, char* string)
 {
     SubtileInfo* subtile = &(tile->subtiles[column][row]);
@@ -2001,7 +2001,7 @@ static int wmParseSubTileInfo(TileInfo* tile, int row, int column, char* string)
     return 0;
 }
 
-// 0x4BE6D4
+// 0x4BE6D4 wmParseFindEncounterTypeMatch_
 static int wmParseFindEncounterTypeMatch(char* string, int* valuePtr)
 {
     for (int index = 0; index < wmMaxEncounterInfoTables; index++) {
@@ -2018,7 +2018,7 @@ static int wmParseFindEncounterTypeMatch(char* string, int* valuePtr)
     return -1;
 }
 
-// 0x4BE73C
+// 0x4BE73C wmParseFindTerrainTypeMatch_
 static int wmParseFindTerrainTypeMatch(char* string, int* valuePtr)
 {
     for (int index = 0; index < wmMaxTerrainTypes; index++) {
@@ -2036,7 +2036,7 @@ static int wmParseFindTerrainTypeMatch(char* string, int* valuePtr)
     return -1;
 }
 
-// 0x4BE7A4
+// 0x4BE7A4 wmParseEncounterItemType_
 static int wmParseEncounterItemType(char** stringPtr, EncounterItem* encounterItem, int* itemCountPtr, const char* delimeters)
 {
     char* string = *stringPtr;
@@ -2077,7 +2077,7 @@ static int wmParseEncounterItemType(char** stringPtr, EncounterItem* encounterIt
     return found ? 0 : -1;
 }
 
-// 0x4BE888
+// 0x4BE888 wmParseItemType_
 static int wmParseItemType(char* string, EncounterItem* encounterItem)
 {
     while (*string == ' ') {
@@ -2138,7 +2138,7 @@ static int wmParseItemType(char* string, EncounterItem* encounterItem)
     return 0;
 }
 
-// 0x4BE988
+// 0x4BE988 wmParseConditional_
 static int wmParseConditional(char** stringPtr, const char* a2, EncounterCondition* condition)
 {
     while (condition->entriesLength < 3) {
@@ -2169,7 +2169,7 @@ static int wmParseConditional(char** stringPtr, const char* a2, EncounterConditi
     return 0;
 }
 
-// 0x4BEA24
+// 0x4BEA24 wmParseSubConditional_
 static int wmParseSubConditional(char** stringPtr, const char* a2, int* typePtr, int* operatorPtr, int* paramPtr, int* valuePtr)
 {
     char* string = *stringPtr;
@@ -2367,7 +2367,7 @@ static int wmParseSubConditional(char** stringPtr, const char* a2, int* typePtr,
     return -1;
 }
 
-// 0x4BEEBC
+// 0x4BEEBC wmParseConditionalEval_
 static int wmParseConditionalEval(char** stringPtr, int* conditionalOperatorPtr)
 {
     char* string = *stringPtr;
@@ -2399,7 +2399,7 @@ static int wmParseConditionalEval(char** stringPtr, int* conditionalOperatorPtr)
 
 // NOTE: Inlined.
 //
-// 0x4BEF1C
+// 0x4BEF1C wmAreaSlotInit_
 static int wmAreaSlotInit(CityInfo* area)
 {
     area->name[0] = '\0';
@@ -2417,7 +2417,7 @@ static int wmAreaSlotInit(CityInfo* area)
     return 0;
 }
 
-// 0x4BEF68
+// 0x4BEF68 wmAreaInit_
 static int wmAreaInit()
 {
     Config cfg;
@@ -2579,7 +2579,7 @@ static int wmAreaInit()
     return 0;
 }
 
-// 0x4BF3E0
+// 0x4BF3E0 wmParseFindMapIdxMatch_
 static int wmParseFindMapIdxMatch(char* string, int* valuePtr)
 {
     for (int index = 0; index < wmMaxMapNum; index++) {
@@ -2598,7 +2598,7 @@ static int wmParseFindMapIdxMatch(char* string, int* valuePtr)
 
 // NOTE: Inlined.
 //
-// 0x4BF448
+// 0x4BF448 wmEntranceSlotInit_
 static int wmEntranceSlotInit(EntranceInfo* entrance)
 {
     entrance->state = 0;
@@ -2612,7 +2612,7 @@ static int wmEntranceSlotInit(EntranceInfo* entrance)
     return 0;
 }
 
-// 0x4BF47C
+// 0x4BF47C wmMapSlotInit_
 static int wmMapSlotInit(MapInfo* map)
 {
     map->lookupName[0] = '\0';
@@ -2627,7 +2627,7 @@ static int wmMapSlotInit(MapInfo* map)
     return 0;
 }
 
-// 0x4BF4BC
+// 0x4BF4BC wmMapInit_
 static int wmMapInit()
 {
     char* str;
@@ -2794,7 +2794,7 @@ static int wmMapInit()
 
 // NOTE: Inlined.
 //
-// 0x4BF954
+// 0x4BF954 wmRStartSlotInit_
 static int wmRStartSlotInit(MapStartPointInfo* rsp)
 {
     rsp->elevation = 0;
@@ -2804,13 +2804,13 @@ static int wmRStartSlotInit(MapStartPointInfo* rsp)
     return 0;
 }
 
-// 0x4BF96C
+// 0x4BF96C wmMapMaxCount_
 int wmMapMaxCount()
 {
     return wmMaxMapNum;
 }
 
-// 0x4BF974
+// 0x4BF974 wmMapIdxToName_
 int wmMapIdxToName(int mapIdx, char* dest, size_t size)
 {
     if (mapIdx == -1 || mapIdx > wmMaxMapNum) {
@@ -2822,7 +2822,7 @@ int wmMapIdxToName(int mapIdx, char* dest, size_t size)
     return 0;
 }
 
-// 0x4BF9BC
+// 0x4BF9BC wmMapMatchNameToIdx_
 int wmMapMatchNameToIdx(char* name)
 {
     compat_strlwr(name);
@@ -2854,25 +2854,25 @@ int wmMapMatchNameToIdx(char* name)
     return map;
 }
 
-// 0x4BFA44
+// 0x4BFA44 wmMapIdxIsSaveable_
 bool wmMapIdxIsSaveable(int mapIdx)
 {
     return (wmMapInfoList[mapIdx].flags & MAP_SAVED) != 0;
 }
 
-// 0x4BFA64
+// 0x4BFA64 wmMapIsSaveable_
 bool wmMapIsSaveable()
 {
     return (wmMapInfoList[gMapHeader.index].flags & MAP_SAVED) != 0;
 }
 
-// 0x4BFA90
+// 0x4BFA90 wmMapDeadBodiesAge_
 bool wmMapDeadBodiesAge()
 {
     return (wmMapInfoList[gMapHeader.index].flags & MAP_DEAD_BODIES_AGE) != 0;
 }
 
-// 0x4BFABC
+// 0x4BFABC wmMapCanRestHere_
 bool wmMapCanRestHere(int elevation)
 {
     int flags[3];
@@ -2885,13 +2885,13 @@ bool wmMapCanRestHere(int elevation)
     return (map->flags & flags[elevation]) != 0;
 }
 
-// 0x4BFAFC
+// 0x4BFAFC wmMapPipboyActive_
 bool wmMapPipboyActive()
 {
     return gameMovieIsSeen(MOVIE_VSUIT);
 }
 
-// 0x4BFB08
+// 0x4BFB08 wmMapMarkVisited_
 int wmMapMarkVisited(int mapIdx)
 {
     if (mapIdx < 0 || mapIdx >= wmMaxMapNum) {
@@ -2914,7 +2914,7 @@ int wmMapMarkVisited(int mapIdx)
     return 0;
 }
 
-// 0x4BFB64
+// 0x4BFB64 wmMatchEntranceFromMap_
 static int wmMatchEntranceFromMap(int areaIdx, int mapIdx, int* entranceIdxPtr)
 {
     CityInfo* city = &(wmAreaInfoList[areaIdx]);
@@ -2932,7 +2932,7 @@ static int wmMatchEntranceFromMap(int areaIdx, int mapIdx, int* entranceIdxPtr)
     return -1;
 }
 
-// 0x4BFBE8
+// 0x4BFBE8 wmMatchEntranceElevFromMap_
 static int wmMatchEntranceElevFromMap(int areaIdx, int mapIdx, int elevation, int* entranceIdxPtr)
 {
     CityInfo* city = &(wmAreaInfoList[areaIdx]);
@@ -2951,7 +2951,7 @@ static int wmMatchEntranceElevFromMap(int areaIdx, int mapIdx, int elevation, in
     return -1;
 }
 
-// 0x4BFC7C
+// 0x4BFC7C wmMatchAreaFromMap_
 static int wmMatchAreaFromMap(int mapIdx, int* areaIdxPtr)
 {
     for (int areaIdx = 0; areaIdx < wmMaxAreaNum; areaIdx++) {
@@ -2972,7 +2972,7 @@ static int wmMatchAreaFromMap(int mapIdx, int* areaIdxPtr)
 
 // Mark map entrance.
 //
-// 0x4BFD50
+// 0x4BFD50 wmMapMarkMapEntranceState_
 int wmMapMarkMapEntranceState(int mapIdx, int elevation, int state)
 {
     if (mapIdx < 0 || mapIdx >= wmMaxMapNum) {
@@ -3001,13 +3001,13 @@ int wmMapMarkMapEntranceState(int mapIdx, int elevation, int state)
     return 0;
 }
 
-// 0x4BFE0C
+// 0x4BFE0C wmWorldMap_
 void wmWorldMap()
 {
     wmWorldMapFunc(0);
 }
 
-// 0x4BFE10
+// 0x4BFE10 wmWorldMapFunc_
 static int wmWorldMapFunc(int a1)
 {
     ScopedGameMode gm(GameMode::kWorldmap);
@@ -3324,7 +3324,7 @@ static int wmWorldMapFunc(int a1)
     return rc;
 }
 
-// 0x4C056C
+// 0x4C056C wmCheckGameAreaEvents_
 int wmCheckGameAreaEvents()
 {
     if (wmGenData.currentAreaId == CITY_FAKE_VAULT_13_A) {
@@ -3340,7 +3340,7 @@ int wmCheckGameAreaEvents()
     return 0;
 }
 
-// 0x4C05C4
+// 0x4C05C4 wmInterfaceCenterOnParty_
 static int wmInterfaceCenterOnParty()
 {
     wmWorldOffsetX = std::clamp(wmGenData.worldPosX - 203, 0, wmGenData.viewportMaxX);
@@ -3353,13 +3353,13 @@ static int wmInterfaceCenterOnParty()
 
 // NOTE: Inlined.
 //
-// 0x4C0624
+// 0x4C0624 wmCheckGameEvents_
 static void wmCheckGameEvents()
 {
     _scriptsCheckGameEvents(nullptr, wmBkWin);
 }
 
-// 0x4C0634
+// 0x4C0634 wmRndEncounterOccurred_
 static int wmRndEncounterOccurred()
 {
     unsigned int now = getTicks();
@@ -3567,13 +3567,13 @@ static int wmRndEncounterOccurred()
 
 // NOTE: Inlined.
 //
-// 0x4C0BE4
+// 0x4C0BE4 wmPartyFindCurSubTile_
 static int wmPartyFindCurSubTile()
 {
     return wmFindCurSubTileFromPos(wmGenData.worldPosX, wmGenData.worldPosY, &(wmGenData.currentSubtile));
 }
 
-// 0x4C0C00
+// 0x4C0C00 wmFindCurSubTileFromPos_
 static int wmFindCurSubTileFromPos(int x, int y, SubtileInfo** subtilePtr)
 {
     int tileIndex = y / WM_TILE_HEIGHT * wmNumHorizontalTiles + x / WM_TILE_WIDTH % wmNumHorizontalTiles;
@@ -3588,7 +3588,7 @@ static int wmFindCurSubTileFromPos(int x, int y, SubtileInfo** subtilePtr)
 
 // NOTE: Inlined.
 //
-// 0x4C0CA8
+// 0x4C0CA8 wmFindCurTileFromPos_
 static int wmFindCurTileFromPos(int x, int y, TileInfo** tilePtr)
 {
     int tileIndex = y / WM_TILE_HEIGHT * wmNumHorizontalTiles + x / WM_TILE_WIDTH % wmNumHorizontalTiles;
@@ -3597,7 +3597,7 @@ static int wmFindCurTileFromPos(int x, int y, TileInfo** tilePtr)
     return 0;
 }
 
-// 0x4C0CF4
+// 0x4C0CF4 wmRndEncounterPick_
 static int wmRndEncounterPick()
 {
     if (wmGenData.currentSubtile == nullptr) {
@@ -3702,7 +3702,7 @@ static int wmRndEncounterPick()
     return 0;
 }
 
-// 0x4C0FA4
+// 0x4C0FA4 wmSetupRandomEncounter_
 int wmSetupRandomEncounter()
 {
     MessageListItem messageListItem;
@@ -3816,7 +3816,7 @@ int wmSetupRandomEncounter()
 }
 
 // wmSetupCritterObjs
-// 0x4C11FC
+// 0x4C11FC wmSetupCritterObjs_
 static int wmSetupCritterObjs(int encounterIndex, Object** critterPtr, int critterCount)
 {
     if (encounterIndex == -1) {
@@ -3949,7 +3949,7 @@ static int wmSetupCritterObjs(int encounterIndex, Object** critterPtr, int critt
     return 0;
 }
 
-// 0x4C155C
+// 0x4C155C wmSetupRndNextTileNumInit_
 static int wmSetupRndNextTileNumInit(Encounter* encounter)
 {
     for (int index = 0; index < 2; index++) {
@@ -4014,7 +4014,7 @@ static int wmSetupRndNextTileNumInit(Encounter* encounter)
 // Determines tile to place the next object in the EncounterEntry at.
 //
 // wmSetupRndNextTileNum
-// 0x4C16F0
+// 0x4C16F0 wmSetupRndNextTileNum_
 static int wmSetupRndNextTileNum(Encounter* encounter, EncounterEntry* encounterEntry, int* tilePtr)
 {
     int tile;
@@ -4127,7 +4127,7 @@ static int wmSetupRndNextTileNum(Encounter* encounter, EncounterEntry* encounter
     return 0;
 }
 
-// 0x4C1A64
+// 0x4C1A64 wmEvalTileNumForPlacement_
 bool wmEvalTileNumForPlacement(int tile)
 {
     if (_obj_blocking_at(gDude, tile, gElevation) != nullptr) {
@@ -4141,7 +4141,7 @@ bool wmEvalTileNumForPlacement(int tile)
     return true;
 }
 
-// 0x4C1AC8
+// 0x4C1AC8 wmEvalConditional_
 static bool wmEvalConditional(EncounterCondition* condition, int* critterCountPtr)
 {
     int value;
@@ -4200,7 +4200,7 @@ static bool wmEvalConditional(EncounterCondition* condition, int* critterCountPt
     return matches;
 }
 
-// 0x4C1C0C
+// 0x4C1C0C wmEvalSubConditional_
 static bool wmEvalSubConditional(int operand1, int condionalOperator, int operand2)
 {
     switch (condionalOperator) {
@@ -4217,7 +4217,7 @@ static bool wmEvalSubConditional(int operand1, int condionalOperator, int operan
     return false;
 }
 
-// 0x4C1C50
+// 0x4C1C50 wmGameTimeIncrement_
 static bool wmGameTimeIncrement(int ticksToAdd)
 {
     if (ticksToAdd == 0) {
@@ -4253,7 +4253,7 @@ static bool wmGameTimeIncrement(int ticksToAdd)
 
 // Reads .msk file if needed.
 //
-// 0x4C1CE8
+// 0x4C1CE8 wmGrabTileWalkMask_
 static int wmGrabTileWalkMask(int tileIdx)
 {
     TileInfo* tileInfo = &(wmTileInfoList[tileIdx]);
@@ -4289,7 +4289,7 @@ static int wmGrabTileWalkMask(int tileIdx)
     return rc;
 }
 
-// 0x4C1D9C
+// 0x4C1D9C wmWorldPosInvalid_
 static bool wmWorldPosInvalid(int x, int y)
 {
     int tileIdx = y / WM_TILE_HEIGHT * wmNumHorizontalTiles + x / WM_TILE_WIDTH % wmNumHorizontalTiles;
@@ -4311,7 +4311,7 @@ static bool wmWorldPosInvalid(int x, int y)
     return (mask[pos] & bit) != 0;
 }
 
-// 0x4C1E54
+// 0x4C1E54 wmPartyInitWalking_
 static void wmPartyInitWalking(int x, int y)
 {
     wmGenData.walkDestinationX = x;
@@ -4357,7 +4357,7 @@ static void wmPartyInitWalking(int x, int y)
     }
 }
 
-// 0x4C1F90
+// 0x4C1F90 wmPartyWalkingStep_
 static void wmPartyWalkingStep()
 {
     if (wmGenData.walkDistance <= 0) {
@@ -4431,7 +4431,7 @@ static void wmPartyWalkingStep()
     }
 }
 
-// 0x4C219C
+// 0x4C219C wmInterfaceScrollTabsStart_
 static void wmInterfaceScrollTabsStart(int delta)
 {
     int tabsScrollMaxOffsetY = std::max(0,
@@ -4462,7 +4462,7 @@ static void wmInterfaceScrollTabsStart(int delta)
     wmInterfaceScrollTabsUpdate();
 }
 
-// 0x4C2270
+// 0x4C2270 wmInterfaceScrollTabsStop_
 static void wmInterfaceScrollTabsStop()
 {
     wmGenData.tabsScrollingDelta = 0;
@@ -4474,7 +4474,7 @@ static void wmInterfaceScrollTabsStop()
 
 // NOTE: Inlined.
 //
-// 0x4C2290
+// 0x4C2290 wmInterfaceScrollTabsUpdate_
 static void wmInterfaceScrollTabsUpdate()
 {
     if (wmGenData.tabsScrollingDelta != 0) {
@@ -4495,7 +4495,7 @@ static void wmInterfaceScrollTabsUpdate()
     }
 }
 
-// 0x4C2324
+// 0x4C2324 wmInterfaceInit_
 static int wmInterfaceInit()
 {
     int fid;
@@ -4791,7 +4791,7 @@ static int wmInterfaceInit()
     return 0;
 }
 
-// 0x4C2E44
+// 0x4C2E44 wmInterfaceExit_
 static int wmInterfaceExit()
 {
     int i;
@@ -4898,7 +4898,7 @@ static int wmInterfaceExit()
 
 // NOTE: Inlined.
 //
-// 0x4C31E8
+// 0x4C31E8 wmInterfaceScroll_
 static int wmInterfaceScroll(int dx, int dy, bool* successPtr)
 {
     return wmInterfaceScrollPixel(20, 20, dx, dy, successPtr, 1);
@@ -4910,7 +4910,7 @@ static int wmInterfaceScroll(int dx, int dy, bool* successPtr)
 // one direction is possible (and in fact occured), it will still be reported as
 // error.
 //
-// 0x4C3200
+// 0x4C3200 wmInterfaceScrollPixel_
 static int wmInterfaceScrollPixel(int stepX, int stepY, int dx, int dy, bool* success, bool shouldRefresh)
 {
     if (success != nullptr) {
@@ -4974,7 +4974,7 @@ static int wmInterfaceScrollPixel(int stepX, int stepY, int dx, int dy, bool* su
     return 0;
 }
 
-// 0x4C32EC
+// 0x4C32EC wmMouseBkProc_
 static void wmMouseBkProc()
 {
     // 0x51DEB0
@@ -5052,7 +5052,7 @@ static void wmMouseBkProc()
 
 // NOTE: Inlined.
 //
-// 0x4C340C
+// 0x4C340C wmMarkSubTileOffsetVisited_
 static int wmMarkSubTileOffsetVisited(int tile, int subtileX, int subtileY, int offsetX, int offsetY)
 {
     return wmMarkSubTileOffsetVisitedFunc(tile, subtileX, subtileY, offsetX, offsetY, SUBTILE_STATE_VISITED);
@@ -5060,13 +5060,13 @@ static int wmMarkSubTileOffsetVisited(int tile, int subtileX, int subtileY, int 
 
 // NOTE: Inlined.
 //
-// 0x4C3420
+// 0x4C3420 wmMarkSubTileOffsetKnown_
 static int wmMarkSubTileOffsetKnown(int tile, int subtileX, int subtileY, int offsetX, int offsetY)
 {
     return wmMarkSubTileOffsetVisitedFunc(tile, subtileX, subtileY, offsetX, offsetY, SUBTILE_STATE_KNOWN);
 }
 
-// 0x4C3434
+// 0x4C3434 wmMarkSubTileOffsetVisitedFunc_
 static int wmMarkSubTileOffsetVisitedFunc(int tile, int subtileX, int subtileY, int offsetX, int offsetY, int subtileState)
 {
     int actualTile;
@@ -5124,7 +5124,7 @@ static int wmMarkSubTileOffsetVisitedFunc(int tile, int subtileX, int subtileY, 
     return 0;
 }
 
-// 0x4C3550
+// 0x4C3550 wmMarkSubTileRadiusVisited_
 static void wmMarkSubTileRadiusVisited(int x, int y)
 {
     int radius = 1;
@@ -5136,7 +5136,7 @@ static void wmMarkSubTileRadiusVisited(int x, int y)
     wmSubTileMarkRadiusVisited(x, y, radius);
 }
 
-// 0x4C35A8
+// 0x4C35A8 wmSubTileMarkRadiusVisited_
 int wmSubTileMarkRadiusVisited(int x, int y, int radius)
 {
     int tile;
@@ -5185,7 +5185,7 @@ int wmSubTileMarkRadiusVisited(int x, int y, int radius)
     return 0;
 }
 
-// 0x4C3740
+// 0x4C3740 wmSubTileGetVisitedState_
 int wmSubTileGetVisitedState(int x, int y, int* statePtr)
 {
     TileInfo* tile;
@@ -5200,7 +5200,7 @@ int wmSubTileGetVisitedState(int x, int y, int* statePtr)
 
 // Load tile art if needed.
 //
-// 0x4C37EC
+// 0x4C37EC wmTileGrabArt_
 static int wmTileGrabArt(int tileIdx)
 {
     TileInfo* tile = &(wmTileInfoList[tileIdx]);
@@ -5218,7 +5218,7 @@ static int wmTileGrabArt(int tileIdx)
     return -1;
 }
 
-// 0x4C3830
+// 0x4C3830 wmInterfaceRefresh_
 static int wmInterfaceRefresh()
 {
     if (wmInterfaceWasInitialized != 1) {
@@ -5368,7 +5368,7 @@ static int wmInterfaceRefresh()
     return 0;
 }
 
-// 0x4C3C9C
+// 0x4C3C9C wmInterfaceRefreshDate_
 static void wmInterfaceRefreshDate(bool shouldRefreshWindow)
 {
     int month;
@@ -5417,7 +5417,7 @@ static void wmInterfaceRefreshDate(bool shouldRefreshWindow)
     }
 }
 
-// 0x4C3F00
+// 0x4C3F00 wmMatchWorldPosToArea_
 static int wmMatchWorldPosToArea(int x, int y, int* areaIdxPtr)
 {
     int v3 = y + WM_VIEW_Y;
@@ -5589,7 +5589,7 @@ static int wmInterfaceDrawCircleOverlaySafe(CityInfo* city, CitySizeDescription*
     return 0;
 }
 
-// 0x4C3FA8
+// 0x4C3FA8 wmInterfaceDrawCircleOverlay_
 static int wmInterfaceDrawCircleOverlay(CityInfo* city, CitySizeDescription* citySizeDescription, unsigned char* dest, int x, int y)
 {
     _dark_translucent_trans_buf_to_buf(citySizeDescription->frmImage.getData(),
@@ -5631,7 +5631,7 @@ static int wmInterfaceDrawCircleOverlay(CityInfo* city, CitySizeDescription* cit
 // Helper function that dims specified rectangle in given buffer. It's used to
 // slightly darken subtile which is known, but not visited.
 //
-// 0x4C40A8
+// 0x4C40A8 wmInterfaceDrawSubTileRectFogged_
 static void wmInterfaceDrawSubTileRectFogged(unsigned char* dest, int width, int height, int pitch)
 {
     int skipY = pitch - width;
@@ -5645,7 +5645,7 @@ static void wmInterfaceDrawSubTileRectFogged(unsigned char* dest, int width, int
     }
 }
 
-// 0x4C40E4
+// 0x4C40E4 wmInterfaceDrawSubTileList_
 static int wmInterfaceDrawSubTileList(TileInfo* tileInfo, int column, int row, int x, int y, int a6)
 {
     SubtileInfo* subtileInfo = &(tileInfo->subtiles[row][column]);
@@ -5692,7 +5692,7 @@ static int wmInterfaceDrawSubTileList(TileInfo* tileInfo, int column, int row, i
     return 0;
 }
 
-// 0x4C41EC
+// 0x4C41EC wmDrawCursorStopped_
 static int wmDrawCursorStopped()
 {
     unsigned char* src;
@@ -5819,7 +5819,7 @@ static int wmDrawCursorStopped()
     return 0;
 }
 
-// 0x4C4490
+// 0x4C4490 wmCursorIsVisible_
 static bool wmCursorIsVisible()
 {
     return wmGenData.worldPosX >= wmWorldOffsetX
@@ -5830,7 +5830,7 @@ static bool wmCursorIsVisible()
 
 // NOTE: Inlined.
 //
-// 0x4C44D8
+// 0x4C44D8 wmGetAreaName_
 static int wmGetAreaName(CityInfo* city, char* name)
 {
     MessageListItem messageListItem;
@@ -5843,7 +5843,7 @@ static int wmGetAreaName(CityInfo* city, char* name)
 
 // Copy city short name.
 //
-// 0x4C450C
+// 0x4C450C wmGetAreaIdxName_
 int wmGetAreaIdxName(int areaIdx, char* name)
 {
     MessageListItem messageListItem;
@@ -5856,7 +5856,7 @@ int wmGetAreaIdxName(int areaIdx, char* name)
 
 // Returns true if world area is known.
 //
-// 0x4C453C
+// 0x4C453C wmAreaIsKnown_
 bool wmAreaIsKnown(int areaIdx)
 {
     if (!cityIsValid(areaIdx)) {
@@ -5873,7 +5873,7 @@ bool wmAreaIsKnown(int areaIdx)
     return false;
 }
 
-// 0x4C457C
+// 0x4C457C wmAreaVisitedState_
 int wmAreaVisitedState(int areaIdx)
 {
     if (!cityIsValid(areaIdx)) {
@@ -5888,7 +5888,7 @@ int wmAreaVisitedState(int areaIdx)
     return 0;
 }
 
-// 0x4C45BC
+// 0x4C45BC wmMapIsKnown_
 bool wmMapIsKnown(int mapIdx)
 {
     int areaIdx;
@@ -5911,13 +5911,13 @@ bool wmMapIsKnown(int mapIdx)
     return true;
 }
 
-// 0x4C4624
+// 0x4C4624 wmAreaMarkVisited_
 int wmAreaMarkVisited(int areaIdx)
 {
     return wmAreaMarkVisitedState(areaIdx, CITY_STATE_VISITED);
 }
 
-// 0x4C4634
+// 0x4C4634 wmAreaMarkVisitedState_
 bool wmAreaMarkVisitedState(int areaIdx, int state)
 {
     if (!cityIsValid(areaIdx)) {
@@ -5946,7 +5946,7 @@ bool wmAreaMarkVisitedState(int areaIdx, int state)
     return true;
 }
 
-// 0x4C46CC
+// 0x4C46CC wmAreaSetVisibleState_
 bool wmAreaSetVisibleState(int areaIdx, int state, bool force)
 {
     if (!cityIsValid(areaIdx)) {
@@ -5962,7 +5962,7 @@ bool wmAreaSetVisibleState(int areaIdx, int state, bool force)
     return false;
 }
 
-// 0x4C4710
+// 0x4C4710 wmAreaSetWorldPos_
 int wmAreaSetWorldPos(int areaIdx, int x, int y)
 {
     if (!cityIsValid(areaIdx)) {
@@ -5986,7 +5986,7 @@ int wmAreaSetWorldPos(int areaIdx, int x, int y)
 
 // Returns current town x/y.
 //
-// 0x4C47A4
+// 0x4C47A4 wmGetPartyWorldPos_
 int wmGetPartyWorldPos(int* xPtr, int* yPtr)
 {
     if (xPtr != nullptr) {
@@ -6002,7 +6002,7 @@ int wmGetPartyWorldPos(int* xPtr, int* yPtr)
 
 // Returns current town.
 //
-// 0x4C47C0
+// 0x4C47C0 wmGetPartyCurArea_
 int wmGetPartyCurArea(int* areaIdxPtr)
 {
     if (areaIdxPtr != nullptr) {
@@ -6013,7 +6013,7 @@ int wmGetPartyCurArea(int* areaIdxPtr)
     return -1;
 }
 
-// 0x4C47D8
+// 0x4C47D8 wmMarkAllSubTiles_
 static void wmMarkAllSubTiles(int state)
 {
     for (int tileIndex = 0; tileIndex < wmMaxTileNum; tileIndex++) {
@@ -6027,13 +6027,13 @@ static void wmMarkAllSubTiles(int state)
     }
 }
 
-// 0x4C4850
+// 0x4C4850 wmTownMap_
 void wmTownMap()
 {
     wmWorldMapFunc(1);
 }
 
-// 0x4C485C
+// 0x4C485C wmTownMapFunc_
 static int wmTownMapFunc(int* mapIdxPtr)
 {
     *mapIdxPtr = -1;
@@ -6138,7 +6138,7 @@ static int wmTownMapFunc(int* mapIdxPtr)
     return 0;
 }
 
-// 0x4C4A6C
+// 0x4C4A6C wmTownMapInit_
 static int wmTownMapInit()
 {
     wmTownMapCurArea = wmGenData.currentAreaId;
@@ -6191,7 +6191,7 @@ static int wmTownMapInit()
     return 0;
 }
 
-// 0x4C4BD0
+// 0x4C4BD0 wmTownMapRefresh_
 static int wmTownMapRefresh()
 {
     blitBufferToBuffer(_townFrmImage.getData(),
@@ -6236,7 +6236,7 @@ static int wmTownMapRefresh()
     return 0;
 }
 
-// 0x4C4D00
+// 0x4C4D00 wmTownMapExit_
 static int wmTownMapExit()
 {
     _townFrmImage.unlock();
@@ -6260,7 +6260,7 @@ static int wmTownMapExit()
     return 0;
 }
 
-// 0x4C4DA4
+// 0x4C4DA4 wmCarUseGas_
 int wmCarUseGas(int amount)
 {
     if (gameGetGlobalVar(GVAR_NEW_RENO_SUPER_CAR) != 0) {
@@ -6286,7 +6286,7 @@ int wmCarUseGas(int amount)
 
 // Returns amount of fuel that does not fit into tank.
 //
-// 0x4C4E34
+// 0x4C4E34 wmCarFillGas_
 int wmCarFillGas(int amount)
 {
     if ((amount + wmGenData.carFuel) <= CAR_FUEL_MAX) {
@@ -6301,25 +6301,25 @@ int wmCarFillGas(int amount)
     return remaining;
 }
 
-// 0x4C4E74
+// 0x4C4E74 wmCarGasAmount_
 int wmCarGasAmount()
 {
     return wmGenData.carFuel;
 }
 
-// 0x4C4E7C
+// 0x4C4E7C wmCarIsOutOfGas_
 bool wmCarIsOutOfGas()
 {
     return wmGenData.carFuel <= 0;
 }
 
-// 0x4C4E8C
+// 0x4C4E8C wmCarCurrentArea_
 int wmCarCurrentArea()
 {
     return wmGenData.currentCarAreaId;
 }
 
-// 0x4C4E94
+// 0x4C4E94 wmCarGiveToParty_
 int wmCarGiveToParty()
 {
     MessageListItem messageListItem;
@@ -6347,7 +6347,7 @@ int wmCarGiveToParty()
     return 0;
 }
 
-// 0x4C4F28
+// 0x4C4F28 wmSfxMaxCount_
 int wmSfxMaxCount()
 {
     int mapIdx = mapGetCurrentMap();
@@ -6359,7 +6359,7 @@ int wmSfxMaxCount()
     return map->ambientSoundEffectsLength;
 }
 
-// 0x4C4F5C
+// 0x4C4F5C wmSfxRollNextIdx_
 int wmSfxRollNextIdx()
 {
     int mapIdx = mapGetCurrentMap();
@@ -6389,7 +6389,7 @@ int wmSfxRollNextIdx()
     return -1;
 }
 
-// 0x4C5004
+// 0x4C5004 wmSfxIdxName_
 int wmSfxIdxName(int sfxIdx, char** namePtr)
 {
     if (namePtr == nullptr) {
@@ -6439,7 +6439,7 @@ int wmSfxIdxName(int sfxIdx, char** namePtr)
     return 0;
 }
 
-// 0x4C50F4
+// 0x4C50F4 wmRefreshInterfaceOverlay_
 static int wmRefreshInterfaceOverlay(bool shouldRefreshWindow)
 {
     blitBufferToBufferTrans(_backgroundFrmImage.getData(),
@@ -6495,7 +6495,7 @@ static int wmRefreshInterfaceOverlay(bool shouldRefreshWindow)
     return 0;
 }
 
-// 0x4C5244
+// 0x4C5244 wmInterfaceRefreshCarFuel_
 static void wmInterfaceRefreshCarFuel()
 {
     int ratio = (WM_WINDOW_CAR_FUEL_BAR_HEIGHT * wmGenData.carFuel) / CAR_FUEL_MAX;
@@ -6521,7 +6521,7 @@ static void wmInterfaceRefreshCarFuel()
     }
 }
 
-// 0x4C52B0
+// 0x4C52B0 wmRefreshTabs_
 static int wmRefreshTabs()
 {
     unsigned char* firstTabBottomDest;
@@ -6630,7 +6630,7 @@ static int wmRefreshTabs()
 
 // Creates array of cities available as quick destinations.
 //
-// 0x4C55D4
+// 0x4C55D4 wmMakeTabsLabelList_
 static int wmMakeTabsLabelList(int** quickDestinationsPtr, int* quickDestinationsLengthPtr)
 {
     int* quickDestinations = *quickDestinationsPtr;
@@ -6673,7 +6673,7 @@ static int wmMakeTabsLabelList(int** quickDestinationsPtr, int* quickDestination
     return 0;
 }
 
-// 0x4C56C8
+// 0x4C56C8 wmTabsCompareNames_
 static int wmTabsCompareNames(const void* a1, const void* a2)
 {
     int index1 = *(int*)a1;
@@ -6687,7 +6687,7 @@ static int wmTabsCompareNames(const void* a1, const void* a2)
 
 // NOTE: Inlined.
 //
-// 0x4C5710
+// 0x4C5710 wmFreeTabsLabelList_
 static int wmFreeTabsLabelList(int** quickDestinationsListPtr, int* quickDestinationsLengthPtr)
 {
     if (*quickDestinationsListPtr != nullptr) {
@@ -6700,7 +6700,7 @@ static int wmFreeTabsLabelList(int** quickDestinationsListPtr, int* quickDestina
     return 0;
 }
 
-// 0x4C5734
+// 0x4C5734 wmRefreshInterfaceDial_
 static void wmRefreshInterfaceDial(bool shouldRefreshWindow)
 {
     unsigned char* data = artGetFrameData(wmGenData.dialFrm, wmGenData.dialFrmCurrentFrameIndex, 0);
@@ -6723,7 +6723,7 @@ static void wmRefreshInterfaceDial(bool shouldRefreshWindow)
 
 // NOTE: Inlined.
 //
-// 0x4C57BC
+// 0x4C57BC wmInterfaceDialSyncTime_
 static void wmInterfaceDialSyncTime(bool shouldRefreshWindow)
 {
     int gameHour;
@@ -6737,7 +6737,7 @@ static void wmInterfaceDialSyncTime(bool shouldRefreshWindow)
     }
 }
 
-// 0x4C5804
+// 0x4C5804 wmAreaFindFirstValidMap_
 static int wmAreaFindFirstValidMap(int* mapIdxPtr)
 {
     *mapIdxPtr = -1;
@@ -6766,7 +6766,7 @@ static int wmAreaFindFirstValidMap(int* mapIdxPtr)
     return 0;
 }
 
-// 0x4C58C0
+// 0x4C58C0 wmMapMusicStart_
 int wmMapMusicStart()
 {
     do {
@@ -6792,7 +6792,7 @@ int wmMapMusicStart()
     return -1;
 }
 
-// 0x4C5928
+// 0x4C5928 wmSetMapMusic_
 int wmSetMapMusic(int mapIdx, const char* name)
 {
     if (mapIdx == -1 || mapIdx >= wmMaxMapNum) {
@@ -6818,7 +6818,7 @@ int wmSetMapMusic(int mapIdx, const char* name)
     return 0;
 }
 
-// 0x4C59A4
+// 0x4C59A4 wmMatchAreaContainingMapIdx_
 int wmMatchAreaContainingMapIdx(int mapIdx, int* areaIdxPtr)
 {
     *areaIdxPtr = 0;
@@ -6837,7 +6837,7 @@ int wmMatchAreaContainingMapIdx(int mapIdx, int* areaIdxPtr)
     return -1;
 }
 
-// 0x4C5A1C
+// 0x4C5A1C wmTeleportToArea_
 int wmTeleportToArea(int areaIdx)
 {
     if (!cityIsValid(areaIdx)) {

--- a/src/worldmap.cc
+++ b/src/worldmap.cc
@@ -572,7 +572,7 @@ static void wmFadeIn();
 static void wmFadeReset();
 static void wmBlinkRndEncounterIcon(bool special);
 
-// 0x4BC860
+// 0x4BC860 can_rest_here
 static const int _can_rest_here[ELEVATION_COUNT] = {
     MAP_CAN_REST_ELEVATION_0,
     MAP_CAN_REST_ELEVATION_1,
@@ -595,25 +595,25 @@ static const char* gWorldmapEncDefaultMsg[2] = {
 // 0x4BC880
 static MessageListItem gWorldmapMessageListItem;
 
-// 0x50EE44
+// 0x50EE44 aCricket
 static char _aCricket[] = "cricket";
 
-// 0x50EE4C
+// 0x50EE4C aCricket1
 static char _aCricket1[] = "cricket1";
 
-// 0x51DD88
+// 0x51DD88 wmStateStrs
 static const char* wmStateStrs[2] = {
     "off",
     "on"
 };
 
-// 0x51DD90
+// 0x51DD90 wmYesNoStrs
 static const char* wmYesNoStrs[2] = {
     "no",
     "yes",
 };
 
-// 0x51DD98
+// 0x51DD98 _wmFreqStrs
 static const char* wmFreqStrs[ENCOUNTER_FREQUENCY_TYPE_COUNT] = {
     "none",
     "rare",
@@ -623,7 +623,7 @@ static const char* wmFreqStrs[ENCOUNTER_FREQUENCY_TYPE_COUNT] = {
     "forced",
 };
 
-// 0x51DDB0
+// 0x51DDB0 wmFillStrs
 static const char* wmFillStrs[SUBTILE_FILL_COUNT] = {
     "no_fill",
     "fill_n",
@@ -636,7 +636,7 @@ static const char* wmFillStrs[SUBTILE_FILL_COUNT] = {
     "fill_se",
 };
 
-// 0x51DDD4
+// 0x51DDD4 wmSceneryStrs
 static const char* wmSceneryStrs[ENCOUNTER_SCENERY_TYPE_COUNT] = {
     "none",
     "light",
@@ -644,16 +644,16 @@ static const char* wmSceneryStrs[ENCOUNTER_SCENERY_TYPE_COUNT] = {
     "heavy",
 };
 
-// 0x51DDE4
+// 0x51DDE4 wmTerrainTypeList
 static Terrain* wmTerrainTypeList = nullptr;
 
-// 0x51DDE8
+// 0x51DDE8 _wmMaxTerrainTypes
 static int wmMaxTerrainTypes = 0;
 
-// 0x51DDEC
+// 0x51DDEC _wmTileInfoList
 static TileInfo* wmTileInfoList = nullptr;
 
-// 0x51DDF0
+// 0x51DDF0 wmMaxTileNum
 static int wmMaxTileNum = 0;
 
 // The width of worldmap grid in tiles.
@@ -662,51 +662,51 @@ static int wmMaxTileNum = 0;
 // [wmMaxTileNum] / [gWorldmapTilesGridWidth].
 //
 // num_horizontal_tiles
-// 0x51DDF4
+// 0x51DDF4 wmNumHorizontalTiles
 static int wmNumHorizontalTiles = 0;
 
-// 0x51DDF8
+// 0x51DDF8 _wmAreaInfoList
 static CityInfo* wmAreaInfoList = nullptr;
 
-// 0x51DDFC
+// 0x51DDFC wmMaxAreaNum
 static int wmMaxAreaNum = 0;
 
-// 0x51DE00
+// 0x51DE00 wmAreaSizeStrs
 static const char* wmAreaSizeStrs[CITY_SIZE_COUNT] = {
     "small",
     "medium",
     "large",
 };
 
-// 0x51DE0C
+// 0x51DE0C _wmMapInfoList
 static MapInfo* wmMapInfoList = nullptr;
 
-// 0x51DE10
+// 0x51DE10 wmMaxMapNum
 static int wmMaxMapNum = 0;
 
-// 0x51DE14
+// 0x51DE14 wmBkWin
 static int wmBkWin = -1;
 
-// 0x51DE24
+// 0x51DE24 wmBkWinBuf
 static unsigned char* wmBkWinBuf = nullptr;
 
 // CE: Offscreen buffer for safe city overlay rendering
 static unsigned char* wmOverlayOffscreenBuf = nullptr;
 #define WM_OVERLAY_BUFFER_SIZE (200)
 
-// 0x51DE2C
+// 0x51DE2C wmWorldOffsetX
 static int wmWorldOffsetX = 0;
 
-// 0x51DE30
+// 0x51DE30 wmWorldOffsetY
 static int wmWorldOffsetY = 0;
 
-// 0x51DE34
+// 0x51DE34 circleBlendTable
 unsigned char* circleBlendTable = nullptr;
 
-// 0x51DE38
+// 0x51DE38 wmInterfaceWasInitialized
 static int wmInterfaceWasInitialized = 0;
 
-// 0x51DE3C
+// 0x51DE3C wmEncOpStrs
 static const char* wmEncOpStrs[ENCOUNTER_SITUATION_COUNT] = {
     "nothing",
     "ambush",
@@ -714,7 +714,7 @@ static const char* wmEncOpStrs[ENCOUNTER_SITUATION_COUNT] = {
     "and",
 };
 
-// 0x51DE4C
+// 0x51DE4C _wmConditionalOpStrs
 static const char* wmConditionalOpStrs[ENCOUNTER_CONDITIONAL_OPERATOR_COUNT] = {
     "_",
     "==",
@@ -729,7 +729,7 @@ static const char* wmConditionalQualifierStrs[2] = {
     "or",
 };
 
-// 0x51DE6C
+// 0x51DE6C wmFormationStrs
 static const char* wmFormationStrs[ENCOUNTER_FORMATION_TYPE_COUNT] = {
     "surrounding",
     "straight_line",
@@ -739,7 +739,7 @@ static const char* wmFormationStrs[ENCOUNTER_FORMATION_TYPE_COUNT] = {
     "huddle",
 };
 
-// 0x51DE84
+// 0x51DE84 wmRndCursorFids
 static const int wmRndCursorFids[WORLD_MAP_ENCOUNTER_FRM_COUNT] = {
     154,
     155,
@@ -754,55 +754,55 @@ typedef struct {
     int y;
 } TrailDot;
 
-// 0x51DE94
+// 0x51DE94 wmLabelList
 static int* wmLabelList = nullptr;
 
-// 0x51DE98
+// 0x51DE98 wmLabelCount
 static int wmLabelCount = 0;
 
-// 0x51DE9C
+// 0x51DE9C wmTownMapCurArea
 static int wmTownMapCurArea = -1;
 
-// 0x51DEA0
+// 0x51DEA0 wmLastRndTime
 static unsigned int wmLastRndTime = 0;
 
-// 0x51DEA4
+// 0x51DEA4 wmRndIndex
 static int wmRndIndex = 0;
 
-// 0x51DEA8
+// 0x51DEA8 wmRndCallCount
 static int wmRndCallCount = 0;
 
-// 0x51DEAC
+// 0x51DEAC terrainCounter
 static int _terrainCounter = 1;
 
-// 0x51DEC8
+// 0x51DEC8 wmRemapSfxList
 static char* wmRemapSfxList[2] = {
     _aCricket,
     _aCricket1,
 };
 
-// 0x672DB8
+// 0x672DB8 wmRndTileDirs
 static int wmRndTileDirs[2];
 
-// 0x672DC0
+// 0x672DC0 wmRndCenterTiles
 static int wmRndCenterTiles[2];
 
-// 0x672DC8
+// 0x672DC8 wmRndCenterRotations
 static int wmRndCenterRotations[2];
 
-// 0x672DD0
+// 0x672DD0 wmRndRotOffsets
 static int wmRndRotOffsets[2];
 
 // Buttons for city entrances.
 //
-// 0x672DD8
+// 0x672DD8 wmTownMapButtonId
 static int wmTownMapButtonId[ENTRANCE_LIST_CAPACITY];
 
 // NOTE: There are no symbols in |mapper2.exe| for the range between |wmGenData|
 // and |wmMsgFile| implying everything in between are fields of the large
 // struct.
 //
-// 0x672E00
+// 0x672E00 wmGenData
 
 static bool mousePressed;
 bool gDidMeetFrankHorrigan;
@@ -811,38 +811,38 @@ static WmGenData wmGenData;
 
 // worldmap.msg
 //
-// 0x672FB0
+// 0x672FB0 wmMsgFile
 static MessageList wmMsgFile;
 
-// 0x672FB8
+// 0x672FB8 wmFreqValues
 static int wmFreqValues[6];
 
-// 0x672FD0
+// 0x672FD0 wmRndOriginalCenterTile
 static int wmRndOriginalCenterTile;
 
 // worldmap.txt
 //
-// 0x672FD4
+// 0x672FD4 pConfigCfg
 static Config* pConfigCfg;
 
-// 0x672FD8
+// 0x672FD8 wmTownMapSubButtonIds
 static int wmTownMapSubButtonIds[WM_TOWN_LIST_VISIBLE_SLOT_COUNT];
 
-// 0x672FF4
+// 0x672FF4 _wmEncBaseTypeList
 static Encounter* wmEncBaseTypeList;
 
-// 0x672FF8
+// 0x672FF8 wmSphereData
 static CitySizeDescription wmSphereData[CITY_SIZE_COUNT];
 
-// 0x673034
+// 0x673034 _wmEncounterTableList
 static EncounterTable* wmEncounterTableList;
 
 // Number of enc_base_types.
 //
-// 0x673038
+// 0x673038 wmMaxEncBaseTypes
 static int wmMaxEncBaseTypes;
 
-// 0x67303C
+// 0x67303C wmMaxEncounterInfoTables
 static int wmMaxEncounterInfoTables;
 
 static bool gTownMapHotkeysFix;
@@ -859,7 +859,7 @@ static inline bool cityIsValid(int city)
     return city >= 0 && city < wmMaxAreaNum;
 }
 
-// 0x4BC890 wmSetFlags_
+// 0x4BC890 wmSetFlags
 static void wmSetFlags(int* flagsPtr, int flag, int value)
 {
     if (value) {
@@ -869,7 +869,7 @@ static void wmSetFlags(int* flagsPtr, int flag, int value)
     }
 }
 
-// 0x4BC89C wmWorldMap_init_
+// 0x4BC89C wmWorldMap_init
 int wmWorldMap_init()
 {
     char path[COMPAT_MAX_PATH];
@@ -917,7 +917,7 @@ int wmWorldMap_init()
     return 0;
 }
 
-// 0x4BC984 wmGenDataInit_
+// 0x4BC984 wmGenDataInit
 static int wmGenDataInit()
 {
     gDidMeetFrankHorrigan = false;
@@ -971,7 +971,7 @@ static int wmGenDataInit()
     return 0;
 }
 
-// 0x4BCBFC wmGenDataReset_
+// 0x4BCBFC wmGenDataReset
 static int wmGenDataReset()
 {
     gDidMeetFrankHorrigan = false;
@@ -1024,7 +1024,7 @@ static int wmGenDataReset()
     return 0;
 }
 
-// 0x4BCE00 wmWorldMap_exit_
+// 0x4BCE00 wmWorldMap_exit
 void wmWorldMap_exit()
 {
     if (wmTerrainTypeList != nullptr) {
@@ -1076,7 +1076,7 @@ void wmWorldMap_exit()
     messageListFree(&wmMsgFile);
 }
 
-// 0x4BCEF8 wmWorldMap_reset_
+// 0x4BCEF8 wmWorldMap_reset
 int wmWorldMap_reset()
 {
     wmWorldOffsetX = 0;
@@ -1091,7 +1091,7 @@ int wmWorldMap_reset()
     return wmGenDataReset();
 }
 
-// 0x4BCF28 wmWorldMap_save_
+// 0x4BCF28 wmWorldMap_save
 int wmWorldMap_save(File* stream)
 {
     int i;
@@ -1174,7 +1174,7 @@ int wmWorldMap_save(File* stream)
     return 0;
 }
 
-// 0x4BD28C wmWorldMap_load_
+// 0x4BD28C wmWorldMap_load
 int wmWorldMap_load(File* stream)
 {
     if (fileReadBool(stream, &gDidMeetFrankHorrigan) == -1) return -1;
@@ -1259,7 +1259,7 @@ int wmWorldMap_load(File* stream)
     return 0;
 }
 
-// 0x4BD678 wmWorldMapSaveTempData_
+// 0x4BD678 wmWorldMapSaveTempData
 static int wmWorldMapSaveTempData()
 {
     File* stream = fileOpen("worldmap.dat", "wb");
@@ -1277,7 +1277,7 @@ static int wmWorldMapSaveTempData()
     return rc;
 }
 
-// 0x4BD6B4 wmWorldMapLoadTempData_
+// 0x4BD6B4 wmWorldMapLoadTempData
 static int wmWorldMapLoadTempData()
 {
     File* stream = fileOpen("worldmap.dat", "rb");
@@ -1295,7 +1295,7 @@ static int wmWorldMapLoadTempData()
     return rc;
 }
 
-// 0x4BD6F0 wmConfigInit_
+// 0x4BD6F0 wmConfigInit
 static int wmConfigInit()
 {
     if (wmAreaInit() == -1) {
@@ -1398,7 +1398,7 @@ static int wmConfigInit()
     return 0;
 }
 
-// 0x4BD9F0 wmReadEncounterType_
+// 0x4BD9F0 wmReadEncounterType
 static int wmReadEncounterType(Config* config, char* lookupName, char* sectionKey)
 {
     wmMaxEncounterInfoTables++;
@@ -1460,7 +1460,7 @@ static int wmReadEncounterType(Config* config, char* lookupName, char* sectionKe
     return 0;
 }
 
-// 0x4BDB64 wmParseEncounterTableIndex_
+// 0x4BDB64 wmParseEncounterTableIndex
 static int wmParseEncounterTableIndex(EncounterTableEntry* encounterTableEntry, char* string)
 {
     // NOTE: Uninline.
@@ -1513,7 +1513,7 @@ static int wmParseEncounterTableIndex(EncounterTableEntry* encounterTableEntry, 
     return 0;
 }
 
-// 0x4BDCA8 wmParseEncounterSubEncStr_
+// 0x4BDCA8 wmParseEncounterSubEncStr
 static int wmParseEncounterSubEncStr(EncounterTableEntry* encounterTableEntry, char** stringPtr)
 {
     char* string = *stringPtr;
@@ -1617,7 +1617,7 @@ static int wmParseEncounterSubEncStr(EncounterTableEntry* encounterTableEntry, c
     return 0;
 }
 
-// 0x4BDE94 wmParseFindSubEncTypeMatch_
+// 0x4BDE94 wmParseFindSubEncTypeMatch
 static int wmParseFindSubEncTypeMatch(char* str, int* valuePtr)
 {
     *valuePtr = 0;
@@ -1638,7 +1638,7 @@ static int wmParseFindSubEncTypeMatch(char* str, int* valuePtr)
     return -1;
 }
 
-// 0x4BDED8 wmFindEncBaseTypeMatch_
+// 0x4BDED8 wmFindEncBaseTypeMatch
 static int wmFindEncBaseTypeMatch(char* str, int* valuePtr)
 {
     for (int index = 0; index < wmMaxEncBaseTypes; index++) {
@@ -1652,7 +1652,7 @@ static int wmFindEncBaseTypeMatch(char* str, int* valuePtr)
     return -1;
 }
 
-// 0x4BDF34 wmReadEncBaseType_
+// 0x4BDF34 wmReadEncBaseType
 static int wmReadEncBaseType(char* name, int* valuePtr)
 {
     char section[40];
@@ -1718,7 +1718,7 @@ static int wmReadEncBaseType(char* name, int* valuePtr)
     return -1;
 }
 
-// 0x4BE140 wmParseEncBaseSubTypeStr_
+// 0x4BE140 wmParseEncBaseSubTypeStr
 static int wmParseEncBaseSubTypeStr(EncounterEntry* encounterEntry, char** stringPtr)
 {
     char* string = *stringPtr;
@@ -1761,7 +1761,7 @@ static int wmParseEncBaseSubTypeStr(EncounterEntry* encounterEntry, char** strin
 
 // NOTE: Inlined.
 //
-// 0x4BE2A0 wmEncBaseTypeSlotInit_
+// 0x4BE2A0 wmEncBaseTypeSlotInit
 static int wmEncBaseTypeSlotInit(Encounter* encounter)
 {
     encounter->name[0] = '\0';
@@ -1775,7 +1775,7 @@ static int wmEncBaseTypeSlotInit(Encounter* encounter)
 
 // NOTE: Inlined.
 //
-// 0x4BE2C4 wmEncBaseSubTypeSlotInit_
+// 0x4BE2C4 wmEncBaseSubTypeSlotInit
 static int wmEncBaseSubTypeSlotInit(EncounterEntry* encounterEntry)
 {
     encounterEntry->field_28 = -1;
@@ -1794,7 +1794,7 @@ static int wmEncBaseSubTypeSlotInit(EncounterEntry* encounterEntry)
 
 // NOTE: Inlined.
 //
-// 0x4BE32C wmEncounterSubEncSlotInit_
+// 0x4BE32C wmEncounterSubEncSlotInit
 static int wmEncounterSubEncSlotInit(EncounterTableSubEntry* encounterTableSubEntry)
 {
     encounterTableSubEntry->minimumCount = 1;
@@ -1807,7 +1807,7 @@ static int wmEncounterSubEncSlotInit(EncounterTableSubEntry* encounterTableSubEn
 
 // NOTE: Inlined.
 //
-// 0x4BE34C wmEncounterTypeSlotInit_
+// 0x4BE34C wmEncounterTypeSlotInit
 static int wmEncounterTypeSlotInit(EncounterTableEntry* encounterTableEntry)
 {
     encounterTableEntry->flags = 0;
@@ -1822,7 +1822,7 @@ static int wmEncounterTypeSlotInit(EncounterTableEntry* encounterTableEntry)
 
 // NOTE: Inlined.
 //
-// 0x4BE3B8 wmEncounterTableSlotInit_
+// 0x4BE3B8 wmEncounterTableSlotInit
 static int wmEncounterTableSlotInit(EncounterTable* encounterTable)
 {
     encounterTable->lookupName[0] = '\0';
@@ -1835,7 +1835,7 @@ static int wmEncounterTableSlotInit(EncounterTable* encounterTable)
 
 // NOTE: Inlined.
 //
-// 0x4BE3D4 wmTileSlotInit_
+// 0x4BE3D4 wmTileSlotInit
 static int wmTileSlotInit(TileInfo* tile)
 {
     tile->fid = -1;
@@ -1850,7 +1850,7 @@ static int wmTileSlotInit(TileInfo* tile)
 
 // NOTE: Inlined.
 //
-// 0x4BE400 wmTerrainTypeSlotInit_
+// 0x4BE400 wmTerrainTypeSlotInit
 static int wmTerrainTypeSlotInit(Terrain* terrain)
 {
     terrain->lookupName[0] = '\0';
@@ -1880,7 +1880,7 @@ static int wmConditionalDataInit(EncounterCondition* condition)
     return 0;
 }
 
-// 0x4BE414 wmParseTerrainTypes_
+// 0x4BE414 wmParseTerrainTypes
 static int wmParseTerrainTypes(Config* config, char* string)
 {
     if (*string == '\0') {
@@ -1945,7 +1945,7 @@ static int wmParseTerrainTypes(Config* config, char* string)
     return 0;
 }
 
-// 0x4BE598 wmParseTerrainRndMaps_
+// 0x4BE598 wmParseTerrainRndMaps
 static int wmParseTerrainRndMaps(Config* config, Terrain* terrain)
 {
     char section[40];
@@ -1974,7 +1974,7 @@ static int wmParseTerrainRndMaps(Config* config, Terrain* terrain)
     return 0;
 }
 
-// 0x4BE61C wmParseSubTileInfo_
+// 0x4BE61C wmParseSubTileInfo
 static int wmParseSubTileInfo(TileInfo* tile, int row, int column, char* string)
 {
     SubtileInfo* subtile = &(tile->subtiles[column][row]);
@@ -2001,7 +2001,7 @@ static int wmParseSubTileInfo(TileInfo* tile, int row, int column, char* string)
     return 0;
 }
 
-// 0x4BE6D4 wmParseFindEncounterTypeMatch_
+// 0x4BE6D4 wmParseFindEncounterTypeMatch
 static int wmParseFindEncounterTypeMatch(char* string, int* valuePtr)
 {
     for (int index = 0; index < wmMaxEncounterInfoTables; index++) {
@@ -2018,7 +2018,7 @@ static int wmParseFindEncounterTypeMatch(char* string, int* valuePtr)
     return -1;
 }
 
-// 0x4BE73C wmParseFindTerrainTypeMatch_
+// 0x4BE73C wmParseFindTerrainTypeMatch
 static int wmParseFindTerrainTypeMatch(char* string, int* valuePtr)
 {
     for (int index = 0; index < wmMaxTerrainTypes; index++) {
@@ -2036,7 +2036,7 @@ static int wmParseFindTerrainTypeMatch(char* string, int* valuePtr)
     return -1;
 }
 
-// 0x4BE7A4 wmParseEncounterItemType_
+// 0x4BE7A4 wmParseEncounterItemType
 static int wmParseEncounterItemType(char** stringPtr, EncounterItem* encounterItem, int* itemCountPtr, const char* delimeters)
 {
     char* string = *stringPtr;
@@ -2077,7 +2077,7 @@ static int wmParseEncounterItemType(char** stringPtr, EncounterItem* encounterIt
     return found ? 0 : -1;
 }
 
-// 0x4BE888 wmParseItemType_
+// 0x4BE888 wmParseItemType
 static int wmParseItemType(char* string, EncounterItem* encounterItem)
 {
     while (*string == ' ') {
@@ -2138,7 +2138,7 @@ static int wmParseItemType(char* string, EncounterItem* encounterItem)
     return 0;
 }
 
-// 0x4BE988 wmParseConditional_
+// 0x4BE988 wmParseConditional
 static int wmParseConditional(char** stringPtr, const char* a2, EncounterCondition* condition)
 {
     while (condition->entriesLength < 3) {
@@ -2169,7 +2169,7 @@ static int wmParseConditional(char** stringPtr, const char* a2, EncounterConditi
     return 0;
 }
 
-// 0x4BEA24 wmParseSubConditional_
+// 0x4BEA24 wmParseSubConditional
 static int wmParseSubConditional(char** stringPtr, const char* a2, int* typePtr, int* operatorPtr, int* paramPtr, int* valuePtr)
 {
     char* string = *stringPtr;
@@ -2367,7 +2367,7 @@ static int wmParseSubConditional(char** stringPtr, const char* a2, int* typePtr,
     return -1;
 }
 
-// 0x4BEEBC wmParseConditionalEval_
+// 0x4BEEBC wmParseConditionalEval
 static int wmParseConditionalEval(char** stringPtr, int* conditionalOperatorPtr)
 {
     char* string = *stringPtr;
@@ -2399,7 +2399,7 @@ static int wmParseConditionalEval(char** stringPtr, int* conditionalOperatorPtr)
 
 // NOTE: Inlined.
 //
-// 0x4BEF1C wmAreaSlotInit_
+// 0x4BEF1C wmAreaSlotInit
 static int wmAreaSlotInit(CityInfo* area)
 {
     area->name[0] = '\0';
@@ -2417,7 +2417,7 @@ static int wmAreaSlotInit(CityInfo* area)
     return 0;
 }
 
-// 0x4BEF68 wmAreaInit_
+// 0x4BEF68 wmAreaInit
 static int wmAreaInit()
 {
     Config cfg;
@@ -2579,7 +2579,7 @@ static int wmAreaInit()
     return 0;
 }
 
-// 0x4BF3E0 wmParseFindMapIdxMatch_
+// 0x4BF3E0 wmParseFindMapIdxMatch
 static int wmParseFindMapIdxMatch(char* string, int* valuePtr)
 {
     for (int index = 0; index < wmMaxMapNum; index++) {
@@ -2598,7 +2598,7 @@ static int wmParseFindMapIdxMatch(char* string, int* valuePtr)
 
 // NOTE: Inlined.
 //
-// 0x4BF448 wmEntranceSlotInit_
+// 0x4BF448 wmEntranceSlotInit
 static int wmEntranceSlotInit(EntranceInfo* entrance)
 {
     entrance->state = 0;
@@ -2612,7 +2612,7 @@ static int wmEntranceSlotInit(EntranceInfo* entrance)
     return 0;
 }
 
-// 0x4BF47C wmMapSlotInit_
+// 0x4BF47C wmMapSlotInit
 static int wmMapSlotInit(MapInfo* map)
 {
     map->lookupName[0] = '\0';
@@ -2627,7 +2627,7 @@ static int wmMapSlotInit(MapInfo* map)
     return 0;
 }
 
-// 0x4BF4BC wmMapInit_
+// 0x4BF4BC wmMapInit
 static int wmMapInit()
 {
     char* str;
@@ -2794,7 +2794,7 @@ static int wmMapInit()
 
 // NOTE: Inlined.
 //
-// 0x4BF954 wmRStartSlotInit_
+// 0x4BF954 wmRStartSlotInit
 static int wmRStartSlotInit(MapStartPointInfo* rsp)
 {
     rsp->elevation = 0;
@@ -2804,13 +2804,13 @@ static int wmRStartSlotInit(MapStartPointInfo* rsp)
     return 0;
 }
 
-// 0x4BF96C wmMapMaxCount_
+// 0x4BF96C wmMapMaxCount
 int wmMapMaxCount()
 {
     return wmMaxMapNum;
 }
 
-// 0x4BF974 wmMapIdxToName_
+// 0x4BF974 wmMapIdxToName
 int wmMapIdxToName(int mapIdx, char* dest, size_t size)
 {
     if (mapIdx == -1 || mapIdx > wmMaxMapNum) {
@@ -2822,7 +2822,7 @@ int wmMapIdxToName(int mapIdx, char* dest, size_t size)
     return 0;
 }
 
-// 0x4BF9BC wmMapMatchNameToIdx_
+// 0x4BF9BC wmMapMatchNameToIdx
 int wmMapMatchNameToIdx(char* name)
 {
     compat_strlwr(name);
@@ -2854,25 +2854,25 @@ int wmMapMatchNameToIdx(char* name)
     return map;
 }
 
-// 0x4BFA44 wmMapIdxIsSaveable_
+// 0x4BFA44 wmMapIdxIsSaveable
 bool wmMapIdxIsSaveable(int mapIdx)
 {
     return (wmMapInfoList[mapIdx].flags & MAP_SAVED) != 0;
 }
 
-// 0x4BFA64 wmMapIsSaveable_
+// 0x4BFA64 wmMapIsSaveable
 bool wmMapIsSaveable()
 {
     return (wmMapInfoList[gMapHeader.index].flags & MAP_SAVED) != 0;
 }
 
-// 0x4BFA90 wmMapDeadBodiesAge_
+// 0x4BFA90 wmMapDeadBodiesAge
 bool wmMapDeadBodiesAge()
 {
     return (wmMapInfoList[gMapHeader.index].flags & MAP_DEAD_BODIES_AGE) != 0;
 }
 
-// 0x4BFABC wmMapCanRestHere_
+// 0x4BFABC wmMapCanRestHere
 bool wmMapCanRestHere(int elevation)
 {
     int flags[3];
@@ -2885,13 +2885,13 @@ bool wmMapCanRestHere(int elevation)
     return (map->flags & flags[elevation]) != 0;
 }
 
-// 0x4BFAFC wmMapPipboyActive_
+// 0x4BFAFC wmMapPipboyActive
 bool wmMapPipboyActive()
 {
     return gameMovieIsSeen(MOVIE_VSUIT);
 }
 
-// 0x4BFB08 wmMapMarkVisited_
+// 0x4BFB08 wmMapMarkVisited
 int wmMapMarkVisited(int mapIdx)
 {
     if (mapIdx < 0 || mapIdx >= wmMaxMapNum) {
@@ -2914,7 +2914,7 @@ int wmMapMarkVisited(int mapIdx)
     return 0;
 }
 
-// 0x4BFB64 wmMatchEntranceFromMap_
+// 0x4BFB64 wmMatchEntranceFromMap
 static int wmMatchEntranceFromMap(int areaIdx, int mapIdx, int* entranceIdxPtr)
 {
     CityInfo* city = &(wmAreaInfoList[areaIdx]);
@@ -2932,7 +2932,7 @@ static int wmMatchEntranceFromMap(int areaIdx, int mapIdx, int* entranceIdxPtr)
     return -1;
 }
 
-// 0x4BFBE8 wmMatchEntranceElevFromMap_
+// 0x4BFBE8 wmMatchEntranceElevFromMap
 static int wmMatchEntranceElevFromMap(int areaIdx, int mapIdx, int elevation, int* entranceIdxPtr)
 {
     CityInfo* city = &(wmAreaInfoList[areaIdx]);
@@ -2951,7 +2951,7 @@ static int wmMatchEntranceElevFromMap(int areaIdx, int mapIdx, int elevation, in
     return -1;
 }
 
-// 0x4BFC7C wmMatchAreaFromMap_
+// 0x4BFC7C wmMatchAreaFromMap
 static int wmMatchAreaFromMap(int mapIdx, int* areaIdxPtr)
 {
     for (int areaIdx = 0; areaIdx < wmMaxAreaNum; areaIdx++) {
@@ -2972,7 +2972,7 @@ static int wmMatchAreaFromMap(int mapIdx, int* areaIdxPtr)
 
 // Mark map entrance.
 //
-// 0x4BFD50 wmMapMarkMapEntranceState_
+// 0x4BFD50 wmMapMarkMapEntranceState
 int wmMapMarkMapEntranceState(int mapIdx, int elevation, int state)
 {
     if (mapIdx < 0 || mapIdx >= wmMaxMapNum) {
@@ -3001,13 +3001,13 @@ int wmMapMarkMapEntranceState(int mapIdx, int elevation, int state)
     return 0;
 }
 
-// 0x4BFE0C wmWorldMap_
+// 0x4BFE0C wmWorldMap
 void wmWorldMap()
 {
     wmWorldMapFunc(0);
 }
 
-// 0x4BFE10 wmWorldMapFunc_
+// 0x4BFE10 wmWorldMapFunc
 static int wmWorldMapFunc(int a1)
 {
     ScopedGameMode gm(GameMode::kWorldmap);
@@ -3324,7 +3324,7 @@ static int wmWorldMapFunc(int a1)
     return rc;
 }
 
-// 0x4C056C wmCheckGameAreaEvents_
+// 0x4C056C wmCheckGameAreaEvents
 int wmCheckGameAreaEvents()
 {
     if (wmGenData.currentAreaId == CITY_FAKE_VAULT_13_A) {
@@ -3340,7 +3340,7 @@ int wmCheckGameAreaEvents()
     return 0;
 }
 
-// 0x4C05C4 wmInterfaceCenterOnParty_
+// 0x4C05C4 wmInterfaceCenterOnParty
 static int wmInterfaceCenterOnParty()
 {
     wmWorldOffsetX = std::clamp(wmGenData.worldPosX - 203, 0, wmGenData.viewportMaxX);
@@ -3353,13 +3353,13 @@ static int wmInterfaceCenterOnParty()
 
 // NOTE: Inlined.
 //
-// 0x4C0624 wmCheckGameEvents_
+// 0x4C0624 wmCheckGameEvents
 static void wmCheckGameEvents()
 {
     _scriptsCheckGameEvents(nullptr, wmBkWin);
 }
 
-// 0x4C0634 wmRndEncounterOccurred_
+// 0x4C0634 wmRndEncounterOccurred
 static int wmRndEncounterOccurred()
 {
     unsigned int now = getTicks();
@@ -3567,13 +3567,13 @@ static int wmRndEncounterOccurred()
 
 // NOTE: Inlined.
 //
-// 0x4C0BE4 wmPartyFindCurSubTile_
+// 0x4C0BE4 wmPartyFindCurSubTile
 static int wmPartyFindCurSubTile()
 {
     return wmFindCurSubTileFromPos(wmGenData.worldPosX, wmGenData.worldPosY, &(wmGenData.currentSubtile));
 }
 
-// 0x4C0C00 wmFindCurSubTileFromPos_
+// 0x4C0C00 wmFindCurSubTileFromPos
 static int wmFindCurSubTileFromPos(int x, int y, SubtileInfo** subtilePtr)
 {
     int tileIndex = y / WM_TILE_HEIGHT * wmNumHorizontalTiles + x / WM_TILE_WIDTH % wmNumHorizontalTiles;
@@ -3588,7 +3588,7 @@ static int wmFindCurSubTileFromPos(int x, int y, SubtileInfo** subtilePtr)
 
 // NOTE: Inlined.
 //
-// 0x4C0CA8 wmFindCurTileFromPos_
+// 0x4C0CA8 wmFindCurTileFromPos
 static int wmFindCurTileFromPos(int x, int y, TileInfo** tilePtr)
 {
     int tileIndex = y / WM_TILE_HEIGHT * wmNumHorizontalTiles + x / WM_TILE_WIDTH % wmNumHorizontalTiles;
@@ -3597,7 +3597,7 @@ static int wmFindCurTileFromPos(int x, int y, TileInfo** tilePtr)
     return 0;
 }
 
-// 0x4C0CF4 wmRndEncounterPick_
+// 0x4C0CF4 wmRndEncounterPick
 static int wmRndEncounterPick()
 {
     if (wmGenData.currentSubtile == nullptr) {
@@ -3702,7 +3702,7 @@ static int wmRndEncounterPick()
     return 0;
 }
 
-// 0x4C0FA4 wmSetupRandomEncounter_
+// 0x4C0FA4 wmSetupRandomEncounter
 int wmSetupRandomEncounter()
 {
     MessageListItem messageListItem;
@@ -3816,7 +3816,7 @@ int wmSetupRandomEncounter()
 }
 
 // wmSetupCritterObjs
-// 0x4C11FC wmSetupCritterObjs_
+// 0x4C11FC wmSetupCritterObjs
 static int wmSetupCritterObjs(int encounterIndex, Object** critterPtr, int critterCount)
 {
     if (encounterIndex == -1) {
@@ -3949,7 +3949,7 @@ static int wmSetupCritterObjs(int encounterIndex, Object** critterPtr, int critt
     return 0;
 }
 
-// 0x4C155C wmSetupRndNextTileNumInit_
+// 0x4C155C wmSetupRndNextTileNumInit
 static int wmSetupRndNextTileNumInit(Encounter* encounter)
 {
     for (int index = 0; index < 2; index++) {
@@ -4014,7 +4014,7 @@ static int wmSetupRndNextTileNumInit(Encounter* encounter)
 // Determines tile to place the next object in the EncounterEntry at.
 //
 // wmSetupRndNextTileNum
-// 0x4C16F0 wmSetupRndNextTileNum_
+// 0x4C16F0 wmSetupRndNextTileNum
 static int wmSetupRndNextTileNum(Encounter* encounter, EncounterEntry* encounterEntry, int* tilePtr)
 {
     int tile;
@@ -4127,7 +4127,7 @@ static int wmSetupRndNextTileNum(Encounter* encounter, EncounterEntry* encounter
     return 0;
 }
 
-// 0x4C1A64 wmEvalTileNumForPlacement_
+// 0x4C1A64 wmEvalTileNumForPlacement
 bool wmEvalTileNumForPlacement(int tile)
 {
     if (_obj_blocking_at(gDude, tile, gElevation) != nullptr) {
@@ -4141,7 +4141,7 @@ bool wmEvalTileNumForPlacement(int tile)
     return true;
 }
 
-// 0x4C1AC8 wmEvalConditional_
+// 0x4C1AC8 wmEvalConditional
 static bool wmEvalConditional(EncounterCondition* condition, int* critterCountPtr)
 {
     int value;
@@ -4200,7 +4200,7 @@ static bool wmEvalConditional(EncounterCondition* condition, int* critterCountPt
     return matches;
 }
 
-// 0x4C1C0C wmEvalSubConditional_
+// 0x4C1C0C wmEvalSubConditional
 static bool wmEvalSubConditional(int operand1, int condionalOperator, int operand2)
 {
     switch (condionalOperator) {
@@ -4217,7 +4217,7 @@ static bool wmEvalSubConditional(int operand1, int condionalOperator, int operan
     return false;
 }
 
-// 0x4C1C50 wmGameTimeIncrement_
+// 0x4C1C50 wmGameTimeIncrement
 static bool wmGameTimeIncrement(int ticksToAdd)
 {
     if (ticksToAdd == 0) {
@@ -4253,7 +4253,7 @@ static bool wmGameTimeIncrement(int ticksToAdd)
 
 // Reads .msk file if needed.
 //
-// 0x4C1CE8 wmGrabTileWalkMask_
+// 0x4C1CE8 wmGrabTileWalkMask
 static int wmGrabTileWalkMask(int tileIdx)
 {
     TileInfo* tileInfo = &(wmTileInfoList[tileIdx]);
@@ -4289,7 +4289,7 @@ static int wmGrabTileWalkMask(int tileIdx)
     return rc;
 }
 
-// 0x4C1D9C wmWorldPosInvalid_
+// 0x4C1D9C wmWorldPosInvalid
 static bool wmWorldPosInvalid(int x, int y)
 {
     int tileIdx = y / WM_TILE_HEIGHT * wmNumHorizontalTiles + x / WM_TILE_WIDTH % wmNumHorizontalTiles;
@@ -4311,7 +4311,7 @@ static bool wmWorldPosInvalid(int x, int y)
     return (mask[pos] & bit) != 0;
 }
 
-// 0x4C1E54 wmPartyInitWalking_
+// 0x4C1E54 wmPartyInitWalking
 static void wmPartyInitWalking(int x, int y)
 {
     wmGenData.walkDestinationX = x;
@@ -4357,7 +4357,7 @@ static void wmPartyInitWalking(int x, int y)
     }
 }
 
-// 0x4C1F90 wmPartyWalkingStep_
+// 0x4C1F90 wmPartyWalkingStep
 static void wmPartyWalkingStep()
 {
     if (wmGenData.walkDistance <= 0) {
@@ -4431,7 +4431,7 @@ static void wmPartyWalkingStep()
     }
 }
 
-// 0x4C219C wmInterfaceScrollTabsStart_
+// 0x4C219C wmInterfaceScrollTabsStart
 static void wmInterfaceScrollTabsStart(int delta)
 {
     int tabsScrollMaxOffsetY = std::max(0,
@@ -4462,7 +4462,7 @@ static void wmInterfaceScrollTabsStart(int delta)
     wmInterfaceScrollTabsUpdate();
 }
 
-// 0x4C2270 wmInterfaceScrollTabsStop_
+// 0x4C2270 wmInterfaceScrollTabsStop
 static void wmInterfaceScrollTabsStop()
 {
     wmGenData.tabsScrollingDelta = 0;
@@ -4474,7 +4474,7 @@ static void wmInterfaceScrollTabsStop()
 
 // NOTE: Inlined.
 //
-// 0x4C2290 wmInterfaceScrollTabsUpdate_
+// 0x4C2290 wmInterfaceScrollTabsUpdate
 static void wmInterfaceScrollTabsUpdate()
 {
     if (wmGenData.tabsScrollingDelta != 0) {
@@ -4495,7 +4495,7 @@ static void wmInterfaceScrollTabsUpdate()
     }
 }
 
-// 0x4C2324 wmInterfaceInit_
+// 0x4C2324 wmInterfaceInit
 static int wmInterfaceInit()
 {
     int fid;
@@ -4791,7 +4791,7 @@ static int wmInterfaceInit()
     return 0;
 }
 
-// 0x4C2E44 wmInterfaceExit_
+// 0x4C2E44 wmInterfaceExit
 static int wmInterfaceExit()
 {
     int i;
@@ -4898,7 +4898,7 @@ static int wmInterfaceExit()
 
 // NOTE: Inlined.
 //
-// 0x4C31E8 wmInterfaceScroll_
+// 0x4C31E8 wmInterfaceScroll
 static int wmInterfaceScroll(int dx, int dy, bool* successPtr)
 {
     return wmInterfaceScrollPixel(20, 20, dx, dy, successPtr, 1);
@@ -4910,7 +4910,7 @@ static int wmInterfaceScroll(int dx, int dy, bool* successPtr)
 // one direction is possible (and in fact occured), it will still be reported as
 // error.
 //
-// 0x4C3200 wmInterfaceScrollPixel_
+// 0x4C3200 wmInterfaceScrollPixel
 static int wmInterfaceScrollPixel(int stepX, int stepY, int dx, int dy, bool* success, bool shouldRefresh)
 {
     if (success != nullptr) {
@@ -4974,7 +4974,7 @@ static int wmInterfaceScrollPixel(int stepX, int stepY, int dx, int dy, bool* su
     return 0;
 }
 
-// 0x4C32EC wmMouseBkProc_
+// 0x4C32EC wmMouseBkProc
 static void wmMouseBkProc()
 {
     // 0x51DEB0
@@ -5052,7 +5052,7 @@ static void wmMouseBkProc()
 
 // NOTE: Inlined.
 //
-// 0x4C340C wmMarkSubTileOffsetVisited_
+// 0x4C340C wmMarkSubTileOffsetVisited
 static int wmMarkSubTileOffsetVisited(int tile, int subtileX, int subtileY, int offsetX, int offsetY)
 {
     return wmMarkSubTileOffsetVisitedFunc(tile, subtileX, subtileY, offsetX, offsetY, SUBTILE_STATE_VISITED);
@@ -5060,13 +5060,13 @@ static int wmMarkSubTileOffsetVisited(int tile, int subtileX, int subtileY, int 
 
 // NOTE: Inlined.
 //
-// 0x4C3420 wmMarkSubTileOffsetKnown_
+// 0x4C3420 wmMarkSubTileOffsetKnown
 static int wmMarkSubTileOffsetKnown(int tile, int subtileX, int subtileY, int offsetX, int offsetY)
 {
     return wmMarkSubTileOffsetVisitedFunc(tile, subtileX, subtileY, offsetX, offsetY, SUBTILE_STATE_KNOWN);
 }
 
-// 0x4C3434 wmMarkSubTileOffsetVisitedFunc_
+// 0x4C3434 wmMarkSubTileOffsetVisitedFunc
 static int wmMarkSubTileOffsetVisitedFunc(int tile, int subtileX, int subtileY, int offsetX, int offsetY, int subtileState)
 {
     int actualTile;
@@ -5124,7 +5124,7 @@ static int wmMarkSubTileOffsetVisitedFunc(int tile, int subtileX, int subtileY, 
     return 0;
 }
 
-// 0x4C3550 wmMarkSubTileRadiusVisited_
+// 0x4C3550 wmMarkSubTileRadiusVisited
 static void wmMarkSubTileRadiusVisited(int x, int y)
 {
     int radius = 1;
@@ -5136,7 +5136,7 @@ static void wmMarkSubTileRadiusVisited(int x, int y)
     wmSubTileMarkRadiusVisited(x, y, radius);
 }
 
-// 0x4C35A8 wmSubTileMarkRadiusVisited_
+// 0x4C35A8 wmSubTileMarkRadiusVisited
 int wmSubTileMarkRadiusVisited(int x, int y, int radius)
 {
     int tile;
@@ -5185,7 +5185,7 @@ int wmSubTileMarkRadiusVisited(int x, int y, int radius)
     return 0;
 }
 
-// 0x4C3740 wmSubTileGetVisitedState_
+// 0x4C3740 wmSubTileGetVisitedState
 int wmSubTileGetVisitedState(int x, int y, int* statePtr)
 {
     TileInfo* tile;
@@ -5200,7 +5200,7 @@ int wmSubTileGetVisitedState(int x, int y, int* statePtr)
 
 // Load tile art if needed.
 //
-// 0x4C37EC wmTileGrabArt_
+// 0x4C37EC wmTileGrabArt
 static int wmTileGrabArt(int tileIdx)
 {
     TileInfo* tile = &(wmTileInfoList[tileIdx]);
@@ -5218,7 +5218,7 @@ static int wmTileGrabArt(int tileIdx)
     return -1;
 }
 
-// 0x4C3830 wmInterfaceRefresh_
+// 0x4C3830 wmInterfaceRefresh
 static int wmInterfaceRefresh()
 {
     if (wmInterfaceWasInitialized != 1) {
@@ -5368,7 +5368,7 @@ static int wmInterfaceRefresh()
     return 0;
 }
 
-// 0x4C3C9C wmInterfaceRefreshDate_
+// 0x4C3C9C wmInterfaceRefreshDate
 static void wmInterfaceRefreshDate(bool shouldRefreshWindow)
 {
     int month;
@@ -5417,7 +5417,7 @@ static void wmInterfaceRefreshDate(bool shouldRefreshWindow)
     }
 }
 
-// 0x4C3F00 wmMatchWorldPosToArea_
+// 0x4C3F00 wmMatchWorldPosToArea
 static int wmMatchWorldPosToArea(int x, int y, int* areaIdxPtr)
 {
     int v3 = y + WM_VIEW_Y;
@@ -5589,7 +5589,7 @@ static int wmInterfaceDrawCircleOverlaySafe(CityInfo* city, CitySizeDescription*
     return 0;
 }
 
-// 0x4C3FA8 wmInterfaceDrawCircleOverlay_
+// 0x4C3FA8 wmInterfaceDrawCircleOverlay
 static int wmInterfaceDrawCircleOverlay(CityInfo* city, CitySizeDescription* citySizeDescription, unsigned char* dest, int x, int y)
 {
     _dark_translucent_trans_buf_to_buf(citySizeDescription->frmImage.getData(),
@@ -5631,7 +5631,7 @@ static int wmInterfaceDrawCircleOverlay(CityInfo* city, CitySizeDescription* cit
 // Helper function that dims specified rectangle in given buffer. It's used to
 // slightly darken subtile which is known, but not visited.
 //
-// 0x4C40A8 wmInterfaceDrawSubTileRectFogged_
+// 0x4C40A8 wmInterfaceDrawSubTileRectFogged
 static void wmInterfaceDrawSubTileRectFogged(unsigned char* dest, int width, int height, int pitch)
 {
     int skipY = pitch - width;
@@ -5645,7 +5645,7 @@ static void wmInterfaceDrawSubTileRectFogged(unsigned char* dest, int width, int
     }
 }
 
-// 0x4C40E4 wmInterfaceDrawSubTileList_
+// 0x4C40E4 wmInterfaceDrawSubTileList
 static int wmInterfaceDrawSubTileList(TileInfo* tileInfo, int column, int row, int x, int y, int a6)
 {
     SubtileInfo* subtileInfo = &(tileInfo->subtiles[row][column]);
@@ -5692,7 +5692,7 @@ static int wmInterfaceDrawSubTileList(TileInfo* tileInfo, int column, int row, i
     return 0;
 }
 
-// 0x4C41EC wmDrawCursorStopped_
+// 0x4C41EC wmDrawCursorStopped
 static int wmDrawCursorStopped()
 {
     unsigned char* src;
@@ -5819,7 +5819,7 @@ static int wmDrawCursorStopped()
     return 0;
 }
 
-// 0x4C4490 wmCursorIsVisible_
+// 0x4C4490 wmCursorIsVisible
 static bool wmCursorIsVisible()
 {
     return wmGenData.worldPosX >= wmWorldOffsetX
@@ -5830,7 +5830,7 @@ static bool wmCursorIsVisible()
 
 // NOTE: Inlined.
 //
-// 0x4C44D8 wmGetAreaName_
+// 0x4C44D8 wmGetAreaName
 static int wmGetAreaName(CityInfo* city, char* name)
 {
     MessageListItem messageListItem;
@@ -5843,7 +5843,7 @@ static int wmGetAreaName(CityInfo* city, char* name)
 
 // Copy city short name.
 //
-// 0x4C450C wmGetAreaIdxName_
+// 0x4C450C wmGetAreaIdxName
 int wmGetAreaIdxName(int areaIdx, char* name)
 {
     MessageListItem messageListItem;
@@ -5856,7 +5856,7 @@ int wmGetAreaIdxName(int areaIdx, char* name)
 
 // Returns true if world area is known.
 //
-// 0x4C453C wmAreaIsKnown_
+// 0x4C453C wmAreaIsKnown
 bool wmAreaIsKnown(int areaIdx)
 {
     if (!cityIsValid(areaIdx)) {
@@ -5873,7 +5873,7 @@ bool wmAreaIsKnown(int areaIdx)
     return false;
 }
 
-// 0x4C457C wmAreaVisitedState_
+// 0x4C457C wmAreaVisitedState
 int wmAreaVisitedState(int areaIdx)
 {
     if (!cityIsValid(areaIdx)) {
@@ -5888,7 +5888,7 @@ int wmAreaVisitedState(int areaIdx)
     return 0;
 }
 
-// 0x4C45BC wmMapIsKnown_
+// 0x4C45BC wmMapIsKnown
 bool wmMapIsKnown(int mapIdx)
 {
     int areaIdx;
@@ -5911,13 +5911,13 @@ bool wmMapIsKnown(int mapIdx)
     return true;
 }
 
-// 0x4C4624 wmAreaMarkVisited_
+// 0x4C4624 wmAreaMarkVisited
 int wmAreaMarkVisited(int areaIdx)
 {
     return wmAreaMarkVisitedState(areaIdx, CITY_STATE_VISITED);
 }
 
-// 0x4C4634 wmAreaMarkVisitedState_
+// 0x4C4634 wmAreaMarkVisitedState
 bool wmAreaMarkVisitedState(int areaIdx, int state)
 {
     if (!cityIsValid(areaIdx)) {
@@ -5946,7 +5946,7 @@ bool wmAreaMarkVisitedState(int areaIdx, int state)
     return true;
 }
 
-// 0x4C46CC wmAreaSetVisibleState_
+// 0x4C46CC wmAreaSetVisibleState
 bool wmAreaSetVisibleState(int areaIdx, int state, bool force)
 {
     if (!cityIsValid(areaIdx)) {
@@ -5962,7 +5962,7 @@ bool wmAreaSetVisibleState(int areaIdx, int state, bool force)
     return false;
 }
 
-// 0x4C4710 wmAreaSetWorldPos_
+// 0x4C4710 wmAreaSetWorldPos
 int wmAreaSetWorldPos(int areaIdx, int x, int y)
 {
     if (!cityIsValid(areaIdx)) {
@@ -5986,7 +5986,7 @@ int wmAreaSetWorldPos(int areaIdx, int x, int y)
 
 // Returns current town x/y.
 //
-// 0x4C47A4 wmGetPartyWorldPos_
+// 0x4C47A4 wmGetPartyWorldPos
 int wmGetPartyWorldPos(int* xPtr, int* yPtr)
 {
     if (xPtr != nullptr) {
@@ -6002,7 +6002,7 @@ int wmGetPartyWorldPos(int* xPtr, int* yPtr)
 
 // Returns current town.
 //
-// 0x4C47C0 wmGetPartyCurArea_
+// 0x4C47C0 wmGetPartyCurArea
 int wmGetPartyCurArea(int* areaIdxPtr)
 {
     if (areaIdxPtr != nullptr) {
@@ -6013,7 +6013,7 @@ int wmGetPartyCurArea(int* areaIdxPtr)
     return -1;
 }
 
-// 0x4C47D8 wmMarkAllSubTiles_
+// 0x4C47D8 wmMarkAllSubTiles
 static void wmMarkAllSubTiles(int state)
 {
     for (int tileIndex = 0; tileIndex < wmMaxTileNum; tileIndex++) {
@@ -6027,13 +6027,13 @@ static void wmMarkAllSubTiles(int state)
     }
 }
 
-// 0x4C4850 wmTownMap_
+// 0x4C4850 wmTownMap
 void wmTownMap()
 {
     wmWorldMapFunc(1);
 }
 
-// 0x4C485C wmTownMapFunc_
+// 0x4C485C wmTownMapFunc
 static int wmTownMapFunc(int* mapIdxPtr)
 {
     *mapIdxPtr = -1;
@@ -6138,7 +6138,7 @@ static int wmTownMapFunc(int* mapIdxPtr)
     return 0;
 }
 
-// 0x4C4A6C wmTownMapInit_
+// 0x4C4A6C wmTownMapInit
 static int wmTownMapInit()
 {
     wmTownMapCurArea = wmGenData.currentAreaId;
@@ -6191,7 +6191,7 @@ static int wmTownMapInit()
     return 0;
 }
 
-// 0x4C4BD0 wmTownMapRefresh_
+// 0x4C4BD0 wmTownMapRefresh
 static int wmTownMapRefresh()
 {
     blitBufferToBuffer(_townFrmImage.getData(),
@@ -6236,7 +6236,7 @@ static int wmTownMapRefresh()
     return 0;
 }
 
-// 0x4C4D00 wmTownMapExit_
+// 0x4C4D00 wmTownMapExit
 static int wmTownMapExit()
 {
     _townFrmImage.unlock();
@@ -6260,7 +6260,7 @@ static int wmTownMapExit()
     return 0;
 }
 
-// 0x4C4DA4 wmCarUseGas_
+// 0x4C4DA4 wmCarUseGas
 int wmCarUseGas(int amount)
 {
     if (gameGetGlobalVar(GVAR_NEW_RENO_SUPER_CAR) != 0) {
@@ -6286,7 +6286,7 @@ int wmCarUseGas(int amount)
 
 // Returns amount of fuel that does not fit into tank.
 //
-// 0x4C4E34 wmCarFillGas_
+// 0x4C4E34 wmCarFillGas
 int wmCarFillGas(int amount)
 {
     if ((amount + wmGenData.carFuel) <= CAR_FUEL_MAX) {
@@ -6301,25 +6301,25 @@ int wmCarFillGas(int amount)
     return remaining;
 }
 
-// 0x4C4E74 wmCarGasAmount_
+// 0x4C4E74 wmCarGasAmount
 int wmCarGasAmount()
 {
     return wmGenData.carFuel;
 }
 
-// 0x4C4E7C wmCarIsOutOfGas_
+// 0x4C4E7C wmCarIsOutOfGas
 bool wmCarIsOutOfGas()
 {
     return wmGenData.carFuel <= 0;
 }
 
-// 0x4C4E8C wmCarCurrentArea_
+// 0x4C4E8C wmCarCurrentArea
 int wmCarCurrentArea()
 {
     return wmGenData.currentCarAreaId;
 }
 
-// 0x4C4E94 wmCarGiveToParty_
+// 0x4C4E94 wmCarGiveToParty
 int wmCarGiveToParty()
 {
     MessageListItem messageListItem;
@@ -6347,7 +6347,7 @@ int wmCarGiveToParty()
     return 0;
 }
 
-// 0x4C4F28 wmSfxMaxCount_
+// 0x4C4F28 wmSfxMaxCount
 int wmSfxMaxCount()
 {
     int mapIdx = mapGetCurrentMap();
@@ -6359,7 +6359,7 @@ int wmSfxMaxCount()
     return map->ambientSoundEffectsLength;
 }
 
-// 0x4C4F5C wmSfxRollNextIdx_
+// 0x4C4F5C wmSfxRollNextIdx
 int wmSfxRollNextIdx()
 {
     int mapIdx = mapGetCurrentMap();
@@ -6389,7 +6389,7 @@ int wmSfxRollNextIdx()
     return -1;
 }
 
-// 0x4C5004 wmSfxIdxName_
+// 0x4C5004 wmSfxIdxName
 int wmSfxIdxName(int sfxIdx, char** namePtr)
 {
     if (namePtr == nullptr) {
@@ -6439,7 +6439,7 @@ int wmSfxIdxName(int sfxIdx, char** namePtr)
     return 0;
 }
 
-// 0x4C50F4 wmRefreshInterfaceOverlay_
+// 0x4C50F4 wmRefreshInterfaceOverlay
 static int wmRefreshInterfaceOverlay(bool shouldRefreshWindow)
 {
     blitBufferToBufferTrans(_backgroundFrmImage.getData(),
@@ -6495,7 +6495,7 @@ static int wmRefreshInterfaceOverlay(bool shouldRefreshWindow)
     return 0;
 }
 
-// 0x4C5244 wmInterfaceRefreshCarFuel_
+// 0x4C5244 wmInterfaceRefreshCarFuel
 static void wmInterfaceRefreshCarFuel()
 {
     int ratio = (WM_WINDOW_CAR_FUEL_BAR_HEIGHT * wmGenData.carFuel) / CAR_FUEL_MAX;
@@ -6521,7 +6521,7 @@ static void wmInterfaceRefreshCarFuel()
     }
 }
 
-// 0x4C52B0 wmRefreshTabs_
+// 0x4C52B0 wmRefreshTabs
 static int wmRefreshTabs()
 {
     unsigned char* firstTabBottomDest;
@@ -6630,7 +6630,7 @@ static int wmRefreshTabs()
 
 // Creates array of cities available as quick destinations.
 //
-// 0x4C55D4 wmMakeTabsLabelList_
+// 0x4C55D4 wmMakeTabsLabelList
 static int wmMakeTabsLabelList(int** quickDestinationsPtr, int* quickDestinationsLengthPtr)
 {
     int* quickDestinations = *quickDestinationsPtr;
@@ -6673,7 +6673,7 @@ static int wmMakeTabsLabelList(int** quickDestinationsPtr, int* quickDestination
     return 0;
 }
 
-// 0x4C56C8 wmTabsCompareNames_
+// 0x4C56C8 wmTabsCompareNames
 static int wmTabsCompareNames(const void* a1, const void* a2)
 {
     int index1 = *(int*)a1;
@@ -6687,7 +6687,7 @@ static int wmTabsCompareNames(const void* a1, const void* a2)
 
 // NOTE: Inlined.
 //
-// 0x4C5710 wmFreeTabsLabelList_
+// 0x4C5710 wmFreeTabsLabelList
 static int wmFreeTabsLabelList(int** quickDestinationsListPtr, int* quickDestinationsLengthPtr)
 {
     if (*quickDestinationsListPtr != nullptr) {
@@ -6700,7 +6700,7 @@ static int wmFreeTabsLabelList(int** quickDestinationsListPtr, int* quickDestina
     return 0;
 }
 
-// 0x4C5734 wmRefreshInterfaceDial_
+// 0x4C5734 wmRefreshInterfaceDial
 static void wmRefreshInterfaceDial(bool shouldRefreshWindow)
 {
     unsigned char* data = artGetFrameData(wmGenData.dialFrm, wmGenData.dialFrmCurrentFrameIndex, 0);
@@ -6723,7 +6723,7 @@ static void wmRefreshInterfaceDial(bool shouldRefreshWindow)
 
 // NOTE: Inlined.
 //
-// 0x4C57BC wmInterfaceDialSyncTime_
+// 0x4C57BC wmInterfaceDialSyncTime
 static void wmInterfaceDialSyncTime(bool shouldRefreshWindow)
 {
     int gameHour;
@@ -6737,7 +6737,7 @@ static void wmInterfaceDialSyncTime(bool shouldRefreshWindow)
     }
 }
 
-// 0x4C5804 wmAreaFindFirstValidMap_
+// 0x4C5804 wmAreaFindFirstValidMap
 static int wmAreaFindFirstValidMap(int* mapIdxPtr)
 {
     *mapIdxPtr = -1;
@@ -6766,7 +6766,7 @@ static int wmAreaFindFirstValidMap(int* mapIdxPtr)
     return 0;
 }
 
-// 0x4C58C0 wmMapMusicStart_
+// 0x4C58C0 wmMapMusicStart
 int wmMapMusicStart()
 {
     do {
@@ -6792,7 +6792,7 @@ int wmMapMusicStart()
     return -1;
 }
 
-// 0x4C5928 wmSetMapMusic_
+// 0x4C5928 wmSetMapMusic
 int wmSetMapMusic(int mapIdx, const char* name)
 {
     if (mapIdx == -1 || mapIdx >= wmMaxMapNum) {
@@ -6818,7 +6818,7 @@ int wmSetMapMusic(int mapIdx, const char* name)
     return 0;
 }
 
-// 0x4C59A4 wmMatchAreaContainingMapIdx_
+// 0x4C59A4 wmMatchAreaContainingMapIdx
 int wmMatchAreaContainingMapIdx(int mapIdx, int* areaIdxPtr)
 {
     *areaIdxPtr = 0;
@@ -6837,7 +6837,7 @@ int wmMatchAreaContainingMapIdx(int mapIdx, int* areaIdxPtr)
     return -1;
 }
 
-// 0x4C5A1C wmTeleportToArea_
+// 0x4C5A1C wmTeleportToArea
 int wmTeleportToArea(int areaIdx)
 {
     if (!cityIsValid(areaIdx)) {

--- a/src/xfile.cc
+++ b/src/xfile.cc
@@ -41,7 +41,7 @@ static XBase* gXbaseHead;
 // 0x6B24D4
 static bool gXbaseExitHandlerRegistered;
 
-// 0x4DED6C
+// 0x4DED6C xfclose_
 int xfileClose(XFile* stream)
 {
     assert(stream); // "stream", "xfile.c", 112
@@ -67,7 +67,7 @@ int xfileClose(XFile* stream)
     return rc;
 }
 
-// 0x4DEE2C
+// 0x4DEE2C xfopen_
 XFile* xfileOpen(const char* filePath, const char* mode)
 {
     assert(filePath); // "filename", "xfile.c", 162
@@ -158,7 +158,7 @@ XFile* xfileOpen(const char* filePath, const char* mode)
     return stream;
 }
 
-// 0x4DF11C
+// 0x4DF11C xfprintf_
 int xfilePrintFormatted(XFile* stream, const char* format, ...)
 {
     assert(format); // "format", "xfile.c", 305
@@ -175,7 +175,7 @@ int xfilePrintFormatted(XFile* stream, const char* format, ...)
 
 // [vfprintf].
 //
-// 0x4DF1AC
+// 0x4DF1AC xvfprintf_
 int xfilePrintFormattedArgs(XFile* stream, const char* format, va_list args)
 {
     assert(stream); // "stream", "xfile.c", 332
@@ -198,7 +198,7 @@ int xfilePrintFormattedArgs(XFile* stream, const char* format, va_list args)
     return rc;
 }
 
-// 0x4DF22C
+// 0x4DF22C xfgetc_
 int xfileReadChar(XFile* stream)
 {
     assert(stream); // "stream", "xfile.c", 354
@@ -220,7 +220,7 @@ int xfileReadChar(XFile* stream)
     return ch;
 }
 
-// 0x4DF280
+// 0x4DF280 xfgets_
 char* xfileReadString(char* string, int size, XFile* stream)
 {
     assert(string); // "s", "xfile.c", 375
@@ -244,7 +244,7 @@ char* xfileReadString(char* string, int size, XFile* stream)
     return result;
 }
 
-// 0x4DF320
+// 0x4DF320 xfputc_
 int xfileWriteChar(int ch, XFile* stream)
 {
     assert(stream); // "stream", "xfile.c", 399
@@ -266,7 +266,7 @@ int xfileWriteChar(int ch, XFile* stream)
     return rc;
 }
 
-// 0x4DF380
+// 0x4DF380 xfputs_
 int xfileWriteString(const char* string, XFile* stream)
 {
     assert(string); // "s", "xfile.c", 421
@@ -289,7 +289,7 @@ int xfileWriteString(const char* string, XFile* stream)
     return rc;
 }
 
-// 0x4DF44C
+// 0x4DF44C xfread_
 size_t xfileRead(void* ptr, size_t size, size_t count, XFile* stream)
 {
     assert(ptr); // "ptr", "xfile.c", 421
@@ -317,7 +317,7 @@ size_t xfileRead(void* ptr, size_t size, size_t count, XFile* stream)
     return elementsRead;
 }
 
-// 0x4DF4E8
+// 0x4DF4E8 xfwrite_
 size_t xfileWrite(const void* ptr, size_t size, size_t count, XFile* stream)
 {
     assert(ptr); // "ptr", "xfile.c", 504
@@ -345,7 +345,7 @@ size_t xfileWrite(const void* ptr, size_t size, size_t count, XFile* stream)
     return elementsWritten;
 }
 
-// 0x4DF5D8
+// 0x4DF5D8 xfseek_
 int xfileSeek(XFile* stream, long offset, int origin)
 {
     assert(stream); // "stream", "xfile.c", 547
@@ -367,7 +367,7 @@ int xfileSeek(XFile* stream, long offset, int origin)
     return result;
 }
 
-// 0x4DF690
+// 0x4DF690 xftell_
 long xfileTell(XFile* stream)
 {
     assert(stream); // "stream", "xfile.c", 588
@@ -389,7 +389,7 @@ long xfileTell(XFile* stream)
     return pos;
 }
 
-// 0x4DF6E4
+// 0x4DF6E4 xrewind_
 void xfileRewind(XFile* stream)
 {
     assert(stream); // "stream", "xfile.c", 608
@@ -407,7 +407,7 @@ void xfileRewind(XFile* stream)
     }
 }
 
-// 0x4DF780
+// 0x4DF780 xfeof_
 int xfileEof(XFile* stream)
 {
     assert(stream); // "stream", "xfile.c", 648
@@ -429,7 +429,7 @@ int xfileEof(XFile* stream)
     return rc;
 }
 
-// 0x4DF828
+// 0x4DF828 xfilelength_
 long xfileGetSize(XFile* stream)
 {
     assert(stream); // "stream", "xfile.c", 690
@@ -456,7 +456,7 @@ long xfileGetSize(XFile* stream)
 // [paths] is a set of paths separated by semicolon. Can be NULL, in this case
 // all open xbases are simply closed.
 //
-// 0x4DF878
+// 0x4DF878 xsetpath_
 bool xbaseReopenAll(char* paths)
 {
     // NOTE: Uninline.
@@ -475,7 +475,7 @@ bool xbaseReopenAll(char* paths)
     return true;
 }
 
-// 0x4DF938
+// 0x4DF938 xaddpath_
 bool xbaseOpen(const char* path)
 {
     assert(path); // "path", "xfile.c", 747
@@ -550,7 +550,7 @@ bool xbaseOpen(const char* path)
     return false; // return false to trigger messages on game load
 }
 
-// 0x4DFB3C
+// 0x4DFB3C xenumfiles_
 static bool xlistEnumerate(const char* pattern, XListEnumerationHandler* handler, XList* xlist)
 {
     assert(pattern); // "filespec", "xfile.c", 845
@@ -670,14 +670,14 @@ static bool xlistEnumerate(const char* pattern, XListEnumerationHandler* handler
     return findFindClose(&directoryFileFindData);
 }
 
-// 0x4DFF28
+// 0x4DFF28 xbuild_filelist_
 bool xlistInit(const char* pattern, XList* xlist)
 {
     xlistEnumerate(pattern, xlistEnumerateHandler, xlist);
     return xlist->fileNamesLength != -1;
 }
 
-// 0x4DFF48
+// 0x4DFF48 xfree_filelist_
 void xlistFree(XList* xlist)
 {
     assert(xlist); // "list", "xfile.c", 949
@@ -695,7 +695,7 @@ void xlistFree(XList* xlist)
 
 // Recursively creates specified file path.
 //
-// 0x4DFFAC
+// 0x4DFFAC xmkdir_
 static int xbaseMakeDirectory(const char* filePath)
 {
     char workingDirectory[COMPAT_MAX_PATH];
@@ -766,7 +766,7 @@ static int xbaseMakeDirectory(const char* filePath)
 //
 // NOTE: Inlined.
 //
-// 0x4E01F8
+// 0x4E01F8 xclearpath_
 static void xbaseCloseAll()
 {
     XBase* curr = gXbaseHead;
@@ -793,7 +793,7 @@ static void xbaseExitHandler(void)
     xbaseCloseAll();
 }
 
-// 0x4E0278
+// 0x4E0278 xlistenumfunc_
 static bool xlistEnumerateHandler(XListEnumerationContext* context)
 {
     if (context->type == XFILE_ENUMERATION_ENTRY_TYPE_DIRECTORY) {

--- a/src/xfile.cc
+++ b/src/xfile.cc
@@ -35,7 +35,7 @@ static void xbaseCloseAll();
 static void xbaseExitHandler(void);
 static bool xlistEnumerateHandler(XListEnumerationContext* context);
 
-// 0x6B24D0 _paths
+// 0x6B24D0 paths
 static XBase* gXbaseHead;
 
 // 0x6B24D4 init

--- a/src/xfile.cc
+++ b/src/xfile.cc
@@ -35,13 +35,13 @@ static void xbaseCloseAll();
 static void xbaseExitHandler(void);
 static bool xlistEnumerateHandler(XListEnumerationContext* context);
 
-// 0x6B24D0
+// 0x6B24D0 _paths
 static XBase* gXbaseHead;
 
-// 0x6B24D4
+// 0x6B24D4 init
 static bool gXbaseExitHandlerRegistered;
 
-// 0x4DED6C xfclose_
+// 0x4DED6C xfclose
 int xfileClose(XFile* stream)
 {
     assert(stream); // "stream", "xfile.c", 112
@@ -67,7 +67,7 @@ int xfileClose(XFile* stream)
     return rc;
 }
 
-// 0x4DEE2C xfopen_
+// 0x4DEE2C xfopen
 XFile* xfileOpen(const char* filePath, const char* mode)
 {
     assert(filePath); // "filename", "xfile.c", 162
@@ -158,7 +158,7 @@ XFile* xfileOpen(const char* filePath, const char* mode)
     return stream;
 }
 
-// 0x4DF11C xfprintf_
+// 0x4DF11C xfprintf
 int xfilePrintFormatted(XFile* stream, const char* format, ...)
 {
     assert(format); // "format", "xfile.c", 305
@@ -175,7 +175,7 @@ int xfilePrintFormatted(XFile* stream, const char* format, ...)
 
 // [vfprintf].
 //
-// 0x4DF1AC xvfprintf_
+// 0x4DF1AC xvfprintf
 int xfilePrintFormattedArgs(XFile* stream, const char* format, va_list args)
 {
     assert(stream); // "stream", "xfile.c", 332
@@ -198,7 +198,7 @@ int xfilePrintFormattedArgs(XFile* stream, const char* format, va_list args)
     return rc;
 }
 
-// 0x4DF22C xfgetc_
+// 0x4DF22C xfgetc
 int xfileReadChar(XFile* stream)
 {
     assert(stream); // "stream", "xfile.c", 354
@@ -220,7 +220,7 @@ int xfileReadChar(XFile* stream)
     return ch;
 }
 
-// 0x4DF280 xfgets_
+// 0x4DF280 xfgets
 char* xfileReadString(char* string, int size, XFile* stream)
 {
     assert(string); // "s", "xfile.c", 375
@@ -244,7 +244,7 @@ char* xfileReadString(char* string, int size, XFile* stream)
     return result;
 }
 
-// 0x4DF320 xfputc_
+// 0x4DF320 xfputc
 int xfileWriteChar(int ch, XFile* stream)
 {
     assert(stream); // "stream", "xfile.c", 399
@@ -266,7 +266,7 @@ int xfileWriteChar(int ch, XFile* stream)
     return rc;
 }
 
-// 0x4DF380 xfputs_
+// 0x4DF380 xfputs
 int xfileWriteString(const char* string, XFile* stream)
 {
     assert(string); // "s", "xfile.c", 421
@@ -289,7 +289,7 @@ int xfileWriteString(const char* string, XFile* stream)
     return rc;
 }
 
-// 0x4DF44C xfread_
+// 0x4DF44C xfread
 size_t xfileRead(void* ptr, size_t size, size_t count, XFile* stream)
 {
     assert(ptr); // "ptr", "xfile.c", 421
@@ -317,7 +317,7 @@ size_t xfileRead(void* ptr, size_t size, size_t count, XFile* stream)
     return elementsRead;
 }
 
-// 0x4DF4E8 xfwrite_
+// 0x4DF4E8 xfwrite
 size_t xfileWrite(const void* ptr, size_t size, size_t count, XFile* stream)
 {
     assert(ptr); // "ptr", "xfile.c", 504
@@ -345,7 +345,7 @@ size_t xfileWrite(const void* ptr, size_t size, size_t count, XFile* stream)
     return elementsWritten;
 }
 
-// 0x4DF5D8 xfseek_
+// 0x4DF5D8 xfseek
 int xfileSeek(XFile* stream, long offset, int origin)
 {
     assert(stream); // "stream", "xfile.c", 547
@@ -367,7 +367,7 @@ int xfileSeek(XFile* stream, long offset, int origin)
     return result;
 }
 
-// 0x4DF690 xftell_
+// 0x4DF690 xftell
 long xfileTell(XFile* stream)
 {
     assert(stream); // "stream", "xfile.c", 588
@@ -389,7 +389,7 @@ long xfileTell(XFile* stream)
     return pos;
 }
 
-// 0x4DF6E4 xrewind_
+// 0x4DF6E4 xrewind
 void xfileRewind(XFile* stream)
 {
     assert(stream); // "stream", "xfile.c", 608
@@ -407,7 +407,7 @@ void xfileRewind(XFile* stream)
     }
 }
 
-// 0x4DF780 xfeof_
+// 0x4DF780 xfeof
 int xfileEof(XFile* stream)
 {
     assert(stream); // "stream", "xfile.c", 648
@@ -429,7 +429,7 @@ int xfileEof(XFile* stream)
     return rc;
 }
 
-// 0x4DF828 xfilelength_
+// 0x4DF828 xfilelength
 long xfileGetSize(XFile* stream)
 {
     assert(stream); // "stream", "xfile.c", 690
@@ -456,7 +456,7 @@ long xfileGetSize(XFile* stream)
 // [paths] is a set of paths separated by semicolon. Can be NULL, in this case
 // all open xbases are simply closed.
 //
-// 0x4DF878 xsetpath_
+// 0x4DF878 xsetpath
 bool xbaseReopenAll(char* paths)
 {
     // NOTE: Uninline.
@@ -475,7 +475,7 @@ bool xbaseReopenAll(char* paths)
     return true;
 }
 
-// 0x4DF938 xaddpath_
+// 0x4DF938 xaddpath
 bool xbaseOpen(const char* path)
 {
     assert(path); // "path", "xfile.c", 747
@@ -550,7 +550,7 @@ bool xbaseOpen(const char* path)
     return false; // return false to trigger messages on game load
 }
 
-// 0x4DFB3C xenumfiles_
+// 0x4DFB3C xenumfiles
 static bool xlistEnumerate(const char* pattern, XListEnumerationHandler* handler, XList* xlist)
 {
     assert(pattern); // "filespec", "xfile.c", 845
@@ -670,14 +670,14 @@ static bool xlistEnumerate(const char* pattern, XListEnumerationHandler* handler
     return findFindClose(&directoryFileFindData);
 }
 
-// 0x4DFF28 xbuild_filelist_
+// 0x4DFF28 xbuild_filelist
 bool xlistInit(const char* pattern, XList* xlist)
 {
     xlistEnumerate(pattern, xlistEnumerateHandler, xlist);
     return xlist->fileNamesLength != -1;
 }
 
-// 0x4DFF48 xfree_filelist_
+// 0x4DFF48 xfree_filelist
 void xlistFree(XList* xlist)
 {
     assert(xlist); // "list", "xfile.c", 949
@@ -695,7 +695,7 @@ void xlistFree(XList* xlist)
 
 // Recursively creates specified file path.
 //
-// 0x4DFFAC xmkdir_
+// 0x4DFFAC xmkdir
 static int xbaseMakeDirectory(const char* filePath)
 {
     char workingDirectory[COMPAT_MAX_PATH];
@@ -766,7 +766,7 @@ static int xbaseMakeDirectory(const char* filePath)
 //
 // NOTE: Inlined.
 //
-// 0x4E01F8 xclearpath_
+// 0x4E01F8 xclearpath
 static void xbaseCloseAll()
 {
     XBase* curr = gXbaseHead;
@@ -793,7 +793,7 @@ static void xbaseExitHandler(void)
     xbaseCloseAll();
 }
 
-// 0x4E0278 xlistenumfunc_
+// 0x4E0278 xlistenumfunc
 static bool xlistEnumerateHandler(XListEnumerationContext* context)
 {
     if (context->type == XFILE_ENUMERATION_ENTRY_TYPE_DIRECTORY) {


### PR DESCRIPTION
e.g.

```
// 0x414E98 register_object_call_
int animationRegisterCallback(

// 0x414E20 register_object_must_erase_
int animationRegisterHideObjectForced(
```

This was programmatically generated so there could be errors.  Spot checking looks pretty good though.

I find seeing the original symbols helpful when cross-referencing against Sfall.
     