### PR TITLE
`--dev-load-game` commandline arg

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,13 @@ For current sfall compatibility status and the remaining work needed to close ga
 
 The project uses CMake, so building mostly comes down to picking the right preset.
 
+## Commandline arguments
+
+```
+--scan-unimplemented:   do an analysis of opcodes and hooks used by loaded mods
+--dev-load-game=SAVE01: load the given save game automatically (useful for LLM automation)
+```
+
 ### macOS
 
 - Install the Command Line Tools if needed: `xcode-select --install`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ The project uses CMake, so building mostly comes down to picking the right prese
 ## Commandline arguments
 
 - `--scan-unimplemented` - do an analysis of opcodes and hooks used by loaded mods
-- `--dev-load-game=SLOT01` - load the given save game automatically (useful for LLM automation)
+- `--dev-load-game=1` - load the given save game automatically (useful for LLM automation)
 
 ### macOS
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,10 +10,8 @@ The project uses CMake, so building mostly comes down to picking the right prese
 
 ## Commandline arguments
 
-```
---scan-unimplemented:   do an analysis of opcodes and hooks used by loaded mods
---dev-load-game=SAVE01: load the given save game automatically (useful for LLM automation)
-```
+- `--scan-unimplemented` - do an analysis of opcodes and hooks used by loaded mods
+- `--dev-load-game=SLOT01` - load the given save game automatically (useful for LLM automation)
 
 ### macOS
 

--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -1113,7 +1113,6 @@ int lsgLoadGame(int mode)
         return -1;
     }
 
-    bool devAutoloadFailed = false;
     bool devAutoloadPending = false;
 
     if (devAutoloadSlot != -1) {
@@ -1124,11 +1123,9 @@ int lsgLoadGame(int mode)
                 devAutoloadPending = true;
             } else {
                 debugPrint("LOADSAVE: dev load slot %d is not occupied\n", _slot_cursor + 1);
-                devAutoloadFailed = true;
             }
         } else {
             debugPrint("LOADSAVE: invalid dev load slot %d\n", devAutoloadSlot + 1);
-            devAutoloadFailed = true;
         }
     }
 
@@ -1167,7 +1164,7 @@ int lsgLoadGame(int mode)
     int rc = -1;
 
     int doubleClickSlot = -1;
-    while (rc == -1 && !devAutoloadFailed) {
+    while (rc == -1) {
         sharedFpsLimiter.mark();
 
         unsigned int time = getTicks();
@@ -1329,12 +1326,7 @@ int lsgLoadGame(int mode)
             if (_LSstatus[_slot_cursor] != SLOT_STATE_EMPTY) {
                 rc = 1;
             } else {
-                if (devAutoloadSlot != -1) {
-                    devAutoloadFailed = true;
-                    rc = -1;
-                } else {
-                    rc = -1;
-                }
+                rc = -1;
             }
 
             selectionChanged = true;
@@ -1482,12 +1474,6 @@ int lsgLoadGame(int mode)
         if (rc == 1) {
             switch (_LSstatus[_slot_cursor]) {
             case SLOT_STATE_UNSUPPORTED_VERSION:
-                if (devAutoloadSlot != -1) {
-                    devAutoloadFailed = true;
-                    rc = -1;
-                    break;
-                }
-
                 soundPlayFile("iisxxxx1");
                 strcpy(_str0, getmsg(&gLoadSaveMessageList, &gLoadSaveMessageListItem, 134));
                 strcpy(_str1, getmsg(&gLoadSaveMessageList, &gLoadSaveMessageListItem, 136));
@@ -1496,12 +1482,6 @@ int lsgLoadGame(int mode)
                 rc = -1;
                 break;
             case SLOT_STATE_ERROR:
-                if (devAutoloadSlot != -1) {
-                    devAutoloadFailed = true;
-                    rc = -1;
-                    break;
-                }
-
                 soundPlayFile("iisxxxx1");
                 strcpy(_str0, getmsg(&gLoadSaveMessageList, &gLoadSaveMessageListItem, 134));
                 strcpy(_str1, getmsg(&gLoadSaveMessageList, &gLoadSaveMessageListItem, 136));
@@ -1510,19 +1490,14 @@ int lsgLoadGame(int mode)
                 break;
             default:
                 if (lsgLoadGameInSlot(_slot_cursor) == -1) {
-                    if (devAutoloadSlot != -1) {
-                        devAutoloadFailed = true;
-                        rc = -1;
-                    } else {
-                        gameMouseSetCursor(MOUSE_CURSOR_ARROW);
-                        soundPlayFile("iisxxxx1");
-                        strcpy(_str0, getmsg(&gLoadSaveMessageList, &gLoadSaveMessageListItem, 134));
-                        strcpy(_str1, getmsg(&gLoadSaveMessageList, &gLoadSaveMessageListItem, 135));
-                        showDialogBox(_str0, body, 1, 169, 116, _colorTable[32328], nullptr, _colorTable[32328], DIALOG_BOX_LARGE);
-                        mapNewMap();
-                        _game_user_wants_to_quit = GAME_QUIT_REQUEST_MAIN_MENU;
-                        rc = -1;
-                    }
+                    gameMouseSetCursor(MOUSE_CURSOR_ARROW);
+                    soundPlayFile("iisxxxx1");
+                    strcpy(_str0, getmsg(&gLoadSaveMessageList, &gLoadSaveMessageListItem, 134));
+                    strcpy(_str1, getmsg(&gLoadSaveMessageList, &gLoadSaveMessageListItem, 135));
+                    showDialogBox(_str0, body, 1, 169, 116, _colorTable[32328], nullptr, _colorTable[32328], DIALOG_BOX_LARGE);
+                    mapNewMap();
+                    _game_user_wants_to_quit = GAME_QUIT_REQUEST_MAIN_MENU;
+                    rc = -1;
                 }
                 break;
             }
@@ -1548,7 +1523,7 @@ int lsgLoadGame(int mode)
         }
     }
 
-    return devAutoloadFailed ? -1 : rc;
+    return rc;
 }
 
 void lsgDevSetLoadGameSlot(int slot)

