### PR TITLE
Fix worldmap 100% cpu lockup

### DIFF
--- a/src/input.cc
+++ b/src/input.cc
@@ -48,6 +48,7 @@ static void buildNormalizedQwertyKeys();
 static void _GNW95_process_key(KeyboardData* data);
 static int inputGetHookMouseButton(int sdlButton);
 static void inputHandleMouseClickHook(int sdlButton, bool pressed);
+static void inputResetInternalEventQueue();
 static void inputHandleProgramActivationChange(bool isActive);
 
 // 0x51E23C
@@ -148,7 +149,9 @@ static void inputHandleProgramActivationChange(bool isActive)
     // of sync with SDL's actual app activation state. Drop queued input on
     // both transitions and reapply the desired mouse mode on return.
     keyboardReset();
-    inputEventQueueReset();
+    mouseReset();
+    windowResetButtonState();
+    inputResetInternalEventQueue();
 
     if (isActive) {
         mouseDeviceInitMode();
@@ -157,6 +160,14 @@ static void inputHandleProgramActivationChange(bool isActive)
     } else {
         audioEnginePause();
     }
+}
+
+static void inputResetInternalEventQueue()
+{
+    gInputEventQueueReadIndex = -1;
+    gInputEventQueueWriteIndex = 0;
+    _input_mx = -1;
+    _input_my = -1;
 }
 
 // 0x4C8A70
@@ -324,8 +335,7 @@ static int dequeueInputEvent()
 // 0x4C8D04
 void inputEventQueueReset()
 {
-    gInputEventQueueReadIndex = -1;
-    gInputEventQueueWriteIndex = 0;
+    inputResetInternalEventQueue();
     SDL_Event e;
     while (SDL_PollEvent(&e)) { } // Clear all input events
 }
@@ -1061,6 +1071,8 @@ void _GNW95_process_message()
                 break;
             case SDL_WINDOWEVENT_SHOWN:
             case SDL_WINDOWEVENT_RESTORED:
+                windowRefreshAll(&_scr_size);
+                break;
             case SDL_WINDOWEVENT_FOCUS_GAINED:
                 inputHandleProgramActivationChange(true);
                 break;

--- a/src/input.cc
+++ b/src/input.cc
@@ -48,6 +48,7 @@ static void buildNormalizedQwertyKeys();
 static void _GNW95_process_key(KeyboardData* data);
 static int inputGetHookMouseButton(int sdlButton);
 static void inputHandleMouseClickHook(int sdlButton, bool pressed);
+static void inputHandleProgramActivationChange(bool isActive);
 
 // 0x51E23C
 static int gKeyboardKeyRepeatRate = 80;
@@ -133,6 +134,29 @@ static void inputHandleMouseClickHook(int sdlButton, bool pressed)
     if (hookButton == -1) return;
 
     ScriptHookCall(HOOK_MOUSECLICK, 0, { pressed ? 1 : 0, hookButton }).call();
+}
+
+static void inputHandleProgramActivationChange(bool isActive)
+{
+    if (gProgramIsActive == isActive) {
+        return;
+    }
+
+    gProgramIsActive = isActive;
+
+    // Cmd-tab on macOS can leave modifier/key repeat state and mouse mode out
+    // of sync with SDL's actual app activation state. Drop queued input on
+    // both transitions and reapply the desired mouse mode on return.
+    keyboardReset();
+    inputEventQueueReset();
+
+    if (isActive) {
+        mouseDeviceInitMode();
+        windowRefreshAll(&_scr_size);
+        audioEngineResume();
+    } else {
+        audioEnginePause();
+    }
 }
 
 // 0x4C8A70
@@ -1034,14 +1058,15 @@ void _GNW95_process_message()
             case SDL_WINDOWEVENT_SIZE_CHANGED:
                 handleWindowSizeChanged();
                 break;
+            case SDL_WINDOWEVENT_SHOWN:
+            case SDL_WINDOWEVENT_RESTORED:
             case SDL_WINDOWEVENT_FOCUS_GAINED:
-                gProgramIsActive = true;
-                windowRefreshAll(&_scr_size);
-                audioEngineResume();
+                inputHandleProgramActivationChange(true);
                 break;
+            case SDL_WINDOWEVENT_HIDDEN:
+            case SDL_WINDOWEVENT_MINIMIZED:
             case SDL_WINDOWEVENT_FOCUS_LOST:
-                gProgramIsActive = false;
-                audioEnginePause();
+                inputHandleProgramActivationChange(false);
                 break;
             }
             break;

