### PR TITLE
Add AI agent related files to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -400,3 +400,14 @@ FodyWeavers.xsd
 # versioning header
 src/platform/git_version.h
 CMakeUserPresets.json
+
+# Local configs for AI agents
+opencode.json
+.opencode
+.agents
+.aider*
+.gemini
+.claude
+.mcp.json
+AGENTS.md
+CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -402,7 +402,6 @@ src/platform/git_version.h
 CMakeUserPresets.json
 
 # Local configs for AI agents
-opencode.json
 .opencode
 .agents
 .aider*
@@ -411,3 +410,5 @@ opencode.json
 .mcp.json
 AGENTS.md
 CLAUDE.md
+GEMINI.md
+opencode.json


### PR DESCRIPTION
Adds everything related to AI agents to .gitignore.

I thought to add AGENTS.md to repo, even removed everything related to local setup, but decided against it. The effectiveness of these rules might be sensitive to whatever model is being used, the prompt, etc. Maybe after more people use these rules for longer time we can "converge" on some md that will be actually useful to share.