### PR TITLE
Add configurable talking heads mapping ([Heads] config)

### DIFF
--- a/files/ddraw.ini
+++ b/files/ddraw.ini
@@ -42,6 +42,14 @@
 ;UnarmedFile=sfall\Unarmed.ini
 
 ;XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+[Heads]
+;Maps critter PIDs to talking head indices in art\heads\heads.lst.
+;Used when dialog scripts don't specify a head (headId=-1) and the critter proto has no head_fid set.
+;Format: <critter_pid>=<head_index>
+;Cassidy (requires cassidy_head mod)
+16777305=13
+
+;XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 [Scripts]
 
 ;Uncomment the option to specify an additional directory for ini files used by scripts

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -36,6 +36,7 @@
 #include "reaction.h"
 #include "scripts.h"
 #include "settings.h"
+#include "sfall_config.h"
 #include "sfall_opcodes.h"
 #include "skill.h"
 #include "stat.h"
@@ -1915,6 +1916,22 @@ static void opStartGameDialog(Program* program)
         Proto* proto;
         if (protoGetProto(obj->pid, &proto) == -1) {
             return;
+        }
+
+        // Use head FID from critter proto when script doesn't specify one.
+        if (headId == -1 && proto->critter.headFid != -1) {
+            headId = proto->critter.headFid & 0xFFF;
+        }
+
+        // Check [Heads] section in ddraw.ini for PID→head index mapping.
+        // This allows mods to add talking heads without modifying dialog scripts.
+        if (headId == -1) {
+            char pidKey[20];
+            snprintf(pidKey, sizeof(pidKey), "%d", obj->pid);
+            int configHeadId;
+            if (configGetInt(&gSfallConfig, SFALL_CONFIG_HEADS_KEY, pidKey, &configHeadId)) {
+                headId = configHeadId;
+            }
         }
     }
 

--- a/src/sfall_config.h
+++ b/src/sfall_config.h
@@ -10,6 +10,7 @@ namespace fallout {
 #define SFALL_CONFIG_MAIN_KEY "Main"
 #define SFALL_CONFIG_MISC_KEY "Misc"
 #define SFALL_CONFIG_SCRIPTS_KEY "Scripts"
+#define SFALL_CONFIG_HEADS_KEY "Heads"
 
 #define SFALL_CONFIG_OVERRIDE_CRITICALS_MODE_KEY "OverrideCriticalTable"
 #define SFALL_CONFIG_OVERRIDE_CRITICALS_FILE_KEY "OverrideCriticalFile"


### PR DESCRIPTION
## Summary

Add a `[Heads]` section in `ddraw.ini` that maps critter PIDs to talking head indices in `art\heads\heads.lst`. When a dialog script starts with `headId=-1`, the engine now:

1. Checks the critter proto's `headFid` first
2. Falls back to the `[Heads]` mapping in ddraw.ini

This lets mods add talking heads to any critter without patching dialog scripts.

### Status

This is a **proof of concept** — currently tailored to Cassidy (`PID 16777305 → head index 13`) for use with the `cassidy_head.dat` mod. The mechanism itself is generic and works for any critter PID → head index mapping.

### Files changed
- `files/ddraw.ini` — new `[Heads]` section with example Cassidy mapping
- `src/sfall_config.h` — `SFALL_CONFIG_HEADS_KEY` constant
- `src/interpreter_extra.cc` — headId lookup in `opStartGameDialog`

needs https://github.com/BGforgeNet/Fallout2_Cassidy_Head

mods_order.txt
```
cassidy_head.dat
cassidy_voice_joey_bracken_lq.dat
cassidy_voice_msg.dat
```

source and compiled dat:
[cassidy_voice_msg.zip](https://github.com/user-attachments/files/26966138/cassidy_voice_msg.zip)