### PR TITLE
Bump versions for v1.4.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,8 +373,8 @@ if(APPLE)
     endif()
 
     set(MACOSX_BUNDLE_GUI_IDENTIFIER "com.alexbatalov.fallout2-ce")
-    set(MACOSX_BUNDLE_SHORT_VERSION_STRING "1.3.0")
-    set(MACOSX_BUNDLE_BUNDLE_VERSION "1.3.0")
+    set(MACOSX_BUNDLE_SHORT_VERSION_STRING "1.4.0")
+    set(MACOSX_BUNDLE_BUNDLE_VERSION "1.4.0")
 endif()
 
 if((NOT ${CMAKE_SYSTEM_NAME} MATCHES "Emscripten"))

--- a/os/android/app/build.gradle
+++ b/os/android/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId 'com.alexbatalov.fallout2ce'
         minSdk 21
         targetSdk 32
-        versionCode 4
-        versionName '1.3.0'
+        versionCode 5
+        versionName '1.4.0'
         externalNativeBuild {
             cmake {
                 arguments '-DANDROID_STL=c++_static'

--- a/os/android/app/src/main/AndroidManifest.xml
+++ b/os/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.alexbatalov.fallout2ce"
-    android:versionCode="1"
-    android:versionName="1.0.0"
+    android:versionCode="5"
+    android:versionName="1.4.0"
     android:installLocation="auto">
 
     <!-- OpenGL ES 2.0 -->


### PR DESCRIPTION
I'd like to create a release before we start removing compatibility with old config files.  Step 1 is to bump these version (though they might not really matter since the apps are side loaded, not directly upgraded)