### PR TITLE
Sfall: save/restore last savegame page/slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ In time this stuff will receive in-game interface, right now you have to do it m
 * Music continues playing between maps
 * Auto open doors
 * 44.1 kHz stereo sound/music supported, in .ogg and .wav format as well as legacy .acm
+* Last used save slot is remembered
 
 ## Contributing
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -853,42 +853,42 @@ bool configSetBool(Config* config, const char* sectionKey, const char* key, bool
 
 ScopedConfig::ScopedConfig()
 {
-    loaded = configInit(&config);
+    _loaded = configInit(&_config);
 }
 
 ScopedConfig::ScopedConfig(const char* filePath, bool isDb)
     : ScopedConfig()
 {
-    if (loaded) {
-        loaded = configRead(&config, filePath, isDb);
+    if (_loaded) {
+        _loaded = configRead(&_config, filePath, isDb);
     }
 }
 
 ScopedConfig::~ScopedConfig()
 {
-    if (config.isInitialized()) {
-        configFree(&config);
+    if (_config.isInitialized()) {
+        configFree(&_config);
     }
 }
 
 bool ScopedConfig::isInitialized() const
 {
-    return config.isInitialized();
+    return _config.isInitialized();
 }
 
-Config* ScopedConfig::operator->()
+Config* ScopedConfig::get()
 {
-    return &config;
+    return &_config;
 }
 
-ScopedConfig::operator Config*()
+const Config* ScopedConfig::get() const
 {
-    return &config;
+    return &_config;
 }
 
 ScopedConfig::operator bool() const
 {
-    return loaded;
+    return _loaded;
 }
 
 } // namespace fallout

--- a/src/config.cc
+++ b/src/config.cc
@@ -851,4 +851,44 @@ bool configSetBool(Config* config, const char* sectionKey, const char* key, bool
     return configSetInt(config, sectionKey, key, value ? 1 : 0);
 }
 
+ScopedConfig::ScopedConfig()
+{
+    loaded = configInit(&config);
+}
+
+ScopedConfig::ScopedConfig(const char* filePath, bool isDb)
+    : ScopedConfig()
+{
+    if (loaded) {
+        loaded = configRead(&config, filePath, isDb);
+    }
+}
+
+ScopedConfig::~ScopedConfig()
+{
+    if (config.isInitialized()) {
+        configFree(&config);
+    }
+}
+
+bool ScopedConfig::isInitialized() const
+{
+    return config.isInitialized();
+}
+
+Config* ScopedConfig::operator->()
+{
+    return &config;
+}
+
+ScopedConfig::operator Config*()
+{
+    return &config;
+}
+
+ScopedConfig::operator bool() const
+{
+    return loaded;
+}
+
 } // namespace fallout

--- a/src/config.h
+++ b/src/config.h
@@ -54,6 +54,28 @@ bool configGetBool(Config* config, const char* sectionKey, const char* key, bool
 bool configGetBool(Config* config, const char* sectionKey, const char* key, bool* valuePtr, bool defaultValue);
 bool configSetBool(Config* config, const char* sectionKey, const char* key, bool value);
 
+class ScopedConfig {
+public:
+    ScopedConfig();
+    ScopedConfig(const char* filePath, bool isDb);
+    ~ScopedConfig();
+
+    ScopedConfig(const ScopedConfig&) = delete;
+    ScopedConfig& operator=(const ScopedConfig&) = delete;
+
+    bool isInitialized() const;
+
+    Config* operator->();
+
+    operator Config*();
+
+    explicit operator bool() const;
+
+private:
+    Config config = {};
+    bool loaded = false;
+};
+
 } // namespace fallout
 
 #endif /* CONFIG_H */

--- a/src/config.h
+++ b/src/config.h
@@ -65,15 +65,14 @@ public:
 
     bool isInitialized() const;
 
-    Config* operator->();
-
-    operator Config*();
+    Config* get();
+    const Config* get() const;
 
     explicit operator bool() const;
 
 private:
-    Config config = {};
-    bool loaded = false;
+    Config _config = {};
+    bool _loaded = false;
 };
 
 } // namespace fallout

