### PR TITLE
Fix aiPacketRead inducing crash when loading saves in certain order

### DIFF
--- a/src/combat_ai.cc
+++ b/src/combat_ai.cc
@@ -615,7 +615,8 @@ int aiSave(File* stream)
 // 0x427BC8
 static int aiPacketRead(File* stream, AiPacket* ai)
 {
-    if (fileReadInt32(stream, &(ai->packet_num)) == -1) return -1;
+    int packetNum;
+    if (fileReadInt32(stream, &packetNum) == -1) return -1;
     if (fileReadInt32(stream, &(ai->max_dist)) == -1) return -1;
     if (fileReadInt32(stream, &(ai->min_to_hit)) == -1) return -1;
     if (fileReadInt32(stream, &(ai->min_hp)) == -1) return -1;

--- a/src/combat_ai.cc
+++ b/src/combat_ai.cc
@@ -617,6 +617,12 @@ static int aiPacketRead(File* stream, AiPacket* ai)
 {
     int packetNum;
     if (fileReadInt32(stream, &packetNum) == -1) return -1;
+
+    // Consume the serialized packet number to preserve save compatibility,
+    // but do not overwrite the value in AiPacket to avoid corrupted data on save loads.
+    // This might happen if saves disagree on packet_num and packets are loaded from AI.TXT only on game init.
+    (void)packetNum;
+
     if (fileReadInt32(stream, &(ai->max_dist)) == -1) return -1;
     if (fileReadInt32(stream, &(ai->min_to_hit)) == -1) return -1;
     if (fileReadInt32(stream, &(ai->min_hp)) == -1) return -1;


### PR DESCRIPTION
Fix aiPacketRead overwriting packet_num from savegames, leading to corrupted state on subsequent loads and crash.

What happens:

- ai.txt is a source of truth for AI packets. But it's only loaded once on game init, not between save loads.
- saves store party member AI packets in the main save stream, that drives master_load_list.
- when loading a save, packet_num is being loaded directly into AI Packet object (previously loaded from txt).
- when loading a different save next, packet_num is used in aiGetPacketByNum to match against number stored in party member's proto
- if the first save happened to have different packet_num than the second for a party member, the stream becomes incoherent, leading to crash down the line

Alternative fix was to re-load ai.txt in aiReset but I thought this was a simpler and more efficient option.
