### PR TITLE
Fix parameter order in metarules set_flags and set_outline.

### DIFF
--- a/src/sfall_metarules.cc
+++ b/src/sfall_metarules.cc
@@ -674,6 +674,9 @@ void mf_message_box(Program* program, int args)
 
     const char* string = programStackPopString(program);
     if (string == nullptr || string[0] == '\0') {
+        for (int index = 1; index < args; index++) {
+            (void)programStackPopInteger(program);
+        }
         programStackPushInteger(program, -1);
         return;
     }


### PR DESCRIPTION
Also fix missing return val in message_box error path

Found testing sfall `gl_highlighting` mod