### PR TITLE
Fix strange mouse behaviour in windowed mode when scale>=2

### DIFF
--- a/src/dinput.cc
+++ b/src/dinput.cc
@@ -7,6 +7,8 @@ namespace fallout {
 static int gMouseWheelDeltaX = 0;
 static int gMouseWheelDeltaY = 0;
 
+static void mouseDeviceMapWindowToLogicalPosition(int* x, int* y);
+
 // 0x4E0400
 bool directInputInit()
 {
@@ -57,6 +59,9 @@ bool mouseDeviceGetData(MouseData* mouseState)
     Uint32 buttons = screenIsFullscreen()
         ? SDL_GetRelativeMouseState(&(mouseState->x), &(mouseState->y))
         : SDL_GetMouseState(&(mouseState->x), &(mouseState->y));
+    if (!screenIsFullscreen()) {
+        mouseDeviceMapWindowToLogicalPosition(&(mouseState->x), &(mouseState->y));
+    }
     mouseState->buttons[0] = (buttons & SDL_BUTTON(SDL_BUTTON_LEFT)) != 0;
     mouseState->buttons[1] = (buttons & SDL_BUTTON(SDL_BUTTON_RIGHT)) != 0;
     mouseState->wheelX = gMouseWheelDeltaX;
@@ -126,6 +131,23 @@ void handleMouseEvent(SDL_Event* event)
         gMouseWheelDeltaX += event->wheel.x;
         gMouseWheelDeltaY += event->wheel.y;
     }
+}
+
+static void mouseDeviceMapWindowToLogicalPosition(int* x, int* y)
+{
+    if (gSdlWindow == nullptr) {
+        return;
+    }
+
+    int windowWidth;
+    int windowHeight;
+    SDL_GetWindowSize(gSdlWindow, &windowWidth, &windowHeight);
+    if (windowWidth <= 0 || windowHeight <= 0) {
+        return;
+    }
+
+    *x = *x * screenGetWidth() / windowWidth;
+    *y = *y * screenGetHeight() / windowHeight;
 }
 
 } // namespace fallout

--- a/src/dinput.cc
+++ b/src/dinput.cc
@@ -13,7 +13,6 @@ static int mouseWindowMappingLogicalHeight = 0;
 static bool mouseRelativeMode = false;
 
 static void mouseDeviceMapWindowToLogicalPosition(int* x, int* y);
-static void mouseDeviceRefreshWindowMapping();
 
 // 0x4E0400
 bool directInputInit()
@@ -51,16 +50,21 @@ bool mouseDeviceInitMode()
 {
     // "Relative mode" means cursor position is owned by the application, and we move based on mouse deltas
     // "Absolute mode" means cursor position is controlled by the OS, and we read it directly.
-    // Mouse sensitity settings can only apply in relative mode.
+    // Mouse sensitivity settings can only apply in relative mode.
 
     // TODO: add setting for mouse capture (relative mode) in windowed, differentiated from the web version.
-    mouseRelativeMode = screenIsFullscreen();
+    bool wantsRelativeMode = screenIsFullscreen();
 
-    if (mouseRelativeMode) {
+    if (wantsRelativeMode) {
+        mouseRelativeMode = true;
         return SDL_SetRelativeMouseMode(SDL_TRUE) == 0;
     }
 
-    SDL_SetRelativeMouseMode(SDL_FALSE);
+    if (SDL_SetRelativeMouseMode(SDL_FALSE) != 0) {
+        return false;
+    }
+
+    mouseRelativeMode = false;
     mouseDeviceRefreshWindowMapping();
     return true;
 }
@@ -173,10 +177,11 @@ static void mouseDeviceMapWindowToLogicalPosition(int* x, int* y)
     *y = *y * mouseWindowMappingLogicalHeight / mouseWindowMappingWindowHeight;
 }
 
