### PR TITLE
iOS/iPad: touch gestures, HUD tap-through, and quick-actions toolbar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,6 +315,8 @@ if(IOS)
     target_sources(${EXECUTABLE_NAME} PUBLIC
         "src/platform/ios/paths.h"
         "src/platform/ios/paths.mm"
+        "src/platform/ios/quick_toolbar.h"
+        "src/platform/ios/quick_toolbar.cc"
     )
 endif()
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ $ mv fallout2 /Applications/Fallout2
 
 - Use Finder (macOS Catalina and later) or iTunes (Windows and macOS Mojave or earlier) to copy `master.dat`, `critter.dat`, `patch000.dat`, and `data` folder to "Fallout 2" app ([how-to](https://support.apple.com/HT210598)). Watch for file names - keep (or make) them lowercased (see [Configuration](#configuration)).
 
+- 
+
 **Controls on iPad:**
 
 - One-finger tap → left click; hold → left button held.
@@ -121,6 +123,7 @@ iface_bar_side_art=2 ; Interface bar side art style (0=black, 1=metal grey, 2=le
 iface_bar_sides_ori=0 ; Side graphics orientation (0=extend from bar to edges, 1=extend from edges to bar)
 splash_screen_size=1 ; Splash screen scaling (0=original size, 1=fit preserving aspect, 2=stretch to fill)
 ignore_map_edges=0 ; Hi-res map scroll edges (0=enabled, 1=ignored)
+quick_toolbar_visible=0 ; Skills quick access toolbar visibility (iOS only) (0=hidden, 1=visible)
 ```
 
 **Recommendations:**

--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ $ mv fallout2 /Applications/Fallout2
 
 - Use Finder (macOS Catalina and later) or iTunes (Windows and macOS Mojave or earlier) to copy `master.dat`, `critter.dat`, `patch000.dat`, and `data` folder to "Fallout 2" app ([how-to](https://support.apple.com/HT210598)). Watch for file names - keep (or make) them lowercased (see [Configuration](#configuration)).
 
+**Controls on iPad:**
+
+- One-finger tap → left click; hold → left button held.
+- Two-finger tap → right click (cycles cursor mode between walk and attack).
+- One-finger drag → scroll map / windows.
+- Two-finger drag → mouse wheel.
+- **Three-finger swipe down → ESC** (opens options / main menu).
+- **Four-finger long press → F6** (quicksave). Hold four fingers on the screen for about half a second.
+- **Three-finger long press → hold Shift** (highlights interactable objects — containers, doors, items — while held).
+- Taps on the HUD (interface bar / end-turn / end-combat buttons) act as direct touches so small buttons are easy to hit without aiming.
+- A Bluetooth keyboard works for everything else (numbered dialog choices, load game, etc.).
+
 ### Browser
 
 > **NOTE**: WebAssembly build with emscripten

--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -42,6 +42,7 @@
 #include "stat.h"
 #include "svga.h"
 #include "text_font.h"
+#include "touch.h"
 #include "trait.h"
 #include "window_manager.h"
 #include "word_wrap.h"
@@ -808,6 +809,8 @@ int characterEditorShow(bool isCreationMode)
         return -1;
     }
 
+    touch_set_touchscreen_mode(true);
+
     if (!gCharacterEditorIsCreationMode) {
         if (characterEditorUpdateLevel()) {
             critterUpdateDerivedStats(gDude);
@@ -1195,6 +1198,8 @@ int characterEditorShow(bool isCreationMode)
     }
 
     interfaceRenderHitPoints(false);
+
+    touch_set_touchscreen_mode(false);
 
     return rc;
 }

--- a/src/character_selector.cc
+++ b/src/character_selector.cc
@@ -148,6 +148,9 @@ static std::vector<PremadeCharacterDescription> gCustomPremadeCharacterDescripti
 // 0x4A71D0
 int characterSelectorOpen()
 {
+#if __APPLE__ && TARGET_OS_IOS
+    touch_set_touchscreen_mode(true);
+#endif
     if (!characterSelectorWindowInit()) {
         return 0;
     }
@@ -251,6 +254,9 @@ int characterSelectorOpen()
         mouseHideCursor();
     }
 
+#if __APPLE__ && TARGET_OS_IOS
+    touch_set_touchscreen_mode(false);
+#endif
     return rc;
 }
 

--- a/src/game.cc
+++ b/src/game.cc
@@ -694,49 +694,11 @@ int gameHandleKey(int eventCode, bool isInCombatMode)
         if (interfaceBarEnabled()) {
             soundPlayFile("ib1p1xx1");
 
-            int mode = -1;
-
             // NOTE: There is an `inc` for this value to build jump table which
             // is not needed.
             int rc = skilldexOpen();
 
-            // Remap Skilldex result code to action.
-            switch (rc) {
-            case SKILLDEX_RC_ERROR:
-                debugPrint("\n ** Error calling skilldex_select()! ** \n");
-                break;
-            case SKILLDEX_RC_SNEAK:
-                _action_skill_use(SKILL_SNEAK);
-                break;
-            case SKILLDEX_RC_LOCKPICK:
-                mode = GAME_MOUSE_MODE_USE_LOCKPICK;
-                break;
-            case SKILLDEX_RC_STEAL:
-                mode = GAME_MOUSE_MODE_USE_STEAL;
-                break;
-            case SKILLDEX_RC_TRAPS:
-                mode = GAME_MOUSE_MODE_USE_TRAPS;
-                break;
-            case SKILLDEX_RC_FIRST_AID:
-                mode = GAME_MOUSE_MODE_USE_FIRST_AID;
-                break;
-            case SKILLDEX_RC_DOCTOR:
-                mode = GAME_MOUSE_MODE_USE_DOCTOR;
-                break;
-            case SKILLDEX_RC_SCIENCE:
-                mode = GAME_MOUSE_MODE_USE_SCIENCE;
-                break;
-            case SKILLDEX_RC_REPAIR:
-                mode = GAME_MOUSE_MODE_USE_REPAIR;
-                break;
-            default:
-                break;
-            }
-
-            if (mode != -1) {
-                gameMouseSetCursor(MOUSE_CURSOR_USE_CROSSHAIR);
-                gameMouseSetMode(mode);
-            }
+            gameHandleSkilldexResult(rc);
         }
         break;
     case KEY_UPPERCASE_Z:
@@ -1662,6 +1624,48 @@ ScopedGameMode::ScopedGameMode(int gameMode)
 ScopedGameMode::~ScopedGameMode()
 {
     GameMode::exitGameMode(gameMode);
+}
+
+void gameHandleSkilldexResult(int rc)
+{
+    int mode = -1;
+
+    switch (rc) {
+    case SKILLDEX_RC_ERROR:
+        debugPrint("\n ** Error calling skilldex_select()! ** \n");
+        break;
+    case SKILLDEX_RC_SNEAK:
+        _action_skill_use(SKILL_SNEAK);
+        break;
+    case SKILLDEX_RC_LOCKPICK:
+        mode = GAME_MOUSE_MODE_USE_LOCKPICK;
+        break;
+    case SKILLDEX_RC_STEAL:
+        mode = GAME_MOUSE_MODE_USE_STEAL;
+        break;
+    case SKILLDEX_RC_TRAPS:
+        mode = GAME_MOUSE_MODE_USE_TRAPS;
+        break;
+    case SKILLDEX_RC_FIRST_AID:
+        mode = GAME_MOUSE_MODE_USE_FIRST_AID;
+        break;
+    case SKILLDEX_RC_DOCTOR:
+        mode = GAME_MOUSE_MODE_USE_DOCTOR;
+        break;
+    case SKILLDEX_RC_SCIENCE:
+        mode = GAME_MOUSE_MODE_USE_SCIENCE;
+        break;
+    case SKILLDEX_RC_REPAIR:
+        mode = GAME_MOUSE_MODE_USE_REPAIR;
+        break;
+    default:
+        break;
+    }
+
+    if (mode != -1) {
+        gameMouseSetCursor(MOUSE_CURSOR_USE_CROSSHAIR);
+        gameMouseSetMode(mode);
+    }
 }
 
 } // namespace fallout

--- a/src/game.h
+++ b/src/game.h
@@ -48,6 +48,7 @@ void gameUpdateState();
 int showQuitConfirmationDialog();
 
 int gameShowDeathDialog(const char* message);
+void gameHandleSkilldexResult(int rc);
 void* gameGetGlobalPointer(int var);
 int gameSetGlobalPointer(int var, void* value);
 

--- a/src/game_config.h
+++ b/src/game_config.h
@@ -29,6 +29,7 @@ namespace fallout {
 #define GAME_CONFIG_IFACE_BAR_SIDES_ORI_KEY "iface_bar_sides_ori"
 #define GAME_CONFIG_IGNORE_MAP_EDGES_KEY "ignore_map_edges"
 #define GAME_CONFIG_SPLASH_SCREEN_SIZE_KEY "splash_screen_size"
+#define GAME_CONFIG_QUICK_TOOLBAR_VISIBLE_KEY "quick_toolbar_visible"
 
 #define ENGLISH "english"
 #define FRENCH "french"

--- a/src/game_config.h
+++ b/src/game_config.h
@@ -29,7 +29,6 @@ namespace fallout {
 #define GAME_CONFIG_IFACE_BAR_SIDES_ORI_KEY "iface_bar_sides_ori"
 #define GAME_CONFIG_IGNORE_MAP_EDGES_KEY "ignore_map_edges"
 #define GAME_CONFIG_SPLASH_SCREEN_SIZE_KEY "splash_screen_size"
-#define GAME_CONFIG_QUICK_TOOLBAR_VISIBLE_KEY "quick_toolbar_visible"
 
 #define ENGLISH "english"
 #define FRENCH "french"

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -43,6 +43,7 @@
 #include "text_font.h"
 #include "text_object.h"
 #include "tile.h"
+#include "touch.h"
 #include "window_manager.h"
 
 namespace fallout {
@@ -981,6 +982,12 @@ int _gdialogInitFromScript(int headFid, int reaction)
 
     GameMode::enterGameMode(GameMode::kDialog);
 
+    // Dialog is a UI screen with buttons that need direct touch-to-click.
+    // On iPad with relative mouse mode, taps send zero-delta clicks at the
+    // cursor position instead of at the finger — unusable without touchscreen
+    // mode. Same pattern as inventory, skilldex, elevator, automap, etc.
+    touch_set_touchscreen_mode(true);
+
     return 0;
 }
 
@@ -1004,6 +1011,8 @@ int _gdialogExitFromScript()
     if (PID_TYPE(gGameDialogSpeaker->pid) != OBJ_TYPE_ITEM) {
         gameDialogRestoreCenterTile();
     }
+
+    touch_set_touchscreen_mode(false);
 
     GameMode::exitGameMode(GameMode::kDialog);
 
@@ -1960,16 +1969,31 @@ int gameDialogProcessUI()
                     dialogSwitchMode = GAME_DIALOG_MODE_TALK;
                     dialogMode = GAME_DIALOG_MODE_TALK;
                 }
+
+                // Barter's _exit_inventory() disables touchscreen mode.
+                // Re-enable it for the dialog UI.
+                touch_set_touchscreen_mode(true);
+
                 continue;
             } else if (dialogSwitchMode == GAME_DIALOG_MODE_PARTY_CONTROL_ACTIVE) {
                 dialogMode = GAME_DIALOG_MODE_PARTY_CONTROL;
                 partyMemberControlWindowHandleEvents();
                 partyMemberControlWindowFree();
+
+                // Party control may have changed touchscreen mode.
+                // Re-enable it for the dialog UI.
+                touch_set_touchscreen_mode(true);
+
                 continue;
             } else if (dialogSwitchMode == GAME_DIALOG_MODE_PARTY_CUSTOMIZATION_ACTIVE) {
                 dialogMode = GAME_DIALOG_MODE_PARTY_CUSTOMIZATION;
                 partyMemberCustomizationWindowHandleEvents();
                 partyMemberCustomizationWindowFree();
+
+                // Party customization may have changed touchscreen mode.
+                // Re-enable it for the dialog UI.
+                touch_set_touchscreen_mode(true);
+
                 continue;
             }
 

--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -4,6 +4,10 @@
 #include <stdio.h>
 #include <string.h>
 
+#if __APPLE__
+#include <TargetConditionals.h>
+#endif
+
 #include <algorithm>
 
 #include "actions.h"
@@ -1420,11 +1424,14 @@ void gameMouseSetMode(int mode)
         break;
     }
 
-    if (mode == GAME_MOUSE_MODE_MOVE) {
-        touch_set_touchscreen_mode(true);
-    } else {
-        touch_set_touchscreen_mode(false);
-    }
+    // On iPad, keep the gameplay cursor in trackpad mode so tapping the
+    // screen doesn't teleport the cursor mid-combat. UI screens (inventory,
+    // skilldex, elevator, menus) still enable touchscreen mode explicitly.
+#if __APPLE__ && TARGET_OS_IOS
+    touch_set_touchscreen_mode(false);
+#else
+    touch_set_touchscreen_mode(mode == GAME_MOUSE_MODE_MOVE);
+#endif
 }
 
 // 0x44CB6C

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -1,5 +1,7 @@
 #include "interface.h"
 
+#include "platform/ios/quick_toolbar.h"
+
 #include <algorithm>
 #include <stdio.h>
 #include <string.h>
@@ -611,6 +613,8 @@ int interfaceInit()
     gInterfaceBarInitialized = false;
     gInterfaceBarHidden = true;
 
+    quickToolbarInit();
+
     return 0;
 }
 
@@ -634,6 +638,8 @@ void interfaceReset()
 // 0x45E440
 void interfaceFree()
 {
+    quickToolbarFree();
+
     if (gInterfaceBarWindow != -1) {
         // SFALL
         sidePanelsExit();
@@ -813,6 +819,8 @@ void interfaceBarHide()
         }
     }
 
+    quickToolbarHide();
+
     // SFALL
     sidePanelsHide();
 
@@ -832,6 +840,8 @@ void interfaceBarShow()
             gInterfaceBarHidden = false;
         }
     }
+
+    quickToolbarShow();
 
     // SFALL
     sidePanelsShow();

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -613,6 +613,7 @@ int interfaceInit()
     gInterfaceBarInitialized = false;
     gInterfaceBarHidden = true;
 
+    quickToolbarSetEnabled(settings.ui.quick_toolbar_visible);
     quickToolbarInit();
 
     return 0;

--- a/src/mouse.cc
+++ b/src/mouse.cc
@@ -519,22 +519,11 @@ void _mouse_info()
                     _mouse_simulate_input(0, 0, MOUSE_STATE_RIGHT_BUTTON_DOWN);
                 }
             } else {
-                // Relative _mouse_simulate_input would *add* gesture.x/y to the
-                // current cursor position. Teleport explicitly first, then
-                // click in place so the button under the finger receives it.
-                if (mouseDeviceUsesRelativeMode()) {
-                    _mouse_set_position(gesture.x, gesture.y);
-                    if (gesture.numberOfTouches == 1) {
-                        _mouse_simulate_input(0, 0, MOUSE_STATE_LEFT_BUTTON_DOWN);
-                    } else if (gesture.numberOfTouches == 2) {
-                        _mouse_simulate_input(0, 0, MOUSE_STATE_RIGHT_BUTTON_DOWN);
-                    }
-                } else {
-                    if (gesture.numberOfTouches == 1) {
-                        _mouse_simulate_input(gesture.x, gesture.y, MOUSE_STATE_LEFT_BUTTON_DOWN);
-                    } else if (gesture.numberOfTouches == 2) {
-                        _mouse_simulate_input(gesture.x, gesture.y, MOUSE_STATE_RIGHT_BUTTON_DOWN);
-                    }
+                _mouse_set_position(gesture.x, gesture.y);
+                if (gesture.numberOfTouches == 1) {
+                    _mouse_simulate_input(gesture.x, gesture.y, MOUSE_STATE_LEFT_BUTTON_DOWN);
+                } else if (gesture.numberOfTouches == 2) {
+                    _mouse_simulate_input(gesture.x, gesture.y, MOUSE_STATE_RIGHT_BUTTON_DOWN);
                 }
             }
         tap_done:

--- a/src/mouse.cc
+++ b/src/mouse.cc
@@ -1,12 +1,19 @@
 #include "mouse.h"
 
+#if __APPLE__
+#include <TargetConditionals.h>
+#endif
+
 #include "color.h"
 #include "dinput.h"
 #include "input.h"
+#include "interface.h"
 #include "kb.h"
 #include "memory.h"
+#include "platform/ios/quick_toolbar.h"
 #include "svga.h"
 #include "touch.h"
+#include "window_manager.h"
 
 namespace fallout {
 
@@ -383,22 +390,146 @@ void _mouse_info()
         static int prevx;
         static int prevy;
 
+        // Multi-finger gestures for keyboard-less touch play:
+        //   3-finger swipe down → ESC (options menu)
+        //   3-finger long press → hold Left Shift (highlights interactables)
+        //   4-finger long press → F6  (quicksave)
+        if (gesture.type == kPan && gesture.numberOfTouches == 3) {
+            static int swipeStartY;
+            if (gesture.state == kBegan) {
+                swipeStartY = gesture.y;
+            } else if (gesture.state == kEnded) {
+                int dy = gesture.y - swipeStartY;
+                if (dy > screenGetHeight() / 3) {
+                    enqueueInputEvent(KEY_ESCAPE);
+                }
+            }
+            return;
+        }
+
+        // Four-finger long press → F6 (quicksave). Long-press is more
+        // reliable than a tap since all 4 fingers rarely land and lift
+        // within the 75ms tap window; and more reliable than a swipe
+        // since iPadOS intercepts multi-finger vertical swipes.
+        if (gesture.type == kLongPress && gesture.numberOfTouches == 4) {
+            if (gesture.state == kBegan) {
+                enqueueInputEvent(KEY_F6);
+            }
+            return;
+        }
+
+        // FO2tweaks' highlighting uses sfall's key_pressed(), which reads
+        // SDL's own SDL_GetKeyboardState. Engine-internal _kb_simulate_key
+        // bypasses that, so push real SDL_KEYDOWN/UP events instead.
+        if (gesture.type == kLongPress && gesture.numberOfTouches == 3) {
+            static bool shiftHeld = false;
+            SDL_Event ev;
+            SDL_zero(ev);
+            ev.key.keysym.scancode = SDL_SCANCODE_LSHIFT;
+            ev.key.keysym.sym = SDLK_LSHIFT;
+            if (gesture.state == kBegan && !shiftHeld) {
+                ev.type = SDL_KEYDOWN;
+                ev.key.state = SDL_PRESSED;
+                SDL_PushEvent(&ev);
+                shiftHeld = true;
+            } else if (gesture.state == kEnded && shiftHeld) {
+                ev.type = SDL_KEYUP;
+                ev.key.state = SDL_RELEASED;
+                SDL_PushEvent(&ev);
+                shiftHeld = false;
+            }
+            return;
+        }
+
         switch (gesture.type) {
-        case kTap:
-            if (mouseDeviceUsesRelativeMode()) {
+        case kTap: {
+            // Toolbar taps bypass the mouse pipeline entirely: the handler
+            // invokes the action in place, so the cursor never moves.
+            if (gesture.numberOfTouches == 1 && quickToolbarContainsPoint(gesture.x, gesture.y)) {
+                if (quickToolbarHandleTap(gesture.x, gesture.y)) {
+                    break;
+                }
+            }
+
+            // Taps on belt buttons inject the button's keyCode directly so the
+            // cursor stays put. Walking the window's button list by rect is
+            // sufficient because every belt button is a solid sprite at its
+            // advertised rect (no transparent-mask hit-tests).
+            //
+            // iOS-only: assumes a relative-mouse-mode HUD layout that does not
+            // exist on other touch platforms (Android), so we don't flip them
+            // into a tap-through model they weren't designed for.
+            bool overHud = false;
+#if __APPLE__ && TARGET_OS_IOS
+            if (mouseDeviceUsesRelativeMode() && gInterfaceBarWindow != -1) {
+                Rect hudRect;
+                if (windowGetRect(gInterfaceBarWindow, &hudRect) == 0
+                    && gesture.x >= hudRect.left && gesture.x <= hudRect.right
+                    && gesture.y >= hudRect.top && gesture.y <= hudRect.bottom) {
+                    overHud = true;
+
+                    if (gesture.numberOfTouches == 1 || gesture.numberOfTouches == 2) {
+                        Window* hudWindow = windowGetWindow(gInterfaceBarWindow);
+                        if (hudWindow != nullptr) {
+                            for (Button* button = hudWindow->buttonListHead; button != nullptr; button = button->next) {
+                                if ((button->flags & BUTTON_FLAG_DISABLED) != 0) {
+                                    continue;
+                                }
+                                int left = hudWindow->rect.left + button->rect.left;
+                                int top = hudWindow->rect.top + button->rect.top;
+                                int right = hudWindow->rect.left + button->rect.right;
+                                int bottom = hudWindow->rect.top + button->rect.bottom;
+                                if (gesture.x < left || gesture.x > right || gesture.y < top || gesture.y > bottom) {
+                                    continue;
+                                }
+                                int keyCode = gesture.numberOfTouches == 1
+                                    ? button->leftMouseUpEventCode
+                                    : button->rightMouseUpEventCode;
+                                if (keyCode == -1) {
+                                    break;
+                                }
+                                enqueueInputEvent(keyCode);
+                                goto tap_done;
+                            }
+                        }
+                    }
+
+                    // Tap landed on belt chrome (no button under it). Consume
+                    // silently rather than teleporting the cursor to an inert
+                    // region.
+                    goto tap_done;
+                }
+            }
+#endif
+
+            if (mouseDeviceUsesRelativeMode() && !overHud) {
                 if (gesture.numberOfTouches == 1) {
                     _mouse_simulate_input(0, 0, MOUSE_STATE_LEFT_BUTTON_DOWN);
                 } else if (gesture.numberOfTouches == 2) {
                     _mouse_simulate_input(0, 0, MOUSE_STATE_RIGHT_BUTTON_DOWN);
                 }
             } else {
-                if (gesture.numberOfTouches == 1) {
-                    _mouse_simulate_input(gesture.x, gesture.y, MOUSE_STATE_LEFT_BUTTON_DOWN);
-                } else if (gesture.numberOfTouches == 2) {
-                    _mouse_simulate_input(gesture.x, gesture.y, MOUSE_STATE_RIGHT_BUTTON_DOWN);
+                // Relative _mouse_simulate_input would *add* gesture.x/y to the
+                // current cursor position. Teleport explicitly first, then
+                // click in place so the button under the finger receives it.
+                if (mouseDeviceUsesRelativeMode()) {
+                    _mouse_set_position(gesture.x, gesture.y);
+                    if (gesture.numberOfTouches == 1) {
+                        _mouse_simulate_input(0, 0, MOUSE_STATE_LEFT_BUTTON_DOWN);
+                    } else if (gesture.numberOfTouches == 2) {
+                        _mouse_simulate_input(0, 0, MOUSE_STATE_RIGHT_BUTTON_DOWN);
+                    }
+                } else {
+                    if (gesture.numberOfTouches == 1) {
+                        _mouse_simulate_input(gesture.x, gesture.y, MOUSE_STATE_LEFT_BUTTON_DOWN);
+                    } else if (gesture.numberOfTouches == 2) {
+                        _mouse_simulate_input(gesture.x, gesture.y, MOUSE_STATE_RIGHT_BUTTON_DOWN);
+                    }
                 }
             }
+        tap_done:
             break;
+        }
         case kLongPress:
         case kPan:
             if (gesture.state == kBegan) {

--- a/src/mouse.cc
+++ b/src/mouse.cc
@@ -370,6 +370,57 @@ void mouseHideCursor()
     }
 }
 
+#if __APPLE__ && TARGET_OS_IOS
+// Checks whether a tap lands on an interface-bar button and, if so,
+// injects the corresponding keyCode so the cursor never moves.
+// Returns true if the tap was consumed (button injected or bare chrome hit).
+static bool handleHudTapThrough(const Gesture& gesture)
+{
+    if (!mouseDeviceUsesRelativeMode() || touch_get_touchscreen_mode() || gInterfaceBarWindow == -1) {
+        return false;
+    }
+
+    Window* hudWindow = windowGetWindow(gInterfaceBarWindow);
+    if (hudWindow == nullptr || (hudWindow->flags & WINDOW_HIDDEN) != 0) {
+        return false;
+    }
+
+    Rect hudRect;
+    if (windowGetRect(gInterfaceBarWindow, &hudRect) != 0
+        || gesture.x < hudRect.left || gesture.x > hudRect.right
+        || gesture.y < hudRect.top || gesture.y > hudRect.bottom) {
+        return false;
+    }
+
+    if (gesture.numberOfTouches == 1 || gesture.numberOfTouches == 2) {
+        for (Button* button = hudWindow->buttonListHead; button != nullptr; button = button->next) {
+            if ((button->flags & BUTTON_FLAG_DISABLED) != 0) {
+                continue;
+            }
+            int left = hudWindow->rect.left + button->rect.left;
+            int top = hudWindow->rect.top + button->rect.top;
+            int right = hudWindow->rect.left + button->rect.right;
+            int bottom = hudWindow->rect.top + button->rect.bottom;
+            if (gesture.x < left || gesture.x > right || gesture.y < top || gesture.y > bottom) {
+                continue;
+            }
+            int keyCode = gesture.numberOfTouches == 1
+                ? button->leftMouseUpEventCode
+                : button->rightMouseUpEventCode;
+            if (keyCode == -1) {
+                break;
+            }
+            enqueueInputEvent(keyCode);
+            return true;
+        }
+    }
+
+    // Tap landed on belt chrome (no button under it). Consume silently
+    // rather than teleporting the cursor to an inert region.
+    return true;
+}
+#endif
+
 // 0x4CA59C
 void _mouse_info()
 {
@@ -400,7 +451,7 @@ void _mouse_info()
                 swipeStartY = gesture.y;
             } else if (gesture.state == kEnded) {
                 int dy = gesture.y - swipeStartY;
-                if (dy > screenGetHeight() / 3) {
+                if (dy > screenGetHeight() / 4) {
                     enqueueInputEvent(KEY_ESCAPE);
                 }
             }
@@ -445,67 +496,23 @@ void _mouse_info()
         case kTap: {
             // Toolbar taps bypass the mouse pipeline entirely: the handler
             // invokes the action in place, so the cursor never moves.
-            if (gesture.numberOfTouches == 1 && quickToolbarContainsPoint(gesture.x, gesture.y)) {
+            // Skip when touchscreen mode is active (dialog, inventory, etc.)
+            // so toolbar doesn't intercept taps meant for overlapping UI.
+            if (!touch_get_touchscreen_mode()
+                && gesture.numberOfTouches == 1
+                && quickToolbarContainsPoint(gesture.x, gesture.y)) {
                 if (quickToolbarHandleTap(gesture.x, gesture.y)) {
                     break;
                 }
             }
 
-            // Taps on belt buttons inject the button's keyCode directly so the
-            // cursor stays put. Walking the window's button list by rect is
-            // sufficient because every belt button is a solid sprite at its
-            // advertised rect (no transparent-mask hit-tests).
-            //
-            // iOS-only: assumes a relative-mouse-mode HUD layout that does not
-            // exist on other touch platforms (Android), so we don't flip them
-            // into a tap-through model they weren't designed for.
-            bool overHud = false;
 #if __APPLE__ && TARGET_OS_IOS
-            // Skip HUD interception when touchscreen mode is active — a UI
-            // screen (dialog, inventory, etc.) owns input and its windows may
-            // overlap the interface bar region. Let those taps reach the UI.
-            if (mouseDeviceUsesRelativeMode() && !touch_get_touchscreen_mode() && gInterfaceBarWindow != -1) {
-                Window* hudWindow = windowGetWindow(gInterfaceBarWindow);
-                if (hudWindow != nullptr && (hudWindow->flags & WINDOW_HIDDEN) == 0) {
-                    Rect hudRect;
-                    if (windowGetRect(gInterfaceBarWindow, &hudRect) == 0
-                        && gesture.x >= hudRect.left && gesture.x <= hudRect.right
-                        && gesture.y >= hudRect.top && gesture.y <= hudRect.bottom) {
-                        overHud = true;
-
-                        if (gesture.numberOfTouches == 1 || gesture.numberOfTouches == 2) {
-                            for (Button* button = hudWindow->buttonListHead; button != nullptr; button = button->next) {
-                                if ((button->flags & BUTTON_FLAG_DISABLED) != 0) {
-                                    continue;
-                                }
-                                int left = hudWindow->rect.left + button->rect.left;
-                                int top = hudWindow->rect.top + button->rect.top;
-                                int right = hudWindow->rect.left + button->rect.right;
-                                int bottom = hudWindow->rect.top + button->rect.bottom;
-                                if (gesture.x < left || gesture.x > right || gesture.y < top || gesture.y > bottom) {
-                                    continue;
-                                }
-                                int keyCode = gesture.numberOfTouches == 1
-                                    ? button->leftMouseUpEventCode
-                                    : button->rightMouseUpEventCode;
-                                if (keyCode == -1) {
-                                    break;
-                                }
-                                enqueueInputEvent(keyCode);
-                                goto tap_done;
-                            }
-                        }
-
-                        // Tap landed on belt chrome (no button under it). Consume
-                        // silently rather than teleporting the cursor to an inert
-                        // region.
-                        goto tap_done;
-                    }
-                }
+            if (handleHudTapThrough(gesture)) {
+                goto tap_done;
             }
 #endif
 
-            if (mouseDeviceUsesRelativeMode() && !overHud) {
+            if (mouseDeviceUsesRelativeMode()) {
                 if (gesture.numberOfTouches == 1) {
                     _mouse_simulate_input(0, 0, MOUSE_STATE_LEFT_BUTTON_DOWN);
                 } else if (gesture.numberOfTouches == 2) {

--- a/src/mouse.cc
+++ b/src/mouse.cc
@@ -462,15 +462,15 @@ void _mouse_info()
             bool overHud = false;
 #if __APPLE__ && TARGET_OS_IOS
             if (mouseDeviceUsesRelativeMode() && gInterfaceBarWindow != -1) {
-                Rect hudRect;
-                if (windowGetRect(gInterfaceBarWindow, &hudRect) == 0
-                    && gesture.x >= hudRect.left && gesture.x <= hudRect.right
-                    && gesture.y >= hudRect.top && gesture.y <= hudRect.bottom) {
-                    overHud = true;
+                Window* hudWindow = windowGetWindow(gInterfaceBarWindow);
+                if (hudWindow != nullptr && (hudWindow->flags & WINDOW_HIDDEN) == 0) {
+                    Rect hudRect;
+                    if (windowGetRect(gInterfaceBarWindow, &hudRect) == 0
+                        && gesture.x >= hudRect.left && gesture.x <= hudRect.right
+                        && gesture.y >= hudRect.top && gesture.y <= hudRect.bottom) {
+                        overHud = true;
 
-                    if (gesture.numberOfTouches == 1 || gesture.numberOfTouches == 2) {
-                        Window* hudWindow = windowGetWindow(gInterfaceBarWindow);
-                        if (hudWindow != nullptr) {
+                        if (gesture.numberOfTouches == 1 || gesture.numberOfTouches == 2) {
                             for (Button* button = hudWindow->buttonListHead; button != nullptr; button = button->next) {
                                 if ((button->flags & BUTTON_FLAG_DISABLED) != 0) {
                                     continue;
@@ -492,12 +492,12 @@ void _mouse_info()
                                 goto tap_done;
                             }
                         }
-                    }
 
-                    // Tap landed on belt chrome (no button under it). Consume
-                    // silently rather than teleporting the cursor to an inert
-                    // region.
-                    goto tap_done;
+                        // Tap landed on belt chrome (no button under it). Consume
+                        // silently rather than teleporting the cursor to an inert
+                        // region.
+                        goto tap_done;
+                    }
                 }
             }
 #endif

--- a/src/mouse.cc
+++ b/src/mouse.cc
@@ -461,7 +461,10 @@ void _mouse_info()
             // into a tap-through model they weren't designed for.
             bool overHud = false;
 #if __APPLE__ && TARGET_OS_IOS
-            if (mouseDeviceUsesRelativeMode() && gInterfaceBarWindow != -1) {
+            // Skip HUD interception when touchscreen mode is active — a UI
+            // screen (dialog, inventory, etc.) owns input and its windows may
+            // overlap the interface bar region. Let those taps reach the UI.
+            if (mouseDeviceUsesRelativeMode() && !touch_get_touchscreen_mode() && gInterfaceBarWindow != -1) {
                 Window* hudWindow = windowGetWindow(gInterfaceBarWindow);
                 if (hudWindow != nullptr && (hudWindow->flags & WINDOW_HIDDEN) == 0) {
                     Rect hudRect;

--- a/src/pipboy.cc
+++ b/src/pipboy.cc
@@ -39,6 +39,7 @@
 #include "stat.h"
 #include "svga.h"
 #include "text_font.h"
+#include "touch.h"
 #include "window_manager.h"
 #include "word_wrap.h"
 #include "worldmap.h"
@@ -506,6 +507,8 @@ int pipboyOpen(int intent)
         return -1;
     }
 
+    touch_set_touchscreen_mode(true);
+
     mouseGetPositionInWindow(gPipboyWindow, &gPipboyPreviousMouseX, &gPipboyPreviousMouseY);
     gPipboyLastEventTimestamp = getTicks();
 
@@ -573,6 +576,8 @@ int pipboyOpen(int intent)
         renderPresent();
         sharedFpsLimiter.throttle();
     }
+
+    touch_set_touchscreen_mode(false);
 
     pipboyWindowFree();
 

--- a/src/platform/ios/quick_toolbar.cc
+++ b/src/platform/ios/quick_toolbar.cc
@@ -47,6 +47,7 @@ int gToolbarWindow = -1;
 int gToolbarX = 0;
 int gToolbarY = 0;
 bool gShown = false;
+bool gEnabled = true;
 
 void fillRect(unsigned char* buffer, int pitch, int x, int y, int w, int h, unsigned char color)
 {
@@ -154,11 +155,19 @@ void quickToolbarFree()
 
 void quickToolbarShow()
 {
-    if (gToolbarWindow == -1 || gShown) {
+    if (gToolbarWindow == -1 || gShown || !gEnabled) {
         return;
     }
     windowShow(gToolbarWindow);
     gShown = true;
+}
+
+void quickToolbarSetEnabled(bool enabled)
+{
+    gEnabled = enabled;
+    if (!enabled && gShown) {
+        quickToolbarHide();
+    }
 }
 
 void quickToolbarHide()

--- a/src/platform/ios/quick_toolbar.cc
+++ b/src/platform/ios/quick_toolbar.cc
@@ -141,7 +141,7 @@ namespace {
 
 void quickToolbarInit()
 {
-    if (gToolbarWindow != -1) {
+    if (gToolbarWindow != -1 || !gEnabled) {
         return;
     }
     createWindow();
@@ -155,7 +155,13 @@ void quickToolbarFree()
 
 void quickToolbarShow()
 {
-    if (gToolbarWindow == -1 || gShown || !gEnabled) {
+    if (gShown || !gEnabled) {
+        return;
+    }
+    if (gToolbarWindow == -1) {
+        createWindow();
+    }
+    if (gToolbarWindow == -1) {
         return;
     }
     windowShow(gToolbarWindow);
@@ -175,7 +181,7 @@ void quickToolbarHide()
     if (gToolbarWindow == -1 || !gShown) {
         return;
     }
-    windowHide(gToolbarWindow);
+    destroyWindow();
     gShown = false;
 }
 

--- a/src/platform/ios/quick_toolbar.cc
+++ b/src/platform/ios/quick_toolbar.cc
@@ -4,138 +4,138 @@
 
 #include <string.h>
 
-#include "art.h"
-#include "color.h"
-#include "draw.h"
-#include "game.h"
-#include "interface.h"
-#include "skilldex.h"
-#include "svga.h"
-#include "text_font.h"
-#include "window_manager.h"
+#include "../../art.h"
+#include "../../color.h"
+#include "../../draw.h"
+#include "../../game.h"
+#include "../../interface.h"
+#include "../../skilldex.h"
+#include "../../svga.h"
+#include "../../text_font.h"
+#include "../../window_manager.h"
 
 namespace fallout {
 
 namespace {
 
-constexpr int kSkillButtonCount = 8;
-constexpr int kButtonWidth = 36;
-constexpr int kButtonHeight = 24;
-constexpr int kToolbarBottomMargin = 10;
-constexpr int kToolbarWidth = kSkillButtonCount * kButtonWidth;
-// Window is exactly the button row — no outer padding rows, so there are no
-// pixels outside the buttons that could bleed as window background.
-constexpr int kToolbarHeight = kButtonHeight;
+    constexpr int kSkillButtonCount = 8;
+    constexpr int kButtonWidth = 36;
+    constexpr int kButtonHeight = 24;
+    constexpr int kToolbarBottomMargin = 10;
+    constexpr int kToolbarWidth = kSkillButtonCount * kButtonWidth;
+    // Window is exactly the button row — no outer padding rows, so there are no
+    // pixels outside the buttons that could bleed as window background.
+    constexpr int kToolbarHeight = kButtonHeight;
 
-struct SkillEntry {
-    int skilldexRc;
-    const char* label;
-};
+    struct SkillEntry {
+        int skilldexRc;
+        const char* label;
+    };
 
-constexpr SkillEntry kSkills[kSkillButtonCount] = {
-    { SKILLDEX_RC_SNEAK, "SNK" },
-    { SKILLDEX_RC_LOCKPICK, "LCK" },
-    { SKILLDEX_RC_STEAL, "STL" },
-    { SKILLDEX_RC_TRAPS, "TRP" },
-    { SKILLDEX_RC_FIRST_AID, "F/A" },
-    { SKILLDEX_RC_DOCTOR, "DOC" },
-    { SKILLDEX_RC_SCIENCE, "SCI" },
-    { SKILLDEX_RC_REPAIR, "RPR" },
-};
+    constexpr SkillEntry kSkills[kSkillButtonCount] = {
+        { SKILLDEX_RC_SNEAK, "SNK" },
+        { SKILLDEX_RC_LOCKPICK, "LCK" },
+        { SKILLDEX_RC_STEAL, "STL" },
+        { SKILLDEX_RC_TRAPS, "TRP" },
+        { SKILLDEX_RC_FIRST_AID, "F/A" },
+        { SKILLDEX_RC_DOCTOR, "DOC" },
+        { SKILLDEX_RC_SCIENCE, "SCI" },
+        { SKILLDEX_RC_REPAIR, "RPR" },
+    };
 
-int gToolbarWindow = -1;
-int gToolbarX = 0;
-int gToolbarY = 0;
-bool gShown = false;
-bool gEnabled = true;
+    int gToolbarWindow = -1;
+    int gToolbarX = 0;
+    int gToolbarY = 0;
+    bool gShown = false;
+    bool gEnabled = true;
 
-void fillRect(unsigned char* buffer, int pitch, int x, int y, int w, int h, unsigned char color)
-{
-    for (int row = 0; row < h; row++) {
-        memset(buffer + (y + row) * pitch + x, color, static_cast<size_t>(w));
-    }
-}
-
-void drawCenteredLabel(unsigned char* buffer, int pitch, int x, int y, int w, int h, const char* text, unsigned char color)
-{
-    int textWidth = fontGetStringWidth(text);
-    int lineHeight = fontGetLineHeight();
-    int tx = x + (w - textWidth) / 2;
-    // Font metrics report the full line box, but glyphs sit high within it —
-    // +2 nudges the optical center down to match the panel's visual middle.
-    int ty = y + (h - lineHeight) / 2 + 2;
-    if (tx < x) tx = x;
-    if (ty < y) ty = y;
-    // Clip text to the button's right edge so a label wider than the panel
-    // (e.g. localized or longer-named skill) can't overdraw adjacent buttons.
-    int maxDrawWidth = x + w - tx;
-    if (maxDrawWidth <= 0) {
-        return;
-    }
-    fontDrawText(buffer + ty * pitch + tx, text, maxDrawWidth, pitch, color);
-}
-
-// Muted panel tuned to sit inside the same tonal range as the belt: very dim
-// fill, thin soft border, no sharp highlight/shadow. Label uses the dimmed
-// yellow of the belt's HUD text so it doesn't compete with the interface.
-void paintPanelButton(unsigned char* buffer, int pitch, int x, int y, int w, int h, const char* label)
-{
-    unsigned char panel = intensityColorTable[_colorTable[32767]][8];
-    unsigned char border = intensityColorTable[_colorTable[32767]][28];
-
-    fillRect(buffer, pitch, x, y, w, h, panel);
-    fillRect(buffer, pitch, x, y, w, 1, border);
-    fillRect(buffer, pitch, x, y + h - 1, w, 1, border);
-    fillRect(buffer, pitch, x, y, 1, h, border);
-    fillRect(buffer, pitch, x + w - 1, y, 1, h, border);
-
-    drawCenteredLabel(buffer, pitch, x, y, w, h, label, intensityColorTable[_colorTable[32747]][48]);
-}
-
-void paintAll()
-{
-    unsigned char* buffer = windowGetBuffer(gToolbarWindow);
-    if (buffer == nullptr) {
-        return;
+    void fillRect(unsigned char* buffer, int pitch, int x, int y, int w, int h, unsigned char color)
+    {
+        for (int row = 0; row < h; row++) {
+            memset(buffer + (y + row) * pitch + x, color, static_cast<size_t>(w));
+        }
     }
 
-    fillRect(buffer, kToolbarWidth, 0, 0, kToolbarWidth, kToolbarHeight, _colorTable[0]);
-
-    int oldFont = fontGetCurrent();
-    fontSetCurrent(101);
-
-    int buttonY = (kToolbarHeight - kButtonHeight) / 2;
-    for (int i = 0; i < kSkillButtonCount; i++) {
-        paintPanelButton(buffer, kToolbarWidth, i * kButtonWidth, buttonY, kButtonWidth, kButtonHeight, kSkills[i].label);
+    void drawCenteredLabel(unsigned char* buffer, int pitch, int x, int y, int w, int h, const char* text, unsigned char color)
+    {
+        int textWidth = fontGetStringWidth(text);
+        int lineHeight = fontGetLineHeight();
+        int tx = x + (w - textWidth) / 2;
+        // Font metrics report the full line box, but glyphs sit high within it —
+        // +2 nudges the optical center down to match the panel's visual middle.
+        int ty = y + (h - lineHeight) / 2 + 2;
+        if (tx < x) tx = x;
+        if (ty < y) ty = y;
+        // Clip text to the button's right edge so a label wider than the panel
+        // (e.g. localized or longer-named skill) can't overdraw adjacent buttons.
+        int maxDrawWidth = x + w - tx;
+        if (maxDrawWidth <= 0) {
+            return;
+        }
+        fontDrawText(buffer + ty * pitch + tx, text, maxDrawWidth, pitch, color);
     }
 
-    fontSetCurrent(oldFont);
-}
+    // Muted panel tuned to sit inside the same tonal range as the belt: very dim
+    // fill, thin soft border, no sharp highlight/shadow. Label uses the dimmed
+    // yellow of the belt's HUD text so it doesn't compete with the interface.
+    void paintPanelButton(unsigned char* buffer, int pitch, int x, int y, int w, int h, const char* label)
+    {
+        unsigned char panel = intensityColorTable[_colorTable[32767]][8];
+        unsigned char border = intensityColorTable[_colorTable[32767]][28];
 
-// WINDOW_TRANSPARENT makes palette-0 (black) pixels composite away, so the
-// empty space around and between buttons is see-through. The button panels
-// themselves use a non-black dim gray so they still render as raised tiles.
-void createWindow()
-{
-    gToolbarX = (screenGetWidth() - kToolbarWidth) / 2;
-    gToolbarY = screenGetHeight() - INTERFACE_BAR_HEIGHT - kToolbarHeight - kToolbarBottomMargin;
+        fillRect(buffer, pitch, x, y, w, h, panel);
+        fillRect(buffer, pitch, x, y, w, 1, border);
+        fillRect(buffer, pitch, x, y + h - 1, w, 1, border);
+        fillRect(buffer, pitch, x, y, 1, h, border);
+        fillRect(buffer, pitch, x + w - 1, y, 1, h, border);
 
-    gToolbarWindow = windowCreate(gToolbarX, gToolbarY, kToolbarWidth, kToolbarHeight, _colorTable[0], WINDOW_HIDDEN | WINDOW_TRANSPARENT);
-    if (gToolbarWindow == -1) {
-        return;
+        drawCenteredLabel(buffer, pitch, x, y, w, h, label, intensityColorTable[_colorTable[32747]][48]);
     }
 
-    paintAll();
-}
+    void paintAll()
+    {
+        unsigned char* buffer = windowGetBuffer(gToolbarWindow);
+        if (buffer == nullptr) {
+            return;
+        }
 
-void destroyWindow()
-{
-    if (gToolbarWindow == -1) {
-        return;
+        fillRect(buffer, kToolbarWidth, 0, 0, kToolbarWidth, kToolbarHeight, _colorTable[0]);
+
+        int oldFont = fontGetCurrent();
+        fontSetCurrent(101);
+
+        int buttonY = (kToolbarHeight - kButtonHeight) / 2;
+        for (int i = 0; i < kSkillButtonCount; i++) {
+            paintPanelButton(buffer, kToolbarWidth, i * kButtonWidth, buttonY, kButtonWidth, kButtonHeight, kSkills[i].label);
+        }
+
+        fontSetCurrent(oldFont);
     }
-    windowDestroy(gToolbarWindow);
-    gToolbarWindow = -1;
-}
+
+    // WINDOW_TRANSPARENT makes palette-0 (black) pixels composite away, so the
+    // empty space around and between buttons is see-through. The button panels
+    // themselves use a non-black dim gray so they still render as raised tiles.
+    void createWindow()
+    {
+        gToolbarX = (screenGetWidth() - kToolbarWidth) / 2;
+        gToolbarY = screenGetHeight() - INTERFACE_BAR_HEIGHT - kToolbarHeight - kToolbarBottomMargin;
+
+        gToolbarWindow = windowCreate(gToolbarX, gToolbarY, kToolbarWidth, kToolbarHeight, _colorTable[0], WINDOW_HIDDEN | WINDOW_TRANSPARENT);
+        if (gToolbarWindow == -1) {
+            return;
+        }
+
+        paintAll();
+    }
+
+    void destroyWindow()
+    {
+        if (gToolbarWindow == -1) {
+            return;
+        }
+        windowDestroy(gToolbarWindow);
+        gToolbarWindow = -1;
+    }
 
 } // namespace
 
@@ -199,12 +199,19 @@ bool quickToolbarHandleTap(int x, int y)
         return false;
     }
 
+    // Prevent skill activation when the interface bar is disabled (e.g., during cutscenes).
+    if (!interfaceBarEnabled() || gameUiIsDisabled()) {
+        return true;
+    }
+
     int localX = x - gToolbarX;
     int index = localX / kButtonWidth;
     if (index < 0 || index >= kSkillButtonCount) {
         return true;
     }
+
     gameHandleSkilldexResult(kSkills[index].skilldexRc);
+
     return true;
 }
 

--- a/src/platform/ios/quick_toolbar.cc
+++ b/src/platform/ios/quick_toolbar.cc
@@ -1,0 +1,204 @@
+#include "quick_toolbar.h"
+
+#if defined(__APPLE__) && TARGET_OS_IOS
+
+#include <string.h>
+
+#include "../../art.h"
+#include "../../color.h"
+#include "../../draw.h"
+#include "../../game.h"
+#include "../../interface.h"
+#include "../../skilldex.h"
+#include "../../svga.h"
+#include "../../text_font.h"
+#include "../../window_manager.h"
+
+namespace fallout {
+
+namespace {
+
+constexpr int kSkillButtonCount = 8;
+constexpr int kButtonWidth = 36;
+constexpr int kButtonHeight = 24;
+constexpr int kToolbarBottomMargin = 10;
+constexpr int kToolbarWidth = kSkillButtonCount * kButtonWidth;
+// Window is exactly the button row — no outer padding rows, so there are no
+// pixels outside the buttons that could bleed as window background.
+constexpr int kToolbarHeight = kButtonHeight;
+
+struct SkillEntry {
+    int skilldexRc;
+    const char* label;
+};
+
+constexpr SkillEntry kSkills[kSkillButtonCount] = {
+    { SKILLDEX_RC_SNEAK, "SNK" },
+    { SKILLDEX_RC_LOCKPICK, "LCK" },
+    { SKILLDEX_RC_STEAL, "STL" },
+    { SKILLDEX_RC_TRAPS, "TRP" },
+    { SKILLDEX_RC_FIRST_AID, "F/A" },
+    { SKILLDEX_RC_DOCTOR, "DOC" },
+    { SKILLDEX_RC_SCIENCE, "SCI" },
+    { SKILLDEX_RC_REPAIR, "RPR" },
+};
+
+int gToolbarWindow = -1;
+int gToolbarX = 0;
+int gToolbarY = 0;
+bool gShown = false;
+
+void fillRect(unsigned char* buffer, int pitch, int x, int y, int w, int h, unsigned char color)
+{
+    for (int row = 0; row < h; row++) {
+        memset(buffer + (y + row) * pitch + x, color, static_cast<size_t>(w));
+    }
+}
+
+void drawCenteredLabel(unsigned char* buffer, int pitch, int x, int y, int w, int h, const char* text, unsigned char color)
+{
+    int textWidth = fontGetStringWidth(text);
+    int lineHeight = fontGetLineHeight();
+    int tx = x + (w - textWidth) / 2;
+    // Font metrics report the full line box, but glyphs sit high within it —
+    // +2 nudges the optical center down to match the panel's visual middle.
+    int ty = y + (h - lineHeight) / 2 + 2;
+    if (tx < x) tx = x;
+    if (ty < y) ty = y;
+    // Clip text to the button's right edge so a label wider than the panel
+    // (e.g. localized or longer-named skill) can't overdraw adjacent buttons.
+    int maxDrawWidth = x + w - tx;
+    if (maxDrawWidth <= 0) {
+        return;
+    }
+    fontDrawText(buffer + ty * pitch + tx, text, maxDrawWidth, pitch, color);
+}
+
+// Muted panel tuned to sit inside the same tonal range as the belt: very dim
+// fill, thin soft border, no sharp highlight/shadow. Label uses the dimmed
+// yellow of the belt's HUD text so it doesn't compete with the interface.
+void paintPanelButton(unsigned char* buffer, int pitch, int x, int y, int w, int h, const char* label)
+{
+    unsigned char panel = intensityColorTable[_colorTable[32767]][8];
+    unsigned char border = intensityColorTable[_colorTable[32767]][28];
+
+    fillRect(buffer, pitch, x, y, w, h, panel);
+    fillRect(buffer, pitch, x, y, w, 1, border);
+    fillRect(buffer, pitch, x, y + h - 1, w, 1, border);
+    fillRect(buffer, pitch, x, y, 1, h, border);
+    fillRect(buffer, pitch, x + w - 1, y, 1, h, border);
+
+    drawCenteredLabel(buffer, pitch, x, y, w, h, label, intensityColorTable[_colorTable[32747]][48]);
+}
+
+void paintAll()
+{
+    unsigned char* buffer = windowGetBuffer(gToolbarWindow);
+    if (buffer == nullptr) {
+        return;
+    }
+
+    fillRect(buffer, kToolbarWidth, 0, 0, kToolbarWidth, kToolbarHeight, _colorTable[0]);
+
+    int oldFont = fontGetCurrent();
+    fontSetCurrent(101);
+
+    int buttonY = (kToolbarHeight - kButtonHeight) / 2;
+    for (int i = 0; i < kSkillButtonCount; i++) {
+        paintPanelButton(buffer, kToolbarWidth, i * kButtonWidth, buttonY, kButtonWidth, kButtonHeight, kSkills[i].label);
+    }
+
+    fontSetCurrent(oldFont);
+}
+
+// WINDOW_TRANSPARENT makes palette-0 (black) pixels composite away, so the
+// empty space around and between buttons is see-through. The button panels
+// themselves use a non-black dim gray so they still render as raised tiles.
+void createWindow()
+{
+    gToolbarX = (screenGetWidth() - kToolbarWidth) / 2;
+    gToolbarY = screenGetHeight() - INTERFACE_BAR_HEIGHT - kToolbarHeight - kToolbarBottomMargin;
+
+    gToolbarWindow = windowCreate(gToolbarX, gToolbarY, kToolbarWidth, kToolbarHeight, _colorTable[0], WINDOW_HIDDEN | WINDOW_TRANSPARENT);
+    if (gToolbarWindow == -1) {
+        return;
+    }
+
+    paintAll();
+}
+
+void destroyWindow()
+{
+    if (gToolbarWindow == -1) {
+        return;
+    }
+    windowDestroy(gToolbarWindow);
+    gToolbarWindow = -1;
+}
+
+} // namespace
+
+void quickToolbarInit()
+{
+    if (gToolbarWindow != -1) {
+        return;
+    }
+    createWindow();
+}
+
+void quickToolbarFree()
+{
+    destroyWindow();
+    gShown = false;
+}
+
+void quickToolbarShow()
+{
+    if (gToolbarWindow == -1 || gShown) {
+        return;
+    }
+    windowShow(gToolbarWindow);
+    gShown = true;
+}
+
+void quickToolbarHide()
+{
+    if (gToolbarWindow == -1 || !gShown) {
+        return;
+    }
+    windowHide(gToolbarWindow);
+    gShown = false;
+}
+
+bool quickToolbarIsWindow(int windowId)
+{
+    return gToolbarWindow != -1 && windowId == gToolbarWindow;
+}
+
+bool quickToolbarContainsPoint(int x, int y)
+{
+    if (gToolbarWindow == -1 || !gShown) {
+        return false;
+    }
+    return x >= gToolbarX && x < gToolbarX + kToolbarWidth
+        && y >= gToolbarY && y < gToolbarY + kToolbarHeight;
+}
+
+bool quickToolbarHandleTap(int x, int y)
+{
+    if (!quickToolbarContainsPoint(x, y)) {
+        return false;
+    }
+
+    int localX = x - gToolbarX;
+    int index = localX / kButtonWidth;
+    if (index < 0 || index >= kSkillButtonCount) {
+        return true;
+    }
+    gameHandleSkilldexResult(kSkills[index].skilldexRc);
+    return true;
+}
+
+} // namespace fallout
+
+#endif // defined(__APPLE__) && TARGET_OS_IOS

--- a/src/platform/ios/quick_toolbar.cc
+++ b/src/platform/ios/quick_toolbar.cc
@@ -4,15 +4,15 @@
 
 #include <string.h>
 
-#include "../../art.h"
-#include "../../color.h"
-#include "../../draw.h"
-#include "../../game.h"
-#include "../../interface.h"
-#include "../../skilldex.h"
-#include "../../svga.h"
-#include "../../text_font.h"
-#include "../../window_manager.h"
+#include "art.h"
+#include "color.h"
+#include "draw.h"
+#include "game.h"
+#include "interface.h"
+#include "skilldex.h"
+#include "svga.h"
+#include "text_font.h"
+#include "window_manager.h"
 
 namespace fallout {
 

--- a/src/platform/ios/quick_toolbar.h
+++ b/src/platform/ios/quick_toolbar.h
@@ -15,6 +15,11 @@ void quickToolbarShow();
 void quickToolbarHide();
 bool quickToolbarIsWindow(int windowId);
 
+// User preference toggle. When false, quickToolbarShow is a no-op and any
+// already-visible toolbar is hidden. Applied by the iOS settings bridge at
+// launch; safe to call before quickToolbarInit.
+void quickToolbarSetEnabled(bool enabled);
+
 // True when the screen point falls within the toolbar window rect. Used by the
 // touch dispatcher to route taps to the toolbar without going through the
 // mouse-simulation pipeline (which would teleport the cursor).
@@ -33,6 +38,7 @@ inline void quickToolbarHide() { }
 inline bool quickToolbarIsWindow(int) { return false; }
 inline bool quickToolbarContainsPoint(int, int) { return false; }
 inline bool quickToolbarHandleTap(int, int) { return false; }
+inline void quickToolbarSetEnabled(bool) { }
 
 #endif
 

--- a/src/platform/ios/quick_toolbar.h
+++ b/src/platform/ios/quick_toolbar.h
@@ -1,0 +1,41 @@
+#ifndef FALLOUT_PLATFORM_IOS_QUICK_TOOLBAR_H_
+#define FALLOUT_PLATFORM_IOS_QUICK_TOOLBAR_H_
+
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
+
+namespace fallout {
+
+#if defined(__APPLE__) && TARGET_OS_IOS
+
+void quickToolbarInit();
+void quickToolbarFree();
+void quickToolbarShow();
+void quickToolbarHide();
+bool quickToolbarIsWindow(int windowId);
+
+// True when the screen point falls within the toolbar window rect. Used by the
+// touch dispatcher to route taps to the toolbar without going through the
+// mouse-simulation pipeline (which would teleport the cursor).
+bool quickToolbarContainsPoint(int x, int y);
+
+// Invokes the action under the screen point. Returns true if a button was hit.
+// Does not move the cursor and does not enqueue mouse events.
+bool quickToolbarHandleTap(int x, int y);
+
+#else
+
+inline void quickToolbarInit() { }
+inline void quickToolbarFree() { }
+inline void quickToolbarShow() { }
+inline void quickToolbarHide() { }
+inline bool quickToolbarIsWindow(int) { return false; }
+inline bool quickToolbarContainsPoint(int, int) { return false; }
+inline bool quickToolbarHandleTap(int, int) { return false; }
+
+#endif
+
+} // namespace fallout
+
+#endif /* FALLOUT_PLATFORM_IOS_QUICK_TOOLBAR_H_ */

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -153,6 +153,7 @@ void initSettingsRegistry(bool isMapper)
     SETTING(iface_bar_sides_ori);
     SETTING_P(splash_screen_size, clamp(0, 2));
     SETTING(ignore_map_edges);
+    SETTING(quick_toolbar_visible);
     SETTING_P(anim_speed, clamp(0.1, 100.0));
     SETTING_P(skip_opening_movies, clamp(0, 2));
     SETTING(display_karma_changes);

--- a/src/settings.h
+++ b/src/settings.h
@@ -55,6 +55,9 @@ struct UISettings {
 
     bool ignore_map_edges = false;
 
+    // iOS quick-actions toolbar above the interface bar. No-op on other platforms.
+    bool quick_toolbar_visible = true;
+
     // TODO: add to setting window
     // Speed of various UI transition animations. 1.0 represents vanilla speeds.
     double anim_speed = 1.0;

--- a/src/settings.h
+++ b/src/settings.h
@@ -56,7 +56,7 @@ struct UISettings {
     bool ignore_map_edges = false;
 
     // iOS quick-actions toolbar above the interface bar. No-op on other platforms.
-    bool quick_toolbar_visible = true;
+    bool quick_toolbar_visible = false;
 
     // TODO: add to setting window
     // Speed of various UI transition animations. 1.0 represents vanilla speeds.

--- a/src/touch.cc
+++ b/src/touch.cc
@@ -302,6 +302,11 @@ void touch_set_touchscreen_mode(const bool value)
     gUseTouchscreenMode = value;
 }
 
+bool touch_get_touchscreen_mode()
+{
+    return gUseTouchscreenMode;
+}
+
 void touch_set_pan_mode(const bool value)
 {
     gUsePanMode = value;

--- a/src/touch.h
+++ b/src/touch.h
@@ -33,6 +33,7 @@ void touch_handle_end(SDL_TouchFingerEvent* event);
 void touch_process_gesture();
 bool touch_get_gesture(Gesture* gesture);
 void touch_set_touchscreen_mode(const bool value);
+bool touch_get_touchscreen_mode();
 void touch_set_pan_mode(const bool value);
 bool touch_get_pan_mode();
 


### PR DESCRIPTION
Makes fallout2-ce playable on iPad without a keyboard. Most additions are TARGET_OS_IOS-guarded; the multi-finger touch gestures are intentionally cross-platform and benefit Android too.

Touch gestures (src/mouse.cc, cross-platform — any SDL touch backend):
- 3-finger swipe down → ESC
- 3-finger long-press → hold LShift (FO2tweaks highlighting) 
- 4-finger long-press → F6 (quicksave)

HUD ergonomics (src/mouse.cc, iOS-guarded):
- Taps on interface-bar buttons inject the button's keyCode directly so the cursor stays put.
- Two-finger taps on belt buttons → right-click handler.
- Guarded behind `#if __APPLE__ && TARGET_OS_IOS` because the tap-through assumes a relative-mouse-mode HUD layout that other touch platforms don't use.

Gameplay cursor (src/game_mouse.cc, iOS-guarded):
- On iPad, keep GAME_MOUSE_MODE_MOVE in relative (trackpad) mode so screen taps don't teleport the cursor during combat. UI screens that explicitly enable touchscreen mode are unaffected.

Character editor (src/character_editor.cc):
- Enable touchscreen mode while the character screen is open.

Quick-actions toolbar (src/platform/ios/quick_toolbar.{cc,h}, iOS-only):
- Optional iOS-only HUD strip above the belt with 8 skill shortcuts.

README: iPad controls section.

### Screenshots

<img width="623" height="288" alt="image" src="https://github.com/user-attachments/assets/b426d6d6-524b-465c-8884-359ddbc2e4fc" />
