### PR TITLE
Implement HOOK_ONDEATH

### DIFF
--- a/SFALL_COMPATIBILITY.md
+++ b/SFALL_COMPATIBILITY.md
@@ -82,7 +82,7 @@ See [`https://sfall-team.github.io/sfall/`](https://sfall-team.github.io/sfall/)
 | DeathAnim1 | `HOOK_DEATHANIM1` | 🚫 | Use DEATHANIM2 instead |
 | DeathAnim2 | `HOOK_DEATHANIM2` | ✅ | - |
 | CombatDamage | `HOOK_COMBATDAMAGE` | ✅ | - |
-| OnDeath | `HOOK_ONDEATH` | 🚫 | - |
+| OnDeath | `HOOK_ONDEATH` | ✅ | - |
 | FindTarget | `HOOK_FINDTARGET` | 🚫 | (maybe) |
 | UseObjOn | `HOOK_USEOBJON` | ✅ | - |
 | UseObj | `HOOK_USEOBJ` | ✅ | CE notes an sfall-matching inconsistency around return code `2` behavior between interface contexts. |

--- a/sfall_testing/hooks/gl_ondeath.ssl
+++ b/sfall_testing/hooks/gl_ondeath.ssl
@@ -1,0 +1,52 @@
+#include "sfall.h"
+#include "dik.h"
+#include "define_lite.h"
+
+#define TEST_KEY (DIK_J)
+
+procedure ondeath_handler begin
+    variable
+        dead_critter := get_sfall_arg_at(0),
+        critter_name := "<null>",
+        critter_pid := -1;
+
+    if (dead_critter) then begin
+        critter_name := obj_name(dead_critter);
+        critter_pid := obj_pid(dead_critter);
+    end
+
+    display_msg(string_format2("ondeath critter=%s pid=%d", critter_name, critter_pid));
+end
+
+procedure keypress_handler begin
+    variable
+        pressed := get_sfall_arg_at(0),
+        key := get_sfall_arg_at(1),
+        target;
+
+    if (not pressed) then return;
+    if (key != TEST_KEY) then return;
+
+    target := obj_under_cursor(true, false);
+    if (target == 0) then begin
+        display_msg("ondeath test: no critter under cursor");
+        return;
+    end
+
+    if (target == dude_obj) then begin
+        display_msg("ondeath test: refusing to kill dude");
+        return;
+    end
+
+    display_msg(string_format1("ondeath test: killing %s", obj_name(target)));
+    critter_dmg(target, 9999, DMG_BYPASS_ARMOR);
+end
+
+procedure start begin
+    if (not game_loaded) then return;
+
+    display_msg("ondeath manual test ready: hover a critter and press J");
+
+    register_hook_proc(HOOK_KEYPRESS, keypress_handler);
+    register_hook_proc(HOOK_ONDEATH, ondeath_handler);
+end

--- a/src/combat.cc
+++ b/src/combat.cc
@@ -4938,6 +4938,7 @@ static void _damage_object(Object* a1, int damage, bool animated, int a4, Object
         }
 
         partyMemberRemove(a1);
+        scriptHooks_OnDeath(a1);
     }
 }
 

--- a/src/critter.cc
+++ b/src/critter.cc
@@ -826,6 +826,9 @@ void critterKill(Object* critter, int anim, bool refreshRect)
 
     int elevation = critter->elevation;
 
+    critter->data.critter.hp = 0;
+    critter->data.critter.combat.results |= DAM_DEAD;
+
     partyMemberRemove(critter);
     scriptHooks_OnDeath(critter);
 
@@ -894,9 +897,6 @@ void critterKill(Object* critter, int anim, bool refreshRect)
 
     _obj_turn_off_light(critter, &tempRect);
     rectUnion(&updatedRect, &tempRect, &updatedRect);
-
-    critter->data.critter.hp = 0;
-    critter->data.critter.combat.results |= DAM_DEAD;
 
     if (critter->sid != -1) {
         scriptRemove(critter->sid);

--- a/src/critter.cc
+++ b/src/critter.cc
@@ -25,6 +25,7 @@
 #include "random.h"
 #include "reaction.h"
 #include "scripts.h"
+#include "sfall_script_hooks.h"
 #include "skill.h"
 #include "stat.h"
 #include "tile.h"
@@ -826,6 +827,7 @@ void critterKill(Object* critter, int anim, bool refreshRect)
     int elevation = critter->elevation;
 
     partyMemberRemove(critter);
+    scriptHooks_OnDeath(critter);
 
     // NOTE: Original code uses goto to jump out from nested conditions below.
     bool shouldChangeFid = false;

--- a/src/sfall_script_hooks.cc
+++ b/src/sfall_script_hooks.cc
@@ -165,6 +165,16 @@ void scriptHooks_GameModeChange(int exit, int previousGameMode)
 }
 
 /*
+Runs immediately after a critter dies for any reason.
+
+Critter arg0 - The critter that just died
+*/
+void scriptHooks_OnDeath(Object* critter)
+{
+    ScriptHookCall(HOOK_ONDEATH, 0, { critter }).call();
+}
+
+/*
 Runs before and after each turn in combat (for both PC and NPC).
 
 int     arg0 - event type:

--- a/src/sfall_script_hooks.h
+++ b/src/sfall_script_hooks.h
@@ -257,6 +257,7 @@ void scriptHooksReset();
 void scriptHooksExit();
 
 void scriptHooks_GameModeChange(int exit, int previousGameMode);
+void scriptHooks_OnDeath(Object* critter);
 bool scriptHooks_InventoryMove(HookInventoryMoveType actionType, Object* item, Object* targetItem);
 bool scriptHooks_CombatTurnStart(Object* critter, bool reloadedDuringCombat);
 bool scriptHooks_CombatTurnEnd(Object* critter, int turnResult, bool reloadedDuringCombat);


### PR DESCRIPTION
Test both combat death and script-triggered death

Curious if there's any possible way we'd send a deallocated object to the script, but it seems sound