### PR TITLE
Party members can barter

### DIFF
--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -131,6 +131,9 @@ constexpr int kTradeSlotCount = 3;
 #define INVENTORY_PC_BODY_VIEW_MAX_X (INVENTORY_PC_BODY_VIEW_X + INVENTORY_BODY_VIEW_WIDTH)
 #define INVENTORY_PC_BODY_VIEW_MAX_Y (INVENTORY_PC_BODY_VIEW_Y + INVENTORY_BODY_VIEW_HEIGHT)
 
+#define INVENTORY_BARTER_LEFT_BODY_VIEW_X 18
+#define INVENTORY_BARTER_LEFT_BODY_VIEW_Y 25
+
 #define INVENTORY_LOOT_RIGHT_BODY_VIEW_X 422
 #define INVENTORY_LOOT_RIGHT_BODY_VIEW_Y 35
 
@@ -166,11 +169,6 @@ constexpr int kTradeSlotCount = 3;
 #define INVENTORY_LOOT_RIGHT_SCROLLER_Y_PAD (INVENTORY_LOOT_RIGHT_SCROLLER_Y + INVENTORY_SLOT_PADDING)
 
 #define INVENTORY_LOOT_CRITTER_TOGGLE_Y (INVENTORY_LOOT_LEFT_BODY_VIEW_Y + INVENTORY_BODY_VIEW_HEIGHT + 24)
-// Barter: PC body in background window is at (15, 25); buttons sit just below it.
-#define INVENTORY_BARTER_PC_BODY_VIEW_X 15
-#define INVENTORY_BARTER_PC_BODY_VIEW_Y 25
-#define INVENTORY_BARTER_CRITTER_TOGGLE_Y (INVENTORY_BARTER_PC_BODY_VIEW_Y + INVENTORY_BODY_VIEW_HEIGHT + 6)
-
 #define INVENTORY_TRADE_LEFT_SCROLLER_X_PAD (INVENTORY_TRADE_LEFT_SCROLLER_Y + INVENTORY_SLOT_PADDING)
 #define INVENTORY_TRADE_LEFT_SCROLLER_Y_PAD (INVENTORY_TRADE_LEFT_SCROLLER_Y + INVENTORY_SLOT_PADDING)
 
@@ -362,9 +360,7 @@ static int inventoryLootGetSlotY(int slotIndex);
 static bool inventoryLootMouseHitTestScroller(bool targetInventory);
 static int inventoryComputeAlignedMaxOffset(int length, int visibleSlots, int scrollStep);
 static int inventoryGetCenteredWindowY(int windowHeight);
