### PR TITLE
Debug logging improvements

### DIFF
--- a/src/debug.cc
+++ b/src/debug.cc
@@ -1,11 +1,11 @@
 #include "debug.h"
 
+#include <SDL.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <SDL.h>
+#include <string>
 
 #include "memory.h"
 #include "platform_compat.h"
@@ -15,11 +15,17 @@ namespace fallout {
 
 static int _debug_puts(char* string);
 static void _debug_clear();
-static int _debug_mono(char* string);
-static int _debug_log(char* string);
-static int _debug_screen(char* string);
+static int _debug_mono(const char* string);
+static int _debug_log(const char* string);
+static int _debug_screen(const char* string);
 static void _debug_putc(int ch);
 static void _debug_scroll();
+static void debugFlushBuffer();
+
+// Messages logged before any debug proc is registered are held here and
+// flushed when the first proc is registered.
+static std::string gDebugBuffer;
+static constexpr size_t kDebugBufferMaxSize = 64 * 1024;
 
 // 0x51DEF8
 static FILE* _fd = nullptr;
@@ -35,6 +41,10 @@ static DebugPrintProc* gDebugPrintProc = nullptr;
 
 void debugModeInit(const char* debugMode)
 {
+    if (debugMode == nullptr) {
+        return;
+    }
+
     // CE: Handle debug mode (exactly as seen in `mapper2.exe`).
     if (compat_stricmp(debugMode, "environment") == 0) {
         _debug_register_env();
@@ -46,6 +56,10 @@ void debugModeInit(const char* debugMode)
         _debug_register_mono();
     } else if (compat_stricmp(debugMode, "gnw") == 0) {
         _debug_register_func(_win_debug);
+    }
+
+    if (gDebugPrintProc == nullptr) {
+        gDebugBuffer.clear();
     }
 }
 
@@ -66,6 +80,7 @@ void _debug_register_mono()
 
         gDebugPrintProc = _debug_mono;
         _debug_clear();
+        debugFlushBuffer();
     }
 }
 
@@ -79,6 +94,7 @@ void _debug_register_log(const char* fileName, const char* mode)
 
         _fd = compat_fopen(fileName, mode);
         gDebugPrintProc = _debug_log;
+        debugFlushBuffer();
     }
 }
 
@@ -92,6 +108,7 @@ void _debug_register_screen()
         }
 
         gDebugPrintProc = _debug_screen;
+        debugFlushBuffer();
     }
 }
 
@@ -137,6 +154,7 @@ void _debug_register_func(DebugPrintProc* proc)
         }
 
         gDebugPrintProc = proc;
+        debugFlushBuffer();
     }
 }
 
@@ -146,23 +164,35 @@ int debugPrint(const char* format, ...)
     va_list args;
     va_start(args, format);
 
-    int rc;
-
-    if (gDebugPrintProc != nullptr) {
-        char string[260];
-        vsnprintf(string, sizeof(string), format, args);
-
-        rc = gDebugPrintProc(string);
-    } else {
-#ifndef NDEBUG
-        SDL_LogMessageV(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO, format, args);
-#endif
-        rc = -1;
-    }
+    char string[260];
+    int len = vsnprintf(string, sizeof(string), format, args);
 
     va_end(args);
 
+    int rc;
+    if (gDebugPrintProc != nullptr) {
+        rc = gDebugPrintProc(string);
+    } else {
+        if (len > 0 && gDebugBuffer.size() + len <= kDebugBufferMaxSize) {
+            gDebugBuffer += string;
+        }
+        rc = -1;
+    }
+
+#ifndef NDEBUG
+    SDL_Log("%s", string);
+#endif
+
     return rc;
+}
+
+static void debugFlushBuffer()
+{
+    if (gDebugBuffer.empty() || gDebugPrintProc == nullptr) {
+        return;
+    }
+    gDebugPrintProc(gDebugBuffer.c_str());
+    gDebugBuffer.clear();
 }
 
 // 0x4C6F94
@@ -203,7 +233,7 @@ static void _debug_clear()
 }
 
 // 0x4C7004
