### PR TITLE
Fix crash when using op_pickup with global scripts

### DIFF
--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -1569,7 +1569,7 @@ static void opPickup(Program* program)
     int sid = scriptGetSid(program);
 
     Script* script;
-    if (scriptGetScript(sid, &script) == 1) {
+    if (scriptGetScript(sid, &script) == -1) {
         scriptPredefinedError(program, "pickup_obj", SCRIPT_ERROR_CANT_MATCH_PROGRAM_TO_SID);
         return;
     }


### PR DESCRIPTION
1 isn't valid return value here. 0 is success, -1 is failure.  Verified against original assembly and dozens of other examples.

<img width="267" height="267" alt="image" src="https://github.com/user-attachments/assets/aee928ca-6da2-45e9-b6d5-30df2318635c" />

Note: this is erroring because global scripts in CE don't register as Scripts.  This needs to be fixed in the future.


Crash was:
```
  0   Fallout II Community Edition  	       0x104f29e94 fallout::opPickup(fallout::Program*) + 108 (interpreter_extra.cc:1577)
  1   Fallout II Community Edition  	       0x104f3ca9c fallout::programInterpret(fallout::Program*, int) + 764 (interpreter.cc:2713)
  2   Fallout II Community Edition  	       0x104f3d28c fallout::programExecuteProcedure(fallout::Program*, int) + 428 (interpreter.cc:2912)
  3   Fallout II Community Edition  	       0x10500d818 fallout::sfall_gl_scr_execute_proc_if_ready(fallout::Program*, int) + 72 (sfall_global_scripts.cc:118)
  4   Fallout II Community Edition  	       0x10500d950 fallout::sfall_gl_scr_process_simple(int, int) + 224 (sfall_global_scripts.cc:140)
  5   Fallout II Community Edition  	       0x10500d868 fallout::sfall_gl_scr_process_main() + 20 (sfall_global_scripts.cc:158)
  6   Fallout II Community Edition  	       0x104f69908 fallout::mainLoop() + 100 (main.cc:341)
  7   Fallout II Community Edition  	       0x104f695d8 fallout::falloutMain(int, char**) + 944 (main.cc:175)
  8   Fallout II Community Edition  	       0x104fd6438 fallout::main(int, char**) + 128 (win32.cc:70)
  9   Fallout II Community Edition  	       0x104fd647c main + 36 (win32.cc:83)
  10  dyld                          	       0x18ea8ab98 start + 6076
```