### PR TITLE
Speed up Fallout1 .dat reader

### DIFF
--- a/src/dfile.cc
+++ b/src/dfile.cc
@@ -14,7 +14,7 @@
 namespace fallout {
 
 // The size of decompression buffer for reading compressed [DFile]s.
-#define DFILE_DECOMPRESSION_BUFFER_SIZE (0x400)
+#define DFILE_DECOMPRESSION_BUFFER_SIZE (0x1000)
 
 // Specifies that [DFile] has unget character.
 //

--- a/tools/dat_archive.cc
+++ b/tools/dat_archive.cc
@@ -189,20 +189,11 @@ bool readFo1EntryData(FILE* stream, const DatArchiveEntry& entry, std::vector<un
 
         output->resize(static_cast<size_t>(entry.uncompressedSize));
         {
-            size_t decodeBufferSize = 0;
-            if (!trySafeFo1DecodeBufferSize(static_cast<unsigned int>(*entry.storedSize), &decodeBufferSize)) {
-                return false;
-            }
-
-            size_t decodeCapacity = std::max(output->size(), decodeBufferSize);
-            std::vector<unsigned char> decodeBuffer(decodeCapacity);
-            int bytesWritten = lzss_decode_to_buf(stream, decodeBuffer.data(), static_cast<unsigned int>(*entry.storedSize));
+            int bytesWritten = lzss_decode_to_buf(stream, output->data(), static_cast<unsigned int>(*entry.storedSize));
             if (bytesWritten != entry.uncompressedSize) {
                 return false;
             }
 
-            *output = std::move(decodeBuffer);
-            output->resize(static_cast<size_t>(bytesWritten));
             return true;
         }
     case fo1UncompressedFlags:
@@ -211,6 +202,7 @@ bool readFo1EntryData(FILE* stream, const DatArchiveEntry& entry, std::vector<un
     case fo1ChunkedFlags: {
         output->clear();
         output->reserve(static_cast<size_t>(entry.uncompressedSize));
+        std::vector<unsigned char> decodeBuffer;
         while (output->size() < static_cast<size_t>(entry.uncompressedSize)) {
             unsigned short chunkHeader;
             if (!readBe16(stream, &chunkHeader)) {
@@ -234,8 +226,10 @@ bool readFo1EntryData(FILE* stream, const DatArchiveEntry& entry, std::vector<un
                     return false;
                 }
 
-                size_t decodeCapacity = std::max(static_cast<size_t>(entry.uncompressedSize - output->size()), decodeBufferSize);
-                std::vector<unsigned char> decodeBuffer(decodeCapacity);
+                if (decodeBuffer.size() < decodeBufferSize) {
+                    decodeBuffer.resize(decodeBufferSize);
+                }
+
                 int bytesWritten = lzss_decode_to_buf(stream, decodeBuffer.data(), chunkHeader);
                 if (bytesWritten <= 0 || output->size() + static_cast<size_t>(bytesWritten) > static_cast<size_t>(entry.uncompressedSize)) {
                     return false;
@@ -420,6 +414,13 @@ public:
     {
     }
 
+    ~Fo1Archive() override
+    {
+        if (stream_ != nullptr) {
+            fclose(stream_);
+        }
+    }
+
     static std::unique_ptr<Fo1Archive> open(const std::string& path)
     {
         FILE* stream = compat_fopen(path.c_str(), "rb");
@@ -505,15 +506,15 @@ public:
             return nullptr;
         }
 
-        FILE* stream = compat_fopen(path_.c_str(), "rb");
-        if (stream == nullptr) {
-            return nullptr;
+        if (stream_ == nullptr) {
+            stream_ = compat_fopen(path_.c_str(), "rb");
+            if (stream_ == nullptr) {
+                return nullptr;
+            }
         }
 
-        std::unique_ptr<FILE, decltype(&fclose)> file(stream, &fclose);
-
         std::vector<unsigned char> buffer;
-        if (!readFo1EntryData(file.get(), *entry, &buffer)) {
+        if (!readFo1EntryData(stream_, *entry, &buffer)) {
             return nullptr;
         }
 
@@ -523,6 +524,7 @@ public:
 private:
     std::string path_;
     std::vector<DatArchiveEntry> entries_;
+    mutable FILE* stream_ = nullptr;
 };
 
 } // namespace

--- a/tools/dat_archive.cc
+++ b/tools/dat_archive.cc
@@ -189,11 +189,18 @@ bool readFo1EntryData(FILE* stream, const DatArchiveEntry& entry, std::vector<un
 
         output->resize(static_cast<size_t>(entry.uncompressedSize));
         {
-            int bytesWritten = lzss_decode_to_buf(stream, output->data(), static_cast<unsigned int>(*entry.storedSize));
+            size_t decodeBufferSize = 0;
+            if (!trySafeFo1DecodeBufferSize(static_cast<unsigned int>(*entry.storedSize), &decodeBufferSize)) {
+                return false;
+            }
+
+            std::vector<unsigned char> decodeBuffer(std::max(output->size(), decodeBufferSize));
+            int bytesWritten = lzss_decode_to_buf(stream, decodeBuffer.data(), static_cast<unsigned int>(*entry.storedSize));
             if (bytesWritten != entry.uncompressedSize) {
                 return false;
             }
 
+            std::copy_n(decodeBuffer.begin(), output->size(), output->begin());
             return true;
         }
     case fo1UncompressedFlags:
@@ -411,15 +418,16 @@ class Fo1Archive final : public DatArchive {
 public:
     explicit Fo1Archive(std::string path)
         : path_(std::move(path))
+        , stream_(nullptr, &fclose)
     {
     }
 
-    ~Fo1Archive() override
-    {
-        if (stream_ != nullptr) {
-            fclose(stream_);
-        }
-    }
+    ~Fo1Archive() override = default;
+
+    Fo1Archive(const Fo1Archive&) = delete;
+    Fo1Archive& operator=(const Fo1Archive&) = delete;
+    Fo1Archive(Fo1Archive&&) = delete;
+    Fo1Archive& operator=(Fo1Archive&&) = delete;
 
     static std::unique_ptr<Fo1Archive> open(const std::string& path)
     {
@@ -507,14 +515,14 @@ public:
         }
 
         if (stream_ == nullptr) {
-            stream_ = compat_fopen(path_.c_str(), "rb");
+            stream_.reset(compat_fopen(path_.c_str(), "rb"));
             if (stream_ == nullptr) {
                 return nullptr;
             }
         }
 
         std::vector<unsigned char> buffer;
-        if (!readFo1EntryData(stream_, *entry, &buffer)) {
+        if (!readFo1EntryData(stream_.get(), *entry, &buffer)) {
             return nullptr;
         }
 
@@ -524,7 +532,7 @@ public:
 private:
     std::string path_;
     std::vector<DatArchiveEntry> entries_;
-    mutable FILE* stream_ = nullptr;
+    mutable std::unique_ptr<FILE, decltype(&fclose)> stream_;
 };
 
 } // namespace


### PR DESCRIPTION
It was reallocating a buffer on a loop, which caused large files to take minutes.  Fixing this reduced it to a reasonable time, but it's still ~120s to extract the entire Fallout1 master.dat after this change.

Also, bump the F2 zlib buffer to 4kB. It was only 1024 bytes.  I don't expect that to make a noticeable difference, but I was looking to see if the F2 dat code had similar issues and thought it might as well be something closer to a modern value (at least a memory page).  