-static int _debug_mono(char* string)
+static int _debug_mono(const char* string)
 {
     if (gDebugPrintProc == _debug_mono) {
         while (*string != '\0') {
@@ -215,7 +245,7 @@ static int _debug_mono(char* string)
 }
 
 // 0x4C7028
-static int _debug_log(char* string)
+static int _debug_log(const char* string)
 {
     if (gDebugPrintProc == _debug_log) {
         if (_fd == nullptr) {
@@ -235,7 +265,7 @@ static int _debug_log(char* string)
 }
 
 // 0x4C7068
-static int _debug_screen(char* string)
+static int _debug_screen(const char* string)
 {
     if (gDebugPrintProc == _debug_screen) {
         printf("%s", string);

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -24,8 +24,9 @@ static void debugFlushBuffer();
 
 // Messages logged before any debug proc is registered are held here and
 // flushed when the first proc is registered.
-static std::string gDebugBuffer;
+static std::string debugBuffer;
 static constexpr size_t kDebugBufferMaxSize = 64 * 1024;
+static bool debugBufferDisabled = false;
 
 // 0x51DEF8
 static FILE* _fd = nullptr;
@@ -41,6 +42,8 @@ static DebugPrintProc* gDebugPrintProc = nullptr;
 
 void debugModeInit(const char* debugMode)
 {
+    debugBufferDisabled = true;
+
     if (debugMode == nullptr) {
         return;
     }
@@ -59,7 +62,7 @@ void debugModeInit(const char* debugMode)
     }
 
     if (gDebugPrintProc == nullptr) {
-        gDebugBuffer.clear();
+        debugBuffer.clear();
     }
 }
 
@@ -166,15 +169,17 @@ int debugPrint(const char* format, ...)
 
     char string[260];
     int len = vsnprintf(string, sizeof(string), format, args);
-
+    if (len < 0) {
+        string[0] = '\0';
+    }
     va_end(args);
 
     int rc;
     if (gDebugPrintProc != nullptr) {
         rc = gDebugPrintProc(string);
     } else {
-        if (len > 0 && gDebugBuffer.size() + len <= kDebugBufferMaxSize) {
-            gDebugBuffer += string;
+        if (!debugBufferDisabled && debugBuffer.size() + strlen(string) <= kDebugBufferMaxSize) {
+            debugBuffer += string;
         }
         rc = -1;
     }
@@ -188,11 +193,11 @@ int debugPrint(const char* format, ...)
 
 static void debugFlushBuffer()
 {
-    if (gDebugBuffer.empty() || gDebugPrintProc == nullptr) {
+    if (debugBuffer.empty() || gDebugPrintProc == nullptr) {
         return;
     }
-    gDebugPrintProc(gDebugBuffer.c_str());
-    gDebugBuffer.clear();
+    gDebugPrintProc(debugBuffer.c_str());
+    debugBuffer.clear();
 }
 
 // 0x4C6F94

--- a/src/debug.h
+++ b/src/debug.h
@@ -3,7 +3,7 @@
 
 namespace fallout {
 
-typedef int(DebugPrintProc)(char* string);
+typedef int(DebugPrintProc)(const char* string);
 
 void debugModeInit(const char* debugMode);
 void _GNW_debug_init();

--- a/src/game.cc
+++ b/src/game.cc
@@ -152,6 +152,8 @@ int gameInitWithOptions(const char* windowTitle, bool isMapper, int font, int fl
 
     settingsInit(isMapper, argc, argv);
 
+    debugModeInit(settings.debug.mode.c_str());
+
     gIsMapper = isMapper;
 
     if (gameDbInit() == -1) {

--- a/src/game_config.cc
+++ b/src/game_config.cc
@@ -119,11 +119,6 @@ bool gameConfigInit(bool isMapper, int argc, char** argv)
 
     configRead(&gGameConfig, gGameConfigFilePath, false);
 
-    // Init debug mode ASAP to catch early debug messages.
-    char* debugMode;
-    configGetString(&gGameConfig, GAME_CONFIG_DEBUG_KEY, GAME_CONFIG_MODE_KEY, &debugMode);
-    debugModeInit(debugMode);
-
     debugPrint("Game config loaded from %s.\n", gGameConfigFilePath);
 
     if (!isMapper && gameConfigMigrateFromF2Res(gGameConfigFilePath, &gGameConfig)) {

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -28,7 +28,7 @@ typedef struct ProgramListNode {
 static unsigned int _defaultTimerFunc();
 static unsigned int getInterpreterTime();
 static char* defaultFilename(char* path);
-static int outputString(char* string);
+static int outputString(const char* string);
 static int checkWait(Program* program);
 static char* programGetCurrentProcedureName(Program* program);
 opcode_t stackReadInt16(unsigned char* data, int pos);
@@ -152,7 +152,7 @@ static unsigned int interpreterTimerTick = 1000;
 static char* (*interpreterFilenameMangler)(char*) = defaultFilename;
 
 // 0x51904C
-static int (*interpreterOutputFunc)(char*) = outputString;
+static int (*interpreterOutputFunc)(const char*) = outputString;
 
 // 0x519050
 static int interpreterCpuBurstSize = 10;
@@ -197,7 +197,7 @@ char* _interpretMangleName(char* s)
 }
 
 // 0x4670C0 (unused)
-static int outputString(char* /*string*/)
+static int outputString(const char*)
 {
     return 1;
 }
@@ -209,7 +209,7 @@ static int checkWait(Program* program)
 }
 
 // 0x4670FC
-void _interpretOutputFunc(int (*func)(char*))
+void _interpretOutputFunc(int (*func)(const char*))
 {
     interpreterOutputFunc = func;
 }

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -217,7 +217,7 @@ extern OpcodeHandler* gInterpreterOpcodeHandlers[OPCODE_MAX_COUNT];
 extern int _TimeOut;
 
 char* _interpretMangleName(char* s);
-void _interpretOutputFunc(int (*func)(char*));
+void _interpretOutputFunc(int (*func)(const char*));
 int _interpretOutput(const char* format, ...);
 [[noreturn]] void programFatalError(const char* str, ...);
 void programPrintError(const char* format, ...);

--- a/src/window.cc
+++ b/src/window.cc
@@ -857,7 +857,7 @@ int scriptWindowCreate(const char* windowName, int x, int y, int width, int heig
 }
 
 // 0x4B80A4
-int scriptWindowOutput(char* string)
+int scriptWindowOutput(const char* string)
 {
     if (gCurrentManagedWindowIndex == -1) {
         return 0;

--- a/src/window.h
+++ b/src/window.h
@@ -72,7 +72,7 @@ bool scriptWindowDelete(const char* windowName);
 int scriptWindowResize(const char* windowName, int x, int y, int width, int height);
 int scriptWindowScale(const char* windowName, int x, int y, int width, int height);
 int scriptWindowCreate(const char* windowName, int x, int y, int width, int height, int a6, int flags);
-int scriptWindowOutput(char* string);
+int scriptWindowOutput(const char* string);
 bool scriptWindowGotoXY(int x, int y);
 bool scriptWindowSelectId(int index);
 int scriptWindowSelect(const char* windowName);

--- a/src/window_manager_private.cc
+++ b/src/window_manager_private.cc
@@ -807,7 +807,7 @@ int _create_pull_down(char** stringList, int stringListLength, int x, int y, int
 }
 
 // 0x4DC30C
-int _win_debug(char* string)
+int _win_debug(const char* string)
 {
     if (!gWindowSystemInitialized) {
         return -1;
@@ -895,7 +895,7 @@ int _win_debug(char* string)
     char temp[2];
     temp[1] = '\0';
 
-    char* pch = string;
+    const char* pch = string;
     while (*pch != '\0') {
         int characterWidth = fontGetCharacterWidth(*pch);
         if (*pch == '\n' || _currx + characterWidth > winWidth - 9) {

--- a/src/window_manager_private.h
+++ b/src/window_manager_private.h
@@ -20,7 +20,7 @@ int win_yes_no(const char* question, int x, int y, int color);
 int _win_msg(const char* string, int x, int y, int color);
 int _win_pull_down(char** items, int itemsLength, int x, int y, int color);
 int _create_pull_down(char** stringList, int stringListLength, int x, int y, int foregroundColor, int backgroundColor, Rect* rect);
-int _win_debug(char* string);
+int _win_debug(const char* string);
 void _win_debug_delete(int btn, int keyCode);
 int _win_register_menu_bar(int win, int x, int y, int width, int height, int foregroundColor, int backgroundColor);
 int _win_register_menu_pulldown(int win, int x, char* title, int keyCode, int itemsLength, char** items, int foregroundColor, int backgroundColor);


### PR DESCRIPTION
- Tidied up early debug printing by buffering into a string and flushing when desired handler is assigned based on config.
- Always duplicate logs to stdout in debug builds for convenient debugging.
- Some related const correctness.

Same as #427 but without the config stuff.