### PR TITLE
Implement HOOK_CALCAPCOST

### DIFF
--- a/SFALL_COMPATIBILITY.md
+++ b/SFALL_COMPATIBILITY.md
@@ -48,8 +48,8 @@ See [`https://sfall-team.github.io/sfall/`](https://sfall-team.github.io/sfall/)
 | Interface / Cursor | get/set_cursor_mode | ✅ | - |
 | Locks | lock_is_jammed<br>unjam_lock<br>set_unjam_locks_time | not implemented | - |
 | INI settings | get_ini_setting<br>get_ini_string<br>get_ini_section<br>get_ini_sections<br>get_ini_config<br>get_ini_config_db<br>set_ini_setting | ✅ except get_ini_config, get_ini_config_db | `modified_ini` is intentionally omitted as deprecated. |
-| Objects and scripts | set_self<br>set_dude_obj<br>real_dude_obj<br>remove_script<br>set_script<br>get_script<br>obj_is_carrying_obj<br>loot_obj<br>dialog_obj<br>obj_under_cursor<br>get_object_data<br>set_object_data<br>get_flags<br>set_flags<br>set_unique_id<br>set_scr_name<br>obj_is_openable<br>get/set_proto_data<br>get_object_ai_data | implemented: set_self, get_script, obj_is_carrying_obj, loot_obj, dialog_obj, obj_under_cursor, get_object_data, get_flags, set_flags, get_proto_data, set_proto_data | - |
-| Other / Game management | set_movie_path<br>stop_game<br>resume_game<br>mark_movie_played<br>game_loaded<br>get_game_mode<br>get_uptime<br>signal_close_game | implemented: game_loaded, get_game_mode, get_uptime, signal_close_game | - |
+| Objects and scripts | set_self<br>set_dude_obj<br>real_dude_obj<br>remove_script<br>get/set_script<br>obj_is_carrying_obj<br>loot_obj<br>dialog_obj<br>obj_under_cursor<br>get/set_object_data<br>get/set_flags<br>set_unique_id<br>set_scr_name<br>obj_is_openable<br>get/set_proto_data<br>get_object_ai_data | implemented: set_self, get_script, obj_is_carrying_obj, loot_obj, dialog_obj, obj_under_cursor, get_object_data, get_flags, set_flags, get_proto_data, set_proto_data | - |
+| Other / Game management | set_movie_path<br>stop/resume_game<br>mark_movie_played<br>game_loaded<br>get_game_mode<br>get_uptime<br>signal_close_game | implemented: game_loaded, get_game_mode, get_uptime, signal_close_game | - |
 | Gameplay tweaks | set_pickpocket_max<br>set_hit_chance_max<br>set_xp_mod<br>set_critter_hit_chance_mod<br>set_base_hit_chance_mod<br>set_hp_per_level_mod<br>get_unspent_ap_bonus<br>gdialog_get_barter_mod<br>set_unspent_ap_bonus<br>get/set_unspent_ap_perk_bonus<br>set_inven_ap_cost<br>set_base_pickpocket_mod<br>set_critter_pickpocket_mod<br>get_inven_ap_cost<br>set_drugs_data<br>get_kill_counter<br>mod_kill_counter<br>set_pipboy_available | not implemented | - |
 | NPCs | inc_npc_level<br>get_npc_level<br>npc_engine_level_up | not implemented | - |
 | Other | get_year<br>set_dm/df_model<br>active_hand<br>toggle_active_hand<br>get/set_viewport_x/y<br>hero_select_win<br>get_light_level<br>message_str_game<br>sneak_success<br>create_spatial<br>unwield_slot<br>add_g_timer_event<br>add_extra_msg_file<br>get_metarule_table<br>metarule_exist<br>remove_timer_event<br>spatial_radius | implemented: get_year, active_hand, toggle_active_hand, message_str_game, add_extra_msg_file, metarule_exist | `input_funcs_available`, `nb_create_char` are deprecated in sfall and intentionally absent in CE. `add_extra_msg_file` does not support the explicit `fileNumber` form in CE. |
@@ -60,7 +60,7 @@ See [`https://sfall-team.github.io/sfall/`](https://sfall-team.github.io/sfall/)
 | --- | --- | --- | --- |
 | ToHit | `HOOK_TOHIT` | ✅ | - |
 | AfterHitRoll | `HOOK_AFTERHITROLL` | 🚫 | Et tu |
-| CalcAPCost | `HOOK_CALCAPCOST` | ✅ | AP cost is displayed correctly on first load, unlike Sfall. |
+| CalcAPCost | `HOOK_CALCAPCOST` | ✅ | - |
 | DeathAnim1 | `HOOK_DEATHANIM1` | 🚫 | Use DEATHANIM2 instead |
 | DeathAnim2 | `HOOK_DEATHANIM2` | ✅ | - |
 | CombatDamage | `HOOK_COMBATDAMAGE` | ✅ | - |

--- a/SFALL_COMPATIBILITY.md
+++ b/SFALL_COMPATIBILITY.md
@@ -60,7 +60,7 @@ See [`https://sfall-team.github.io/sfall/`](https://sfall-team.github.io/sfall/)
 | --- | --- | --- | --- |
 | ToHit | `HOOK_TOHIT` | ✅ | - |
 | AfterHitRoll | `HOOK_AFTERHITROLL` | 🚫 | Et tu |
-| CalcAPCost | `HOOK_CALCAPCOST` | 🚫 | - |
+| CalcAPCost | `HOOK_CALCAPCOST` | ✅ | AP cost is displayed correctly on first load, unlike Sfall. |
 | DeathAnim1 | `HOOK_DEATHANIM1` | 🚫 | Use DEATHANIM2 instead |
 | DeathAnim2 | `HOOK_DEATHANIM2` | ✅ | - |
 | CombatDamage | `HOOK_COMBATDAMAGE` | ✅ | - |

--- a/sfall_testing/hooks/gl_calcapcost.ssl
+++ b/sfall_testing/hooks/gl_calcapcost.ssl
@@ -1,0 +1,64 @@
+#include "sfall.h"
+#include "dik.h"
+#include "lib.arrays.h"
+#include "lib.obj.h"
+
+variable calcapcost_override_enabled := true;
+
+procedure calcapcost_mode_name begin
+    if (calcapcost_override_enabled) then return "override";
+    return "engine";
+end
+
+procedure calcapcost_item_name(variable item) begin
+    if (item == 0) then return "<null>";
+    return obj_name(item);
+end
+
+procedure calcapcost_handler begin
+    variable
+        args := get_sfall_args,
+        critter := args[0],
+        attackType := args[1],
+        isAimed := args[2],
+        defaultCost := args[3],
+        weapon := args[4],
+        weaponPid := 0;
+
+    if (critter != dude_obj) then return;
+    if (weapon) then weaponPid := obj_pid(weapon);
+
+    display_msg(string_format("calcapcost mode=%s attack=%d aimed=%d default=%d weapon=%s pid=%d",
+        calcapcost_mode_name,
+        attackType,
+        isAimed,
+        defaultCost,
+        calcapcost_item_name(weapon),
+        weaponPid));
+
+    if (calcapcost_override_enabled) then
+        set_sfall_return(defaultCost + 3);
+end
+
+procedure keypress_handler begin
+    variable
+        pressed := get_sfall_arg_at(0),
+        key := get_sfall_arg_at(1);
+
+    if (not pressed) then return;
+    if (key != DIK_H) then return;
+
+    calcapcost_override_enabled := not calcapcost_override_enabled;
+    display_msg(string_format1("calcapcost mode -> %s", calcapcost_mode_name));
+    intface_redraw;
+end
+
+procedure start begin
+    if (not game_loaded) then return;
+
+    display_msg("calcapcost manual test ready: press H to toggle override (+3 AP)");
+    display_msg("check weapon, unarmed, and non-weapon hand items; hook logs args for dude only");
+
+    register_hook_proc(HOOK_KEYPRESS, keypress_handler);
+    register_hook_proc(HOOK_CALCAPCOST, calcapcost_handler);
+end

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -734,7 +734,7 @@ int interfaceLoad(File* stream)
 
     // Reset cached hand state so load consistently reselects default actions
     // from the actual equipped items instead of reusing stale pre-load state.
-    interfaceResetItemStates();
+    intface_init_items();
     interfaceUpdateItems(false, INTERFACE_ITEM_ACTION_DEFAULT, INTERFACE_ITEM_ACTION_DEFAULT);
 
     if (interfaceBarEndButtonsIsVisible != gInterfaceBarEndButtonsIsVisible) {
@@ -1550,11 +1550,6 @@ static int intface_init_items()
     gInterfaceItemStates[HAND_RIGHT].item = (Object*)-1;
 
     return 0;
-}
-
-void interfaceResetItemStates()
-{
-    intface_init_items();
 }
 
 // 0x45FD88

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -732,6 +732,9 @@ int interfaceLoad(File* stream)
 
     gInterfaceCurrentHand = interfaceCurrentHand;
 
+    // Reset cached hand state so load consistently reselects default actions
+    // from the actual equipped items instead of reusing stale pre-load state.
+    interfaceResetItemStates();
     interfaceUpdateItems(false, INTERFACE_ITEM_ACTION_DEFAULT, INTERFACE_ITEM_ACTION_DEFAULT);
 
     if (interfaceBarEndButtonsIsVisible != gInterfaceBarEndButtonsIsVisible) {
@@ -1547,6 +1550,11 @@ static int intface_init_items()
     gInterfaceItemStates[HAND_RIGHT].item = (Object*)-1;
 
     return 0;
+}
+
+void interfaceResetItemStates()
+{
+    intface_init_items();
 }
 
 // 0x45FD88

--- a/src/interface.h
+++ b/src/interface.h
@@ -46,6 +46,7 @@ void interfaceBarShow();
 void interfaceBarEnable();
 void interfaceBarDisable();
 bool interfaceBarEnabled();
+void interfaceResetItemStates();
 void interfaceBarRefresh();
 void interfaceRenderHitPoints(bool animate);
 void interfaceRenderArmorClass(bool animate);

--- a/src/interface.h
+++ b/src/interface.h
@@ -46,7 +46,6 @@ void interfaceBarShow();
 void interfaceBarEnable();
 void interfaceBarDisable();
 bool interfaceBarEnabled();
-void interfaceResetItemStates();
 void interfaceBarRefresh();
 void interfaceRenderHitPoints(bool animate);
 void interfaceRenderArmorClass(bool animate);

--- a/src/item.cc
+++ b/src/item.cc
@@ -1025,7 +1025,7 @@ int itemGetActionPointCost(Object* obj, int hitMode, bool aiming)
     Object* item_obj = critterGetWeaponForHitMode(obj, hitMode);
 
     if (item_obj != nullptr && itemGetType(item_obj) != ITEM_TYPE_WEAPON) {
-        return 2;
+        return scriptHooks_CalcApCost(obj, hitMode, aiming, 2, nullptr);
     }
 
     return weaponGetActionPointCost(obj, hitMode, aiming);
@@ -1660,14 +1660,16 @@ int weaponGetActionPointCost(Object* critter, int hitMode, bool aiming)
             Proto* proto;
             protoGetProto(weapon->pid, &proto);
             if (proto->item.data.weapon.perk == PERK_WEAPON_FAST_RELOAD) {
-                return 1;
+                actionPoints = 1;
+            } else if (weapon->pid == PROTO_ID_SOLAR_SCORCHER) {
+                actionPoints = 0;
+            } else {
+                actionPoints = 2;
             }
-
-            if (weapon->pid == PROTO_ID_SOLAR_SCORCHER) {
-                return 0;
-            }
+        } else {
+            actionPoints = 2;
         }
-        return 2;
+        return scriptHooks_CalcApCost(critter, hitMode, aiming, actionPoints, weapon);
     }
 
     // CE: The entire function is different in Sfall.
@@ -1719,7 +1721,7 @@ int weaponGetActionPointCost(Object* critter, int hitMode, bool aiming)
         actionPoints = 1;
     }
 
