### PR TITLE
Fix f2_res migration never working

### DIFF
--- a/src/game_config.cc
+++ b/src/game_config.cc
@@ -117,9 +117,6 @@ bool gameConfigInit(bool isMapper, int argc, char** argv)
         }
     }
 
-    auto configChecker = ConfigChecker(gGameConfig, gGameConfigFilePath);
-    // Read contents of `fallout2.cfg` into config. The values from the file
-    // will override the defaults above.
     configRead(&gGameConfig, gGameConfigFilePath, false);
 
     // Init debug mode ASAP to catch early debug messages.
@@ -133,7 +130,6 @@ bool gameConfigInit(bool isMapper, int argc, char** argv)
         debugPrint("Migrated settings from f2_res.ini.\n");
         configWriteEx(&gGameConfig, gGameConfigFilePath, CONFIG_RETAIN_ALL);
     }
-    configChecker.check(gGameConfig);
 
     // Add key-values from command line, which overrides both defaults and
     // whatever was loaded from `fallout2.cfg`.

--- a/src/game_config.cc
+++ b/src/game_config.cc
@@ -65,9 +65,6 @@ bool gameConfigInit(bool isMapper, int argc, char** argv)
         return false;
     }
 
-    // Writes default values to config.
-    settingsWriteToConfig();
-
     // CE: Detect alternative default music directory.
     char alternativeMusicPath[COMPAT_MAX_PATH];
     strcpy(alternativeMusicPath, R"(data\sound\music\*.acm)");
@@ -141,6 +138,9 @@ bool gameConfigInit(bool isMapper, int argc, char** argv)
     // Add key-values from command line, which overrides both defaults and
     // whatever was loaded from `fallout2.cfg`.
     configParseCommandLineArguments(&gGameConfig, argc, argv);
+
+    // Writes default values to config, skipping keys that were already loaded.
+    settingsWriteToConfig(true);
 
     gGameConfigInitialized = true;
 

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -13,7 +13,7 @@ namespace fallout {
 
 struct SettingDescriptor {
     std::function<void()> read;
-    std::function<void()> write;
+    std::function<void(bool onlyAdd)> write;
 };
 
 static std::vector<SettingDescriptor> settingsRegistry;
@@ -26,6 +26,12 @@ static void settingsRead(const char* section, const char* key, std::string& valu
     if (configGetString(&gGameConfig, section, key, &v)) {
         value = v;
     }
+}
+
+static bool settingsKeyExists(const char* section, const char* key)
+{
+    char* v;
+    return configGetString(&gGameConfig, section, key, &v);
 }
 
 static void settingsRead(const char* section, const char* key, int& value)
@@ -91,23 +97,18 @@ static std::function<void(T&, const char*, const char*)> clamp(T min, T max)
     };
 }
 
-template <typename T>
-void registerSetting(const char* section, const char* key, T& variable)
-{
-    settingsRegistry.push_back(
-        { [&, section, key]() { settingsRead(section, key, variable); },
-            [&, section, key]() { settingsWrite(section, key, variable); } });
-}
-
-template <typename T, typename P>
-void registerSetting(const char* section, const char* key, T& variable, P postProcess)
+template <typename T, typename P = std::function<void(T&, const char*, const char*)>>
+void registerSetting(const char* section, const char* key, T& variable, P postProcess = {})
 {
     settingsRegistry.push_back(
         { [&, section, key, postProcess]() {
              settingsRead(section, key, variable);
-             postProcess(variable, section, key);
+             if (postProcess) postProcess(variable, section, key);
          },
-            [&, section, key]() { settingsWrite(section, key, variable); } });
+            [&, section, key](bool onlyAdd) {
+                if (onlyAdd && settingsKeyExists(section, key)) return;
+                settingsWrite(section, key, variable);
+            } });
 }
 
 // SECT must be defined to the settings sub-struct name, which equals the config section string.
@@ -256,10 +257,10 @@ bool settingsInit(bool isMapper, int argc, char** argv)
     return true;
 }
 
-void settingsWriteToConfig()
+void settingsWriteToConfig(bool onlyAdd)
 {
     for (const auto& descriptor : settingsRegistry) {
-        descriptor.write();
+        descriptor.write(onlyAdd);
     }
 }
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -152,7 +152,7 @@ extern Settings settings;
 
 bool settingsInit(bool isMapper, int argc, char** argv);
 bool settingsSave();
-void settingsWriteToConfig();
+void settingsWriteToConfig(bool onlyAdd = false);
 bool settingsExit(bool shouldSave);
 
 } // namespace fallout


### PR DESCRIPTION
An alternative fix for f2_res.ini migration, see #408

Removed configChecker from game_config. It was redundant as we have already implemented all vanilla settings. There is no reference config to check "are these settings implemented" from.