-static void mouseDeviceRefreshWindowMapping()
+void mouseDeviceRefreshWindowMapping()
 {
     // When mouse is in "absolute mode" and scaling is > 1, we need to transform screen coordinates to game coordinates.
-    // Cache the window sizes so we have them available in mouseDeviceMapWindowToLogicalPosition
+    // Cache the window sizes so we have them available in mouseDeviceMapWindowToLogicalPosition.
+    // Note: if we add letterboxing or other more complex scaling, we'll have to account for it here.
     mouseWindowMappingLogicalWidth = screenGetWidth();
     mouseWindowMappingLogicalHeight = screenGetHeight();
 

--- a/src/dinput.cc
+++ b/src/dinput.cc
@@ -6,12 +6,19 @@ namespace fallout {
 
 static int gMouseWheelDeltaX = 0;
 static int gMouseWheelDeltaY = 0;
+static int gMouseWindowMappingWindowWidth = 0;
+static int gMouseWindowMappingWindowHeight = 0;
+static int gMouseWindowMappingLogicalWidth = 0;
+static int gMouseWindowMappingLogicalHeight = 0;
 
 static void mouseDeviceMapWindowToLogicalPosition(int* x, int* y);
+static void mouseDeviceRefreshWindowMapping();
 
 // 0x4E0400
 bool directInputInit()
 {
+    mouseDeviceRefreshWindowMapping();
+
     if (!mouseDeviceInit()) {
         goto err;
     }
@@ -101,6 +108,8 @@ bool keyboardDeviceGetData(KeyboardData* keyboardData)
 // 0x4E070C
 bool mouseDeviceInit()
 {
+    mouseDeviceRefreshWindowMapping();
+
     return screenIsFullscreen()
         ? SDL_SetRelativeMouseMode(SDL_TRUE) == 0
         : true;
@@ -135,19 +144,25 @@ void handleMouseEvent(SDL_Event* event)
 
 static void mouseDeviceMapWindowToLogicalPosition(int* x, int* y)
 {
-    if (gSdlWindow == nullptr) {
+    if (gMouseWindowMappingWindowWidth <= 0 || gMouseWindowMappingWindowHeight <= 0) {
         return;
     }
 
-    int windowWidth;
-    int windowHeight;
-    SDL_GetWindowSize(gSdlWindow, &windowWidth, &windowHeight);
-    if (windowWidth <= 0 || windowHeight <= 0) {
-        return;
-    }
+    *x = *x * gMouseWindowMappingLogicalWidth / gMouseWindowMappingWindowWidth;
+    *y = *y * gMouseWindowMappingLogicalHeight / gMouseWindowMappingWindowHeight;
+}
 
-    *x = *x * screenGetWidth() / windowWidth;
-    *y = *y * screenGetHeight() / windowHeight;
+static void mouseDeviceRefreshWindowMapping()
+{
+    gMouseWindowMappingLogicalWidth = screenGetWidth();
+    gMouseWindowMappingLogicalHeight = screenGetHeight();
+
+    if (gSdlWindow != nullptr) {
+        SDL_GetWindowSize(gSdlWindow, &gMouseWindowMappingWindowWidth, &gMouseWindowMappingWindowHeight);
+    } else {
+        gMouseWindowMappingWindowWidth = 0;
+        gMouseWindowMappingWindowHeight = 0;
+    }
 }
 
 } // namespace fallout

--- a/src/dinput.cc
+++ b/src/dinput.cc
@@ -6,10 +6,11 @@ namespace fallout {
 
 static int gMouseWheelDeltaX = 0;
 static int gMouseWheelDeltaY = 0;
-static int gMouseWindowMappingWindowWidth = 0;
-static int gMouseWindowMappingWindowHeight = 0;
-static int gMouseWindowMappingLogicalWidth = 0;
-static int gMouseWindowMappingLogicalHeight = 0;
+static int mouseWindowMappingWindowWidth = 0;
+static int mouseWindowMappingWindowHeight = 0;
+static int mouseWindowMappingLogicalWidth = 0;
+static int mouseWindowMappingLogicalHeight = 0;
+static bool mouseRelativeMode = false;
 
 static void mouseDeviceMapWindowToLogicalPosition(int* x, int* y);
 static void mouseDeviceRefreshWindowMapping();
@@ -41,6 +42,29 @@ void directInputFree()
 {
 }
 
+bool mouseDeviceUsesRelativeMode()
+{
+    return mouseRelativeMode;
+}
+
+bool mouseDeviceInitMode()
+{
+    // "Relative mode" means cursor position is owned by the application, and we move based on mouse deltas
+    // "Absolute mode" means cursor position is controlled by the OS, and we read it directly.
+    // Mouse sensitity settings can only apply in relative mode.
+
+    // TODO: add setting for mouse capture (relative mode) in windowed, differentiated from the web version.
+    mouseRelativeMode = screenIsFullscreen();
+
+    if (mouseRelativeMode) {
+        return SDL_SetRelativeMouseMode(SDL_TRUE) == 0;
+    }
+
+    SDL_SetRelativeMouseMode(SDL_FALSE);
+    mouseDeviceRefreshWindowMapping();
+    return true;
+}
+
 // 0x4E04E8
 bool mouseDeviceAcquire()
 {
@@ -63,10 +87,10 @@ bool mouseDeviceGetData(MouseData* mouseState)
     // TODO: Move mouse events processing into `GNW95_process_message` and
     // update mouse position manually.
     SDL_PumpEvents();
-    Uint32 buttons = screenIsFullscreen()
+    Uint32 buttons = mouseDeviceUsesRelativeMode()
         ? SDL_GetRelativeMouseState(&(mouseState->x), &(mouseState->y))
         : SDL_GetMouseState(&(mouseState->x), &(mouseState->y));
-    if (!screenIsFullscreen()) {
+    if (!mouseDeviceUsesRelativeMode()) {
         mouseDeviceMapWindowToLogicalPosition(&(mouseState->x), &(mouseState->y));
     }
     mouseState->buttons[0] = (buttons & SDL_BUTTON(SDL_BUTTON_LEFT)) != 0;
@@ -109,10 +133,7 @@ bool keyboardDeviceGetData(KeyboardData* keyboardData)
 bool mouseDeviceInit()
 {
     mouseDeviceRefreshWindowMapping();
-
-    return screenIsFullscreen()
-        ? SDL_SetRelativeMouseMode(SDL_TRUE) == 0
-        : true;
+    return mouseDeviceInitMode();
 }
 
 // 0x4E078C
@@ -144,24 +165,26 @@ void handleMouseEvent(SDL_Event* event)
 
 static void mouseDeviceMapWindowToLogicalPosition(int* x, int* y)
 {
-    if (gMouseWindowMappingWindowWidth <= 0 || gMouseWindowMappingWindowHeight <= 0) {
+    if (mouseWindowMappingWindowWidth <= 0 || mouseWindowMappingWindowHeight <= 0) {
         return;
     }
 
-    *x = *x * gMouseWindowMappingLogicalWidth / gMouseWindowMappingWindowWidth;
-    *y = *y * gMouseWindowMappingLogicalHeight / gMouseWindowMappingWindowHeight;
+    *x = *x * mouseWindowMappingLogicalWidth / mouseWindowMappingWindowWidth;
+    *y = *y * mouseWindowMappingLogicalHeight / mouseWindowMappingWindowHeight;
 }
 
 static void mouseDeviceRefreshWindowMapping()
 {
-    gMouseWindowMappingLogicalWidth = screenGetWidth();
-    gMouseWindowMappingLogicalHeight = screenGetHeight();
+    // When mouse is in "absolute mode" and scaling is > 1, we need to transform screen coordinates to game coordinates.
+    // Cache the window sizes so we have them available in mouseDeviceMapWindowToLogicalPosition
+    mouseWindowMappingLogicalWidth = screenGetWidth();
+    mouseWindowMappingLogicalHeight = screenGetHeight();
 
     if (gSdlWindow != nullptr) {
-        SDL_GetWindowSize(gSdlWindow, &gMouseWindowMappingWindowWidth, &gMouseWindowMappingWindowHeight);
+        SDL_GetWindowSize(gSdlWindow, &mouseWindowMappingWindowWidth, &mouseWindowMappingWindowHeight);
     } else {
-        gMouseWindowMappingWindowWidth = 0;
-        gMouseWindowMappingWindowHeight = 0;
+        mouseWindowMappingWindowWidth = 0;
+        mouseWindowMappingWindowHeight = 0;
     }
 }
 

--- a/src/dinput.h
+++ b/src/dinput.h
@@ -20,6 +20,8 @@ typedef struct KeyboardData {
 
 bool directInputInit();
 void directInputFree();
+bool mouseDeviceUsesRelativeMode();
+bool mouseDeviceInitMode();
 bool mouseDeviceAcquire();
 bool mouseDeviceUnacquire();
 bool mouseDeviceGetData(MouseData* mouseData);

--- a/src/dinput.h
+++ b/src/dinput.h
@@ -22,6 +22,7 @@ bool directInputInit();
 void directInputFree();
 bool mouseDeviceUsesRelativeMode();
 bool mouseDeviceInitMode();
+void mouseDeviceRefreshWindowMapping();
 bool mouseDeviceAcquire();
 bool mouseDeviceUnacquire();
 bool mouseDeviceGetData(MouseData* mouseData);

--- a/src/mouse.cc
+++ b/src/mouse.cc
@@ -385,7 +385,7 @@ void _mouse_info()
 
         switch (gesture.type) {
         case kTap:
-            if (screenIsFullscreen()) {
+            if (mouseDeviceUsesRelativeMode()) {
                 if (gesture.numberOfTouches == 1) {
                     _mouse_simulate_input(0, 0, MOUSE_STATE_LEFT_BUTTON_DOWN);
                 } else if (gesture.numberOfTouches == 2) {
@@ -405,7 +405,7 @@ void _mouse_info()
                 prevx = gesture.x;
                 prevy = gesture.y;
             }
-            if (!screenIsFullscreen()) {
+            if (!mouseDeviceUsesRelativeMode()) {
                 prevx = 0;
                 prevy = 0;
             }
@@ -464,7 +464,7 @@ void _mouse_info()
 
     // Mouse sensitivity only applies to relative movement. In windowed mode
     // SDL provides absolute coordinates that should not be scaled.
-    if (screenIsFullscreen()) {
+    if (mouseDeviceUsesRelativeMode()) {
         x = (int)(x * gMouseSensitivity);
         y = (int)(y * gMouseSensitivity);
     }
@@ -560,7 +560,7 @@ void _mouse_simulate_input(int delta_x, int delta_y, int buttons)
         mouseRect.top = gMouseCursorY;
         mouseRect.right = gMouseCursorWidth + gMouseCursorX - 1;
         mouseRect.bottom = gMouseCursorHeight + gMouseCursorY - 1;
-        if (screenIsFullscreen()) {
+        if (mouseDeviceUsesRelativeMode()) {
             gMouseCursorX += delta_x;
             gMouseCursorY += delta_y;
         } else {
@@ -572,7 +572,7 @@ void _mouse_simulate_input(int delta_x, int delta_y, int buttons)
 
         mouseShowCursor();
 
-        if (screenIsFullscreen()) {
+        if (mouseDeviceUsesRelativeMode()) {
             _raw_x = gMouseCursorX;
             _raw_y = gMouseCursorY;
         } else {
@@ -675,7 +675,7 @@ void _mouse_get_raw_state(int* out_x, int* out_y, int* out_buttons)
     }
 
     _raw_buttons = 0;
-    if (screenIsFullscreen()) {
+    if (mouseDeviceUsesRelativeMode()) {
         _raw_x += mouseData.x;
         _raw_y += mouseData.y;
     } else {

--- a/src/mouse.cc
+++ b/src/mouse.cc
@@ -462,9 +462,12 @@ void _mouse_info()
         y = 0;
     }
 
-    // Adjust for mouse senstivity.
-    x = (int)(x * gMouseSensitivity);
-    y = (int)(y * gMouseSensitivity);
+    // Mouse sensitivity only applies to relative movement. In windowed mode
+    // SDL provides absolute coordinates that should not be scaled.
+    if (screenIsFullscreen()) {
+        x = (int)(x * gMouseSensitivity);
+        y = (int)(y * gMouseSensitivity);
+    }
 
     _mouse_simulate_input(x, y, buttons);
 
@@ -561,8 +564,7 @@ void _mouse_simulate_input(int delta_x, int delta_y, int buttons)
             gMouseCursorX += delta_x;
             gMouseCursorY += delta_y;
         } else {
-            gMouseCursorX = delta_x;
-            gMouseCursorY = delta_y;
+            _mouse_set_position(delta_x, delta_y);
         }
         _mouse_clip();
 
@@ -570,9 +572,15 @@ void _mouse_simulate_input(int delta_x, int delta_y, int buttons)
 
         mouseShowCursor();
 
-        _raw_x = gMouseCursorX;
-        _raw_y = gMouseCursorY;
+        if (screenIsFullscreen()) {
+            _raw_x = gMouseCursorX;
+            _raw_y = gMouseCursorY;
+        } else {
+            _raw_x = delta_x;
+            _raw_y = delta_y;
+        }
     }
+
 }
 
 // 0x4CA8C8

--- a/src/mouse.cc
+++ b/src/mouse.cc
@@ -580,7 +580,6 @@ void _mouse_simulate_input(int delta_x, int delta_y, int buttons)
             _raw_y = delta_y;
         }
     }
-
 }
 
 // 0x4CA8C8

--- a/src/svga.cc
+++ b/src/svga.cc
@@ -6,6 +6,7 @@
 #include <SDL.h>
 
 #include "config.h"
+#include "dinput.h"
 #include "draw.h"
 #include "game.h"
 #include "interface.h"
@@ -397,6 +398,7 @@ void handleWindowSizeChanged()
 {
     destroyRenderer();
     createRenderer(screenGetWidth(), screenGetHeight());
+    mouseDeviceRefreshWindowMapping();
 }
 
 void renderPresent()


### PR DESCRIPTION
### Description

In https://github.com/fallout2-ce/fallout2-ce/pull/277, we introduced a new mouse mode I'm calling "absolute".  In that mode, we follow the OS cursor position exactly instead of "owning" it ourselves.  The latter is "relative mode", which means we only look at mouse position "deltas" and otherwise control the mouse position.

When we introduced that mode, we left several loose ends.  The biggest one is that when `scale != 1`, we are using window coordinates as game coordinates, which is off by a factor of `scale` (usually 2).  I could repro consistently the OS mouse being exactly half of the game mouse (and both visible together, oddly).  The fix here is to scale the position we get from SDL when translating to logical coordinates.

Another place we missed is applying mouse sensitivity.  We shouldn't be doing that at all if we want to match the OS.  If you want your mouse to move faster, you need to up your OS' mouse sensitivity.  Note that sensitivity was previously implicitly tied to `scale`.  2X scale in windowed mode created 2X mouse sensitivity, which is a little weird.  As a result, the mouse might feel slower if you were using that config before.

This PR fixes both of those things, and one other minor issue (we didn't take into account the hotspot of the mouse when restoring coordinates).  Also added function which is the single source of truth of these modes so we don't need to sprinkle "isFullscreen()" everywhere.  

I imagine we'll want to make the windowed behaviour configurable, too.  That's likely the next step after this.

I could use help testing this PR.  Mouse behaviour is quite sensitive and easy to regress unexpectedly.  I'd like to see if the win11 bug is fixed at least.

Fixes https://github.com/fallout2-ce/fallout2-ce/issues/337