-    return actionPoints;
+    return scriptHooks_CalcApCost(critter, hitMode, aiming, actionPoints, weapon);
 }
 
 // 0x478D08

--- a/src/item.cc
+++ b/src/item.cc
@@ -1025,6 +1025,7 @@ int itemGetActionPointCost(Object* obj, int hitMode, bool aiming)
     Object* item_obj = critterGetWeaponForHitMode(obj, hitMode);
 
     if (item_obj != nullptr && itemGetType(item_obj) != ITEM_TYPE_WEAPON) {
+        // consider passing object here instead of null.  null matches Sfall
         return scriptHooks_CalcApCost(obj, hitMode, aiming, 2, nullptr);
     }
 

--- a/src/sfall_callbacks.cc
+++ b/src/sfall_callbacks.cc
@@ -1,6 +1,7 @@
 #include "sfall_callbacks.h"
 
 #include "display_monitor.h"
+#include "interface.h"
 #include "sfall_config.h"
 #include "sfall_script_hooks.h"
 #include "worldmap.h"
@@ -45,6 +46,15 @@ void sfallOnAfterGameStarted()
 
     if (isDisableHorrigan) {
         gDidMeetFrankHorrigan = true;
+    }
+
+    // Refresh item art after load, which calls the CALCAPCOST hook if present to
+    // display the correct AP cost.
+    if (gInterfaceBarWindow != -1) {
+        int leftItemAction;
+        int rightItemAction;
+        interfaceGetItemActions(&leftItemAction, &rightItemAction);
+        interfaceUpdateItems(false, leftItemAction, rightItemAction);
     }
 }
 

