### PR TITLE
Avoid recursive sfall tap_key hooks

### DIFF
--- a/src/dinput.cc
+++ b/src/dinput.cc
@@ -1,5 +1,6 @@
 #include "dinput.h"
 
+#include "sfall_kb_helpers.h"
 #include "svga.h"
 
 namespace fallout {
@@ -124,6 +125,7 @@ bool keyboardDeviceUnacquire()
 bool keyboardDeviceReset()
 {
     SDL_FlushEvents(SDL_KEYDOWN, SDL_TEXTINPUT);
+    sfall_kb_clear_synthetic_key_events();
     return true;
 }
 

--- a/src/input.cc
+++ b/src/input.cc
@@ -1016,8 +1016,9 @@ void _GNW95_process_message()
             if (!keyboardIsDisabled()) {
                 keyboardData.key = e.key.keysym.scancode;
                 keyboardData.down = (e.key.state & SDL_PRESSED) != 0;
+                bool syntheticSfallKey = sfall_kb_consume_synthetic_key_event(keyboardData.key, keyboardData.down);
 
-                if (!e.key.repeat) {
+                if (!e.key.repeat && !syntheticSfallKey) {
                     int keyOverride = sfall_kb_handle_key_pressed(keyboardData.key, keyboardData.down);
                     if (keyOverride != SDL_SCANCODE_UNKNOWN) {
                         keyboardData.key = keyOverride;

--- a/src/input.cc
+++ b/src/input.cc
@@ -304,6 +304,7 @@ void inputEventQueueReset()
     gInputEventQueueWriteIndex = 0;
     SDL_Event e;
     while (SDL_PollEvent(&e)) { } // Clear all input events
+    sfall_kb_clear_synthetic_key_events();
 }
 
 // 0x4C8D1C
@@ -1012,12 +1013,11 @@ void _GNW95_process_message()
             touch_handle_end(&(e.tfinger));
             break;
         case SDL_KEYDOWN:
-        case SDL_KEYUP:
+        case SDL_KEYUP: {
+            keyboardData.key = e.key.keysym.scancode;
+            keyboardData.down = (e.key.state & SDL_PRESSED) != 0;
+            bool syntheticSfallKey = sfall_kb_consume_synthetic_key_event(keyboardData.key, keyboardData.down);
             if (!keyboardIsDisabled()) {
-                keyboardData.key = e.key.keysym.scancode;
-                keyboardData.down = (e.key.state & SDL_PRESSED) != 0;
-                bool syntheticSfallKey = sfall_kb_consume_synthetic_key_event(keyboardData.key, keyboardData.down);
-
                 if (!e.key.repeat && !syntheticSfallKey) {
                     int keyOverride = sfall_kb_handle_key_pressed(keyboardData.key, keyboardData.down);
                     if (keyOverride != SDL_SCANCODE_UNKNOWN) {
@@ -1027,6 +1027,7 @@ void _GNW95_process_message()
                 _GNW95_process_key(&keyboardData);
             }
             break;
+        }
         case SDL_WINDOWEVENT:
             switch (e.window.event) {
             case SDL_WINDOWEVENT_EXPOSED:

--- a/src/sfall_kb_helpers.cc
+++ b/src/sfall_kb_helpers.cc
@@ -273,8 +273,8 @@ static constexpr SDL_Scancode kDiks[DIK_MAP_COUNT] = {
     SDL_SCANCODE_UNKNOWN,
 };
 
-std::unordered_map<SDL_Scancode, int> kScanCodeToDik;
-std::deque<std::pair<SDL_Scancode, bool>> syntheticKeyEvents;
+static std::unordered_map<SDL_Scancode, int> kScanCodeToDik;
+static std::deque<std::pair<SDL_Scancode, bool>> syntheticKeyEvents;
 
 /// Translates Sfall key code (DIK or VK constant) to SDL scancode.
 static SDL_Scancode get_scancode_from_key(int key)
@@ -357,6 +357,11 @@ bool sfall_kb_consume_synthetic_key_event(int sdlScanCode, bool pressed)
 
     syntheticKeyEvents.pop_front();
     return true;
+}
+
+void sfall_kb_clear_synthetic_key_events()
+{
+    syntheticKeyEvents.clear();
 }
 
 int sfall_kb_handle_key_pressed(int sdlScanCode, bool pressed)

--- a/src/sfall_kb_helpers.cc
+++ b/src/sfall_kb_helpers.cc
@@ -4,7 +4,9 @@
 
 #include "game.h"
 #include "sfall_script_hooks.h"
+#include "svga.h"
 
+#include <deque>
 #include <unordered_map>
 
 namespace fallout {
@@ -272,6 +274,7 @@ static constexpr SDL_Scancode kDiks[DIK_MAP_COUNT] = {
 };
 
 std::unordered_map<SDL_Scancode, int> kScanCodeToDik;
+std::deque<std::pair<SDL_Scancode, bool>> syntheticKeyEvents;
 
 /// Translates Sfall key code (DIK or VK constant) to SDL scancode.
 static SDL_Scancode get_scancode_from_key(int key)
@@ -319,13 +322,41 @@ void sfall_kb_press_key(int key)
     }
 
     SDL_Event event;
-    event.key.keysym.scancode = scancode;
+    SDL_zero(event);
 
     event.type = SDL_KEYDOWN;
-    SDL_PushEvent(&event);
+    event.key.timestamp = SDL_GetTicks();
+    event.key.windowID = gSdlWindow != nullptr ? SDL_GetWindowID(gSdlWindow) : 0;
+    event.key.state = SDL_PRESSED;
+    event.key.repeat = 0;
+    event.key.keysym.scancode = scancode;
+    event.key.keysym.sym = SDL_GetKeyFromScancode(scancode);
+    event.key.keysym.mod = SDL_GetModState();
+    if (SDL_PushEvent(&event) == 1) {
+        syntheticKeyEvents.emplace_back(scancode, true);
+    }
 
     event.type = SDL_KEYUP;
-    SDL_PushEvent(&event);
+    event.key.timestamp = SDL_GetTicks();
+    event.key.state = SDL_RELEASED;
+    if (SDL_PushEvent(&event) == 1) {
+        syntheticKeyEvents.emplace_back(scancode, false);
+    }
+}
+
+bool sfall_kb_consume_synthetic_key_event(int sdlScanCode, bool pressed)
+{
+    if (syntheticKeyEvents.empty()) {
+        return false;
+    }
+
+    const auto& [expectedScanCode, expectedPressed] = syntheticKeyEvents.front();
+    if (expectedScanCode != static_cast<SDL_Scancode>(sdlScanCode) || expectedPressed != pressed) {
+        return false;
+    }
+
+    syntheticKeyEvents.pop_front();
+    return true;
 }
 
 int sfall_kb_handle_key_pressed(int sdlScanCode, bool pressed)

--- a/src/sfall_kb_helpers.h
+++ b/src/sfall_kb_helpers.h
@@ -9,6 +9,9 @@ bool sfall_kb_is_key_pressed(int key);
 /// Simulates pressing `key`.
 void sfall_kb_press_key(int key);
 
+/// Returns `true` when the next matching SDL key event was injected by `tap_key`.
+bool sfall_kb_consume_synthetic_key_event(int sdlScanCode, bool pressed);
+
 int sfall_kb_handle_key_pressed(int sdlScanCode, bool pressed);
 
 } // namespace fallout

--- a/src/sfall_kb_helpers.h
+++ b/src/sfall_kb_helpers.h
@@ -12,6 +12,9 @@ void sfall_kb_press_key(int key);
 /// Returns `true` when the next matching SDL key event was injected by `tap_key`.
 bool sfall_kb_consume_synthetic_key_event(int sdlScanCode, bool pressed);
 
+/// Clears queued synthetic `tap_key` markers after SDL key events are discarded.
+void sfall_kb_clear_synthetic_key_events();
+
 int sfall_kb_handle_key_pressed(int sdlScanCode, bool pressed);
 
 } // namespace fallout


### PR DESCRIPTION
On Mac, when on worldmap, cmd-tab out of a windowed game then back locks the game 100% of the time for me.  

Cause was [FO2Tweaks](https://github.com/BGforgeNet/FO2tweaks/blob/acf81c2b923c55e6b0a0eb9d267dcf6627e03410/source/gl_g_map_hotkey.tssl#L41):

```
function keypress_handler() {
    const pressed = get_sfall_arg() as number;
    const key = get_sfall_arg() as number;
    if (!pressed) return; // released

    // allow to use the same town map key on world map
    if (in_world_map()) {
        tap_key(DIK_T);
        return;
    }
```

Two problems:
 - we fire HOOK_KEYPRESSED from `tap_key()` events, which was causing an infinite loop.  This is fixed in this PR.
 - the script allows any key to fire the town map.  this just seems like a bug in the script, and I reported it.

Also, we were creating an `SDL_Event` with garbage data.  Fixed that using `SDL_zero`
```
    SDL_Event event;
    event.key.keysym.scancode = scancode;
``