### PR TITLE
Load f2_res.dat after master.dat 

### DIFF
--- a/src/game.cc
+++ b/src/game.cc
@@ -1392,8 +1392,12 @@ static int gameDbInit()
 
     int master_db_handle = dbOpen(main_file_name, patch_file_name);
     if (master_db_handle == -1) {
-        showMesageBox("Could not find the master datafile. Please make sure the FALLOUT CD is in the drive and that you are running FALLOUT from the directory you installed it to.");
+        showMessageBox("Could not find the master datafile. Please make sure the FALLOUT CD is in the drive and that you are running FALLOUT from the directory you installed it to.");
         return -1;
+    }
+
+    if (compat_access("f2_res.dat", 0) == 0) {
+        dbOpen("f2_res.dat");
     }
 
     main_file_name = settings.system.critter_dat_path.c_str();
@@ -1408,7 +1412,7 @@ static int gameDbInit()
 
     int critter_db_handle = dbOpen(main_file_name, patch_file_name);
     if (critter_db_handle == -1) {
-        showMesageBox("Could not find the critter datafile. Please make sure the FALLOUT CD is in the drive and that you are running FALLOUT from the directory you installed it to.");
+        showMessageBox("Could not find the critter datafile. Please make sure the FALLOUT CD is in the drive and that you are running FALLOUT from the directory you installed it to.");
         return -1;
     }
 
@@ -1431,10 +1435,6 @@ static int gameDbInit()
     TryLoadBaseCEMod();
 
     sfallLoadMods();
-
-    if (compat_access("f2_res.dat", 0) == 0) {
-        dbOpen("f2_res.dat");
-    }
 
     return 0;
 }

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -1681,7 +1681,7 @@ void gameDialogReviewWindowUpdate(int win, int origin)
         }
 
         if (replyText == nullptr) {
-            showMesageBox("\nGDialog::Error Grabbing text message!");
+            showMessageBox("\nGDialog::Error Grabbing text message!");
             exit(1);
         }
 
@@ -1714,7 +1714,7 @@ void gameDialogReviewWindowUpdate(int win, int origin)
             }
 
             if (optionText == nullptr) {
-                showMesageBox("\nGDialog::Error Grabbing text message!");
+                showMessageBox("\nGDialog::Error Grabbing text message!");
                 exit(1);
             }
 
