### PR TITLE
Fix f2_res.ini migration

### DIFF
--- a/src/game_config_migration.cc
+++ b/src/game_config_migration.cc
@@ -26,8 +26,8 @@ namespace {
 
     static bool gameConfigHasKey(Config* config, const char* section, const char* key);
     static bool gameConfigNeedsF2ResMigration(Config* gameConfig);
-    static bool gameConfigMigrateStringKey(Config* legacyConfig, Config* gameConfig, const F2ResMigrationEntry& entry);
-    static bool gameConfigMigrateScaleKey(Config* legacyConfig, Config* gameConfig);
+    static bool gameConfigMigrateStringKey(Config* legacyConfig, Config* gameConfig, Config* targetConfig, const F2ResMigrationEntry& entry);
+    static bool gameConfigMigrateScaleKey(Config* legacyConfig, Config* gameConfig, Config* targetConfig);
 
     static constexpr F2ResMigrationEntry kF2ResMigrationEntries[] = {
         { "MAIN", "SCR_WIDTH", GAME_CONFIG_SCREEN_KEY, GAME_CONFIG_RESOLUTION_X_KEY },
@@ -54,9 +54,9 @@ namespace {
         return !gameConfigHasKey(gameConfig, GAME_CONFIG_SCREEN_KEY, GAME_CONFIG_RESOLUTION_X_KEY);
     }
 
-    static bool gameConfigMigrateStringKey(Config* legacyConfig, Config* gameConfig, const F2ResMigrationEntry& entry)
+    static bool gameConfigMigrateStringKey(Config* legacyConfig, Config* gameConfig, Config* targetConfig, const F2ResMigrationEntry& entry)
     {
-        assert(legacyConfig != nullptr && gameConfig != nullptr);
+        assert(legacyConfig != nullptr && gameConfig != nullptr && targetConfig != nullptr);
 
         if (gameConfigHasKey(gameConfig, entry.targetSection, entry.targetKey)) {
             return false;
@@ -67,12 +67,12 @@ namespace {
             return false;
         }
 
-        return configSetString(gameConfig, entry.targetSection, entry.targetKey, value);
+        return configSetString(targetConfig, entry.targetSection, entry.targetKey, value);
     }
 
-    static bool gameConfigMigrateScaleKey(Config* legacyConfig, Config* gameConfig)
+    static bool gameConfigMigrateScaleKey(Config* legacyConfig, Config* gameConfig, Config* targetConfig)
     {
-        assert(legacyConfig != nullptr && gameConfig != nullptr);
+        assert(legacyConfig != nullptr && gameConfig != nullptr && targetConfig != nullptr);
 
         if (gameConfigHasKey(gameConfig, GAME_CONFIG_SCREEN_KEY, GAME_CONFIG_SCALE_KEY)) {
             return false;
@@ -83,7 +83,7 @@ namespace {
             return false;
         }
 
-        return configSetInt(gameConfig, GAME_CONFIG_SCREEN_KEY, GAME_CONFIG_SCALE_KEY, value + 1);
+        return configSetInt(targetConfig, GAME_CONFIG_SCREEN_KEY, GAME_CONFIG_SCALE_KEY, value + 1);
     }
 
 } // namespace
@@ -97,7 +97,15 @@ bool gameConfigMigrateFromF2Res(const char* gameConfigFilePath, Config* gameConf
         return false;
     }
 
-    if (!gameConfigNeedsF2ResMigration(gameConfig)) {
+    Config fileConfig;
+    if (!configInit(&fileConfig)) {
+        return false;
+    }
+
+    configRead(&fileConfig, gameConfigFilePath, false);
+
+    if (!gameConfigNeedsF2ResMigration(&fileConfig)) {
+        configFree(&fileConfig);
         return false;
     }
 
@@ -109,23 +117,25 @@ bool gameConfigMigrateFromF2Res(const char* gameConfigFilePath, Config* gameConf
 
     Config legacyConfig;
     if (!configInit(&legacyConfig)) {
+        configFree(&fileConfig);
         return false;
     }
 
     bool migrated = false;
     if (configRead(&legacyConfig, f2ResFilePath, false)) {
         for (const auto& entry : kF2ResMigrationEntries) {
-            if (gameConfigMigrateStringKey(&legacyConfig, gameConfig, entry)) {
+            if (gameConfigMigrateStringKey(&legacyConfig, &fileConfig, gameConfig, entry)) {
                 migrated = true;
             }
         }
 
-        if (gameConfigMigrateScaleKey(&legacyConfig, gameConfig)) {
+        if (gameConfigMigrateScaleKey(&legacyConfig, &fileConfig, gameConfig)) {
             migrated = true;
         }
     }
 
     configFree(&legacyConfig);
+    configFree(&fileConfig);
     return migrated;
 }
 

--- a/src/sfall_global_scripts.cc
+++ b/src/sfall_global_scripts.cc
@@ -7,6 +7,7 @@
 
 #include "animation.h"
 #include "db.h"
+#include "debug.h"
 #include "input.h"
 #include "platform_compat.h"
 #include "scripts.h"
@@ -34,6 +35,25 @@ struct GlobalScriptsState {
 
 static GlobalScriptsState* state = nullptr;
 
+static bool sfall_gl_scr_is_loadable(const char* path)
+{
+    File* stream = fileOpen(path, "rb");
+    if (stream == nullptr) {
+        debugPrint("Skipping global script %s: cannot open.\n", path);
+        return false;
+    }
+
+    int size = fileGetSize(stream);
+    fileClose(stream);
+
+    if (size <= 0) {
+        debugPrint("Skipping global script %s: empty file.\n", path);
+        return false;
+    }
+
+    return true;
+}
+
 bool sfall_gl_scr_init()
 {
     state = new (std::nothrow) GlobalScriptsState();
@@ -50,7 +70,9 @@ bool sfall_gl_scr_init()
         for (int index = 0; index < filesLength; index++) {
             char path[COMPAT_MAX_PATH];
             snprintf(path, sizeof(path), "%s\\%s", dir, files[index]);
-            state->paths.push_back(std::string { path });
+            if (sfall_gl_scr_is_loadable(path)) {
+                state->paths.push_back(std::string { path });
+            }
         }
 
         fileNameListFree(&files, 0);


### PR DESCRIPTION
In https://github.com/fallout2-ce/fallout2-ce/commit/9e8eaa13f56988ef9e462d0ec6a31833931b7297, f2_res.ini stopped getting migrated, since settings were loaded in memory (with defaults) earlier.  This is a small fix that checks the value in the file instead of in memory.

Also, added some correctness checking to global scripts loading.  somehow I had a length 0 .int file in my scripts/ directly which caused a crash (now skips with an error log)
