### PR TITLE
Fix high pitch voiced dialog 

### DIFF
--- a/src/audio.cc
+++ b/src/audio.cc
@@ -264,7 +264,6 @@ int audioOpen(const char* fname, AudioFileInfo* info, bool* isMemoryBackedPtr)
 
         if (info != nullptr) {
             info->sampleRate = audioFile->sampleRate;
-            info->channels = audioFile->channels;
             info->bitsPerSample = audioFile->bitsPerSample;
         }
         if (isMemoryBackedPtr != nullptr) {

--- a/src/audio_file.cc
+++ b/src/audio_file.cc
@@ -100,7 +100,6 @@ int audioFileOpen(const char* fname, AudioFileInfo* info, bool* isMemoryBackedPt
         audioFile->fileSize *= 2;
         if (info != nullptr) {
             info->sampleRate = audioFile->sampleRate;
-            info->channels = audioFile->channels;
             info->bitsPerSample = 16;
         }
         if (isMemoryBackedPtr != nullptr) {


### PR DESCRIPTION
In 8b2ead8a2b2a0ed6cf65f37d373f45029a43a61a, `soundLoad` started honoring `AudioFileInfo.channels`, but the ACM decoder path historically only propagated sample rate.  This changes playback in a way that caused the bug.

Verified by talking to good ol' Sulik