@@ -2380,7 +2380,7 @@ void _gdProcessUpdate()
     if (gDialogReplyMessageListId > 0) {
         char* s = _scr_get_msg_str_speech(gDialogReplyMessageListId, gDialogReplyMessageId, 1);
         if (s == nullptr) {
-            showMesageBox("\n'GDialog::Error Grabbing text message!");
+            showMessageBox("\n'GDialog::Error Grabbing text message!");
             exit(1);
         }
 
@@ -2423,7 +2423,7 @@ void _gdProcessUpdate()
         if (dialogOptionEntry->messageListId >= 0) {
             char* text = _scr_get_msg_str_speech(dialogOptionEntry->messageListId, dialogOptionEntry->messageId, 0);
             if (text == nullptr) {
-                showMesageBox("\nGDialog::Error Grabbing text message!");
+                showMessageBox("\nGDialog::Error Grabbing text message!");
                 exit(1);
             }
 

--- a/src/party_member.cc
+++ b/src/party_member.cc
@@ -586,7 +586,7 @@ static int _partyMemberPrepLoadInstance(PartyMemberListItem* a1)
 
     a1->script = (Script*)internal_malloc(sizeof(*script));
     if (a1->script == nullptr) {
-        showMesageBox("\n  Error!: partyMemberPrepLoad: Out of memory!");
+        showMessageBox("\n  Error!: partyMemberPrepLoad: Out of memory!");
         exit(1);
     }
 
@@ -595,7 +595,7 @@ static int _partyMemberPrepLoadInstance(PartyMemberListItem* a1)
     if (script->localVarsCount != 0 && script->localVarsOffset != -1) {
         a1->vars = (int*)internal_malloc(sizeof(*a1->vars) * script->localVarsCount);
         if (a1->vars == nullptr) {
-            showMesageBox("\n  Error!: partyMemberPrepLoad: Out of memory!");
+            showMessageBox("\n  Error!: partyMemberPrepLoad: Out of memory!");
             exit(1);
         }
 
@@ -678,13 +678,13 @@ static int _partyMemberRecoverLoadInstance(PartyMemberListItem* a1)
 
     int v1 = -1;
     if (scriptAdd(&v1, scriptType) == -1) {
-        showMesageBox("\n  Error!: partyMemberRecoverLoad: Can't create script!");
+        showMessageBox("\n  Error!: partyMemberRecoverLoad: Can't create script!");
         exit(1);
     }
 
     Script* script;
     if (scriptGetScript(v1, &script) == -1) {
-        showMesageBox("\n  Error!: partyMemberRecoverLoad: Can't find script!");
+        showMessageBox("\n  Error!: partyMemberRecoverLoad: Can't find script!");
         exit(1);
     }
 
@@ -994,7 +994,7 @@ static int _partyMemberPrepItemSave(Object* object)
     if (object->sid != -1) {
         Script* script;
         if (scriptGetScript(object->sid, &script) == -1) {
-            showMesageBox("\n  Error!: partyMemberPrepItemSaveAll: Can't find script!");
+            showMessageBox("\n  Error!: partyMemberPrepItemSaveAll: Can't find script!");
             exit(1);
         }
 
@@ -1016,7 +1016,7 @@ static int _partyMemberItemSave(Object* object)
     if (object->sid != -1) {
         Script* script;
         if (scriptGetScript(object->sid, &script) == -1) {
-            showMesageBox("\n  Error!: partyMemberItemSave: Can't find script!");
+            showMessageBox("\n  Error!: partyMemberItemSave: Can't find script!");
             exit(1);
         }
 
@@ -1027,7 +1027,7 @@ static int _partyMemberItemSave(Object* object)
 
         PartyMemberListItem* node = (PartyMemberListItem*)internal_malloc(sizeof(*node));
         if (node == nullptr) {
-            showMesageBox("\n  Error!: partyMemberItemSave: Out of memory!");
+            showMessageBox("\n  Error!: partyMemberItemSave: Out of memory!");
             exit(1);
         }
 
@@ -1035,7 +1035,7 @@ static int _partyMemberItemSave(Object* object)
 
         node->script = (Script*)internal_malloc(sizeof(*script));
         if (node->script == nullptr) {
-            showMesageBox("\n  Error!: partyMemberItemSave: Out of memory!");
+            showMessageBox("\n  Error!: partyMemberItemSave: Out of memory!");
             exit(1);
         }
 
@@ -1044,7 +1044,7 @@ static int _partyMemberItemSave(Object* object)
         if (script->localVarsCount != 0 && script->localVarsOffset != -1) {
             node->vars = (int*)internal_malloc(sizeof(*node->vars) * script->localVarsCount);
             if (node->vars == nullptr) {
-                showMesageBox("\n  Error!: partyMemberItemSave: Out of memory!");
+                showMessageBox("\n  Error!: partyMemberItemSave: Out of memory!");
                 exit(1);
             }
 
@@ -1073,13 +1073,13 @@ static int _partyMemberItemRecover(PartyMemberListItem* a1)
 {
     int sid = -1;
     if (scriptAdd(&sid, SCRIPT_TYPE_ITEM) == -1) {
-        showMesageBox("\n  Error!: partyMemberItemRecover: Can't create script!");
+        showMessageBox("\n  Error!: partyMemberItemRecover: Can't create script!");
         exit(1);
     }
 
     Script* script;
     if (scriptGetScript(sid, &script) == -1) {
-        showMesageBox("\n  Error!: partyMemberItemRecover: Can't find script!");
+        showMessageBox("\n  Error!: partyMemberItemRecover: Can't find script!");
         exit(1);
     }
 

--- a/src/tile_hires_stencil.cc
+++ b/src/tile_hires_stencil.cc
@@ -413,7 +413,7 @@ void tile_hires_stencil_init()
     if (settings.ui.ignore_map_edges) {
         static bool isMessageShown = false;
         if (!isMessageShown) {
-            showMesageBox("Tile hires stencil is disabled because map edges are ignored.");
+            showMessageBox("Tile hires stencil is disabled because map edges are ignored.");
             isMessageShown = true;
         }
         gIsTileHiresStencilEnabled = false;

--- a/src/window.cc
+++ b/src/window.cc
@@ -1388,37 +1388,37 @@ void windowInit(int resolution, int flags)
         switch (rc) {
         case WINDOW_MANAGER_ERR_INITIALIZING_VIDEO_MODE:
             snprintf(err, sizeof(err), "Error initializing video mode %dx%d\n", _xres, _yres);
-            showMesageBox(err);
+            showMessageBox(err);
             exit(1);
             break;
         case WINDOW_MANAGER_ERR_NO_MEMORY:
             snprintf(err, sizeof(err), "Not enough memory to initialize video mode\n");
-            showMesageBox(err);
+            showMessageBox(err);
             exit(1);
             break;
         case WINDOW_MANAGER_ERR_INITIALIZING_TEXT_FONTS:
             snprintf(err, sizeof(err), "Couldn't find/load text fonts\n");
-            showMesageBox(err);
+            showMessageBox(err);
             exit(1);
             break;
         case WINDOW_MANAGER_ERR_WINDOW_SYSTEM_ALREADY_INITIALIZED:
             snprintf(err, sizeof(err), "Attempt to initialize window system twice\n");
-            showMesageBox(err);
+            showMessageBox(err);
             exit(1);
             break;
         case WINDOW_MANAGER_ERR_WINDOW_SYSTEM_NOT_INITIALIZED:
             snprintf(err, sizeof(err), "Window system not initialized\n");
-            showMesageBox(err);
+            showMessageBox(err);
             exit(1);
             break;
         case WINDOW_MANAGER_ERR_CURRENT_WINDOWS_TOO_BIG:
             snprintf(err, sizeof(err), "Current windows are too big for new resolution\n");
-            showMesageBox(err);
+            showMessageBox(err);
             exit(1);
             break;
         case WINDOW_MANAGER_ERR_INITIALIZING_DEFAULT_DATABASE:
             snprintf(err, sizeof(err), "Error initializing default database.\n");
-            showMesageBox(err);
+            showMessageBox(err);
             exit(1);
             break;
         case WINDOW_MANAGER_ERR_8:
@@ -1426,22 +1426,22 @@ void windowInit(int resolution, int flags)
             break;
         case WINDOW_MANAGER_ERR_ALREADY_RUNNING:
             snprintf(err, sizeof(err), "Program already running.\n");
-            showMesageBox(err);
+            showMessageBox(err);
             exit(1);
             break;
         case WINDOW_MANAGER_ERR_TITLE_NOT_SET:
             snprintf(err, sizeof(err), "Program title not set.\n");
-            showMesageBox(err);
+            showMessageBox(err);
             exit(1);
             break;
         case WINDOW_MANAGER_ERR_INITIALIZING_INPUT:
             snprintf(err, sizeof(err), "Failure initializing input devices.\n");
-            showMesageBox(err);
+            showMessageBox(err);
             exit(1);
             break;
         default:
             snprintf(err, sizeof(err), "Unknown error code %d\n", rc);
-            showMesageBox(err);
+            showMessageBox(err);
             exit(1);
             break;
         }

--- a/src/window_manager.cc
+++ b/src/window_manager.cc
@@ -1363,8 +1363,9 @@ void programWindowSetTitle(const char* title)
 }
 
 // 0x4D8200
-bool showMesageBox(const char* text)
+bool showMessageBox(const char* text)
 {
+    debugPrint("showMessageBox: %s\n", text);
     SDL_Cursor* prev = SDL_GetCursor();
     SDL_Cursor* cursor = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_ARROW);
     SDL_SetCursor(cursor);

--- a/src/window_manager.h
+++ b/src/window_manager.h
@@ -214,7 +214,7 @@ int windowGetRect(int win, Rect* rect);
 int _win_check_all_buttons();
 int _GNW_check_menu_bars(int input);
 void programWindowSetTitle(const char* title);
-bool showMesageBox(const char* str);
+bool showMessageBox(const char* str);
 int buttonCreate(int win, int x, int y, int width, int height, int mouseEnterEventCode = -1, int mouseExitEventCode = -1, int mouseDownEventCode = -1, int mouseUpEventCode = -1, unsigned char* normal = nullptr, unsigned char* pressed = nullptr, unsigned char* hover = nullptr, int flags = 0);
 // Same as buttonCreate, but accepts FrmId instead of direct data pointers. Frames will be locked from cache and unlocked automatically when the button is destroyed.
 // Only normalId is required to be non-empty.

--- a/src/worldmap.cc
+++ b/src/worldmap.cc
@@ -1336,7 +1336,7 @@ static int wmConfigInit()
         }
 
         if (!configGetInt(&config, "Tile Data", "num_horizontal_tiles", &wmNumHorizontalTiles)) {
-            showMesageBox("\nwmConfigInit::Error loading tile data!");
+            showMessageBox("\nwmConfigInit::Error loading tile data!");
             return -1;
         }
 
@@ -1353,7 +1353,7 @@ static int wmConfigInit()
 
             TileInfo* worldmapTiles = (TileInfo*)internal_realloc(wmTileInfoList, sizeof(*wmTileInfoList) * wmMaxTileNum);
             if (worldmapTiles == nullptr) {
-                showMesageBox("\nwmConfigInit::Error loading tiles!");
+                showMessageBox("\nwmConfigInit::Error loading tiles!");
                 exit(1);
             }
 
@@ -1383,12 +1383,12 @@ static int wmConfigInit()
 
                     char* subtileProps;
                     if (!configGetString(&config, section, key, &subtileProps)) {
-                        showMesageBox("\nwmConfigInit::Error loading tiles!");
+                        showMessageBox("\nwmConfigInit::Error loading tiles!");
                         exit(1);
                     }
 
                     if (wmParseSubTileInfo(tile, row, column, subtileProps) == -1) {
-                        showMesageBox("\nwmConfigInit::Error loading tiles!");
+                        showMessageBox("\nwmConfigInit::Error loading tiles!");
                         exit(1);
                     }
                 }
@@ -1408,7 +1408,7 @@ static int wmReadEncounterType(Config* config, char* lookupName, char* sectionKe
 
     EncounterTable* encounterTables = (EncounterTable*)internal_realloc(wmEncounterTableList, sizeof(EncounterTable) * wmMaxEncounterInfoTables);
     if (encounterTables == nullptr) {
-        showMesageBox("\nwmConfigInit::Error loading Encounter Table!");
+        showMessageBox("\nwmConfigInit::Error loading Encounter Table!");
         exit(1);
     }
 
@@ -1447,7 +1447,7 @@ static int wmReadEncounterType(Config* config, char* lookupName, char* sectionKe
         }
 
         if (encounterTable->entriesLength >= 40) {
-            showMesageBox("\nwmConfigInit::Error: Encounter Table: Too many table indexes!!");
+            showMessageBox("\nwmConfigInit::Error: Encounter Table: Too many table indexes!!");
             exit(1);
         }
 
@@ -1673,7 +1673,7 @@ static int wmReadEncBaseType(char* name, int* valuePtr)
 
     Encounter* encounters = (Encounter*)internal_realloc(wmEncBaseTypeList, sizeof(*wmEncBaseTypeList) * wmMaxEncBaseTypes);
     if (encounters == nullptr) {
-        showMesageBox("\nwmConfigInit::Error Reading EncBaseType!");
+        showMessageBox("\nwmConfigInit::Error Reading EncBaseType!");
         exit(1);
     }
 
@@ -2453,7 +2453,7 @@ static int wmAreaInit()
 
             cities = (CityInfo*)internal_realloc(wmAreaInfoList, sizeof(CityInfo) * wmMaxAreaNum);
             if (cities == nullptr) {
-                showMesageBox("\nwmConfigInit::Error loading areas!");
+                showMessageBox("\nwmConfigInit::Error loading areas!");
                 exit(1);
             }
 
@@ -2481,14 +2481,14 @@ static int wmAreaInit()
             }
 
             if (!configGetString(&cfg, section, "area_name", &str)) {
-                showMesageBox("\nwmConfigInit::Error loading areas!");
+                showMessageBox("\nwmConfigInit::Error loading areas!");
                 exit(1);
             }
 
             strncpy(city->name, str, 40);
 
             if (!configGetString(&cfg, section, "world_pos", &str)) {
-                showMesageBox("\nwmConfigInit::Error loading areas!");
+                showMessageBox("\nwmConfigInit::Error loading areas!");
                 exit(1);
             }
 
@@ -2501,7 +2501,7 @@ static int wmAreaInit()
             }
 
             if (!configGetString(&cfg, section, "start_state", &str)) {
-                showMesageBox("\nwmConfigInit::Error loading areas!");
+                showMessageBox("\nwmConfigInit::Error loading areas!");
                 exit(1);
             }
 
@@ -2516,7 +2516,7 @@ static int wmAreaInit()
             }
 
             if (!configGetString(&cfg, section, "size", &str)) {
-                showMesageBox("\nwmConfigInit::Error loading areas!");
+                showMessageBox("\nwmConfigInit::Error loading areas!");
                 exit(1);
             }
 
@@ -2656,7 +2656,7 @@ static int wmMapInit()
 
             maps = (MapInfo*)internal_realloc(wmMapInfoList, sizeof(*wmMapInfoList) * wmMaxMapNum);
             if (maps == nullptr) {
-                showMesageBox("\nwmConfigInit::Error loading maps!");
+                showMessageBox("\nwmConfigInit::Error loading maps!");
                 exit(1);
             }
 
@@ -2668,7 +2668,7 @@ static int wmMapInit()
             strncpy(map->lookupName, str, 40);
 
             if (!configGetString(&config, section, "map_name", &str)) {
-                showMesageBox("\nwmConfigInit::Error loading maps!");
+                showMessageBox("\nwmConfigInit::Error loading maps!");
                 exit(1);
             }
 


### PR DESCRIPTION
This bring CE much closer to sfall's load order, and fixes RPU install.

 master_patches > critter_patches > mods_order.txt > PatchFileXX > patchXXX.dat > sfall.dat > critter_dat > f2_res_patches > f2_res_dat > master_dat

Also fixed typo in `showMessageBox`, and added a debugPrint in that function, so errors are visible in the log (LLMs otherwise find it hard to figure out what happened)