### PR TITLE
Bundle ce.dat into release packages

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -6,10 +6,15 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   format:
     runs-on: ubuntu-latest
     if: github.actor != 'github-actions[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/ci-build-web.yml
+++ b/.github/workflows/ci-build-web.yml
@@ -8,11 +8,16 @@ on:
       - opened
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   build_webassembly_version:
     name: Build webassembly version
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      contents: write
+      deployments: write
     steps:
       - name: start deployment
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
@@ -138,4 +143,3 @@ jobs:
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
           ref: ${{ github.event.pull_request.head.sha }}
           env_url: https://${{ github.repository_owner }}.github.io/fallout2-ce/PR-${{ github.event.pull_request.number }}/
-

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
-          name: fallout2-ce-android-debug.zip
+          name: fallout2-ce-android-debug
           path: out/dist/fallout2-ce-android-debug.zip
           retention-days: 7
 
@@ -206,7 +206,7 @@ jobs:
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
-          name: fallout2-ce-ios.zip
+          name: fallout2-ce-ios
           path: out/dist/fallout2-ce-ios.zip
           retention-days: 7
 
@@ -270,7 +270,7 @@ jobs:
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
-          name: fallout2-ce-linux-${{ matrix.arch }}.tar.gz
+          name: fallout2-ce-linux-${{ matrix.arch }}
           path: out/dist/fallout2-ce-linux-${{ matrix.arch }}.tar.gz
           retention-days: 7
 
@@ -320,7 +320,7 @@ jobs:
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
-          name: fallout2-ce-linux-armhf.tar.gz
+          name: fallout2-ce-linux-armhf
           path: out/dist/fallout2-ce-linux-armhf.tar.gz
           retention-days: 7
 
@@ -361,7 +361,7 @@ jobs:
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
-          name: fallout2-ce-linux-arm64.tar.gz
+          name: fallout2-ce-linux-arm64
           path: out/dist/fallout2-ce-linux-arm64.tar.gz
           retention-days: 7
 
@@ -396,7 +396,7 @@ jobs:
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
-          name: fallout2-ce-macos.dmg
+          name: fallout2-ce-macos
           path: out/build/macos/Fallout II Community Edition.dmg
           retention-days: 7
 
@@ -459,7 +459,7 @@ jobs:
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
-          name: fallout2-ce-windows-${{ matrix.arch }}.zip
+          name: fallout2-ce-windows-${{ matrix.arch }}
           path: out/dist/fallout2-ce-windows-${{ matrix.arch }}.zip
           retention-days: 7
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -71,6 +71,7 @@ jobs:
     name: Android
 
     runs-on: ubuntu-latest
+    needs: [ce-dat]
 
     steps:
       - name: Clone
@@ -104,15 +105,25 @@ jobs:
           cd os/android
           ./gradlew assembleDebug
 
-      - name: Change apk file name
+      - name: Download ce.dat
+        uses: actions/download-artifact@v4
+        with:
+          name: ce-dat
+          path: out/dist
+
+      - name: Package
         run: |
-          mv os/android/app/build/outputs/apk/debug/app-debug.apk os/android/app/build/outputs/apk/debug/fallout2-ce.apk
+          mkdir -p out/dist/fallout2-ce-android-debug
+          cp os/android/app/build/outputs/apk/debug/app-debug.apk out/dist/fallout2-ce-android-debug/fallout2-ce.apk
+          cp out/dist/ce.dat out/dist/fallout2-ce-android-debug/ce.dat
+          cd out/dist
+          zip -r fallout2-ce-android-debug.zip fallout2-ce-android-debug
 
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
-          name: fallout2-ce-debug.apk
-          path: os/android/app/build/outputs/apk/debug/fallout2-ce.apk
+          name: fallout2-ce-android-debug.zip
+          path: out/dist/fallout2-ce-android-debug.zip
           retention-days: 7
 
   ce-dat:
@@ -153,6 +164,7 @@ jobs:
     name: iOS
 
     runs-on: macos-14
+    needs: [ce-dat]
 
     steps:
       - name: Clone
@@ -177,11 +189,25 @@ jobs:
           cd out/build/ios
           cpack -C Debug
 
+      - name: Download ce.dat
+        uses: actions/download-artifact@v4
+        with:
+          name: ce-dat
+          path: out/dist
+
+      - name: Package
+        run: |
+          mkdir -p out/dist/fallout2-ce-ios
+          cp out/build/ios/fallout2-ce.ipa out/dist/fallout2-ce-ios/fallout2-ce-ios.ipa
+          cp out/dist/ce.dat out/dist/fallout2-ce-ios/ce.dat
+          cd out/dist
+          zip -r fallout2-ce-ios.zip fallout2-ce-ios
+
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
-          name: fallout2-ce.ipa
-          path:  out/build/ios/fallout2-ce.ipa
+          name: fallout2-ce-ios.zip
+          path: out/dist/fallout2-ce-ios.zip
           retention-days: 7
 
   linux:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -134,37 +134,9 @@ jobs:
 
   ce-dat:
     name: Build ce.dat
-
-    runs-on: ubuntu-22.04
-
-    steps:
-      - name: Clone
-        uses: actions/checkout@v4
-
-      - name: Dependencies
-        run: |
-          sudo apt update
-          sudo apt install libsdl2-dev zlib1g-dev
-
-      - name: Configure
-        run: |
-          cmake --preset linux-x64-debug
-
-      - name: Build ce-dat-tool
-        run: |
-          cmake --build --preset linux-x64-debug --target ce-dat-tool
-
-      - name: Create ce.dat
-        run: |
-          mkdir -p out/dist
-          out/build/linux-x64-debug/ce-dat-tool create files/ce.dat out/dist/ce.dat
-
-      - name: Upload ce.dat artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ce-dat
-          path: out/dist/ce.dat
-          retention-days: 7
+    uses: ./.github/workflows/reusable-build-ce-dat.yml
+    with:
+      preset: linux-x64-debug
 
   ios:
     name: iOS

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -343,7 +343,6 @@ jobs:
     name: macOS
 
     runs-on: macos-14
-    needs: [ce-dat]
 
     steps:
       - name: Clone
@@ -362,16 +361,6 @@ jobs:
       - name: Build
         run: |
           cmake --build --preset macos-debug
-
-      - name: Download ce.dat
-        uses: actions/download-artifact@v4
-        with:
-          name: ce-dat
-          path: out/dist
-
-      - name: Bundle ce.dat
-        run: |
-          cp out/dist/ce.dat "out/build/macos/Debug/Fallout II Community Edition.app/Contents/MacOS/ce.dat"
 
       - name: Pack
         run: |

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -9,6 +9,9 @@ on:
       - opened
       - synchronize
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash
@@ -35,6 +38,9 @@ jobs:
     name: Code format check
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
 
     steps:
       - name: Clone
@@ -468,7 +474,8 @@ jobs:
     name: Release Continuous build
     runs-on: ubuntu-latest
     needs: [android, ios, linux, linux-armhf, linux-arm64, macos, windows]
