### PR TITLE
Set DPI Awareness hint on windows

### DIFF
--- a/src/win32.cc
+++ b/src/win32.cc
@@ -38,7 +38,9 @@ int main(int argc, char* argv[])
     if (GetLastError() != ERROR_SUCCESS) {
         return 0;
     }
+#ifdef SDL_HINT_WINDOWS_DPI_AWARENESS
     SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS, "permonitorv2");
+#endif
 #endif
 
 #if __APPLE__ && TARGET_OS_IOS

--- a/src/win32.cc
+++ b/src/win32.cc
@@ -58,6 +58,7 @@ int main(int argc, char* argv[])
     chdir(SDL_AndroidGetExternalStoragePath());
 #endif
 
+    SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS, "permonitorv2");
     if (SDL_Init(SDL_INIT_AUDIO | SDL_INIT_VIDEO | SDL_INIT_EVENTS) != 0) {
         return EXIT_FAILURE;
     }

--- a/src/win32.cc
+++ b/src/win32.cc
@@ -38,6 +38,7 @@ int main(int argc, char* argv[])
     if (GetLastError() != ERROR_SUCCESS) {
         return 0;
     }
+    SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS, "permonitorv2");
 #endif
 
 #if __APPLE__ && TARGET_OS_IOS
@@ -58,7 +59,6 @@ int main(int argc, char* argv[])
     chdir(SDL_AndroidGetExternalStoragePath());
 #endif
 
-    SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS, "permonitorv2");
     if (SDL_Init(SDL_INIT_AUDIO | SDL_INIT_VIDEO | SDL_INIT_EVENTS) != 0) {
         return EXIT_FAILURE;
     }


### PR DESCRIPTION
Forces the application to be DPI-aware on Windows, preventing the OS from applying bitmap stretching to the game window. 

By setting SDL_HINT_WINDOWS_DPI_AWARENESS to permonitorv2 before SDL_Init, the application now correctly handles its own coordinate system. This ensures that the engine's integer scaling logic correctly maps to the physical display pixels, regardless of the user's system-wide DPI scaling settings in Windows.

Fixes https://github.com/alexbatalov/fallout2-ce/issues/495