--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -204,6 +204,8 @@ static int _currentSlotPage = 0;
 // 0x5193B8
 static int _slot_cursor = 0;
 
+static int gDevLoadGameSlot = -1;
+
 // 0x5193BC
 static bool _quick_done = false;
 
@@ -1079,6 +1081,12 @@ int lsgLoadGame(int mode)
         assert(false && "Should be unreachable");
     }
 
+    int devAutoloadSlot = -1;
+    if (mode == LOAD_SAVE_MODE_FROM_MAIN_MENU && gDevLoadGameSlot != -1) {
+        devAutoloadSlot = gDevLoadGameSlot;
+        gDevLoadGameSlot = -1;
+    }
+
     touch_set_touchscreen_mode(windowType == LOAD_SAVE_WINDOW_TYPE_LOAD_GAME || windowType == LOAD_SAVE_WINDOW_TYPE_LOAD_GAME_FROM_MAIN_MENU);
 
     if (lsgWindowInit(windowType) == -1) {
@@ -1103,6 +1111,25 @@ int lsgLoadGame(int mode)
         showDialogBox(_str0, body, 2, 169, 116, _colorTable[32328], nullptr, _colorTable[32328], DIALOG_BOX_LARGE);
         lsgWindowFree(windowType);
         return -1;
+    }
+
+    bool devAutoloadFailed = false;
+    bool devAutoloadPending = false;
+
+    if (devAutoloadSlot != -1) {
+        if (devAutoloadSlot >= 0 && devAutoloadSlot < saveLoadTotalSlots) {
+            _slot_cursor = devAutoloadSlot;
+            _currentSlotPage = devAutoloadSlot / slotsPerPage;
+            if (_LSstatus[_slot_cursor] == SLOT_STATE_OCCUPIED) {
+                devAutoloadPending = true;
+            } else {
+                debugPrint("LOADSAVE: dev load slot %d is not occupied\n", _slot_cursor + 1);
+                devAutoloadFailed = true;
+            }
+        } else {
+            debugPrint("LOADSAVE: invalid dev load slot %d\n", devAutoloadSlot + 1);
+            devAutoloadFailed = true;
+        }
     }
 
     switch (_LSstatus[_slot_cursor]) {
@@ -1138,12 +1165,17 @@ int lsgLoadGame(int mode)
     _dbleclkcntr = 24;
 
     int rc = -1;
+    if (devAutoloadFailed) {
+        rc = 2;
+    }
+
     int doubleClickSlot = -1;
     while (rc == -1) {
         sharedFpsLimiter.mark();
 
         unsigned int time = getTicks();
-        int keyCode = inputGetInput();
+        int keyCode = devAutoloadPending ? 500 : inputGetInput();
+        devAutoloadPending = false;
         bool selectionChanged = false;
         int scrollDirection = LOAD_SAVE_SCROLL_DIRECTION_NONE;
 
@@ -1497,7 +1529,12 @@ int lsgLoadGame(int mode)
         }
     }
 