-    permissions: write-all
+    permissions:
+      contents: write
     steps:
       - name: Fetch artifacts
         if: ${{ always() && github.ref == 'refs/heads/main' && github.event_name == 'push' }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -115,6 +115,40 @@ jobs:
           path: os/android/app/build/outputs/apk/debug/fallout2-ce.apk
           retention-days: 7
 
+  ce-dat:
+    name: Build ce.dat
+
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v4
+
+      - name: Dependencies
+        run: |
+          sudo apt update
+          sudo apt install libsdl2-dev zlib1g-dev
+
+      - name: Configure
+        run: |
+          cmake --preset linux-x64-debug
+
+      - name: Build ce-dat-tool
+        run: |
+          cmake --build --preset linux-x64-debug --target ce-dat-tool
+
+      - name: Create ce.dat
+        run: |
+          mkdir -p out/dist
+          out/build/linux-x64-debug/ce-dat-tool create files/ce.dat out/dist/ce.dat
+
+      - name: Upload ce.dat artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ce-dat
+          path: out/dist/ce.dat
+          retention-days: 7
+
   ios:
     name: iOS
 
@@ -154,6 +188,7 @@ jobs:
     name: Linux (${{ matrix.arch }})
 
     runs-on: ubuntu-22.04
+    needs: [ce-dat]
 
     strategy:
       fail-fast: false
@@ -193,21 +228,31 @@ jobs:
         run: |
           cmake --build --preset linux-${{ matrix.arch }}-debug
 
-      - name: Change executable file name
+      - name: Download ce.dat
+        uses: actions/download-artifact@v4
+        with:
+          name: ce-dat
+          path: out/dist
+
+      - name: Package
         run: |
-          mv out/build/linux-${{ matrix.arch }}-debug/fallout2-ce out/build/linux-${{ matrix.arch }}-debug/fallout2-ce-linux-${{ matrix.arch }}
+          mkdir -p out/dist/fallout2-ce-linux-${{ matrix.arch }}
+          cp out/build/linux-${{ matrix.arch }}-debug/fallout2-ce out/dist/fallout2-ce-linux-${{ matrix.arch }}/fallout2-ce
+          cp out/dist/ce.dat out/dist/fallout2-ce-linux-${{ matrix.arch }}/ce.dat
+          tar -czvf out/dist/fallout2-ce-linux-${{ matrix.arch }}.tar.gz -C out/dist fallout2-ce-linux-${{ matrix.arch }}
 
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
-          name: fallout2-ce-linux-${{ matrix.arch }}
-          path:  out/build/linux-${{ matrix.arch }}-debug/fallout2-ce-linux-${{ matrix.arch }}
+          name: fallout2-ce-linux-${{ matrix.arch }}.tar.gz
+          path: out/dist/fallout2-ce-linux-${{ matrix.arch }}.tar.gz
           retention-days: 7
 
   linux-armhf:
     name: Linux (armhf)
 
     runs-on: ubuntu-22.04-arm
+    needs: [ce-dat]
 
     steps:
       - name: Clone
@@ -233,21 +278,31 @@ jobs:
       - name: Build
         run: cmake --build build
 
-      - name: Change executable file name
+      - name: Download ce.dat
+        uses: actions/download-artifact@v4
+        with:
+          name: ce-dat
+          path: out/dist
+
+      - name: Package
         run: |
-          mv build/fallout2-ce build/fallout2-ce-linux-armhf
+          mkdir -p out/dist/fallout2-ce-linux-armhf
+          cp build/fallout2-ce out/dist/fallout2-ce-linux-armhf/fallout2-ce
+          cp out/dist/ce.dat out/dist/fallout2-ce-linux-armhf/ce.dat
+          tar -czvf out/dist/fallout2-ce-linux-armhf.tar.gz -C out/dist fallout2-ce-linux-armhf
 
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
-          name: fallout2-ce-linux-armhf
-          path:  build/fallout2-ce-linux-armhf
+          name: fallout2-ce-linux-armhf.tar.gz
+          path: out/dist/fallout2-ce-linux-armhf.tar.gz
           retention-days: 7
 
   linux-arm64:
     name: Linux (arm64)
 
     runs-on: ubuntu-22.04-arm
+    needs: [ce-dat]
 
     steps:
       - name: Clone
@@ -264,21 +319,31 @@ jobs:
       - name: Build
         run: cmake --build build
 
-      - name: Change executable file name
+      - name: Download ce.dat
+        uses: actions/download-artifact@v4
+        with:
+          name: ce-dat
+          path: out/dist
+
+      - name: Package
         run: |
-          mv build/fallout2-ce build/fallout2-ce-linux-arm64
+          mkdir -p out/dist/fallout2-ce-linux-arm64
+          cp build/fallout2-ce out/dist/fallout2-ce-linux-arm64/fallout2-ce
+          cp out/dist/ce.dat out/dist/fallout2-ce-linux-arm64/ce.dat
+          tar -czvf out/dist/fallout2-ce-linux-arm64.tar.gz -C out/dist fallout2-ce-linux-arm64
 
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
-          name: fallout2-ce-linux-arm64
-          path:  build/fallout2-ce-linux-arm64
+          name: fallout2-ce-linux-arm64.tar.gz
+          path: out/dist/fallout2-ce-linux-arm64.tar.gz
           retention-days: 7
 
   macos:
     name: macOS
 
     runs-on: macos-14
+    needs: [ce-dat]
 
     steps:
       - name: Clone
@@ -298,6 +363,16 @@ jobs:
         run: |
           cmake --build --preset macos-debug
 
+      - name: Download ce.dat
+        uses: actions/download-artifact@v4
+        with:
+          name: ce-dat
+          path: out/dist
+
+      - name: Bundle ce.dat
+        run: |
+          cp out/dist/ce.dat "out/build/macos/Debug/Fallout II Community Edition.app/Contents/MacOS/ce.dat"
+
       - name: Pack
         run: |
           cd out/build/macos
@@ -314,6 +389,7 @@ jobs:
     name: Windows (${{ matrix.arch }})
 
     runs-on: windows-2025
+    needs: [ce-dat]
 
     strategy:
       fail-fast: false
@@ -351,15 +427,25 @@ jobs:
           call "%VS_PATH%\Common7\Tools\VsDevCmd.bat" ^
           && cmake --build --preset windows-${{ matrix.arch }}-release
 
-      - name: Change executable file name
+      - name: Download ce.dat
+        uses: actions/download-artifact@v4
+        with:
+          name: ce-dat
+          path: out/dist
+
+      - name: Package
         run: |
-          mv out/build/windows-${{ matrix.arch }}/RelWithDebInfo/fallout2-ce.exe out/build/windows-${{ matrix.arch }}/RelWithDebInfo/fallout2-ce-${{ matrix.arch }}.exe
+          mkdir -p out/dist/fallout2-ce-windows-${{ matrix.arch }}
+          cp out/build/windows-${{ matrix.arch }}/RelWithDebInfo/fallout2-ce.exe out/dist/fallout2-ce-windows-${{ matrix.arch }}/fallout2-ce.exe
+          cp out/dist/ce.dat out/dist/fallout2-ce-windows-${{ matrix.arch }}/ce.dat
+          cd out/dist
+          7z a fallout2-ce-windows-${{ matrix.arch }}.zip fallout2-ce-windows-${{ matrix.arch }}
 
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
-          name: fallout2-ce-windows-${{ matrix.arch }}
-          path:  out/build/windows-${{ matrix.arch }}/RelWithDebInfo/fallout2-ce-${{ matrix.arch }}.exe
+          name: fallout2-ce-windows-${{ matrix.arch }}.zip
+          path: out/dist/fallout2-ce-windows-${{ matrix.arch }}.zip
           retention-days: 7
 
 
@@ -387,6 +473,7 @@ jobs:
       - name: Move unpacked artifacts to root folder
         if: ${{ always() && github.ref == 'refs/heads/main' && github.event_name == 'push' }}
         run: |
+          rm -rf artifacts/ce-dat
           ls -Rlah .
           find .
           cd artifacts/

--- a/.github/workflows/ci-delete-pr-preview.yml
+++ b/.github/workflows/ci-delete-pr-preview.yml
@@ -5,6 +5,9 @@ on:
     types:
       - closed
 
+permissions:
+  contents: read
+
 jobs:
   delete_pr_preview:
     name: Delete PR preview from gh-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,7 +220,6 @@ jobs:
     name: macOS
 
     runs-on: macos-11
-    needs: [ce-dat]
 
     steps:
       - name: Clone
@@ -255,16 +254,6 @@ jobs:
             --config RelWithDebInfo \
             -j $(sysctl -n hw.physicalcpu) \
             # EOL
-
-      - name: Download ce.dat
-        uses: actions/download-artifact@v4
-        with:
-          name: ce-dat
-          path: out/dist
-
-      - name: Bundle ce.dat
-        run: |
-          cp out/dist/ce.dat "build/RelWithDebInfo/Fallout II Community Edition.app/Contents/MacOS/ce.dat"
 
       - name: Pack
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,37 +15,9 @@ defaults:
 jobs:
   ce-dat:
     name: Build ce.dat
-
-    runs-on: ubuntu-22.04
-
-    steps:
-      - name: Clone
-        uses: actions/checkout@v4
-
-      - name: Dependencies
-        run: |
-          sudo apt update
-          sudo apt install libsdl2-dev zlib1g-dev
-
-      - name: Configure
-        run: |
-          cmake --preset linux-x64-release
-
-      - name: Build ce-dat-tool
-        run: |
-          cmake --build --preset linux-x64-release --target ce-dat-tool
-
-      - name: Create ce.dat
-        run: |
-          mkdir -p out/dist
-          out/build/linux-x64-release/ce-dat-tool create files/ce.dat out/dist/ce.dat
-
-      - name: Upload ce.dat artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ce-dat
-          path: out/dist/ce.dat
-          retention-days: 7
+    uses: ./.github/workflows/reusable-build-ce-dat.yml
+    with:
+      preset: linux-x64-release
 
   android:
     name: Android

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     types:
       - published
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash
@@ -49,6 +52,8 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: [ce-dat]
+    permissions:
+      contents: write
 
     steps:
       - name: Clone
@@ -105,6 +110,8 @@ jobs:
 
     runs-on: macos-14
     needs: [ce-dat]
+    permissions:
+      contents: write
 
     steps:
       - name: Clone
@@ -163,6 +170,8 @@ jobs:
 
     runs-on: ubuntu-20.04
     needs: [ce-dat]
+    permissions:
+      contents: write
 
     strategy:
       fail-fast: false
@@ -240,6 +249,8 @@ jobs:
     name: macOS
 
     runs-on: macos-11
+    permissions:
+      contents: write
 
     steps:
       - name: Clone
@@ -308,6 +319,8 @@ jobs:
 
     runs-on: windows-2025
     needs: [ce-dat]
+    permissions:
+      contents: write
 
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,40 @@ defaults:
     shell: bash
 
 jobs:
+  ce-dat:
+    name: Build ce.dat
+
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v4
+
+      - name: Dependencies
+        run: |
+          sudo apt update
+          sudo apt install libsdl2-dev zlib1g-dev
+
+      - name: Configure
+        run: |
+          cmake --preset linux-x64-release
+
+      - name: Build ce-dat-tool
+        run: |
+          cmake --build --preset linux-x64-release --target ce-dat-tool
+
+      - name: Create ce.dat
+        run: |
+          mkdir -p out/dist
+          out/build/linux-x64-release/ce-dat-tool create files/ce.dat out/dist/ce.dat
+
+      - name: Upload ce.dat artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ce-dat
+          path: out/dist/ce.dat
+          retention-days: 7
+
   android:
     name: Android
 
@@ -108,6 +142,7 @@ jobs:
     name: Linux (${{ matrix.arch }})
 
     runs-on: ubuntu-20.04
+    needs: [ce-dat]
 
     strategy:
       fail-fast: false
@@ -164,10 +199,18 @@ jobs:
             -j $(nproc) \
             # EOL
 
+      - name: Download ce.dat
+        uses: actions/download-artifact@v4
+        with:
+          name: ce-dat
+          path: out/dist
+
       - name: Upload
         run: |
-          cd build
-          tar -czvf fallout2-ce-linux-${{ matrix.arch }}.tar.gz fallout2-ce
+          mkdir -p out/dist/fallout2-ce-linux-${{ matrix.arch }}
+          cp build/fallout2-ce out/dist/fallout2-ce-linux-${{ matrix.arch }}/fallout2-ce
+          cp out/dist/ce.dat out/dist/fallout2-ce-linux-${{ matrix.arch }}/ce.dat
+          tar -czvf fallout2-ce-linux-${{ matrix.arch }}.tar.gz -C out/dist fallout2-ce-linux-${{ matrix.arch }}
           gh release upload ${{ github.event.release.tag_name }} fallout2-ce-linux-${{ matrix.arch }}.tar.gz
           rm fallout2-ce-linux-${{ matrix.arch }}.tar.gz
         env:
@@ -177,6 +220,7 @@ jobs:
     name: macOS
 
     runs-on: macos-11
+    needs: [ce-dat]
 
     steps:
       - name: Clone
@@ -212,6 +256,16 @@ jobs:
             -j $(sysctl -n hw.physicalcpu) \
             # EOL
 
+      - name: Download ce.dat
+        uses: actions/download-artifact@v4
+        with:
+          name: ce-dat
+          path: out/dist
+
+      - name: Bundle ce.dat
+        run: |
+          cp out/dist/ce.dat "build/RelWithDebInfo/Fallout II Community Edition.app/Contents/MacOS/ce.dat"
+
       - name: Pack
         run: |
           cd build
@@ -244,6 +298,7 @@ jobs:
     name: Windows (${{ matrix.arch }})
 
     runs-on: windows-2025
+    needs: [ce-dat]
 
     strategy:
       fail-fast: false
@@ -281,10 +336,19 @@ jobs:
           call "%VS_PATH%\Common7\Tools\VsDevCmd.bat" ^
           && cmake --build --preset windows-${{ matrix.arch }}-release
 
+      - name: Download ce.dat
+        uses: actions/download-artifact@v4
+        with:
+          name: ce-dat
+          path: out/dist
+
       - name: Upload
         run: |
-          cd out/build/windows-${{ matrix.arch }}/RelWithDebInfo
-          7z a fallout2-ce-windows-${{ matrix.arch }}.zip fallout2-ce.exe
+          mkdir -p out/dist/fallout2-ce-windows-${{ matrix.arch }}
+          cp out/build/windows-${{ matrix.arch }}/RelWithDebInfo/fallout2-ce.exe out/dist/fallout2-ce-windows-${{ matrix.arch }}/fallout2-ce.exe
+          cp out/dist/ce.dat out/dist/fallout2-ce-windows-${{ matrix.arch }}/ce.dat
+          cd out/dist
+          7z a fallout2-ce-windows-${{ matrix.arch }}.zip fallout2-ce-windows-${{ matrix.arch }}
           gh release upload ${{ github.event.release.tag_name }} fallout2-ce-windows-${{ matrix.arch }}.zip
           rm fallout2-ce-windows-${{ matrix.arch }}.zip
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
     name: Android
 
     runs-on: ubuntu-latest
+    needs: [ce-dat]
 
     steps:
       - name: Clone
@@ -81,12 +82,21 @@ jobs:
           cd os/android
           ./gradlew assembleRelease
 
+      - name: Download ce.dat
+        uses: actions/download-artifact@v4
+        with:
+          name: ce-dat
+          path: out/dist
+
       - name: Upload
         run: |
-          cd os/android/app/build/outputs/apk/release
-          cp app-release.apk fallout2-ce-android.apk
-          gh release upload ${{ github.event.release.tag_name }} fallout2-ce-android.apk
-          rm fallout2-ce-android.apk
+          mkdir -p out/dist/fallout2-ce-android
+          cp os/android/app/build/outputs/apk/release/app-release.apk out/dist/fallout2-ce-android/fallout2-ce-android.apk
+          cp out/dist/ce.dat out/dist/fallout2-ce-android/ce.dat
+          cd out/dist
+          zip -r fallout2-ce-android.zip fallout2-ce-android
+          gh release upload ${{ github.event.release.tag_name }} fallout2-ce-android.zip
+          rm fallout2-ce-android.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -94,6 +104,7 @@ jobs:
     name: iOS
 
     runs-on: macos-14
+    needs: [ce-dat]
 
     steps:
       - name: Clone
@@ -129,12 +140,21 @@ jobs:
           cd build
           cpack -C RelWithDebInfo
 
+      - name: Download ce.dat
+        uses: actions/download-artifact@v4
+        with:
+          name: ce-dat
+          path: out/dist
+
       - name: Upload
         run: |
-          cd build
-          cp fallout2-ce.ipa fallout2-ce-ios.ipa
-          gh release upload ${{ github.event.release.tag_name }} fallout2-ce-ios.ipa
-          rm fallout2-ce-ios.ipa
+          mkdir -p out/dist/fallout2-ce-ios
+          cp build/fallout2-ce.ipa out/dist/fallout2-ce-ios/fallout2-ce-ios.ipa
+          cp out/dist/ce.dat out/dist/fallout2-ce-ios/ce.dat
+          cd out/dist
+          zip -r fallout2-ce-ios.zip fallout2-ce-ios
+          gh release upload ${{ github.event.release.tag_name }} fallout2-ce-ios.zip
+          rm fallout2-ce-ios.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/reusable-build-ce-dat.yml
+++ b/.github/workflows/reusable-build-ce-dat.yml
@@ -1,0 +1,49 @@
+name: Reusable Build ce.dat
+
+on:
+  workflow_call:
+    inputs:
+      preset:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build-ce-dat:
+    name: Build ce.dat
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v4
+
+      - name: Dependencies
+        run: |
+          sudo apt update
+          sudo apt install libsdl2-dev zlib1g-dev
+
+      - name: Configure
+        run: |
+          cmake --preset ${{ inputs.preset }}
+
+      - name: Build ce-dat-tool
+        run: |
+          cmake --build --preset ${{ inputs.preset }} --target ce-dat-tool
+
+      - name: Create ce.dat
+        run: |
+          mkdir -p out/dist
+          out/build/${{ inputs.preset }}/ce-dat-tool create files/ce.dat out/dist/ce.dat
+
+      - name: Upload ce.dat artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ce-dat
+          path: out/dist/ce.dat
+          retention-days: 7

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,6 +369,8 @@ if(APPLE)
             "os/macos/fallout2-ce.icns"
         )
 