--- a/src/sfall_script_hooks.cc
+++ b/src/sfall_script_hooks.cc
@@ -238,6 +238,32 @@ PerceptionResult scriptHooks_WithinPerception(Object* watcher, Object* target, P
 }
 
 /*
+Runs whenever Fallout calculates the AP cost of using an active item in hand
+(or unarmed attack). Doesn't run for moving.
+
+Critter arg0 - The critter performing the action
+int     arg1 - Attack Type (see ATKTYPE_* constants)
+int     arg2 - Is aimed attack (1 or 0)
+int     arg3 - The default AP cost
+Item    arg4 - The weapon for which the cost is calculated. If it is 0, the
+               pointer to the weapon can still be obtained by checking item
+               slot based on attack type and then calling critter_inven_obj
+
+int     ret0 - The new AP cost
+*/
+int scriptHooks_CalcApCost(Object* critter, int hitMode, bool aiming, int actionPoints, Object* weapon)
+{
+    ScriptHookCall hook(HOOK_CALCAPCOST, 1, { critter, hitMode, aiming ? 1 : 0, actionPoints, weapon });
+    hook.call();
+
+    if (hook.numReturnValues() <= 0) {
+        return actionPoints;
+    }
+
+    return hook.getReturnValueAt(0).asInt();
+}
+
+/*
 Runs before moving items between inventory slots in dude interface. You can override the action.
 
 int     arg0 - Target slot:

--- a/src/sfall_script_hooks.cc
+++ b/src/sfall_script_hooks.cc
@@ -242,7 +242,7 @@ Runs whenever Fallout calculates the AP cost of using an active item in hand
 (or unarmed attack). Doesn't run for moving.
 
 Critter arg0 - The critter performing the action
-int     arg1 - Attack Type (see ATKTYPE_* constants)
+int     arg1 - Attack Type / hitmode (see ATKTYPE_* constants)
 int     arg2 - Is aimed attack (1 or 0)
 int     arg3 - The default AP cost
 Item    arg4 - The weapon for which the cost is calculated. If it is 0, the

--- a/src/sfall_script_hooks.h
+++ b/src/sfall_script_hooks.h
@@ -262,6 +262,7 @@ bool scriptHooks_CombatTurnStart(Object* critter, bool reloadedDuringCombat);
 bool scriptHooks_CombatTurnEnd(Object* critter, int turnResult, bool reloadedDuringCombat);
 void scriptHooks_CombatTurnCombatEnd(Object* critter);
 PerceptionResult scriptHooks_WithinPerception(Object* watcher, Object* target, PerceptionType type, PerceptionResult result);
+int scriptHooks_CalcApCost(Object* critter, int hitMode, bool aiming, int actionPoints, Object* weapon);
 int scriptHooks_ToHit(Object* attacker, Object* defender, int tile, int hitMode, int hitLocation, int hitChance, int hitChanceUncapped, bool useDistance);
 void scriptHooks_DeathAnim(Object* attacker, Object* defender, Object* weapon, int damage, int* anim);
 int scriptHooks_UseItem(Object* user, Object* objUsed);


### PR DESCRIPTION
An opcode a day keeps the stimpak away.

https://sfall-team.github.io/sfall/hook-types/#calcapcost

Same as Sfall, but also calls the hook on game load to display the correct AP cost on load.

Also fix a minor bug where the attack mode of the current hand sometimes leaked when loading a save game.  Normally attack mode (burst/reload/&c) isn't saved.  But if you are in aimed mode (say), and load a game with the same weapon equipped, the attack mode will persist.  This is pretty weird, so changed it to always be in the default mode when loading a save.