-    return rc;
+    return devAutoloadFailed ? -1 : rc;
+}
+
+void lsgDevSetLoadGameSlot(int slot)
+{
+    gDevLoadGameSlot = slot;
 }
 
 // 0x47D2E4
@@ -1936,6 +1973,11 @@ bool _isLoadingGame()
 // 0x47DC68
 static int lsgLoadGameInSlot(int slot)
 {
+    if (slot < 0 || slot >= saveLoadTotalSlots) {
+        return -1;
+    }
+    assert(slot == _slot_cursor);
+
     _loadingGame = true;
 
     if (isInCombat()) {
@@ -1949,9 +1991,6 @@ static int lsgLoadGameInSlot(int slot)
 
     snprintf(_gmpath, sizeof(_gmpath), "%s\\%s%.2d\\", "SAVEGAME", "SLOT", _slot_cursor + 1);
     strcat(_gmpath, "SAVE.DAT");
-
-    LoadSaveSlotData* ptr = &(_LSData[slot]);
-    debugPrint("\nLOADSAVE: Load name: %s\n", ptr->description);
 
     _flptr = fileOpen(_gmpath, "rb");
     if (_flptr == nullptr) {
@@ -1968,6 +2007,9 @@ static int lsgLoadGameInSlot(int slot)
         _loadingGame = false;
         return -1;
     }
+
+    LoadSaveSlotData* ptr = &(_LSData[slot]);
+    debugPrint("\nLOADSAVE: Load name: %s\n", ptr->description);
 
     debugPrint("LOADSAVE: Load file header size read: %d bytes.\n", fileTell(_flptr) - pos);
 

--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -1532,6 +1532,11 @@ void lsgDevSetLoadGameSlot(int slot)
     gDevLoadGameSlot = slot;
 }
 
+int lsgGetTotalSlotCount()
+{
+    return saveLoadTotalSlots;
+}
+
 // 0x47D2E4
 static int lsgWindowInit(int windowType)
 {

--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -197,6 +197,7 @@ static const int gLoadSaveFrmIds[LOAD_SAVE_FRM_COUNT] = {
 const int saveLoadPages = 10;
 constexpr int slotsPerPage = 10;
 const int saveLoadTotalSlots = saveLoadPages * slotsPerPage;
+constexpr int kLoadSaveActionDone = 500;
 
 // Global variable to track the current slot page
 static int _currentSlotPage = 0;
@@ -647,7 +648,7 @@ int lsgSaveGame(int mode)
 
                 _slot_cursor = clickedSlot;
                 if (clickedSlot == doubleClickSlot) {
-                    keyCode = 500;
+                    keyCode = kLoadSaveActionDone;
                     soundPlayFile("ib1p1xx1");
                 }
 
@@ -674,12 +675,12 @@ int lsgSaveGame(int mode)
                 brightnessDecrease();
                 break;
             case KEY_RETURN:
-                keyCode = 500;
+                keyCode = kLoadSaveActionDone;
                 break;
             }
         }
 
-        if (keyCode == 500) {
+        if (keyCode == kLoadSaveActionDone) {
             if (_LSstatus[_slot_cursor] == SLOT_STATE_OCCUPIED) {
                 rc = 1;
                 // Save game already exists, overwrite?
@@ -1168,7 +1169,7 @@ int lsgLoadGame(int mode)
         sharedFpsLimiter.mark();
 
         unsigned int time = getTicks();
-        int keyCode = devAutoloadPending ? 500 : inputGetInput();
+        int keyCode = devAutoloadPending ? kLoadSaveActionDone : inputGetInput();
         devAutoloadPending = false;
         bool selectionChanged = false;
         int scrollDirection = LOAD_SAVE_SCROLL_DIRECTION_NONE;
@@ -1291,7 +1292,7 @@ int lsgLoadGame(int mode)
 
                 _slot_cursor = clickedSlot;
                 if (clickedSlot == doubleClickSlot) {
-                    keyCode = 500;
+                    keyCode = kLoadSaveActionDone;
                     soundPlayFile("ib1p1xx1");
                 }
 
@@ -1309,7 +1310,7 @@ int lsgLoadGame(int mode)
                 brightnessIncrease();
                 break;
             case KEY_RETURN:
-                keyCode = 500;
+                keyCode = kLoadSaveActionDone;
                 break;
             case KEY_CTRL_Q:
             case KEY_CTRL_X:
@@ -1322,7 +1323,7 @@ int lsgLoadGame(int mode)
             }
         }
 
-        if (keyCode == 500) {
+        if (keyCode == kLoadSaveActionDone) {
             if (_LSstatus[_slot_cursor] != SLOT_STATE_EMPTY) {
                 rc = 1;
             } else {
@@ -1690,7 +1691,7 @@ static int lsgWindowInit(int windowType)
         -1,
         -1,
         -1,
-        500,
+        kLoadSaveActionDone,
         _loadsaveFrmImages[LOAD_SAVE_FRM_RED_BUTTON_NORMAL].getData(),
         _loadsaveFrmImages[LOAD_SAVE_FRM_RED_BUTTON_PRESSED].getData(),
         nullptr,

--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -1165,12 +1165,9 @@ int lsgLoadGame(int mode)
     _dbleclkcntr = 24;
 
     int rc = -1;
-    if (devAutoloadFailed) {
-        rc = 2;
-    }
 
     int doubleClickSlot = -1;
-    while (rc == -1) {
+    while (rc == -1 && !devAutoloadFailed) {
         sharedFpsLimiter.mark();
 
         unsigned int time = getTicks();
@@ -1332,7 +1329,12 @@ int lsgLoadGame(int mode)
             if (_LSstatus[_slot_cursor] != SLOT_STATE_EMPTY) {
                 rc = 1;
             } else {
-                rc = -1;
+                if (devAutoloadSlot != -1) {
+                    devAutoloadFailed = true;
+                    rc = -1;
+                } else {
+                    rc = -1;
+                }
             }
 
             selectionChanged = true;
@@ -1480,6 +1482,12 @@ int lsgLoadGame(int mode)
         if (rc == 1) {
             switch (_LSstatus[_slot_cursor]) {
             case SLOT_STATE_UNSUPPORTED_VERSION:
+                if (devAutoloadSlot != -1) {
+                    devAutoloadFailed = true;
+                    rc = -1;
+                    break;
+                }
+
                 soundPlayFile("iisxxxx1");
                 strcpy(_str0, getmsg(&gLoadSaveMessageList, &gLoadSaveMessageListItem, 134));
                 strcpy(_str1, getmsg(&gLoadSaveMessageList, &gLoadSaveMessageListItem, 136));
@@ -1488,6 +1496,12 @@ int lsgLoadGame(int mode)
                 rc = -1;
                 break;
             case SLOT_STATE_ERROR:
+                if (devAutoloadSlot != -1) {
+                    devAutoloadFailed = true;
+                    rc = -1;
+                    break;
+                }
+
                 soundPlayFile("iisxxxx1");
                 strcpy(_str0, getmsg(&gLoadSaveMessageList, &gLoadSaveMessageListItem, 134));
                 strcpy(_str1, getmsg(&gLoadSaveMessageList, &gLoadSaveMessageListItem, 136));
@@ -1496,14 +1510,19 @@ int lsgLoadGame(int mode)
                 break;
             default:
                 if (lsgLoadGameInSlot(_slot_cursor) == -1) {
-                    gameMouseSetCursor(MOUSE_CURSOR_ARROW);
-                    soundPlayFile("iisxxxx1");
-                    strcpy(_str0, getmsg(&gLoadSaveMessageList, &gLoadSaveMessageListItem, 134));
-                    strcpy(_str1, getmsg(&gLoadSaveMessageList, &gLoadSaveMessageListItem, 135));
-                    showDialogBox(_str0, body, 1, 169, 116, _colorTable[32328], nullptr, _colorTable[32328], DIALOG_BOX_LARGE);
-                    mapNewMap();
-                    _game_user_wants_to_quit = GAME_QUIT_REQUEST_MAIN_MENU;
-                    rc = -1;
+                    if (devAutoloadSlot != -1) {
+                        devAutoloadFailed = true;
+                        rc = -1;
+                    } else {
+                        gameMouseSetCursor(MOUSE_CURSOR_ARROW);
+                        soundPlayFile("iisxxxx1");
+                        strcpy(_str0, getmsg(&gLoadSaveMessageList, &gLoadSaveMessageListItem, 134));
+                        strcpy(_str1, getmsg(&gLoadSaveMessageList, &gLoadSaveMessageListItem, 135));
+                        showDialogBox(_str0, body, 1, 169, 116, _colorTable[32328], nullptr, _colorTable[32328], DIALOG_BOX_LARGE);
+                        mapNewMap();
+                        _game_user_wants_to_quit = GAME_QUIT_REQUEST_MAIN_MENU;
+                        rc = -1;
+                    }
                 }
                 break;
             }

--- a/src/loadsave.h
+++ b/src/loadsave.h
@@ -18,6 +18,7 @@ void _InitLoadSave();
 void _ResetLoadSave();
 int lsgSaveGame(int mode);
 int lsgLoadGame(int mode);
+void lsgDevSetLoadGameSlot(int slot);
 bool _isLoadingGame();
 void lsgInit();
 int MapDirErase(const char* path, const char* extension);

--- a/src/loadsave.h
+++ b/src/loadsave.h
@@ -19,6 +19,7 @@ void _ResetLoadSave();
 int lsgSaveGame(int mode);
 int lsgLoadGame(int mode);
 void lsgDevSetLoadGameSlot(int slot);
+int lsgGetTotalSlotCount();
 bool _isLoadingGame();
 void lsgInit();
 int MapDirErase(const char* path, const char* extension);

--- a/src/main.cc
+++ b/src/main.cc
@@ -285,7 +285,7 @@ static bool mainTryParseDevLoadGameSlot(const char* value, int* slotPtr)
 
     char* end = nullptr;
     long slotNumber = strtol(value, &end, 10);
-    if (end == value || *end != '\0' || slotNumber < 1 || slotNumber > 100) {
+    if (end == value || *end != '\0' || slotNumber < 1 || slotNumber > lsgGetTotalSlotCount()) {
         return false;
     }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,6 +1,7 @@
 #include "main.h"
 
 #include <limits.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "art.h"
@@ -53,6 +54,8 @@ static void main_exit_system();
 static int _main_load_new(char* fname);
 static int main_loadgame_new();
 static void main_unload_new();
+static void mainParseCommandLineArguments(int argc, char** argv);
+static bool mainTryParseDevLoadGameSlot(const char* value, int* slotPtr);
 static void mainLoop();
 static void showDeath();
 static void _main_death_voiceover_callback();
@@ -71,6 +74,8 @@ static bool _main_show_death_scene = false;
 // 0x614838
 static bool _main_death_voiceover_done;
 
+static int gDevLoadGameSlot = -1;
+
 // 0x48099C
 int falloutMain(int argc, char** argv)
 {
@@ -81,6 +86,8 @@ int falloutMain(int argc, char** argv)
     if (!falloutInit(argc, argv)) {
         return 1;
     }
+
+    mainParseCommandLineArguments(argc, argv);
 
     // SFALL: Allow to skip intro movies
     int skipOpeningMovies = settings.ui.skip_opening_movies;
@@ -102,7 +109,14 @@ int falloutMain(int argc, char** argv)
             mainMenuWindowUnhide(true);
 
             mouseShowCursor();
-            int mainMenuRc = mainMenuWindowHandleEvents();
+            int devLoadGameSlot = gDevLoadGameSlot;
+            int mainMenuRc;
+            if (devLoadGameSlot != -1) {
+                gDevLoadGameSlot = -1;
+                mainMenuRc = MAIN_MENU_LOAD_GAME;
+            } else {
+                mainMenuRc = mainMenuWindowHandleEvents();
+            }
             mouseHideCursor();
 
             switch (mainMenuRc) {
@@ -163,6 +177,9 @@ int falloutMain(int argc, char** argv)
                     // NOTE: Uninline.
                     main_loadgame_new();
 
+                    if (devLoadGameSlot != -1) {
+                        lsgDevSetLoadGameSlot(devLoadGameSlot);
+                    }
                     int loadGameRc = lsgLoadGame(LOAD_SAVE_MODE_FROM_MAIN_MENU);
                     if (loadGameRc == -1) {
                         debugPrint("\n ** Error running LoadGame()! **\n");
@@ -240,6 +257,48 @@ static bool falloutInit(int argc, char** argv)
         return false;
     }
 
+    return true;
+}
+
+static void mainParseCommandLineArguments(int argc, char** argv)
+{
+    const char* devLoadGamePrefix = "--dev-load-game=";
+    size_t devLoadGamePrefixLength = strlen(devLoadGamePrefix);
+
+    for (int arg = 1; arg < argc; arg += 1) {
+        if (strncmp(argv[arg], devLoadGamePrefix, devLoadGamePrefixLength) == 0) {
+            int slot;
+            if (mainTryParseDevLoadGameSlot(argv[arg] + devLoadGamePrefixLength, &slot)) {
+                gDevLoadGameSlot = slot;
+            } else {
+                debugPrint("MAIN: invalid --dev-load-game value '%s'\n", argv[arg] + devLoadGamePrefixLength);
+            }
+        }
+    }
+}
+
+static bool mainTryParseDevLoadGameSlot(const char* value, int* slotPtr)
+{
+    if (value == nullptr || slotPtr == nullptr) {
+        return false;
+    }
+
+    if (compat_strnicmp(value, "SLOT", 4) != 0) {
+        return false;
+    }
+
+    const char* slotValue = value + 4;
+    if (*slotValue == '\0') {
+        return false;
+    }
+
+    char* end = nullptr;
+    long slotNumber = strtol(slotValue, &end, 10);
+    if (end == slotValue || *end != '\0' || slotNumber < 1 || slotNumber > 100) {
+        return false;
+    }
+
+    *slotPtr = static_cast<int>(slotNumber - 1);
     return true;
 }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -74,7 +74,7 @@ static bool _main_show_death_scene = false;
 // 0x614838
 static bool _main_death_voiceover_done;
 
-static int gDevLoadGameSlot = -1;
+static int commandLineDevLoadGameSlot = -1;
 
 // 0x48099C
 int falloutMain(int argc, char** argv)
@@ -109,10 +109,10 @@ int falloutMain(int argc, char** argv)
             mainMenuWindowUnhide(true);
 
             mouseShowCursor();
-            int devLoadGameSlot = gDevLoadGameSlot;
+            int devLoadGameSlot = commandLineDevLoadGameSlot;
             int mainMenuRc;
             if (devLoadGameSlot != -1) {
-                gDevLoadGameSlot = -1;
+                commandLineDevLoadGameSlot = -1;
                 mainMenuRc = MAIN_MENU_LOAD_GAME;
             } else {
                 mainMenuRc = mainMenuWindowHandleEvents();
@@ -269,7 +269,7 @@ static void mainParseCommandLineArguments(int argc, char** argv)
         if (strncmp(argv[arg], devLoadGamePrefix, devLoadGamePrefixLength) == 0) {
             int slot;
             if (mainTryParseDevLoadGameSlot(argv[arg] + devLoadGamePrefixLength, &slot)) {
-                gDevLoadGameSlot = slot;
+                commandLineDevLoadGameSlot = slot;
             } else {
                 debugPrint("MAIN: invalid --dev-load-game value '%s'\n", argv[arg] + devLoadGamePrefixLength);
             }

--- a/src/main.cc
+++ b/src/main.cc
@@ -283,18 +283,9 @@ static bool mainTryParseDevLoadGameSlot(const char* value, int* slotPtr)
         return false;
     }
 
-    if (compat_strnicmp(value, "SLOT", 4) != 0) {
-        return false;
-    }
-
-    const char* slotValue = value + 4;
-    if (*slotValue == '\0') {
-        return false;
-    }
-
     char* end = nullptr;
-    long slotNumber = strtol(slotValue, &end, 10);
-    if (end == slotValue || *end != '\0' || slotNumber < 1 || slotNumber > 100) {
+    long slotNumber = strtol(value, &end, 10);
+    if (end == value || *end != '\0' || slotNumber < 1 || slotNumber > 100) {
         return false;
     }
 


### PR DESCRIPTION
This allows you to use --dev-load-game=SLOTXX` to immediately load a saved game after the game is launched.  This is mostly useful so that LLMs can launch the game and see the result of an .ssl test script without a human needing to be in the loop.

Workflow for the agent is to instruct it to write a .ssl test, give it access to a tool to compile it, and instruct how it can launch the game with this commandline arg and see test output in debug.log