--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -364,16 +364,10 @@ static void loadSaveRememberSelectedSlot()
     char path[COMPAT_MAX_PATH];
     snprintf(path, sizeof(path), "%s\\%s", _patches, kLoadSaveSlotDataFile);
 
-    Config config;
-    if (!configInit(&config)) {
-        return;
-    }
-
     int slot = 0;
-    if (configRead(&config, path, false)) {
-        configGetInt(&config, kLoadSaveSlotDataSection, kLoadSaveSlotDataKey, &slot, 0);
+    if (ScopedConfig config{ path, false }; config) {
+        configGetInt(config, kLoadSaveSlotDataSection, kLoadSaveSlotDataKey, &slot, 0);
     }
-    configFree(&config);
 
     _slot_cursor = std::clamp(slot, 0, saveLoadTotalSlots - 1);
     _currentSlotPage = _slot_cursor / slotsPerPage;
@@ -390,15 +384,13 @@ static void loadSavePersistSelectedSlot()
     char path[COMPAT_MAX_PATH];
     snprintf(path, sizeof(path), "%s\\%s", _patches, kLoadSaveSlotDataFile);
 
-    Config config;
-    if (!configInit(&config)) {
+    ScopedConfig config{ path, false };
+    if (!config.isInitialized()) {
         return;
     }
 
-    configRead(&config, path, false);
-    configSetInt(&config, kLoadSaveSlotDataSection, kLoadSaveSlotDataKey, _slot_cursor);
-    configWrite(&config, path, false);
-    configFree(&config);
+    configSetInt(config, kLoadSaveSlotDataSection, kLoadSaveSlotDataKey, _slot_cursor);
+    configWrite(config, path, false);
 }
 
 // 0x47B7E4

--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -13,6 +13,7 @@
 #include "color.h"
 #include "combat.h"
 #include "combat_ai.h"
+#include "config.h"
 #include "critter.h"
 #include "cycle.h"
 #include "db.h"
@@ -349,12 +350,63 @@ static FrmImage _loadsaveFrmImages[LOAD_SAVE_FRM_COUNT];
 static int quickSaveSlots = 0;
 static bool autoQuickSaveSlots = false;
 
+static constexpr char kLoadSaveSlotDataSection[] = "POSITION";
+static constexpr char kLoadSaveSlotDataKey[] = "CurrentSlot";
+static constexpr char kLoadSaveSlotDataFile[] = "SAVEGAME\\slotdat.ini";
+
+static void loadSaveRememberSelectedSlot()
+{
+    assert(_patches != nullptr);
+
+    _slot_cursor = 0;
+    _currentSlotPage = 0;
+
+    char path[COMPAT_MAX_PATH];
+    snprintf(path, sizeof(path), "%s\\%s", _patches, kLoadSaveSlotDataFile);
+
+    Config config;
+    if (!configInit(&config)) {
+        return;
+    }
+
+    int slot = 0;
+    if (configRead(&config, path, false)) {
+        configGetInt(&config, kLoadSaveSlotDataSection, kLoadSaveSlotDataKey, &slot, 0);
+    }
+    configFree(&config);
+
+    _slot_cursor = std::clamp(slot, 0, saveLoadTotalSlots - 1);
+    _currentSlotPage = _slot_cursor / slotsPerPage;
+}
+
+static void loadSavePersistSelectedSlot()
+{
+    assert(_patches != nullptr);
+
+    char savegamePath[COMPAT_MAX_PATH];
+    snprintf(savegamePath, sizeof(savegamePath), "%s\\SAVEGAME", _patches);
+    compat_mkdir(savegamePath);
+
+    char path[COMPAT_MAX_PATH];
+    snprintf(path, sizeof(path), "%s\\%s", _patches, kLoadSaveSlotDataFile);
+
+    Config config;
+    if (!configInit(&config)) {
+        return;
+    }
+
+    configRead(&config, path, false);
+    configSetInt(&config, kLoadSaveSlotDataSection, kLoadSaveSlotDataKey, _slot_cursor);
+    configWrite(&config, path, false);
+    configFree(&config);
+}
+
 // 0x47B7E4
 void _InitLoadSave()
 {
     _quick_done = false;
-    _slot_cursor = 0;
     _patches = settings.system.master_patches_path.c_str();
+    loadSaveRememberSelectedSlot();
 
     MapDirErase("MAPS\\", "SAV");
     MapDirErase(PROTO_DIR_NAME "\\" CRITTERS_DIR_NAME "\\", PROTO_FILE_EXT);
@@ -1768,6 +1820,8 @@ static int lsgWindowInit(int windowType)
 // 0x47D824
 static int lsgWindowFree(int windowType)
 {
+    loadSavePersistSelectedSlot();
+
     windowDestroy(gLoadSaveWindow);
     fontSetCurrent(gLoadSaveWindowOldFont);
     messageListFree(&gLoadSaveMessageList);

--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -365,7 +365,7 @@ static void loadSaveRememberSelectedSlot()
     snprintf(path, sizeof(path), "%s\\%s", _patches, kLoadSaveSlotDataFile);
 
     int slot = 0;
-    if (ScopedConfig config{ path, false }; config) {
+    if (ScopedConfig config { path, false }; config) {
         configGetInt(config, kLoadSaveSlotDataSection, kLoadSaveSlotDataKey, &slot, 0);
     }
 
@@ -384,7 +384,7 @@ static void loadSavePersistSelectedSlot()
     char path[COMPAT_MAX_PATH];
     snprintf(path, sizeof(path), "%s\\%s", _patches, kLoadSaveSlotDataFile);
 
-    ScopedConfig config{ path, false };
+    ScopedConfig config { path, false };
     if (!config.isInitialized()) {
         return;
     }

--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -366,7 +366,7 @@ static void loadSaveRememberSelectedSlot()
 
     int slot = 0;
     if (ScopedConfig config { path, false }; config) {
-        configGetInt(config, kLoadSaveSlotDataSection, kLoadSaveSlotDataKey, &slot, 0);
+        configGetInt(config.get(), kLoadSaveSlotDataSection, kLoadSaveSlotDataKey, &slot, 0);
     }
 
     _slot_cursor = std::clamp(slot, 0, saveLoadTotalSlots - 1);
@@ -389,8 +389,8 @@ static void loadSavePersistSelectedSlot()
         return;
     }
 
-    configSetInt(config, kLoadSaveSlotDataSection, kLoadSaveSlotDataKey, _slot_cursor);
-    configWrite(config, path, false);
+    configSetInt(config.get(), kLoadSaveSlotDataSection, kLoadSaveSlotDataKey, _slot_cursor);
+    configWrite(config.get(), path, false);
 }
 
 // 0x47B7E4

--- a/src/sfall_ini.cc
+++ b/src/sfall_ini.cc
@@ -75,8 +75,8 @@ static bool is_system_file_name(const char* fileName)
 
 // Loads an INI file specified by 'ini_file_name' (e.g., "myconfig.ini" or "ddraw.ini")
 // into the provided 'config_out' object.
-// The 'config_out' object must be initialized by the caller (using configInit).
-// The caller is also responsible for freeing 'config_out' (using configFree).
+// The caller must provide a live config instance and keep it alive while the
+// loaded values are being read.
 // Returns true if the file was successfully found and read, false otherwise.
 static bool sfall_load_named_ini_file(const char* ini_file_name, Config* config_out)
 {
@@ -142,12 +142,12 @@ static bool sfall_ini_get_string_internal(const char* triplet, char* value, size
         return false;
     }
 
-    Config config;
-    if (!configInit(&config)) {
+    ScopedConfig config;
+    if (!config) {
         return false;
     }
 
-    bool loaded = sfall_load_named_ini_file(fileName, &config);
+    bool loaded = sfall_load_named_ini_file(fileName, config);
 
     // NOTE: Sfall's `GetIniSetting` returns error code (-1) only when it cannot
     // parse triplet. Otherwise the default for string settings is empty string.
@@ -155,7 +155,7 @@ static bool sfall_ini_get_string_internal(const char* triplet, char* value, size
 
     if (loaded) {
         char* stringValue;
-        if (configGetString(&config, section, key, &stringValue)) {
+        if (configGetString(config, section, key, &stringValue)) {
             strncpy(value, stringValue, size - 1);
             value[size - 1] = '\0';
             if (found != nullptr) {
@@ -163,8 +163,6 @@ static bool sfall_ini_get_string_internal(const char* triplet, char* value, size
             }
         }
     }
-
-    configFree(&config);
 
     return true;
 }
@@ -212,8 +210,8 @@ bool sfall_ini_set_string(const char* triplet, const char* value)
         return false;
     }
 
-    Config config;
-    if (!configInit(&config)) {
+    ScopedConfig config;
+    if (!config) {
         return false;
     }
 
@@ -223,7 +221,7 @@ bool sfall_ini_set_string(const char* triplet, const char* value)
     if (basePath[0] != '\0' && !is_system_file_name(fileName)) {
         // Attempt to load requested file in base directory.
         snprintf(path, sizeof(path), "%s\\%s", basePath, fileName);
-        loaded = configRead(&config, path, false);
+        loaded = configRead(config, path, false);
     }
 
     if (!loaded) {
@@ -231,14 +229,12 @@ bool sfall_ini_set_string(const char* triplet, const char* value)
         // non-system config file was not found the base path - attempt to load
         // from current working directory.
         strcpy(path, fileName);
-        loaded = configRead(&config, path, false);
+        loaded = configRead(config, path, false);
     }
 
-    configSetString(&config, section, key, value);
+    configSetString(config, section, key, value);
 
-    bool saved = configWrite(&config, path, false);
-
-    configFree(&config);
+    bool saved = configWrite(config, path, false);
 
     return saved;
 }
@@ -296,15 +292,15 @@ void mf_get_ini_section(OpcodeContext& ctx)
         return;
     }
 
-    Config iniConfig;
-    if (!configInit(&iniConfig)) {
+    ScopedConfig iniConfig;
+    if (!iniConfig) {
         debugPrint("mf_get_ini_section: Failed to initialize Config structure.");
         ctx.setReturn(arrayId);
         return;
     }
 
-    if (sfall_load_named_ini_file(filePath, &iniConfig)) {
-        const ConfigSection* section = sfall_find_section_in_config(&iniConfig, sectionName);
+    if (sfall_load_named_ini_file(filePath, iniConfig)) {
+        const ConfigSection* section = sfall_find_section_in_config(iniConfig, sectionName);
 
         if (section != nullptr) {
             for (int i = 0; i < section->entriesLength; ++i) {
@@ -318,8 +314,6 @@ void mf_get_ini_section(OpcodeContext& ctx)
             }
         }
     }
-
-    configFree(&iniConfig);
 
     ctx.setReturn(arrayId);
 }
@@ -336,19 +330,19 @@ void mf_get_ini_sections(OpcodeContext& ctx)
         return;
     }
 
-    Config iniConfig;
-    if (!configInit(&iniConfig)) {
+    ScopedConfig iniConfig;
+    if (!iniConfig) {
         debugPrint("mf_get_ini_sections: Failed to initialize Config structure.");
         ctx.setReturn(arrayId);
         return;
     }
 
     // note: seems to load sections in random order
-    if (sfall_load_named_ini_file(filePath, &iniConfig)) {
-        if (iniConfig.entriesLength > 0) {
-            arrayId = CreateTempArray(iniConfig.entriesLength, 0);
-            for (int i = 0; i < iniConfig.entriesLength; ++i) {
-                DictionaryEntry* entry = &(iniConfig.entries[i]);
+    if (sfall_load_named_ini_file(filePath, iniConfig)) {
+        if (iniConfig->entriesLength > 0) {
+            arrayId = CreateTempArray(iniConfig->entriesLength, 0);
+            for (int i = 0; i < iniConfig->entriesLength; ++i) {
+                DictionaryEntry* entry = &(iniConfig->entries[i]);
                 const char* sectionName = entry->key;
 
                 if (sectionName != nullptr) {
@@ -357,8 +351,6 @@ void mf_get_ini_sections(OpcodeContext& ctx)
             }
         }
     }
-
-    configFree(&iniConfig);
 
     if (arrayId == -1) {
         arrayId = CreateTempArray(0, 0);

--- a/src/sfall_ini.cc
+++ b/src/sfall_ini.cc
@@ -147,7 +147,7 @@ static bool sfall_ini_get_string_internal(const char* triplet, char* value, size
         return false;
     }
 
-    bool loaded = sfall_load_named_ini_file(fileName, config);
+    bool loaded = sfall_load_named_ini_file(fileName, config.get());
 
     // NOTE: Sfall's `GetIniSetting` returns error code (-1) only when it cannot
     // parse triplet. Otherwise the default for string settings is empty string.
@@ -155,7 +155,7 @@ static bool sfall_ini_get_string_internal(const char* triplet, char* value, size
 
     if (loaded) {
         char* stringValue;
-        if (configGetString(config, section, key, &stringValue)) {
+        if (configGetString(config.get(), section, key, &stringValue)) {
             strncpy(value, stringValue, size - 1);
             value[size - 1] = '\0';
             if (found != nullptr) {
@@ -221,7 +221,7 @@ bool sfall_ini_set_string(const char* triplet, const char* value)
     if (basePath[0] != '\0' && !is_system_file_name(fileName)) {
         // Attempt to load requested file in base directory.
         snprintf(path, sizeof(path), "%s\\%s", basePath, fileName);
-        loaded = configRead(config, path, false);
+        loaded = configRead(config.get(), path, false);
     }
 
     if (!loaded) {
@@ -229,12 +229,12 @@ bool sfall_ini_set_string(const char* triplet, const char* value)
         // non-system config file was not found the base path - attempt to load
         // from current working directory.
         strcpy(path, fileName);
-        loaded = configRead(config, path, false);
+        loaded = configRead(config.get(), path, false);
     }
 
-    configSetString(config, section, key, value);
+    configSetString(config.get(), section, key, value);
 
-    bool saved = configWrite(config, path, false);
+    bool saved = configWrite(config.get(), path, false);
 
     return saved;
 }
@@ -299,8 +299,8 @@ void mf_get_ini_section(OpcodeContext& ctx)
         return;
     }
 
-    if (sfall_load_named_ini_file(filePath, iniConfig)) {
-        const ConfigSection* section = sfall_find_section_in_config(iniConfig, sectionName);
+    if (sfall_load_named_ini_file(filePath, iniConfig.get())) {
+        const ConfigSection* section = sfall_find_section_in_config(iniConfig.get(), sectionName);
 
         if (section != nullptr) {
             for (int i = 0; i < section->entriesLength; ++i) {
@@ -338,11 +338,11 @@ void mf_get_ini_sections(OpcodeContext& ctx)
     }
 
     // note: seems to load sections in random order
-    if (sfall_load_named_ini_file(filePath, iniConfig)) {
-        if (iniConfig->entriesLength > 0) {
-            arrayId = CreateTempArray(iniConfig->entriesLength, 0);
-            for (int i = 0; i < iniConfig->entriesLength; ++i) {
-                DictionaryEntry* entry = &(iniConfig->entries[i]);
+    if (sfall_load_named_ini_file(filePath, iniConfig.get())) {
+        if (iniConfig.get()->entriesLength > 0) {
+            arrayId = CreateTempArray(iniConfig.get()->entriesLength, 0);
+            for (int i = 0; i < iniConfig.get()->entriesLength; ++i) {
+                DictionaryEntry* entry = &(iniConfig.get()->entries[i]);
                 const char* sectionName = entry->key;
 
                 if (sectionName != nullptr) {


### PR DESCRIPTION
Same as Sfall, but not gated behind `ExtraSaveSlots` (CE's extra slots aren't gated by config)

In commit 2, added an RAII accessor for Config, which avoids the init/read/free dance for one-off config reads.  If we end up liking it, there are a few dozen places in the code base that would be slightly nicer—several use `goto` for cleanup now.

If this seems too finicky, commit 1 is the most straightforward option.