### PR TITLE
Rename `fallout2-dat` to `ce-dat-tool`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -453,7 +453,7 @@ target_link_libraries(${EXECUTABLE_NAME} ${SDL2_LIBRARIES})
 target_include_directories(${EXECUTABLE_NAME} PRIVATE ${SDL2_INCLUDE_DIRS})
 
 if((NOT ANDROID) AND (NOT IOS) AND (NOT CMAKE_SYSTEM_NAME MATCHES "Emscripten"))
-    add_executable(fallout2-dat
+    add_executable(ce-dat-tool
         "tools/dat_tool.cc"
         "tools/dat_archive.cc"
         "tools/fo1_dat_lzss.cc"
@@ -462,23 +462,23 @@ if((NOT ANDROID) AND (NOT IOS) AND (NOT CMAKE_SYSTEM_NAME MATCHES "Emscripten"))
     )
 
     if(APPLE)
-        set_target_properties(fallout2-dat PROPERTIES
+        set_target_properties(ce-dat-tool PROPERTIES
             XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED "NO"
             XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED "NO"
         )
     endif()
 
-    target_link_libraries(fallout2-dat
+    target_link_libraries(ce-dat-tool
         fpattern_windows::fpattern_windows
         ${ZLIB_LIBRARIES}
         ${SDL2_LIBRARIES}
     )
     if(WIN32)
-        target_link_libraries(fallout2-dat winmm)
+        target_link_libraries(ce-dat-tool winmm)
     endif()
-    target_include_directories(fallout2-dat PRIVATE "src")
-    target_include_directories(fallout2-dat PRIVATE ${ZLIB_INCLUDE_DIRS})
-    target_include_directories(fallout2-dat PRIVATE ${SDL2_INCLUDE_DIRS})
+    target_include_directories(ce-dat-tool PRIVATE "src")
+    target_include_directories(ce-dat-tool PRIVATE ${ZLIB_INCLUDE_DIRS})
+    target_include_directories(ce-dat-tool PRIVATE ${SDL2_INCLUDE_DIRS})
 endif()
 
 if(APPLE)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,23 +55,23 @@ TODO: add Visual Studio build instructions. This will likely need a Visual Studi
 
 There is a small command-line archive tool in this repo for inspecting Fallout `.dat` files. It supports both Fallout 2 and Fallout 1 archives.
 
-From the repo root, build it with your normal CMake workflow, targeting `fallout2-dat`:
+From the repo root, build it with your normal CMake workflow, targeting `ce-dat-tool`:
 
-`cmake --build out/build/<preset-name> --target fallout2-dat`
+`cmake --build out/build/<preset-name> --target ce-dat-tool`
 
 The executable is written to your selected build directory, so the exact path will vary by preset and configuration.
 
 The current tool is read-only. Available commands:
 
-1. `./<BUILD_DIR>/fallout2-dat <archive.dat> list [pattern]`
-2. `./<BUILD_DIR>/fallout2-dat <archive.dat> info [pattern]`
-3. `./<BUILD_DIR>/fallout2-dat <archive.dat> extract [--lower] <output-dir> [pattern]`
-4. `./<BUILD_DIR>/fallout2-dat <archive.dat> cat <entry>`
+1. `./<BUILD_DIR>/ce-dat-tool <archive.dat> list [pattern]`
+2. `./<BUILD_DIR>/ce-dat-tool <archive.dat> info [pattern]`
+3. `./<BUILD_DIR>/ce-dat-tool <archive.dat> extract [--lower] <output-dir> [pattern]`
+4. `./<BUILD_DIR>/ce-dat-tool <archive.dat> cat <entry>`
 
 Use `--lower` with `extract` when you want every extracted file and directory name forced to lowercase.
 For example:
 
-`fallout2-dat master.dat extract --lower /tmp/fallout2-dat-lower data\\*`
+`ce-dat-tool master.dat extract --lower /tmp/ce-dat-tool-lower data\\*`
 
 ## Updating SDL
 

--- a/tools/dat_tool.cc
+++ b/tools/dat_tool.cc
@@ -598,7 +598,7 @@ bool createTemporaryArchiveFile(const std::string& archivePath, std::string* tem
 
     for (int attempt = 0; attempt < 1000; attempt++) {
         std::string candidatePath = joinNativePath(directoryPath,
-            ".fallout2-dat-create-"
+            ".ce-dat-tool-create-"
                 + std::to_string(processId)
                 + "-"
                 + std::to_string(static_cast<long long>(std::time(nullptr)))
@@ -785,11 +785,11 @@ void printUsage(std::ostream& stream)
 {
     stream
         << "Usage:\n"
-        << "  fallout2-dat create <input-dir> <archive.dat>\n"
-        << "  fallout2-dat <archive.dat> list [pattern]\n"
-        << "  fallout2-dat <archive.dat> info [pattern]\n"
-        << "  fallout2-dat <archive.dat> extract [--lower] <output-dir> [pattern]\n"
-        << "  fallout2-dat <archive.dat> cat <entry>\n"
+        << "  ce-dat-tool create <input-dir> <archive.dat>\n"
+        << "  ce-dat-tool <archive.dat> list [pattern]\n"
+        << "  ce-dat-tool <archive.dat> info [pattern]\n"
+        << "  ce-dat-tool <archive.dat> extract [--lower] <output-dir> [pattern]\n"
+        << "  ce-dat-tool <archive.dat> cat <entry>\n"
         << "\n"
         << "Notes:\n"
         << "  - Create preserves input path casing and stores Windows-style archive paths.\n"


### PR DESCRIPTION
This is a generic tool that works with FO1 and FO2 archives, so name it appropriately.