--- a/src/input.cc
+++ b/src/input.cc
@@ -1040,8 +1040,9 @@ void _GNW95_process_message()
             if (!keyboardIsDisabled()) {
                 keyboardData.key = e.key.keysym.scancode;
                 keyboardData.down = (e.key.state & SDL_PRESSED) != 0;
+                bool syntheticSfallKey = sfall_kb_consume_synthetic_key_event(keyboardData.key, keyboardData.down);
 
-                if (!e.key.repeat) {
+                if (!e.key.repeat && !syntheticSfallKey) {
                     int keyOverride = sfall_kb_handle_key_pressed(keyboardData.key, keyboardData.down);
                     if (keyOverride != SDL_SCANCODE_UNKNOWN) {
                         keyboardData.key = keyOverride;

--- a/src/mouse.cc
+++ b/src/mouse.cc
@@ -656,6 +656,15 @@ int mouseGetEvent()
     return gMouseEvent;
 }
 
+void mouseReset()
+{
+    gMouseEvent = 0;
+    _raw_buttons = 0;
+    last_buttons = 0;
+    gMouseWheelX = 0;
+    gMouseWheelY = 0;
+}
+
 // 0x4CAAA8
 bool cursorIsHidden()
 {

--- a/src/mouse.h
+++ b/src/mouse.h
@@ -47,6 +47,7 @@ void mouseGetRect(Rect* rect);
 void mouseGetPosition(int* out_x, int* out_y);
 void _mouse_set_position(int x, int y);
 int mouseGetEvent();
+void mouseReset();
 bool cursorIsHidden();
 void _mouse_get_raw_state(int* out_x, int* out_y, int* out_buttons);
 void mouseSetSensitivity(double value);

--- a/src/sfall_kb_helpers.cc
+++ b/src/sfall_kb_helpers.cc
@@ -4,7 +4,9 @@
 
 #include "game.h"
 #include "sfall_script_hooks.h"
+#include "svga.h"
 
+#include <deque>
 #include <unordered_map>
 
 namespace fallout {
@@ -272,6 +274,7 @@ static constexpr SDL_Scancode kDiks[DIK_MAP_COUNT] = {
 };
 
 std::unordered_map<SDL_Scancode, int> kScanCodeToDik;
+std::deque<std::pair<SDL_Scancode, bool>> syntheticKeyEvents;
 
 /// Translates Sfall key code (DIK or VK constant) to SDL scancode.
 static SDL_Scancode get_scancode_from_key(int key)
@@ -319,13 +322,41 @@ void sfall_kb_press_key(int key)
     }
 
     SDL_Event event;
-    event.key.keysym.scancode = scancode;
+    SDL_zero(event);
 
     event.type = SDL_KEYDOWN;
-    SDL_PushEvent(&event);
+    event.key.timestamp = SDL_GetTicks();
+    event.key.windowID = gSdlWindow != nullptr ? SDL_GetWindowID(gSdlWindow) : 0;
+    event.key.state = SDL_PRESSED;
+    event.key.repeat = 0;
+    event.key.keysym.scancode = scancode;
+    event.key.keysym.sym = SDL_GetKeyFromScancode(scancode);
+    event.key.keysym.mod = SDL_GetModState();
+    if (SDL_PushEvent(&event) == 1) {
+        syntheticKeyEvents.emplace_back(scancode, true);
+    }
 
     event.type = SDL_KEYUP;
-    SDL_PushEvent(&event);
+    event.key.timestamp = SDL_GetTicks();
+    event.key.state = SDL_RELEASED;
+    if (SDL_PushEvent(&event) == 1) {
+        syntheticKeyEvents.emplace_back(scancode, false);
+    }
+}
+
+bool sfall_kb_consume_synthetic_key_event(int sdlScanCode, bool pressed)
+{
+    if (syntheticKeyEvents.empty()) {
+        return false;
+    }
+
+    const auto& [expectedScanCode, expectedPressed] = syntheticKeyEvents.front();
+    if (expectedScanCode != static_cast<SDL_Scancode>(sdlScanCode) || expectedPressed != pressed) {
+        return false;
+    }
+
+    syntheticKeyEvents.pop_front();
+    return true;
 }
 
 int sfall_kb_handle_key_pressed(int sdlScanCode, bool pressed)

--- a/src/sfall_kb_helpers.h
+++ b/src/sfall_kb_helpers.h
@@ -9,6 +9,9 @@ bool sfall_kb_is_key_pressed(int key);
 /// Simulates pressing `key`.
 void sfall_kb_press_key(int key);
 
+/// Returns `true` when the next matching SDL key event was injected by `tap_key`.
+bool sfall_kb_consume_synthetic_key_event(int sdlScanCode, bool pressed);
+
 int sfall_kb_handle_key_pressed(int sdlScanCode, bool pressed);
 
 } // namespace fallout

--- a/src/window_manager.cc
+++ b/src/window_manager.cc
@@ -1238,6 +1238,19 @@ int _win_check_all_buttons()
     return keyCode;
 }
 
+void windowResetButtonState()
+{
+    if (!gWindowSystemInitialized) {
+        return;
+    }
+
+    for (int index = 0; index < gWindowsLength; index++) {
+        Window* window = gWindows[index];
+        window->hoveredButton = nullptr;
+        window->clickedButton = nullptr;
+    }
+}
+
 // 0x4D79DC
 Button* buttonGetButton(int btn, Window** windowPtr)
 {

--- a/src/window_manager.h
+++ b/src/window_manager.h
@@ -195,6 +195,7 @@ int windowGetHeight(int win);
 int windowGetRect(int win, Rect* rect);
 int _win_check_all_buttons();
 int _GNW_check_menu_bars(int input);
+void windowResetButtonState();
 void programWindowSetTitle(const char* title);
 bool showMesageBox(const char* str);
 int buttonCreate(int win, int x, int y, int width, int height, int mouseEnterEventCode, int mouseExitEventCode, int mouseDownEventCode, int mouseUpEventCode, unsigned char* up, unsigned char* dn, unsigned char* hover, int flags);


### PR DESCRIPTION
On Mac, when on worldmap, cmd-tab out of a windowed game then back locks the game 100% of the time for me.  This PR does a more thorough reset of the input to prevent it from getting out of sync, and fixes the issue.