-static void inventoryDisplayLeftPaneCompanionName(unsigned char* windowBuffer, int windowPitch, const Rect& rect, int index);
-
-constexpr int kInventoryLeftBodyViewOffsetX = 3;
+static void inventoryDisplayLeftPaneCompanionName(unsigned char* windowBuffer, int windowPitch, const Rect& rect, int index, int yOffset = 0);
 
 // 0x46E6D0
 static const int gSummaryStats[7] = {
@@ -1400,7 +1396,7 @@ static bool _setup_inventory(int inventoryWindowType)
 
             // Invisible button representing left character.
             buttonCreateAction(gInventoryBarterBackgroundWindow,
-                15 + kInventoryLeftBodyViewOffsetX, 25, INVENTORY_BODY_VIEW_WIDTH, INVENTORY_BODY_VIEW_HEIGHT, 2500);
+                INVENTORY_BARTER_LEFT_BODY_VIEW_X, INVENTORY_BARTER_LEFT_BODY_VIEW_Y, INVENTORY_BODY_VIEW_WIDTH, INVENTORY_BODY_VIEW_HEIGHT, 2500);
 
             // Invisible button representing right character.
             buttonCreateAction(gInventoryBarterBackgroundWindow,
@@ -1435,7 +1431,7 @@ static bool _setup_inventory(int inventoryWindowType)
             if (inventoryWindowType == INVENTORY_WINDOW_TYPE_LOOT) {
                 // Invisible button representing left character.
                 buttonCreateAction(gInventoryWindow,
-                    inventoryLootLayout.leftBodyViewX + kInventoryLeftBodyViewOffsetX, INVENTORY_LOOT_LEFT_BODY_VIEW_Y,
+                    inventoryLootLayout.leftBodyViewX, INVENTORY_LOOT_LEFT_BODY_VIEW_Y,
                     INVENTORY_BODY_VIEW_WIDTH, INVENTORY_BODY_VIEW_HEIGHT, 2500);
 
                 // Right inventory down button.
@@ -2117,8 +2113,8 @@ static void _display_body(int fid, int inventoryWindowType)
                 rect.left = 560;
                 rect.top = 25;
             } else {
-                rect.left = 15 + kInventoryLeftBodyViewOffsetX;
-                rect.top = 25;
+                rect.left = INVENTORY_BARTER_LEFT_BODY_VIEW_X;
+                rect.top = INVENTORY_BARTER_LEFT_BODY_VIEW_Y;
             }
 
             rect.right = rect.left + INVENTORY_BODY_VIEW_WIDTH - 1;
@@ -2162,7 +2158,7 @@ static void _display_body(int fid, int inventoryWindowType)
                 }
             } else {
                 if (inventoryWindowType == INVENTORY_WINDOW_TYPE_LOOT) {
-                    rect.left = inventoryLootLayout.leftBodyViewX + kInventoryLeftBodyViewOffsetX;
+                    rect.left = inventoryLootLayout.leftBodyViewX;
                     rect.top = INVENTORY_LOOT_LEFT_BODY_VIEW_Y;
                 } else if (inventoryWindowType == INVENTORY_WINDOW_TYPE_USE_ITEM_ON) {
                     rect.left = 176; // Use item cha window
@@ -2196,7 +2192,7 @@ static void _display_body(int fid, int inventoryWindowType)
                 windowPitch);
 
             if (inventoryWindowType == INVENTORY_WINDOW_TYPE_LOOT) {
-                inventoryDisplayLeftPaneCompanionName(windowBuffer, windowPitch, rect, index);
+                inventoryDisplayLeftPaneCompanionName(windowBuffer, windowPitch, rect, index, 6);
             }
 
             win = gInventoryWindow;
@@ -3745,7 +3741,7 @@ static void inventoryDrawCenteredText(unsigned char* buffer, int pitch, int widt
     fontSetCurrent(oldFont);
 }
 
-static void inventoryDisplayLeftPaneCompanionName(unsigned char* windowBuffer, int windowPitch, const Rect& rect, int index)
+static void inventoryDisplayLeftPaneCompanionName(unsigned char* windowBuffer, int windowPitch, const Rect& rect, int index, int yOffset)
 {
     if (index != 0 || _stack[0] == gDude) {
         return;
@@ -3756,7 +3752,7 @@ static void inventoryDisplayLeftPaneCompanionName(unsigned char* windowBuffer, i
         return;
     }
 
-    int nameY = rect.bottom - fontGetLineHeight() - 1;
+    int nameY = rect.bottom - fontGetLineHeight() - 2 + yOffset;
     inventoryDrawCenteredText(windowBuffer, windowPitch, INVENTORY_BODY_VIEW_WIDTH, rect.left, nameY, name, _colorTable[992]);
 }
 
@@ -4392,7 +4388,7 @@ int inventoryOpenLooting(Object* looter, Object* target)
 
             if (critterCount > 1) {
                 int btn = buttonCreateWithFrm(gInventoryWindow,
-                    inventoryLootLayout.prevCritterButtonX + kInventoryLeftBodyViewOffsetX, INVENTORY_LOOT_CRITTER_TOGGLE_Y,
+                    inventoryLootLayout.prevCritterButtonX, INVENTORY_LOOT_CRITTER_TOGGLE_Y,
                     -1, -1, KEY_PAGE_UP, -1,
                     FrmId(OBJ_TYPE_INTERFACE, gInventoryArrowFrmIds[INVENTORY_ARROW_FRM_LEFT_ARROW_UP]),
                     FrmId(OBJ_TYPE_INTERFACE, gInventoryArrowFrmIds[INVENTORY_ARROW_FRM_LEFT_ARROW_DOWN]));
@@ -4434,7 +4430,7 @@ int inventoryOpenLooting(Object* looter, Object* target)
     int partyTargetIndex = 0;
 
     if (partyTargets.size() > 1) {
-        const int btnCenterX = inventoryLootLayout.leftBodyViewX + kInventoryLeftBodyViewOffsetX + INVENTORY_BODY_VIEW_WIDTH / 2;
+        const int btnCenterX = inventoryLootLayout.leftBodyViewX + INVENTORY_BODY_VIEW_WIDTH / 2;
 
         int btn = buttonCreateWithFrm(gInventoryWindow,
             btnCenterX - 20, INVENTORY_LOOT_CRITTER_TOGGLE_Y,
@@ -5332,29 +5328,6 @@ void barterProcessUI(int win, Object* barterer, Object* playerTable, Object* bar
     int partyTargetIndex = 0;
 
     bool isoWasEnabled = _setup_inventory(INVENTORY_WINDOW_TYPE_TRADE);
-
-    if (partyTargets.size() > 1) {
-        const int arrowY = INVENTORY_BARTER_CRITTER_TOGGLE_Y;
-        const int btnCenterX = INVENTORY_BARTER_PC_BODY_VIEW_X + kInventoryLeftBodyViewOffsetX + INVENTORY_BODY_VIEW_WIDTH / 2;
-
-        int btn = buttonCreateWithFrm(win,
-            btnCenterX - 20, arrowY,
-            -1, -1, KEY_ARROW_LEFT, -1,
-            FrmId(OBJ_TYPE_INTERFACE, gInventoryArrowFrmIds[INVENTORY_ARROW_FRM_LEFT_ARROW_UP]),
-            FrmId(OBJ_TYPE_INTERFACE, gInventoryArrowFrmIds[INVENTORY_ARROW_FRM_LEFT_ARROW_DOWN]));
-        if (btn != -1) {
-            buttonSetCallbacks(btn, _gsound_red_butt_press, _gsound_red_butt_release);
-        }
-
-        btn = buttonCreateWithFrm(win,
-            btnCenterX, arrowY,
-            -1, -1, KEY_ARROW_RIGHT, -1,
-            FrmId(OBJ_TYPE_INTERFACE, gInventoryArrowFrmIds[INVENTORY_ARROW_FRM_RIGHT_ARROW_UP]),
-            FrmId(OBJ_TYPE_INTERFACE, gInventoryArrowFrmIds[INVENTORY_ARROW_FRM_RIGHT_ARROW_DOWN]));
-        if (btn != -1) {
-            buttonSetCallbacks(btn, _gsound_red_butt_press, _gsound_red_butt_release);
-        }
-    }
 
     _display_target_inventory(_target_stack_offset[_target_curr_stack], -1, _target_pud, INVENTORY_WINDOW_TYPE_TRADE);
     _display_inventory(_stack_offset[0], -1, INVENTORY_WINDOW_TYPE_TRADE);

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -1399,8 +1399,8 @@ static bool _setup_inventory(int inventoryWindowType)
             }
 
             // Invisible button representing left character.
-                buttonCreateAction(gInventoryBarterBackgroundWindow,
-                    15 + kInventoryLeftBodyViewOffsetX, 25, INVENTORY_BODY_VIEW_WIDTH, INVENTORY_BODY_VIEW_HEIGHT, 2500);
+            buttonCreateAction(gInventoryBarterBackgroundWindow,
+                15 + kInventoryLeftBodyViewOffsetX, 25, INVENTORY_BODY_VIEW_WIDTH, INVENTORY_BODY_VIEW_HEIGHT, 2500);
 
             // Invisible button representing right character.
             buttonCreateAction(gInventoryBarterBackgroundWindow,

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -360,7 +360,7 @@ static int inventoryLootGetSlotY(int slotIndex);
 static bool inventoryLootMouseHitTestScroller(bool targetInventory);
 static int inventoryComputeAlignedMaxOffset(int length, int visibleSlots, int scrollStep);
 static int inventoryGetCenteredWindowY(int windowHeight);
-static void inventoryDisplayLeftPaneCompanionName(unsigned char* windowBuffer, int windowPitch, const Rect& rect, int index, int yOffset = 0);
+static void inventoryDisplayLeftPaneCompanionName(unsigned char* windowBuffer, int windowPitch, const Rect& rect, int index);
 
 // 0x46E6D0
 static const int gSummaryStats[7] = {
@@ -2192,7 +2192,7 @@ static void _display_body(int fid, int inventoryWindowType)
                 windowPitch);
 
             if (inventoryWindowType == INVENTORY_WINDOW_TYPE_LOOT) {
-                inventoryDisplayLeftPaneCompanionName(windowBuffer, windowPitch, rect, index, 6);
+                inventoryDisplayLeftPaneCompanionName(windowBuffer, windowPitch, rect, index);
             }
 
             win = gInventoryWindow;
@@ -2984,7 +2984,9 @@ static void inventorySetLeftPaneCritter(Object* critter, Object* target, int inv
     assert(critter != nullptr);
     assert(target != nullptr);
 
-    inventoryRestoreEquippedFromGlobals(_inven_dude);
+    // _inven_dude can point at a nested container while browsing bags, but
+    // equipped items always need to be restored onto the owning critter.
+    inventoryRestoreEquippedFromGlobals(_stack[0]);
     inventoryStripEquippedToGlobals(critter);
     _inven_dude = critter;
     _curr_stack = 0;
@@ -3741,7 +3743,7 @@ static void inventoryDrawCenteredText(unsigned char* buffer, int pitch, int widt
     fontSetCurrent(oldFont);
 }
 
-static void inventoryDisplayLeftPaneCompanionName(unsigned char* windowBuffer, int windowPitch, const Rect& rect, int index, int yOffset)
+static void inventoryDisplayLeftPaneCompanionName(unsigned char* windowBuffer, int windowPitch, const Rect& rect, int index)
 {
     if (index != 0 || _stack[0] == gDude) {
         return;
@@ -3752,7 +3754,11 @@ static void inventoryDisplayLeftPaneCompanionName(unsigned char* windowBuffer, i
         return;
     }
 
-    int nameY = rect.bottom - fontGetLineHeight() - 2 + yOffset;
+    int oldFont = fontGetCurrent();
+    fontSetCurrent(101);
+    int nameY = rect.bottom - fontGetLineHeight() - 2;
+    fontSetCurrent(oldFont);
+
     inventoryDrawCenteredText(windowBuffer, windowPitch, INVENTORY_BODY_VIEW_WIDTH, rect.left, nameY, name, _colorTable[992]);
 }
 
@@ -5320,7 +5326,7 @@ void barterProcessUI(int win, Object* barterer, Object* playerTable, Object* bar
     std::vector<Object*> partyTargets = { _inven_dude };
     if (settings.qol.party_loot_and_barter) {
         for (Object* pm : get_all_party_members_objects(false)) {
-            if (pm != gDude) {
+            if (pm != gDude && pm != barterer) {
                 partyTargets.push_back(pm);
             }
         }

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -166,6 +166,10 @@ constexpr int kTradeSlotCount = 3;
 #define INVENTORY_LOOT_RIGHT_SCROLLER_Y_PAD (INVENTORY_LOOT_RIGHT_SCROLLER_Y + INVENTORY_SLOT_PADDING)
 
 #define INVENTORY_LOOT_CRITTER_TOGGLE_Y (INVENTORY_LOOT_LEFT_BODY_VIEW_Y + INVENTORY_BODY_VIEW_HEIGHT + 24)
+// Barter: PC body in background window is at (15, 25); buttons sit just below it.
+#define INVENTORY_BARTER_PC_BODY_VIEW_X 15
+#define INVENTORY_BARTER_PC_BODY_VIEW_Y 25
+#define INVENTORY_BARTER_CRITTER_TOGGLE_Y (INVENTORY_BARTER_PC_BODY_VIEW_Y + INVENTORY_BODY_VIEW_HEIGHT + 6)
 
 #define INVENTORY_TRADE_LEFT_SCROLLER_X_PAD (INVENTORY_TRADE_LEFT_SCROLLER_Y + INVENTORY_SLOT_PADDING)
 #define INVENTORY_TRADE_LEFT_SCROLLER_Y_PAD (INVENTORY_TRADE_LEFT_SCROLLER_Y + INVENTORY_SLOT_PADDING)
@@ -323,8 +327,9 @@ static void _adjust_fid();
 static void inventoryRenderSummary();
 static int _inven_from_button(int keyCode, Object** outItem, Object*** outItemSlot, Object** outOwner);
 static void inventoryRenderItemDescription(const char* string);
+static void inventoryDrawCenteredText(unsigned char* buffer, int pitch, int width, int x, int y, const char* text, int color);
 static void inventoryExamineItem(Object* critter, Object* item);
-static void inventorySetLootLeftPaneCritter(Object* critter, Object* target);
+static void inventorySetLeftPaneCritter(Object* critter, Object* target, int inventoryWindowType);
 static void inventoryWindowOpenContextMenu(int eventCode, int inventoryWindowType);
 static InventoryMoveResult _move_inventory(Object* item, int slotIndex, Object* targetObj, bool isPlanting);
 static std::pair<int, int> barterComputeTablesValue(Object* dude, Object* npc, bool offerButton = false);
@@ -357,6 +362,9 @@ static int inventoryLootGetSlotY(int slotIndex);
 static bool inventoryLootMouseHitTestScroller(bool targetInventory);
 static int inventoryComputeAlignedMaxOffset(int length, int visibleSlots, int scrollStep);
 static int inventoryGetCenteredWindowY(int windowHeight);
+static void inventoryDisplayLeftPaneCompanionName(unsigned char* windowBuffer, int windowPitch, const Rect& rect, int index);
+
+constexpr int kInventoryLeftBodyViewOffsetX = 3;
 
 // 0x46E6D0
 static const int gSummaryStats[7] = {
@@ -1391,8 +1399,8 @@ static bool _setup_inventory(int inventoryWindowType)
             }
 
             // Invisible button representing left character.
-            buttonCreateAction(gInventoryBarterBackgroundWindow,
-                15, 25, INVENTORY_BODY_VIEW_WIDTH, INVENTORY_BODY_VIEW_HEIGHT, 2500);
+                buttonCreateAction(gInventoryBarterBackgroundWindow,
+                    15 + kInventoryLeftBodyViewOffsetX, 25, INVENTORY_BODY_VIEW_WIDTH, INVENTORY_BODY_VIEW_HEIGHT, 2500);
 
             // Invisible button representing right character.
             buttonCreateAction(gInventoryBarterBackgroundWindow,
@@ -1427,7 +1435,7 @@ static bool _setup_inventory(int inventoryWindowType)
             if (inventoryWindowType == INVENTORY_WINDOW_TYPE_LOOT) {
                 // Invisible button representing left character.
                 buttonCreateAction(gInventoryWindow,
-                    inventoryLootLayout.leftBodyViewX, INVENTORY_LOOT_LEFT_BODY_VIEW_Y,
+                    inventoryLootLayout.leftBodyViewX + kInventoryLeftBodyViewOffsetX, INVENTORY_LOOT_LEFT_BODY_VIEW_Y,
                     INVENTORY_BODY_VIEW_WIDTH, INVENTORY_BODY_VIEW_HEIGHT, 2500);
 
                 // Right inventory down button.
@@ -1858,10 +1866,8 @@ static void _display_inventory(int stackOffset, int dragSlotIndex, int inventory
             snprintf(formattedText, sizeof(formattedText), "%d", inventoryWeight);
         }
 
-        int width = fontGetStringWidth(formattedText);
-        int x = inventoryLootLayout.leftScrollerX + inventoryLootLayout.scrollerWidth / 2 - width / 2;
         int y = inventoryLootLayout.leftScrollerY + inventoryLootLayout.scrollerHeight + 2;
-        fontDrawText(windowBuffer + pitch * y + x, formattedText, width, pitch, color);
+        inventoryDrawCenteredText(windowBuffer, pitch, inventoryLootLayout.scrollerWidth, inventoryLootLayout.leftScrollerX, y, formattedText, color);
 
         fontSetCurrent(oldFont);
     }
@@ -1987,10 +1993,8 @@ static void _display_target_inventory(int stackOffset, int dragSlotIndex, Invent
             snprintf(formattedText, sizeof(formattedText), "%d", inventoryWeight);
         }
 
-        int width = fontGetStringWidth(formattedText);
-        int x = inventoryLootLayout.rightScrollerX + inventoryLootLayout.scrollerWidth / 2 - width / 2;
         int y = inventoryLootLayout.rightScrollerY + inventoryLootLayout.scrollerHeight + 2;
-        fontDrawText(windowBuffer + pitch * y + x, formattedText, width, pitch, color);
+        inventoryDrawCenteredText(windowBuffer, pitch, inventoryLootLayout.scrollerWidth, inventoryLootLayout.rightScrollerX, y, formattedText, color);
 
         fontSetCurrent(oldFont);
     }
@@ -2113,7 +2117,7 @@ static void _display_body(int fid, int inventoryWindowType)
                 rect.left = 560;
                 rect.top = 25;
             } else {
-                rect.left = 15;
+                rect.left = 15 + kInventoryLeftBodyViewOffsetX;
                 rect.top = 25;
             }
 
@@ -2134,6 +2138,8 @@ static void _display_body(int fid, int inventoryWindowType)
             blitBufferToBufferTrans(frameData, frameWidth, frameHeight, framePitch,
                 windowBuffer + windowPitch * (rect.top + (INVENTORY_BODY_VIEW_HEIGHT - frameHeight) / 2) + (INVENTORY_BODY_VIEW_WIDTH - frameWidth) / 2 + rect.left,
                 windowPitch);
+
+            inventoryDisplayLeftPaneCompanionName(windowBuffer, windowPitch, rect, index);
 
             win = gInventoryBarterBackgroundWindow;
         } else {
@@ -2156,7 +2162,7 @@ static void _display_body(int fid, int inventoryWindowType)
                 }
             } else {
                 if (inventoryWindowType == INVENTORY_WINDOW_TYPE_LOOT) {
-                    rect.left = inventoryLootLayout.leftBodyViewX;
+                    rect.left = inventoryLootLayout.leftBodyViewX + kInventoryLeftBodyViewOffsetX;
                     rect.top = INVENTORY_LOOT_LEFT_BODY_VIEW_Y;
                 } else if (inventoryWindowType == INVENTORY_WINDOW_TYPE_USE_ITEM_ON) {
                     rect.left = 176; // Use item cha window
@@ -2189,19 +2195,8 @@ static void _display_body(int fid, int inventoryWindowType)
                 windowBuffer + windowPitch * (rect.top + (INVENTORY_BODY_VIEW_HEIGHT - frameHeight) / 2) + (INVENTORY_BODY_VIEW_WIDTH - frameWidth) / 2 + rect.left,
                 windowPitch);
 
-            // Draw party member name at bottom of left avatar in loot mode.
-            if (index == 0 && inventoryWindowType == INVENTORY_WINDOW_TYPE_LOOT && _stack[0] != gDude) {
-                const char* name = critterGetName(_stack[0]);
-                if (name != nullptr) {
-                    // TODO: clean up text rendering
-                    int oldFont = fontGetCurrent();
-                    fontSetCurrent(101);
-                    int nameWidth = std::min(fontGetStringWidth(name), INVENTORY_BODY_VIEW_WIDTH);
-                    int nameX = rect.left + INVENTORY_BODY_VIEW_WIDTH / 2 - nameWidth / 2;
-                    int nameY = rect.bottom - fontGetLineHeight() - 1;
-                    fontDrawText(windowBuffer + windowPitch * nameY + nameX, name, INVENTORY_BODY_VIEW_WIDTH, windowPitch, _colorTable[992]);
-                    fontSetCurrent(oldFont);
-                }
+            if (inventoryWindowType == INVENTORY_WINDOW_TYPE_LOOT) {
+                inventoryDisplayLeftPaneCompanionName(windowBuffer, windowPitch, rect, index);
             }
 
             win = gInventoryWindow;
@@ -2988,7 +2983,7 @@ static void inventoryRestoreEquippedFromGlobals(Object* critter)
     gInventoryArmor = nullptr;
 }
 
-static void inventorySetLootLeftPaneCritter(Object* critter, Object* target)
+static void inventorySetLeftPaneCritter(Object* critter, Object* target, int inventoryWindowType)
 {
     assert(critter != nullptr);
     assert(target != nullptr);
@@ -3014,8 +3009,8 @@ static void inventorySetLootLeftPaneCritter(Object* critter, Object* target)
 
     gInventoryWindowDudeFid = buildFid(OBJ_TYPE_CRITTER, critter->fid & 0xFFF, 0, animationCode, 0);
     gInventoryWindowDudeRotationTimestamp = 0;
-    _display_inventory(0, -1, INVENTORY_WINDOW_TYPE_LOOT);
-    _display_body(target->fid, INVENTORY_WINDOW_TYPE_LOOT);
+    _display_inventory(0, -1, inventoryWindowType);
+    _display_body(target->fid, inventoryWindowType);
 }
 
 // 0x471CA0
@@ -3736,6 +3731,35 @@ static int _inven_from_button(int keyCode, Object** outItem, Object*** outItemSl
     return quantity;
 }
 
+static void inventoryDrawCenteredText(unsigned char* buffer, int pitch, int width, int x, int y, const char* text, int color)
+{
+    if (text == nullptr) {
+        return;
+    }
+
+    int oldFont = fontGetCurrent();
+    fontSetCurrent(101);
+    int textWidth = std::min(fontGetStringWidth(text), width);
+    int textX = x + width / 2 - textWidth / 2;
+    fontDrawText(buffer + pitch * y + textX, text, width, pitch, color);
+    fontSetCurrent(oldFont);
+}
+
+static void inventoryDisplayLeftPaneCompanionName(unsigned char* windowBuffer, int windowPitch, const Rect& rect, int index)
+{
+    if (index != 0 || _stack[0] == gDude) {
+        return;
+    }
+
+    const char* name = critterGetName(_stack[0]);
+    if (name == nullptr) {
+        return;
+    }
+
+    int nameY = rect.bottom - fontGetLineHeight() - 1;
+    inventoryDrawCenteredText(windowBuffer, windowPitch, INVENTORY_BODY_VIEW_WIDTH, rect.left, nameY, name, _colorTable[992]);
+}
+
 // Displays item description.
 //
 // inven_display_msg
@@ -4368,7 +4392,7 @@ int inventoryOpenLooting(Object* looter, Object* target)
 
             if (critterCount > 1) {
                 int btn = buttonCreateWithFrm(gInventoryWindow,
-                    inventoryLootLayout.prevCritterButtonX, INVENTORY_LOOT_CRITTER_TOGGLE_Y,
+                    inventoryLootLayout.prevCritterButtonX + kInventoryLeftBodyViewOffsetX, INVENTORY_LOOT_CRITTER_TOGGLE_Y,
                     -1, -1, KEY_PAGE_UP, -1,
                     FrmId(OBJ_TYPE_INTERFACE, gInventoryArrowFrmIds[INVENTORY_ARROW_FRM_LEFT_ARROW_UP]),
                     FrmId(OBJ_TYPE_INTERFACE, gInventoryArrowFrmIds[INVENTORY_ARROW_FRM_LEFT_ARROW_DOWN]));
@@ -4410,7 +4434,7 @@ int inventoryOpenLooting(Object* looter, Object* target)
     int partyTargetIndex = 0;
 
     if (partyTargets.size() > 1) {
-        const int btnCenterX = inventoryLootLayout.leftBodyViewX + INVENTORY_BODY_VIEW_WIDTH / 2;
+        const int btnCenterX = inventoryLootLayout.leftBodyViewX + kInventoryLeftBodyViewOffsetX + INVENTORY_BODY_VIEW_WIDTH / 2;
 
         int btn = buttonCreateWithFrm(gInventoryWindow,
             btnCenterX - 20, INVENTORY_LOOT_CRITTER_TOGGLE_Y,
@@ -4486,12 +4510,12 @@ int inventoryOpenLooting(Object* looter, Object* target)
         } else if (keyCode == KEY_ARROW_LEFT) {
             if (partyTargets.size() > 1) {
                 partyTargetIndex = (partyTargetIndex > 0) ? partyTargetIndex - 1 : (int)partyTargets.size() - 1;
-                inventorySetLootLeftPaneCritter(partyTargets[partyTargetIndex], target);
+                inventorySetLeftPaneCritter(partyTargets[partyTargetIndex], target, INVENTORY_WINDOW_TYPE_LOOT);
             }
         } else if (keyCode == KEY_ARROW_RIGHT) {
             if (partyTargets.size() > 1) {
                 partyTargetIndex = (partyTargetIndex < (int)partyTargets.size() - 1) ? partyTargetIndex + 1 : 0;
-                inventorySetLootLeftPaneCritter(partyTargets[partyTargetIndex], target);
+                inventorySetLeftPaneCritter(partyTargets[partyTargetIndex], target, INVENTORY_WINDOW_TYPE_LOOT);
             }
 
         } else if (keyCode == KEY_ARROW_UP) {
@@ -5294,7 +5318,44 @@ void barterProcessUI(int win, Object* barterer, Object* playerTable, Object* bar
     _target_stack[0] = barterer;
     _target_stack_offset[0] = 0;
 
+    Object* const playerObj = _inven_dude;
+    int savedDudeFid = gInventoryWindowDudeFid;
+
+    std::vector<Object*> partyTargets = { _inven_dude };
+    if (settings.qol.party_loot_and_barter) {
+        for (Object* pm : get_all_party_members_objects(false)) {
+            if (pm != gDude) {
+                partyTargets.push_back(pm);
+            }
+        }
+    }
+    int partyTargetIndex = 0;
+
     bool isoWasEnabled = _setup_inventory(INVENTORY_WINDOW_TYPE_TRADE);
+
+    if (partyTargets.size() > 1) {
+        const int arrowY = INVENTORY_BARTER_CRITTER_TOGGLE_Y;
+        const int btnCenterX = INVENTORY_BARTER_PC_BODY_VIEW_X + kInventoryLeftBodyViewOffsetX + INVENTORY_BODY_VIEW_WIDTH / 2;
+
+        int btn = buttonCreateWithFrm(win,
+            btnCenterX - 20, arrowY,
+            -1, -1, KEY_ARROW_LEFT, -1,
+            FrmId(OBJ_TYPE_INTERFACE, gInventoryArrowFrmIds[INVENTORY_ARROW_FRM_LEFT_ARROW_UP]),
+            FrmId(OBJ_TYPE_INTERFACE, gInventoryArrowFrmIds[INVENTORY_ARROW_FRM_LEFT_ARROW_DOWN]));
+        if (btn != -1) {
+            buttonSetCallbacks(btn, _gsound_red_butt_press, _gsound_red_butt_release);
+        }
+
+        btn = buttonCreateWithFrm(win,
+            btnCenterX, arrowY,
+            -1, -1, KEY_ARROW_RIGHT, -1,
+            FrmId(OBJ_TYPE_INTERFACE, gInventoryArrowFrmIds[INVENTORY_ARROW_FRM_RIGHT_ARROW_UP]),
+            FrmId(OBJ_TYPE_INTERFACE, gInventoryArrowFrmIds[INVENTORY_ARROW_FRM_RIGHT_ARROW_DOWN]));
+        if (btn != -1) {
+            buttonSetCallbacks(btn, _gsound_red_butt_press, _gsound_red_butt_release);
+        }
+    }
+
     _display_target_inventory(_target_stack_offset[_target_curr_stack], -1, _target_pud, INVENTORY_WINDOW_TYPE_TRADE);
     _display_inventory(_stack_offset[0], -1, INVENTORY_WINDOW_TYPE_TRADE);
     _display_body(barterer->fid, INVENTORY_WINDOW_TYPE_TRADE);
@@ -5402,6 +5463,16 @@ void barterProcessUI(int win, Object* barterer, Object* playerTable, Object* bar
                 _target_stack_offset[_target_curr_stack] += 1;
                 _display_target_inventory(_target_stack_offset[_target_curr_stack], -1, _target_pud, INVENTORY_WINDOW_TYPE_TRADE);
                 windowRefresh(gInventoryWindow);
+            }
+        } else if (keyCode == KEY_ARROW_LEFT) {
+            if (partyTargets.size() > 1) {
+                partyTargetIndex = (partyTargetIndex > 0) ? partyTargetIndex - 1 : (int)partyTargets.size() - 1;
+                inventorySetLeftPaneCritter(partyTargets[partyTargetIndex], barterer, INVENTORY_WINDOW_TYPE_TRADE);
+            }
+        } else if (keyCode == KEY_ARROW_RIGHT) {
+            if (partyTargets.size() > 1) {
+                partyTargetIndex = (partyTargetIndex < (int)partyTargets.size() - 1) ? partyTargetIndex + 1 : 0;
+                inventorySetLeftPaneCritter(partyTargets[partyTargetIndex], barterer, INVENTORY_WINDOW_TYPE_TRADE);
             }
         } else if (keyCode >= 2500 && keyCode <= 2501) {
             _container_exit(keyCode, INVENTORY_WINDOW_TYPE_TRADE);
@@ -5572,7 +5643,9 @@ void barterProcessUI(int win, Object* barterer, Object* playerTable, Object* bar
         itemAdd(barterer, item1, 1);
     }
 
+    gInventoryWindowDudeFid = savedDudeFid;
     _exit_inventory(isoWasEnabled);
+    _inven_dude = playerObj;
 
     // NOTE: Uninline.
     inventoryCommonFree();


### PR DESCRIPTION
Very simple party barter support.  Builds upon the loot screen so is very little code:

* Switch party members with left/right arrow keys
* When leaving barter with items on the table (canceling), all items go to the PC's inventory
* No special handling of money (yet)

The mod pins the player's money stack on top of the inventory list for all party members.  That's nice, but also feels a little odd, but likely just because I'm used to the money stack being stuck at bottom.  We can iterate on that.

Adding an interface will require art.  I considered enabling mouse use triggered by clicking on the avatar which would be quite simple.

<img width="855" height="373" alt="image" src="https://github.com/user-attachments/assets/7ccfe023-9e84-46f8-a688-1b4b05375562" />

Fortunately, "Cassidy" is the longest party member name and _just_ fits.  We might need a different solution if mods end up using companions with longer names, but we can figure out that if/when that happens