+        target_link_libraries(${EXECUTABLE_NAME} "-framework CoreFoundation")
+
         target_sources(${EXECUTABLE_NAME} PUBLIC ${RESOURCES})
         set_source_files_properties(${RESOURCES} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -501,6 +501,28 @@ if((NOT ANDROID) AND (NOT IOS) AND (NOT CMAKE_SYSTEM_NAME MATCHES "Emscripten"))
     target_include_directories(ce-frm2png PRIVATE ${ZLIB_INCLUDE_DIRS})
     target_link_libraries(ce-frm2png ${SDL2_LIBRARIES})
     target_link_libraries(ce-frm2png ${ZLIB_LIBRARIES})
+
+    if(APPLE)
+        file(GLOB_RECURSE CE_DAT_INPUTS CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/files/ce.dat/*")
+        set(CE_DAT_RESOURCE_PATH "${CMAKE_CURRENT_BINARY_DIR}/ce.dat")
+
+        add_custom_command(
+            OUTPUT "${CE_DAT_RESOURCE_PATH}"
+            COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}"
+            COMMAND $<TARGET_FILE:ce-dat-tool> create "${CMAKE_SOURCE_DIR}/files/ce.dat" "${CE_DAT_RESOURCE_PATH}"
+            DEPENDS ce-dat-tool ${CE_DAT_INPUTS}
+            COMMENT "Generating ce.dat for app bundle"
+            VERBATIM
+        )
+
+        add_custom_target(ce-dat-resource DEPENDS "${CE_DAT_RESOURCE_PATH}")
+        add_dependencies(${EXECUTABLE_NAME} ce-dat-resource)
+
+        target_sources(${EXECUTABLE_NAME} PRIVATE "${CE_DAT_RESOURCE_PATH}")
+        set_source_files_properties("${CE_DAT_RESOURCE_PATH}" PROPERTIES
+            GENERATED TRUE
+            MACOSX_PACKAGE_LOCATION "Resources")
+    endif()
 endif()
 
 if(APPLE)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This is a fork of the original Fallout2: CE project, which is no longer getting 
 
 Popular Fallout 2 total conversion mods are partially supported. Original versions of Nevada and Sonora (that do not rely on extended features provided by Sfall) work. [Fallout 2 Restoration Project](https://github.com/BGforgeNet/Fallout2_Restoration_Project) is supported (in Beta). [Fallout Et Tu](https://github.com/rotators/Fo1in2) and [Olympus 2207](https://olympus2207.com) are not yet supported. Other mods (particularly Resurrection and Yesterday) are not tested.
 
+Fallout2: CE has broad (though not total) compatibility with [Sfall](https://github.com/sfall-team/sfall) scripting extensions.  Many traditional Fallout mods work out of the box.
+
 There is also [Fallout 1 Community Edition](https://github.com/alexbatalov/fallout1-ce) (not affiliated with this fork).
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# Fallout 2 Community Edition
+# Fallout 2 Community Engine
 
-Fallout 2 Community Edition is a fully working re-implementation of Fallout 2, with the same original gameplay, engine bugfixes, and some quality of life improvements, that works (mostly) hassle-free on multiple platforms.  This is a fork of the original project, which isn't getting regular updates.
+Fallout 2 Community Engine is a fully working re-implementation of the Fallout 2 engine, optimized for a hassle-free experience on multiple platforms.  It provides high resolution support, quality-of-life improvements, and dozens of bug fixes.
+
+This is a fork of the original Fallout2: CE project, which is no longer getting regular updates.
 
 Popular Fallout 2 total conversion mods are partially supported. Original versions of Nevada and Sonora (that do not rely on extended features provided by Sfall) work. [Fallout 2 Restoration Project](https://github.com/BGforgeNet/Fallout2_Restoration_Project) is supported (in Beta). [Fallout Et Tu](https://github.com/rotators/Fo1in2) and [Olympus 2207](https://olympus2207.com) are not yet supported. Other mods (particularly Resurrection and Yesterday) are not tested.
 
-There is also [Fallout Community Edition](https://github.com/alexbatalov/fallout1-ce) (not affiliated with this fork).
-
-For build and contributor notes, see [CONTRIBUTING.md](CONTRIBUTING.md).
+There is also [Fallout 1 Community Edition](https://github.com/alexbatalov/fallout1-ce) (not affiliated with this fork).
 
 ## Installation
 
-You must own the game to play. Purchase your copy on [GOG](https://www.gog.com/game/fallout_2), [Epic Games](https://store.epicgames.com/p/fallout-2) or [Steam](https://store.steampowered.com/app/38410). Download latest [release](https://github.com/fallout2-ce/fallout2-ce/releases) or build from source.
+You *must* own the game to play. Purchase your copy on [GOG](https://www.gog.com/game/fallout_2), [Epic Games](https://store.epicgames.com/p/fallout-2) or [Steam](https://store.steampowered.com/app/38410). Download latest [release](https://github.com/fallout2-ce/fallout2-ce/releases) or build from source.
 
 ### Windows
 
-Download and copy `fallout2-ce.exe` to your `Fallout2` folder. It serves as a drop-in replacement for `fallout2.exe`.
+[Download](https://github.com/fallout2-ce/fallout2-ce/releases) and unzip into your `Fallout2` folder. Launch the game using `fallout2-ce.exe`.
 
 ### Linux
 
@@ -27,7 +27,7 @@ $ sudo apt install innoextract
 $ innoextract ~/Downloads/setup_fallout_2_1.02_gog_v1_\(77792\).exe -d Fallout2
 ```
 
-- Download the Linux release archive, extract `fallout2-ce`, and copy it into this folder.
+- Download the Linux release archive, extract `fallout2-ce` and `ce.dat`, and copy them into this folder.
 
 - Run `./fallout2-ce`.
 
@@ -61,9 +61,11 @@ $ mv fallout2 /Applications/Fallout2
 
 > **NOTE**: From Android standpoint release and debug builds are different apps. Both apps require their own copy of game assets and have their own savegames. This is intentional. As a gamer just stick with release version and check for updates.
 
-- Use Windows installation as a base - it contains data assets needed to play. Copy `Fallout2` folder to your device, for example to `Downloads`. You need `master.dat`, `critter.dat`, `patch000.dat`, and `data` folder. Watch for file names - keep (or make) them lowercased (see [Configuration](#configuration)).
+- Download the Android [release](https://github.com/fallout2-ce/fallout2-ce/releases), which contains an .apk file an `ce.dat`.
 
-- Download `fallout2-ce.apk` and copy it to your device. Open it with file explorer, follow instructions (install from unknown source).
+- Use Windows installation as a base - it contains data assets needed to play. Copy `Fallout2` folder to your device, for example to `Downloads`. You need `master.dat`, `critter.dat`, `patch000.dat`, and `data` folder. Watch for file names - keep (or make) them lowercased (see [Configuration](#configuration)).  Copy `ce.dat` into this folder.
+
+- Copy `fallout2-ce.apk` from the release to your device. Open it with file explorer, follow instructions (install from unknown source).
 
 - When you run the game for the first time it will immediately present file picker. Select the folder from the first step. Wait until this data is copied. A loading dialog will appear, just wait for about 30 seconds. If you're installing total conversion mod or localized version with a large number of unpacked resources in `data` folder it can take up to 20 minutes. Once copied, the game will start automatically.
 
@@ -75,9 +77,9 @@ $ mv fallout2 /Applications/Fallout2
 
 - Run the game once. You'll see error message saying "Couldn't find/load text fonts". This step is needed for iOS to expose the game via File Sharing feature.
 
-- Use Finder (macOS Catalina and later) or iTunes (Windows and macOS Mojave or earlier) to copy `master.dat`, `critter.dat`, `patch000.dat`, and `data` folder to "Fallout 2" app ([how-to](https://support.apple.com/HT210598)). Watch for file names - keep (or make) them lowercased (see [Configuration](#configuration)).
+- Use Finder (macOS Catalina and later) or iTunes (Windows and macOS Mojave or earlier) to copy `master.dat`, `critter.dat`, `patch000.dat`, `ce.dat`, and `data` folder to "Fallout 2" app ([how-to](https://support.apple.com/HT210598)). Watch for file names - keep (or make) them lowercased (see [Configuration](#configuration)).
 
-- 
+-
 
 **Controls on iPad:**
 
@@ -107,7 +109,7 @@ The `sound` folder (with `music` folder inside) might be located either in `data
 
 Additional settings for screen resolution, UI customization, and map options are now integrated into the main `fallout2.cfg` file (previously part of `f2_res.ini` from Mash's HRP). When Fallout 2 CE starts, if it detects an existing `f2_res.ini` file, it automatically migrates these settings into `fallout2.cfg`. After migration, `fallout2.cfg` becomes the single source of truth for this configuration.
 
-The following settings can be configured in `fallout2.cfg` under the `[screen]` and `[ui]` sections:
+Here are some important settings in `fallout2.cfg` under the `[screen]` and `[ui]` sections.  See [the example config](https://github.com/fallout2-ce/fallout2-ce/tree/refs/heads/main/files/fallout2.cfg) for a full list of settings.
 
 ```ini
 [screen]
@@ -117,12 +119,11 @@ windowed=1 ; 0 = fullscreen
 scale=2 ; 1 = original scale, 2 = 2x scale, etc. (e.g. at scale 2 and screen resolution 1920x1080, in-game resolution will be 960x540, thus every pixel is twice as wide and tall)
 
 [ui]
-iface_bar_mode=0 ; 0 = interface bar below game window, 1 = interface bar overlaps game window
-iface_bar_width=800 ; Width of interface bar (640 = original, 800 = extended)
-iface_bar_side_art=2 ; Interface bar side art style (0=black, 1=metal grey, 2=leather, 3-8=alternative styles)
-iface_bar_sides_ori=0 ; Side graphics orientation (0=extend from bar to edges, 1=extend from edges to bar)
+;Set to 1 to expand the barter/trade window vertically, adding a 4th item slot per side (requires ce.dat)
+expand_barter_window=1
+;Maximum number of columns shown in the main inventory and loot/steal windows (valid range: 1..2)
+inventory_columns=2
 splash_screen_size=1 ; Splash screen scaling (0=original size, 1=fit preserving aspect, 2=stretch to fill)
-ignore_map_edges=0 ; Hi-res map scroll edges (0=enabled, 1=ignored)
 quick_toolbar_visible=0 ; Skills quick access toolbar visibility (iOS only) (0=hidden, 1=visible)
 ```
 
@@ -134,22 +135,23 @@ quick_toolbar_visible=0 ; Skills quick access toolbar visibility (iOS only) (0=h
 In time this stuff will receive in-game interface, right now you have to do it manually. To see all currently working fallout2.cfg settings, just run the game once and quit. It will be automatically updated with defaults for every supported setting.
 *Note*: Use of the IFACE_BAR settings requires the `f2_res.dat` file, which contains graphical assets. Various versions are available, but one compatible with the above settings can be found here: [f2_res.dat](https://github.com/fallout2-ce/fallout2-ce/raw/refs/heads/main/files/f2_res.dat)
 
-The second configuration file is `ddraw.ini` (part of Sfall). There are dozens of options that adjust or override engine behaviour and gameplay mechanics. This file is intended for modders and advanced users.
-
-For a sample ddraw.ini configuration file, containing all currently working settings use this link: [ddraw.ini](https://raw.githubusercontent.com/fallout2-ce/fallout2-ce/refs/heads/main/files/ddraw.ini)
-
 ## Quality of life benefits over vanilla Fallout
 
 * High resolution support
+* Expanded 2-column inventory
+* Expanded 4-row barter screen
+* Expanded AP bar
 * Increased pathfinding nodes 5x for more accurate pathfinding
 * Ctrl-click to quickly move items when bartering, looting, or stealing
 * _a_ to select "all" when selecting item quantity
 * _a_ to `Take All` when looting
 * When bartering, caps default to the right amount to balance the trade (if possible)
-* Music continues playing between maps (requires config)
-* Auto open doors (requires config)
+* Music continues playing between maps
+* Auto open doors
 
 ## Contributing
+
+For build instructions and contributor notes, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 Integrating Sfall goodies is the top priority. Quality of life updates are OK too.  In any case open up an issue with your suggestion or to notify other people that something is being worked on.
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $ mv fallout2 /Applications/Fallout2
 
 > **NOTE**: From Android standpoint release and debug builds are different apps. Both apps require their own copy of game assets and have their own savegames. This is intentional. As a gamer just stick with release version and check for updates.
 
-- Download the Android [release](https://github.com/fallout2-ce/fallout2-ce/releases), which contains an .apk file an `ce.dat`.
+- Download the Android [release](https://github.com/fallout2-ce/fallout2-ce/releases), which contains an .apk file and `ce.dat`.
 
 - Use Windows installation as a base - it contains data assets needed to play. Copy `Fallout2` folder to your device, for example to `Downloads`. You need `master.dat`, `critter.dat`, `patch000.dat`, and `data` folder. Watch for file names - keep (or make) them lowercased (see [Configuration](#configuration)).  Copy `ce.dat` into this folder.
 

--- a/src/game.cc
+++ b/src/game.cc
@@ -72,6 +72,10 @@
 #include "window_manager.h"
 #include "worldmap.h"
 
+#if __APPLE__
+#include <TargetConditionals.h>
+#endif
+
 namespace fallout {
 
 #define HELP_SCREEN_WIDTH (640)
@@ -89,6 +93,9 @@ static int gameDbInit();
 static void showSplash();
 
 inline constexpr char kBaseModPath[] = "ce.dat";
+#if __APPLE__ && TARGET_OS_OSX
+inline constexpr char kMacOsBundleBaseModPath[] = "../Resources/ce.dat";
+#endif
 
 // 0x501C9C
 static char _aGame_0[] = "game\\";
@@ -1313,14 +1320,24 @@ int showQuitConfirmationDialog()
 
 static void TryLoadBaseCEMod()
 {
-    if (compat_access(kBaseModPath, 0) == 0) {
-        debugPrint("Loading base FO:CE mod: %s\n", kBaseModPath);
-        if (dbOpen(kBaseModPath) == -1) {
-            debugPrint("Error opening base mod file/folder!\n");
+    const char* baseModPaths[] = {
+        kBaseModPath,
+#if __APPLE__ && TARGET_OS_OSX
+        kMacOsBundleBaseModPath,
+#endif
+    };
+
+    for (const char* baseModPath : baseModPaths) {
+        if (compat_access(baseModPath, 0) == 0) {
+            debugPrint("Loading base FO:CE mod: %s\n", baseModPath);
+            if (dbOpen(baseModPath) == -1) {
+                debugPrint("Error opening base mod file/folder!\n");
+            }
+            return;
         }
-    } else {
-        debugPrint("Error opening base mod: no file or folder name %s found.\n", kBaseModPath);
     }
+
+    debugPrint("Error opening base mod: no file or folder name %s found.\n", kBaseModPath);
 }
 
 // 0x44418C

--- a/src/game.cc
+++ b/src/game.cc
@@ -69,8 +69,8 @@
 #include "tile.h"
 #include "trait.h"
 #include "version.h"
-#include "window_manager.h"
 #include "win32.h"
+#include "window_manager.h"
 #include "worldmap.h"
 
 #if __APPLE__

--- a/src/game.cc
+++ b/src/game.cc
@@ -88,7 +88,7 @@ namespace fallout {
 static int gameLoadGlobalVars();
 static int gameTakeScreenshot(int width, int height, unsigned char* buffer, unsigned char* palette);
 static void gameFreeGlobalVars();
-static bool tryLoadBaseCEModAtPath(const char* path);
+static bool tryLoadBaseCEModAtPath(const char* path, bool* found);
 static void showHelp();
 static int gameDbInit();
 static void showSplash();
@@ -1321,23 +1321,33 @@ int showQuitConfirmationDialog()
 
 static void TryLoadBaseCEMod()
 {
-    if (tryLoadBaseCEModAtPath(kBaseModPath)) {
+    bool found = false;
+
+    if (tryLoadBaseCEModAtPath(kBaseModPath, &found)) {
         return;
     }
 
 #if __APPLE__ && TARGET_OS_OSX
-    if (tryLoadBaseCEModAtPath(kMacOsBundleBaseModPath)) {
+    if (tryLoadBaseCEModAtPath(kMacOsBundleBaseModPath, &found)) {
         return;
     }
 #endif
 
-    debugPrint("Error opening base mod: no file or folder name %s found.\n", kBaseModPath);
+    if (found) {
+        debugPrint("Error opening base mod file/folder!\n");
+    } else {
+        debugPrint("Error opening base mod: no file or folder name %s found.\n", kBaseModPath);
+    }
 }
 
-static bool tryLoadBaseCEModAtPath(const char* path)
+static bool tryLoadBaseCEModAtPath(const char* path, bool* found)
 {
     if (compat_access(path, 0) != 0) {
         return false;
+    }
+
+    if (found != nullptr) {
+        *found = true;
     }
 
     debugPrint("Loading base FO:CE mod: %s\n", path);

--- a/src/game.cc
+++ b/src/game.cc
@@ -69,7 +69,6 @@
 #include "tile.h"
 #include "trait.h"
 #include "version.h"
-#include "win32.h"
 #include "window_manager.h"
 #include "worldmap.h"
 
@@ -96,7 +95,7 @@ static void showSplash();
 
 inline constexpr char kBaseModPath[] = "ce.dat";
 #if __APPLE__ && TARGET_OS_OSX
-inline constexpr char kMacOsBundleBaseModPath[] = "../Resources/ce.dat";
+inline constexpr char kMacOsBundleBaseModPath[] = "Fallout II Community Edition.app/Contents/Resources/ce.dat";
 #endif
 
 // 0x501C9C
@@ -1330,16 +1329,6 @@ static void TryLoadBaseCEMod()
     if (tryLoadBaseCEModAtPath(kMacOsBundleBaseModPath)) {
         return;
     }
-
-    const char* bundleResourcesPath = getMacOsBundleResourcesPath();
-    if (bundleResourcesPath != nullptr) {
-        char absolutePath[COMPAT_MAX_PATH];
-
-        snprintf(absolutePath, sizeof(absolutePath), "%s/ce.dat", bundleResourcesPath);
-        if (tryLoadBaseCEModAtPath(absolutePath)) {
-            return;
-        }
-    }
 #endif
 
     debugPrint("Error opening base mod: no file or folder name %s found.\n", kBaseModPath);
@@ -1354,6 +1343,7 @@ static bool tryLoadBaseCEModAtPath(const char* path)
     debugPrint("Loading base FO:CE mod: %s\n", path);
     if (dbOpen(path) == -1) {
         debugPrint("Error opening base mod file/folder!\n");
+        return false;
     }
 
     return true;

--- a/src/game.cc
+++ b/src/game.cc
@@ -70,6 +70,7 @@
 #include "trait.h"
 #include "version.h"
 #include "window_manager.h"
+#include "win32.h"
 #include "worldmap.h"
 
 #if __APPLE__
@@ -88,15 +89,12 @@ namespace fallout {
 static int gameLoadGlobalVars();
 static int gameTakeScreenshot(int width, int height, unsigned char* buffer, unsigned char* palette);
 static void gameFreeGlobalVars();
-static bool tryLoadBaseCEModAtPath(const char* path, bool* found);
+static bool tryLoadBaseCEModAtPath(const char* path, bool* found, bool* openFailed);
 static void showHelp();
 static int gameDbInit();
 static void showSplash();
 
 inline constexpr char kBaseModPath[] = "ce.dat";
-#if __APPLE__ && TARGET_OS_OSX
-inline constexpr char kMacOsBundleBaseModPath[] = "Fallout II Community Edition.app/Contents/Resources/ce.dat";
-#endif
 
 // 0x501C9C
 static char _aGame_0[] = "game\\";
@@ -1322,25 +1320,31 @@ int showQuitConfirmationDialog()
 static void TryLoadBaseCEMod()
 {
     bool found = false;
+    bool openFailed = false;
 
-    if (tryLoadBaseCEModAtPath(kBaseModPath, &found)) {
+    if (tryLoadBaseCEModAtPath(kBaseModPath, &found, &openFailed)) {
         return;
     }
 
 #if __APPLE__ && TARGET_OS_OSX
-    if (tryLoadBaseCEModAtPath(kMacOsBundleBaseModPath, &found)) {
-        return;
+    const char* bundleResourcesPath = getMacOsBundleResourcesPath();
+    if (bundleResourcesPath != nullptr) {
+        char absolutePath[COMPAT_MAX_PATH];
+        snprintf(absolutePath, sizeof(absolutePath), "%s/ce.dat", bundleResourcesPath);
+        if (tryLoadBaseCEModAtPath(absolutePath, &found, &openFailed)) {
+            return;
+        }
     }
 #endif
 
-    if (found) {
+    if (openFailed) {
         debugPrint("Error opening base mod file/folder!\n");
     } else {
         debugPrint("Error opening base mod: no file or folder name %s found.\n", kBaseModPath);
     }
 }
 
-static bool tryLoadBaseCEModAtPath(const char* path, bool* found)
+static bool tryLoadBaseCEModAtPath(const char* path, bool* found, bool* openFailed)
 {
     if (compat_access(path, 0) != 0) {
         return false;
@@ -1352,7 +1356,9 @@ static bool tryLoadBaseCEModAtPath(const char* path, bool* found)
 
     debugPrint("Loading base FO:CE mod: %s\n", path);
     if (dbOpen(path) == -1) {
-        debugPrint("Error opening base mod file/folder!\n");
+        if (openFailed != nullptr) {
+            *openFailed = true;
+        }
         return false;
     }
 

--- a/src/game.cc
+++ b/src/game.cc
@@ -69,6 +69,7 @@
 #include "tile.h"
 #include "trait.h"
 #include "version.h"
+#include "win32.h"
 #include "window_manager.h"
 #include "worldmap.h"
 
@@ -88,6 +89,7 @@ namespace fallout {
 static int gameLoadGlobalVars();
 static int gameTakeScreenshot(int width, int height, unsigned char* buffer, unsigned char* palette);
 static void gameFreeGlobalVars();
+static bool tryLoadBaseCEModAtPath(const char* path);
 static void showHelp();
 static int gameDbInit();
 static void showSplash();
@@ -1320,24 +1322,41 @@ int showQuitConfirmationDialog()
 
 static void TryLoadBaseCEMod()
 {
-    const char* baseModPaths[] = {
-        kBaseModPath,
-#if __APPLE__ && TARGET_OS_OSX
-        kMacOsBundleBaseModPath,
-#endif
-    };
+    if (tryLoadBaseCEModAtPath(kBaseModPath)) {
+        return;
+    }
 
-    for (const char* baseModPath : baseModPaths) {
-        if (compat_access(baseModPath, 0) == 0) {
-            debugPrint("Loading base FO:CE mod: %s\n", baseModPath);
-            if (dbOpen(baseModPath) == -1) {
-                debugPrint("Error opening base mod file/folder!\n");
-            }
+#if __APPLE__ && TARGET_OS_OSX
+    if (tryLoadBaseCEModAtPath(kMacOsBundleBaseModPath)) {
+        return;
+    }
+
+    const char* bundleResourcesPath = getMacOsBundleResourcesPath();
+    if (bundleResourcesPath != nullptr) {
+        char absolutePath[COMPAT_MAX_PATH];
+
+        snprintf(absolutePath, sizeof(absolutePath), "%s/ce.dat", bundleResourcesPath);
+        if (tryLoadBaseCEModAtPath(absolutePath)) {
             return;
         }
     }
+#endif
 
     debugPrint("Error opening base mod: no file or folder name %s found.\n", kBaseModPath);
+}
+
+static bool tryLoadBaseCEModAtPath(const char* path)
+{
+    if (compat_access(path, 0) != 0) {
+        return false;
+    }
+
+    debugPrint("Loading base FO:CE mod: %s\n", path);
+    if (dbOpen(path) == -1) {
+        debugPrint("Error opening base mod file/folder!\n");
+    }
+
+    return true;
 }
 
 // 0x44418C
@@ -1347,7 +1366,6 @@ static int gameDbInit()
     const char* patch_file_name;
     int patch_index;
     char filename[COMPAT_MAX_PATH];
-
     main_file_name = nullptr;
     patch_file_name = nullptr;
 

--- a/src/win32.cc
+++ b/src/win32.cc
@@ -4,8 +4,16 @@
 
 #include <SDL.h>
 
+#if __APPLE__
+#include <TargetConditionals.h>
+#endif
+
 #ifndef _WIN32
 #include <unistd.h>
+#endif
+
+#if __APPLE__ && TARGET_OS_OSX
+#include <CoreFoundation/CoreFoundation.h>
 #endif
 
 #include "main.h"
@@ -23,8 +31,19 @@ namespace fallout {
 // 0x51E444
 bool gProgramIsActive = false;
 
+#if __APPLE__ && TARGET_OS_OSX
+static char gMacOsBundleResourcesPath[COMPAT_MAX_PATH];
+#endif
+
 #ifdef _WIN32
 HANDLE GNW95_mutex = nullptr;
+#endif
+
+#if __APPLE__ && TARGET_OS_OSX
+const char* getMacOsBundleResourcesPath()
+{
+    return gMacOsBundleResourcesPath[0] != '\0' ? gMacOsBundleResourcesPath : nullptr;
+}
 #endif
 
 int main(int argc, char* argv[])
@@ -50,6 +69,20 @@ int main(int argc, char* argv[])
 #endif
 
 #if __APPLE__ && TARGET_OS_OSX
+    CFBundleRef mainBundle = CFBundleGetMainBundle();
+    if (mainBundle != nullptr) {
+        CFURLRef resourcesUrl = CFBundleCopyResourcesDirectoryURL(mainBundle);
+        if (resourcesUrl != nullptr) {
+            if (CFURLGetFileSystemRepresentation(resourcesUrl,
+                    true,
+                    reinterpret_cast<UInt8*>(gMacOsBundleResourcesPath),
+                    sizeof(gMacOsBundleResourcesPath))) {
+                gMacOsBundleResourcesPath[sizeof(gMacOsBundleResourcesPath) - 1] = '\0';
+            }
+            CFRelease(resourcesUrl);
+        }
+    }
+
     char* basePath = SDL_GetBasePath();
     chdir(basePath);
     SDL_free(basePath);

--- a/src/win32.cc
+++ b/src/win32.cc
@@ -1,6 +1,8 @@
 #include "win32.h"
 
+#include <limits.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <SDL.h>
 
@@ -23,8 +25,19 @@ namespace fallout {
 // 0x51E444
 bool gProgramIsActive = false;
 
+#if __APPLE__
+static char gMacOsBundleResourcesPath[PATH_MAX];
+#endif
+
 #ifdef _WIN32
 HANDLE GNW95_mutex = nullptr;
+#endif
+
+#if __APPLE__
+const char* getMacOsBundleResourcesPath()
+{
+    return gMacOsBundleResourcesPath[0] != '\0' ? gMacOsBundleResourcesPath : nullptr;
+}
 #endif
 
 int main(int argc, char* argv[])
@@ -50,9 +63,14 @@ int main(int argc, char* argv[])
 #endif
 
 #if __APPLE__ && TARGET_OS_OSX
-    char* basePath = SDL_GetBasePath();
-    chdir(basePath);
-    SDL_free(basePath);
+    char executablePath[PATH_MAX];
+    if (realpath(argv[0], executablePath) != nullptr) {
+        char* sep = strrchr(executablePath, '/');
+        if (sep != nullptr) {
+            *sep = '\0';
+            snprintf(gMacOsBundleResourcesPath, sizeof(gMacOsBundleResourcesPath), "%s/../Resources", executablePath);
+        }
+    }
 #endif
 
 #if __ANDROID__

--- a/src/win32.cc
+++ b/src/win32.cc
@@ -1,8 +1,6 @@
 #include "win32.h"
 
-#include <limits.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include <SDL.h>
 
@@ -25,19 +23,8 @@ namespace fallout {
 // 0x51E444
 bool gProgramIsActive = false;
 
-#if __APPLE__
-static char gMacOsBundleResourcesPath[PATH_MAX];
-#endif
-
 #ifdef _WIN32
 HANDLE GNW95_mutex = nullptr;
-#endif
-
-#if __APPLE__
-const char* getMacOsBundleResourcesPath()
-{
-    return gMacOsBundleResourcesPath[0] != '\0' ? gMacOsBundleResourcesPath : nullptr;
-}
 #endif
 
 int main(int argc, char* argv[])
@@ -63,14 +50,9 @@ int main(int argc, char* argv[])
 #endif
 
 #if __APPLE__ && TARGET_OS_OSX
-    char executablePath[PATH_MAX];
-    if (realpath(argv[0], executablePath) != nullptr) {
-        char* sep = strrchr(executablePath, '/');
-        if (sep != nullptr) {
-            *sep = '\0';
-            snprintf(gMacOsBundleResourcesPath, sizeof(gMacOsBundleResourcesPath), "%s/../Resources", executablePath);
-        }
-    }
+    char* basePath = SDL_GetBasePath();
+    chdir(basePath);
+    SDL_free(basePath);
 #endif
 
 #if __ANDROID__

--- a/src/win32.h
+++ b/src/win32.h
@@ -1,6 +1,8 @@
 #ifndef WIN32_H
 #define WIN32_H
 
+#include "platform_compat.h"
+
 #ifdef _WIN32
 #include <windows.h>
 #endif
@@ -12,6 +14,10 @@ extern bool gProgramIsActive;
 extern HANDLE GNW95_mutex;
 #else
 extern bool gProgramIsActive;
+#endif
+
+#if __APPLE__
+const char* getMacOsBundleResourcesPath();
 #endif
 
 } // namespace fallout

--- a/src/win32.h
+++ b/src/win32.h
@@ -14,6 +14,10 @@ extern HANDLE GNW95_mutex;
 extern bool gProgramIsActive;
 #endif
 
+#if __APPLE__
+const char* getMacOsBundleResourcesPath();
+#endif
+
 } // namespace fallout
 
 #endif /* WIN32_H */

--- a/src/win32.h
+++ b/src/win32.h
@@ -14,10 +14,6 @@ extern HANDLE GNW95_mutex;
 extern bool gProgramIsActive;
 #endif
 
-#if __APPLE__
-const char* getMacOsBundleResourcesPath();
-#endif
-
 } // namespace fallout
 
 #endif /* WIN32_H */


### PR DESCRIPTION
## Summary
- build ce.dat in CI for desktop release artifacts
- bundle ce.dat as a real macOS app resource during the build
- teach macOS runtime lookup to load bundled ce.dat from app resources

Also update README to add references to `ce.dat`