### PR TITLE
Fix crash when global scripts repeat after erroring

### DIFF
--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -2657,8 +2657,9 @@ void programInterpret(Program* program, int numInstructions)
     gInterpreterCurrentProgram = program;
 
     if (setjmp(program->env)) {
+        // longjmp from programFatalError()
         gInterpreterCurrentProgram = oldCurrentProgram;
-        program->flags |= PROGRAM_FLAG_EXITED | PROGRAM_FLAG_0x04;
+        program->flags |= PROGRAM_FLAG_EXITED | PROGRAM_FLAG_FATAL_ERROR;
         return;
     }
 
@@ -2667,7 +2668,7 @@ void programInterpret(Program* program, int numInstructions)
     }
 
     while ((program->flags & PROGRAM_FLAG_CRITICAL_SECTION) != 0 || --numInstructions != -1) {
-        if ((program->flags & (PROGRAM_FLAG_EXITED | PROGRAM_FLAG_0x04 | PROGRAM_FLAG_STOPPED | PROGRAM_FLAG_CHILD_CALL | PROGRAM_FLAG_FINISHED | PROGRAM_FLAG_CHILD_SPAWN)) != 0) {
+        if ((program->flags & (PROGRAM_FLAG_EXITED | PROGRAM_FLAG_FATAL_ERROR | PROGRAM_FLAG_STOPPED | PROGRAM_FLAG_CHILD_CALL | PROGRAM_FLAG_FINISHED | PROGRAM_FLAG_CHILD_SPAWN)) != 0) {
             break;
         }
 
@@ -2949,7 +2950,7 @@ static void doEvents()
                 programListNode->program->instructionPointer = stackReadInt32(procedurePtr, offsetof(Procedure, conditionOffset));
                 programInterpret(programListNode->program, -1);
 
-                if ((programListNode->program->flags & PROGRAM_FLAG_0x04) == 0) {
+                if ((programListNode->program->flags & PROGRAM_FLAG_FATAL_ERROR) == 0) {
                     data = programStackPopInteger(programListNode->program);
 
                     programListNode->program->flags = oldProgramFlags;

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -104,7 +104,7 @@ typedef enum ProcedureFlags {
 typedef enum ProgramFlags {
     PROGRAM_FLAG_EXITED = 0x01,
     PROGRAM_FLAG_RUNNING = 0x02,
-    PROGRAM_FLAG_0x04 = 0x04,
+    PROGRAM_FLAG_FATAL_ERROR = 0x04,
     PROGRAM_FLAG_STOPPED = 0x08,
 
     // Program is in waiting state with `checkWaitFunc` set.

--- a/src/scripts.cc
+++ b/src/scripts.cc
@@ -1254,7 +1254,7 @@ int scriptExecProc(int sid, int proc)
         return -1;
     }
 
-    if ((program->flags & 0x0124) != 0) {
+    if ((program->flags & (PROGRAM_FLAG_FATAL_ERROR | PROGRAM_FLAG_CHILD_CALL | PROGRAM_FLAG_CHILD_SPAWN)) != 0) {
         return 0;
     }
 

--- a/src/sfall_global_scripts.cc
+++ b/src/sfall_global_scripts.cc
@@ -110,7 +110,7 @@ void sfall_gl_scr_remove_all()
     state->globalScripts.clear();
 }
 
-// Execute proc if it is found and not "busy".  
+// Execute proc if it is found and not "busy".
 static void sfall_gl_scr_execute_proc_if_ready(Program* program, int proc)
 {
     // matches check in scriptExecProc()

--- a/src/sfall_global_scripts.cc
+++ b/src/sfall_global_scripts.cc
@@ -14,6 +14,10 @@
 
 namespace fallout {
 
+static constexpr int kGlobalScriptBusyFlags = PROGRAM_FLAG_FATAL_ERROR
+    | PROGRAM_FLAG_CHILD_CALL
+    | PROGRAM_FLAG_CHILD_SPAWN;
+
 struct GlobalScript {
     Program* program = nullptr;
     int procs[SCRIPT_PROC_COUNT] = { 0 };
@@ -106,13 +110,20 @@ void sfall_gl_scr_remove_all()
     state->globalScripts.clear();
 }
 
+// Execute proc if it is found and not "busy".  
+static void sfall_gl_scr_execute_proc_if_ready(Program* program, int proc)
+{
+    // matches check in scriptExecProc()
+    if (proc != -1 && (program->flags & kGlobalScriptBusyFlags) == 0) {
+        programExecuteProcedure(program, proc);
+    }
+}
+
 void sfall_gl_scr_exec_map_update_scripts(int action)
 {
     for (auto& scr : state->globalScripts) {
         if (scr.mode == 0 || scr.mode == 3) {
-            if (scr.procs[action] != -1) {
-                programExecuteProcedure(scr.program, scr.procs[action]);
-            }
+            sfall_gl_scr_execute_proc_if_ready(scr.program, scr.procs[action]);
         }
     }
 }
@@ -123,7 +134,7 @@ static void sfall_gl_scr_process_simple(int mode1, int mode2)
         if (scr.repeat != 0 && (scr.mode == mode1 || scr.mode == mode2)) {
             scr.count++;
             if (scr.count >= scr.repeat) {
-                programExecuteProcedure(scr.program, scr.procs[SCRIPT_PROC_START]);
+                sfall_gl_scr_execute_proc_if_ready(scr.program, scr.procs[SCRIPT_PROC_START]);
                 scr.count = 0;
             }
         }

--- a/src/sfall_global_scripts.cc
+++ b/src/sfall_global_scripts.cc
@@ -110,13 +110,16 @@ void sfall_gl_scr_remove_all()
     state->globalScripts.clear();
 }
 
-// Execute proc if it is found and not "busy".
-static void sfall_gl_scr_execute_proc_if_ready(Program* program, int proc)
+// Execute proc if it is found and not "busy".  Returns true if proc was executed
+static bool sfall_gl_scr_execute_proc_if_ready(Program* program, int proc)
 {
     // matches check in scriptExecProc()
     if (proc != -1 && (program->flags & kGlobalScriptBusyFlags) == 0) {
         programExecuteProcedure(program, proc);
+        return true;
     }
+
+    return false;
 }
 
 void sfall_gl_scr_exec_map_update_scripts(int action)
@@ -134,8 +137,11 @@ static void sfall_gl_scr_process_simple(int mode1, int mode2)
         if (scr.repeat != 0 && (scr.mode == mode1 || scr.mode == mode2)) {
             scr.count++;
             if (scr.count >= scr.repeat) {
-                sfall_gl_scr_execute_proc_if_ready(scr.program, scr.procs[SCRIPT_PROC_START]);
-                scr.count = 0;
+                if (sfall_gl_scr_execute_proc_if_ready(scr.program, scr.procs[SCRIPT_PROC_START])) {
+                    scr.count = 0;
+                } else {
+                    scr.count = scr.repeat;
+                }
             }
         }
     }


### PR DESCRIPTION
Saw a crash while testing gl_ShowLootWeight.  The issue was that the script uses `repeat(1)`, and we tried to spawn it after it fatal_error'd due to missing opcode.

The fix is to check if the program is "ready", using the same logic as the game does when running scripts.
