### PR TITLE
Use `ScopeConfig` for function-scoped Config uses

### DIFF
--- a/src/combat.cc
+++ b/src/combat.cc
@@ -6596,41 +6596,39 @@ static void unarmedInitCustom()
 {
     char* unarmedFileName = nullptr;
     configGetString(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_UNARMED_FILE_KEY, &unarmedFileName);
-    if (unarmedFileName != nullptr && *unarmedFileName == '\0') {
-        unarmedFileName = nullptr;
-    }
-
-    if (unarmedFileName == nullptr) {
+    if (unarmedFileName == nullptr || *unarmedFileName == '\0') {
         return;
     }
 
     ScopedConfig unarmedConfig(unarmedFileName, false);
-    if (unarmedConfig) {
-        char section[4];
-        char statKey[6];
+    if (!unarmedConfig) {
+        return;
+    }
 
-        for (int hitMode = 0; hitMode < HIT_MODE_COUNT; hitMode++) {
-            if (!isUnarmedHitMode(hitMode)) {
-                continue;
-            }
+    char section[4];
+    char statKey[6];
 
-            UnarmedHitDescription* hitDescription = &(gUnarmedHitDescriptions[hitMode]);
-            snprintf(section, sizeof(section), "%d", hitMode);
+    for (int hitMode = 0; hitMode < HIT_MODE_COUNT; hitMode++) {
+        if (!isUnarmedHitMode(hitMode)) {
+            continue;
+        }
 
-            configGetInt(unarmedConfig.get(), section, "ReqLevel", &(hitDescription->requiredLevel));
-            configGetInt(unarmedConfig.get(), section, "SkillLevel", &(hitDescription->requiredSkill));
-            configGetInt(unarmedConfig.get(), section, "MinDamage", &(hitDescription->minDamage));
-            configGetInt(unarmedConfig.get(), section, "MaxDamage", &(hitDescription->maxDamage));
-            configGetInt(unarmedConfig.get(), section, "BonusDamage", &(hitDescription->bonusDamage));
-            configGetInt(unarmedConfig.get(), section, "BonusCrit", &(hitDescription->bonusCriticalChance));
-            configGetInt(unarmedConfig.get(), section, "APCost", &(hitDescription->actionPointCost));
-            configGetBool(unarmedConfig.get(), section, "BonusDamage", &(hitDescription->isPenetrate));
-            configGetBool(unarmedConfig.get(), section, "Secondary", &(hitDescription->isSecondary));
+        UnarmedHitDescription* hitDescription = &(gUnarmedHitDescriptions[hitMode]);
+        snprintf(section, sizeof(section), "%d", hitMode);
 
-            for (int stat = 0; stat < PRIMARY_STAT_COUNT; stat++) {
-                snprintf(statKey, sizeof(statKey), "Stat%d", stat);
-                configGetInt(unarmedConfig.get(), section, statKey, &(hitDescription->requiredStats[stat]));
-            }
+        configGetInt(unarmedConfig.get(), section, "ReqLevel", &(hitDescription->requiredLevel));
+        configGetInt(unarmedConfig.get(), section, "SkillLevel", &(hitDescription->requiredSkill));
+        configGetInt(unarmedConfig.get(), section, "MinDamage", &(hitDescription->minDamage));
+        configGetInt(unarmedConfig.get(), section, "MaxDamage", &(hitDescription->maxDamage));
+        configGetInt(unarmedConfig.get(), section, "BonusDamage", &(hitDescription->bonusDamage));
+        configGetInt(unarmedConfig.get(), section, "BonusCrit", &(hitDescription->bonusCriticalChance));
+        configGetInt(unarmedConfig.get(), section, "APCost", &(hitDescription->actionPointCost));
+        configGetBool(unarmedConfig.get(), section, "BonusDamage", &(hitDescription->isPenetrate));
+        configGetBool(unarmedConfig.get(), section, "Secondary", &(hitDescription->isSecondary));
+
+        for (int stat = 0; stat < PRIMARY_STAT_COUNT; stat++) {
+            snprintf(statKey, sizeof(statKey), "Stat%d", stat);
+            configGetInt(unarmedConfig.get(), section, statKey, &(hitDescription->requiredStats[stat]));
         }
     }
 }

--- a/src/combat.cc
+++ b/src/combat.cc
@@ -6254,79 +6254,75 @@ static void criticalsInit()
     }
 
     if (mode == 1 || mode == 3) {
-        Config criticalsConfig;
-        if (configInit(&criticalsConfig)) {
-            char* criticalsConfigFilePath;
-            configGetString(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_OVERRIDE_CRITICALS_FILE_KEY, &criticalsConfigFilePath);
-            if (criticalsConfigFilePath != nullptr && *criticalsConfigFilePath == '\0') {
-                criticalsConfigFilePath = nullptr;
-            }
+        char* criticalsConfigFilePath;
+        configGetString(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_OVERRIDE_CRITICALS_FILE_KEY, &criticalsConfigFilePath);
+        if (criticalsConfigFilePath != nullptr && *criticalsConfigFilePath == '\0') {
+            criticalsConfigFilePath = nullptr;
+        }
 
-            if (configRead(&criticalsConfig, criticalsConfigFilePath, false)) {
-                if (mode == 1) {
-                    char sectionKey[16];
+        ScopedConfig criticalsConfig(criticalsConfigFilePath, false);
+        if (criticalsConfig) {
+            if (mode == 1) {
+                char sectionKey[16];
 
-                    // Read original kill types (19) plus one for the player.
-                    for (int killType = 0; killType < KILL_TYPE_COUNT + 1; killType++) {
-                        for (int hitLocation = 0; hitLocation < HIT_LOCATION_COUNT; hitLocation++) {
-                            for (int effect = 0; effect < CRTICIAL_EFFECT_COUNT; effect++) {
-                                snprintf(sectionKey, sizeof(sectionKey), "c_%02d_%d_%d", killType, hitLocation, effect);
+                // Read original kill types (19) plus one for the player.
+                for (int killType = 0; killType < KILL_TYPE_COUNT + 1; killType++) {
+                    for (int hitLocation = 0; hitLocation < HIT_LOCATION_COUNT; hitLocation++) {
+                        for (int effect = 0; effect < CRTICIAL_EFFECT_COUNT; effect++) {
+                            snprintf(sectionKey, sizeof(sectionKey), "c_%02d_%d_%d", killType, hitLocation, effect);
 
-                                // Update player kill type if needed.
-                                int newKillType = killType == KILL_TYPE_COUNT ? SFALL_KILL_TYPE_COUNT : killType;
-                                for (int dataMember = 0; dataMember < CRIT_DATA_MEMBER_COUNT; dataMember++) {
-                                    int value = criticalsGetValue(newKillType, hitLocation, effect, dataMember);
-                                    if (configGetInt(&criticalsConfig, sectionKey, gCritDataMemberKeys[dataMember], &value)) {
-                                        criticalsSetValue(newKillType, hitLocation, effect, dataMember, value);
-                                    }
+                            // Update player kill type if needed.
+                            int newKillType = killType == KILL_TYPE_COUNT ? SFALL_KILL_TYPE_COUNT : killType;
+                            for (int dataMember = 0; dataMember < CRIT_DATA_MEMBER_COUNT; dataMember++) {
+                                int value = criticalsGetValue(newKillType, hitLocation, effect, dataMember);
+                                if (configGetInt(criticalsConfig.get(), sectionKey, gCritDataMemberKeys[dataMember], &value)) {
+                                    criticalsSetValue(newKillType, hitLocation, effect, dataMember, value);
                                 }
                             }
                         }
                     }
-                } else if (mode == 3) {
-                    char ktSectionKey[32];
-                    char hitLocationSectionKey[32];
-                    char key[32];
+                }
+            } else if (mode == 3) {
+                char ktSectionKey[32];
+                char hitLocationSectionKey[32];
+                char key[32];
 
-                    // Read Sfall kill types (38) plus one for the player.
-                    for (int killType = 0; killType < SFALL_KILL_TYPE_COUNT + 1; killType++) {
-                        snprintf(ktSectionKey, sizeof(ktSectionKey), "c_%02d", killType);
+                // Read Sfall kill types (38) plus one for the player.
+                for (int killType = 0; killType < SFALL_KILL_TYPE_COUNT + 1; killType++) {
+                    snprintf(ktSectionKey, sizeof(ktSectionKey), "c_%02d", killType);
 
-                        int enabled = 0;
-                        configGetInt(&criticalsConfig, ktSectionKey, "Enabled", &enabled);
-                        if (enabled == 0) {
-                            continue;
+                    int enabled = 0;
+                    configGetInt(criticalsConfig.get(), ktSectionKey, "Enabled", &enabled);
+                    if (enabled == 0) {
+                        continue;
+                    }
+
+                    for (int hitLocation = 0; hitLocation < HIT_LOCATION_COUNT; hitLocation++) {
+                        if (enabled < 2) {
+                            bool hitLocationChanged = false;
+
+                            snprintf(key, sizeof(key), "Part_%d", hitLocation);
+                            configGetBool(criticalsConfig.get(), ktSectionKey, key, &hitLocationChanged);
+
+                            if (!hitLocationChanged) {
+                                continue;
+                            }
                         }
 
-                        for (int hitLocation = 0; hitLocation < HIT_LOCATION_COUNT; hitLocation++) {
-                            if (enabled < 2) {
-                                bool hitLocationChanged = false;
+                        snprintf(hitLocationSectionKey, sizeof(hitLocationSectionKey), "c_%02d_%d", killType, hitLocation);
 
-                                snprintf(key, sizeof(key), "Part_%d", hitLocation);
-                                configGetBool(&criticalsConfig, ktSectionKey, key, &hitLocationChanged);
-
-                                if (!hitLocationChanged) {
-                                    continue;
-                                }
-                            }
-
-                            snprintf(hitLocationSectionKey, sizeof(hitLocationSectionKey), "c_%02d_%d", killType, hitLocation);
-
-                            for (int effect = 0; effect < CRTICIAL_EFFECT_COUNT; effect++) {
-                                for (int dataMember = 0; dataMember < CRIT_DATA_MEMBER_COUNT; dataMember++) {
-                                    int value = criticalsGetValue(killType, hitLocation, effect, dataMember);
-                                    snprintf(key, sizeof(key), "e%d_%s", effect, gCritDataMemberKeys[dataMember]);
-                                    if (configGetInt(&criticalsConfig, hitLocationSectionKey, key, &value)) {
-                                        criticalsSetValue(killType, hitLocation, effect, dataMember, value);
-                                    }
+                        for (int effect = 0; effect < CRTICIAL_EFFECT_COUNT; effect++) {
+                            for (int dataMember = 0; dataMember < CRIT_DATA_MEMBER_COUNT; dataMember++) {
+                                int value = criticalsGetValue(killType, hitLocation, effect, dataMember);
+                                snprintf(key, sizeof(key), "e%d_%s", effect, gCritDataMemberKeys[dataMember]);
+                                if (configGetInt(criticalsConfig.get(), hitLocationSectionKey, key, &value)) {
+                                    criticalsSetValue(killType, hitLocation, effect, dataMember, value);
                                 }
                             }
                         }
                     }
                 }
             }
-
-            configFree(&criticalsConfig);
         }
     }
 
@@ -6608,38 +6604,34 @@ static void unarmedInitCustom()
         return;
     }
 
-    Config unarmedConfig;
-    if (configInit(&unarmedConfig)) {
-        if (configRead(&unarmedConfig, unarmedFileName, false)) {
-            char section[4];
-            char statKey[6];
+    ScopedConfig unarmedConfig(unarmedFileName, false);
+    if (unarmedConfig) {
+        char section[4];
+        char statKey[6];
 
-            for (int hitMode = 0; hitMode < HIT_MODE_COUNT; hitMode++) {
-                if (!isUnarmedHitMode(hitMode)) {
-                    continue;
-                }
+        for (int hitMode = 0; hitMode < HIT_MODE_COUNT; hitMode++) {
+            if (!isUnarmedHitMode(hitMode)) {
+                continue;
+            }
 
-                UnarmedHitDescription* hitDescription = &(gUnarmedHitDescriptions[hitMode]);
-                snprintf(section, sizeof(section), "%d", hitMode);
+            UnarmedHitDescription* hitDescription = &(gUnarmedHitDescriptions[hitMode]);
+            snprintf(section, sizeof(section), "%d", hitMode);
 
-                configGetInt(&unarmedConfig, section, "ReqLevel", &(hitDescription->requiredLevel));
-                configGetInt(&unarmedConfig, section, "SkillLevel", &(hitDescription->requiredSkill));
-                configGetInt(&unarmedConfig, section, "MinDamage", &(hitDescription->minDamage));
-                configGetInt(&unarmedConfig, section, "MaxDamage", &(hitDescription->maxDamage));
-                configGetInt(&unarmedConfig, section, "BonusDamage", &(hitDescription->bonusDamage));
-                configGetInt(&unarmedConfig, section, "BonusCrit", &(hitDescription->bonusCriticalChance));
-                configGetInt(&unarmedConfig, section, "APCost", &(hitDescription->actionPointCost));
-                configGetBool(&unarmedConfig, section, "BonusDamage", &(hitDescription->isPenetrate));
-                configGetBool(&unarmedConfig, section, "Secondary", &(hitDescription->isSecondary));
+            configGetInt(unarmedConfig.get(), section, "ReqLevel", &(hitDescription->requiredLevel));
+            configGetInt(unarmedConfig.get(), section, "SkillLevel", &(hitDescription->requiredSkill));
+            configGetInt(unarmedConfig.get(), section, "MinDamage", &(hitDescription->minDamage));
+            configGetInt(unarmedConfig.get(), section, "MaxDamage", &(hitDescription->maxDamage));
+            configGetInt(unarmedConfig.get(), section, "BonusDamage", &(hitDescription->bonusDamage));
+            configGetInt(unarmedConfig.get(), section, "BonusCrit", &(hitDescription->bonusCriticalChance));
+            configGetInt(unarmedConfig.get(), section, "APCost", &(hitDescription->actionPointCost));
+            configGetBool(unarmedConfig.get(), section, "BonusDamage", &(hitDescription->isPenetrate));
+            configGetBool(unarmedConfig.get(), section, "Secondary", &(hitDescription->isSecondary));
 
-                for (int stat = 0; stat < PRIMARY_STAT_COUNT; stat++) {
-                    snprintf(statKey, sizeof(statKey), "Stat%d", stat);
-                    configGetInt(&unarmedConfig, section, statKey, &(hitDescription->requiredStats[stat]));
-                }
+            for (int stat = 0; stat < PRIMARY_STAT_COUNT; stat++) {
+                snprintf(statKey, sizeof(statKey), "Stat%d", stat);
+                configGetInt(unarmedConfig.get(), section, statKey, &(hitDescription->requiredStats[stat]));
             }
         }
-
-        configFree(&unarmedConfig);
     }
 }
 

--- a/src/combat.cc
+++ b/src/combat.cc
@@ -6625,41 +6625,39 @@ static void unarmedInitCustom()
 {
     char* unarmedFileName = nullptr;
     configGetString(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_UNARMED_FILE_KEY, &unarmedFileName);
-    if (unarmedFileName != nullptr && *unarmedFileName == '\0') {
-        unarmedFileName = nullptr;
-    }
-
-    if (unarmedFileName == nullptr) {
+    if (unarmedFileName == nullptr || *unarmedFileName == '\0') {
         return;
     }
 
     ScopedConfig unarmedConfig(unarmedFileName, false);
-    if (unarmedConfig) {
-        char section[4];
-        char statKey[6];
+    if (!unarmedConfig) {
+        return;
+    }
 
-        for (HitMode hitMode = HIT_MODE_FIRST; hitMode < HIT_MODE_COUNT; hitMode++) {
-            if (!isUnarmedHitMode(hitMode)) {
-                continue;
-            }
+    char section[4];
+    char statKey[6];
 
-            UnarmedHitDescription* hitDescription = &(gUnarmedHitDescriptions[hitMode]);
-            snprintf(section, sizeof(section), "%d", hitMode);
+    for (HitMode hitMode = HIT_MODE_FIRST; hitMode < HIT_MODE_COUNT; hitMode++) {
+        if (!isUnarmedHitMode(hitMode)) {
+            continue;
+        }
 
-            configGetInt(unarmedConfig.get(), section, "ReqLevel", &(hitDescription->requiredLevel));
-            configGetInt(unarmedConfig.get(), section, "SkillLevel", &(hitDescription->requiredSkill));
-            configGetInt(unarmedConfig.get(), section, "MinDamage", &(hitDescription->minDamage));
-            configGetInt(unarmedConfig.get(), section, "MaxDamage", &(hitDescription->maxDamage));
-            configGetInt(unarmedConfig.get(), section, "BonusDamage", &(hitDescription->bonusDamage));
-            configGetInt(unarmedConfig.get(), section, "BonusCrit", &(hitDescription->bonusCriticalChance));
-            configGetInt(unarmedConfig.get(), section, "APCost", &(hitDescription->actionPointCost));
-            configGetBool(unarmedConfig.get(), section, "BonusDamage", &(hitDescription->isPenetrate));
-            configGetBool(unarmedConfig.get(), section, "Secondary", &(hitDescription->isSecondary));
+        UnarmedHitDescription* hitDescription = &(gUnarmedHitDescriptions[hitMode]);
+        snprintf(section, sizeof(section), "%d", hitMode);
 
-            for (Stat stat = STAT_FIRST; stat < PRIMARY_STAT_COUNT; stat++) {
-                snprintf(statKey, sizeof(statKey), "Stat%d", stat);
-                configGetInt(unarmedConfig.get(), section, statKey, &(hitDescription->requiredStats[stat]));
-            }
+        configGetInt(unarmedConfig.get(), section, "ReqLevel", &(hitDescription->requiredLevel));
+        configGetInt(unarmedConfig.get(), section, "SkillLevel", &(hitDescription->requiredSkill));
+        configGetInt(unarmedConfig.get(), section, "MinDamage", &(hitDescription->minDamage));
+        configGetInt(unarmedConfig.get(), section, "MaxDamage", &(hitDescription->maxDamage));
+        configGetInt(unarmedConfig.get(), section, "BonusDamage", &(hitDescription->bonusDamage));
+        configGetInt(unarmedConfig.get(), section, "BonusCrit", &(hitDescription->bonusCriticalChance));
+        configGetInt(unarmedConfig.get(), section, "APCost", &(hitDescription->actionPointCost));
+        configGetBool(unarmedConfig.get(), section, "BonusDamage", &(hitDescription->isPenetrate));
+        configGetBool(unarmedConfig.get(), section, "Secondary", &(hitDescription->isSecondary));
+
+        for (Stat stat = STAT_FIRST; stat < PRIMARY_STAT_COUNT; stat++) {
+            snprintf(statKey, sizeof(statKey), "Stat%d", stat);
+            configGetInt(unarmedConfig.get(), section, statKey, &(hitDescription->requiredStats[stat]));
         }
     }
 }

--- a/src/combat.cc
+++ b/src/combat.cc
@@ -6283,79 +6283,75 @@ static void criticalsInit()
     }
 
     if (mode == 1 || mode == 3) {
-        Config criticalsConfig;
-        if (configInit(&criticalsConfig)) {
-            char* criticalsConfigFilePath;
-            configGetString(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_OVERRIDE_CRITICALS_FILE_KEY, &criticalsConfigFilePath);
-            if (criticalsConfigFilePath != nullptr && *criticalsConfigFilePath == '\0') {
-                criticalsConfigFilePath = nullptr;
-            }
+        char* criticalsConfigFilePath;
+        configGetString(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_OVERRIDE_CRITICALS_FILE_KEY, &criticalsConfigFilePath);
+        if (criticalsConfigFilePath != nullptr && *criticalsConfigFilePath == '\0') {
+            criticalsConfigFilePath = nullptr;
+        }
 
-            if (configRead(&criticalsConfig, criticalsConfigFilePath, false)) {
-                if (mode == 1) {
-                    char sectionKey[16];
+        ScopedConfig criticalsConfig(criticalsConfigFilePath, false);
+        if (criticalsConfig) {
+            if (mode == 1) {
+                char sectionKey[16];
 
-                    // Read original kill types (19) plus one for the player.
-                    for (KillType killType = KILL_TYPE_FIRST; killType < KILL_TYPE_DEFAULT_COUNT + 1; killType++) {
-                        for (HitLocation hitLocation = HIT_LOCATION_FIRST; hitLocation < HIT_LOCATION_COUNT; hitLocation++) {
-                            for (CriticalEffect effect = CRITICAL_EFFECT_FIRST; effect < CRITICAL_EFFECT_COUNT; effect++) {
-                                snprintf(sectionKey, sizeof(sectionKey), "c_%02d_%d_%d", killType, hitLocation, effect);
+                // Read original kill types (19) plus one for the player.
+                for (KillType killType = KILL_TYPE_FIRST; killType < KILL_TYPE_DEFAULT_COUNT + 1; killType++) {
+                    for (HitLocation hitLocation = HIT_LOCATION_FIRST; hitLocation < HIT_LOCATION_COUNT; hitLocation++) {
+                        for (CriticalEffect effect = CRITICAL_EFFECT_FIRST; effect < CRITICAL_EFFECT_COUNT; effect++) {
+                            snprintf(sectionKey, sizeof(sectionKey), "c_%02d_%d_%d", killType, hitLocation, effect);
 
-                                // Update player kill type if needed.
-                                KillType newKillType = killType == KILL_TYPE_DEFAULT_COUNT ? KILL_TYPE_PLAYER : killType;
-                                for (CriticalHitDataMember dataMember = CRIT_DATA_MEMBER_FIRST; dataMember < CRIT_DATA_MEMBER_COUNT; dataMember++) {
-                                    int value = criticalsGetValue(newKillType, hitLocation, effect, dataMember);
-                                    if (configGetInt(&criticalsConfig, sectionKey, gCritDataMemberKeys[dataMember], &value)) {
-                                        criticalsSetValue(newKillType, hitLocation, effect, dataMember, value);
-                                    }
+                            // Update player kill type if needed.
+                            KillType newKillType = killType == KILL_TYPE_DEFAULT_COUNT ? KILL_TYPE_PLAYER : killType;
+                            for (CriticalHitDataMember dataMember = CRIT_DATA_MEMBER_FIRST; dataMember < CRIT_DATA_MEMBER_COUNT; dataMember++) {
+                                int value = criticalsGetValue(newKillType, hitLocation, effect, dataMember);
+                                if (configGetInt(criticalsConfig.get(), sectionKey, gCritDataMemberKeys[dataMember], &value)) {
+                                    criticalsSetValue(newKillType, hitLocation, effect, dataMember, value);
                                 }
                             }
                         }
                     }
-                } else if (mode == 3) {
-                    char ktSectionKey[32];
-                    char hitLocationSectionKey[32];
-                    char key[32];
+                }
+            } else if (mode == 3) {
+                char ktSectionKey[32];
+                char hitLocationSectionKey[32];
+                char key[32];
 
-                    // Read Sfall kill types (38) plus one for the player.
-                    for (KillType killType = KILL_TYPE_FIRST; killType < KILL_TYPE_OVERRIDE_COUNT + 1; killType++) {
-                        snprintf(ktSectionKey, sizeof(ktSectionKey), "c_%02d", killType);
+                // Read Sfall kill types (38) plus one for the player.
+                for (KillType killType = KILL_TYPE_FIRST; killType < KILL_TYPE_OVERRIDE_COUNT + 1; killType++) {
+                    snprintf(ktSectionKey, sizeof(ktSectionKey), "c_%02d", killType);
 
-                        int enabled = 0;
-                        configGetInt(&criticalsConfig, ktSectionKey, "Enabled", &enabled);
-                        if (enabled == 0) {
-                            continue;
+                    int enabled = 0;
+                    configGetInt(criticalsConfig.get(), ktSectionKey, "Enabled", &enabled);
+                    if (enabled == 0) {
+                        continue;
+                    }
+
+                    for (HitLocation hitLocation = HIT_LOCATION_FIRST; hitLocation < HIT_LOCATION_COUNT; hitLocation++) {
+                        if (enabled < 2) {
+                            bool hitLocationChanged = false;
+
+                            snprintf(key, sizeof(key), "Part_%d", hitLocation);
+                            configGetBool(criticalsConfig.get(), ktSectionKey, key, &hitLocationChanged);
+
+                            if (!hitLocationChanged) {
+                                continue;
+                            }
                         }
 
-                        for (HitLocation hitLocation = HIT_LOCATION_FIRST; hitLocation < HIT_LOCATION_COUNT; hitLocation++) {
-                            if (enabled < 2) {
-                                bool hitLocationChanged = false;
+                        snprintf(hitLocationSectionKey, sizeof(hitLocationSectionKey), "c_%02d_%d", killType, hitLocation);
 
-                                snprintf(key, sizeof(key), "Part_%d", hitLocation);
-                                configGetBool(&criticalsConfig, ktSectionKey, key, &hitLocationChanged);
-
-                                if (!hitLocationChanged) {
-                                    continue;
-                                }
-                            }
-
-                            snprintf(hitLocationSectionKey, sizeof(hitLocationSectionKey), "c_%02d_%d", killType, hitLocation);
-
-                            for (CriticalEffect effect = CRITICAL_EFFECT_FIRST; effect < CRITICAL_EFFECT_COUNT; effect++) {
-                                for (CriticalHitDataMember dataMember = CRIT_DATA_MEMBER_FIRST; dataMember < CRIT_DATA_MEMBER_COUNT; dataMember++) {
-                                    int value = criticalsGetValue(killType, hitLocation, effect, dataMember);
-                                    snprintf(key, sizeof(key), "e%d_%s", effect, gCritDataMemberKeys[dataMember]);
-                                    if (configGetInt(&criticalsConfig, hitLocationSectionKey, key, &value)) {
-                                        criticalsSetValue(killType, hitLocation, effect, dataMember, value);
-                                    }
+                        for (CriticalEffect effect = CRITICAL_EFFECT_FIRST; effect < CRITICAL_EFFECT_COUNT; effect++) {
+                            for (CriticalHitDataMember dataMember = CRIT_DATA_MEMBER_FIRST; dataMember < CRIT_DATA_MEMBER_COUNT; dataMember++) {
+                                int value = criticalsGetValue(killType, hitLocation, effect, dataMember);
+                                snprintf(key, sizeof(key), "e%d_%s", effect, gCritDataMemberKeys[dataMember]);
+                                if (configGetInt(criticalsConfig.get(), hitLocationSectionKey, key, &value)) {
+                                    criticalsSetValue(killType, hitLocation, effect, dataMember, value);
                                 }
                             }
                         }
                     }
                 }
             }
-
-            configFree(&criticalsConfig);
         }
     }
 
@@ -6637,38 +6633,34 @@ static void unarmedInitCustom()
         return;
     }
 
-    Config unarmedConfig;
-    if (configInit(&unarmedConfig)) {
-        if (configRead(&unarmedConfig, unarmedFileName, false)) {
-            char section[4];
-            char statKey[6];
+    ScopedConfig unarmedConfig(unarmedFileName, false);
+    if (unarmedConfig) {
+        char section[4];
+        char statKey[6];
 
-            for (HitMode hitMode = HIT_MODE_FIRST; hitMode < HIT_MODE_COUNT; hitMode++) {
-                if (!isUnarmedHitMode(hitMode)) {
-                    continue;
-                }
+        for (HitMode hitMode = HIT_MODE_FIRST; hitMode < HIT_MODE_COUNT; hitMode++) {
+            if (!isUnarmedHitMode(hitMode)) {
+                continue;
+            }
 
-                UnarmedHitDescription* hitDescription = &(gUnarmedHitDescriptions[hitMode]);
-                snprintf(section, sizeof(section), "%d", hitMode);
+            UnarmedHitDescription* hitDescription = &(gUnarmedHitDescriptions[hitMode]);
+            snprintf(section, sizeof(section), "%d", hitMode);
 
-                configGetInt(&unarmedConfig, section, "ReqLevel", &(hitDescription->requiredLevel));
-                configGetInt(&unarmedConfig, section, "SkillLevel", &(hitDescription->requiredSkill));
-                configGetInt(&unarmedConfig, section, "MinDamage", &(hitDescription->minDamage));
-                configGetInt(&unarmedConfig, section, "MaxDamage", &(hitDescription->maxDamage));
-                configGetInt(&unarmedConfig, section, "BonusDamage", &(hitDescription->bonusDamage));
-                configGetInt(&unarmedConfig, section, "BonusCrit", &(hitDescription->bonusCriticalChance));
-                configGetInt(&unarmedConfig, section, "APCost", &(hitDescription->actionPointCost));
-                configGetBool(&unarmedConfig, section, "BonusDamage", &(hitDescription->isPenetrate));
-                configGetBool(&unarmedConfig, section, "Secondary", &(hitDescription->isSecondary));
+            configGetInt(unarmedConfig.get(), section, "ReqLevel", &(hitDescription->requiredLevel));
+            configGetInt(unarmedConfig.get(), section, "SkillLevel", &(hitDescription->requiredSkill));
+            configGetInt(unarmedConfig.get(), section, "MinDamage", &(hitDescription->minDamage));
+            configGetInt(unarmedConfig.get(), section, "MaxDamage", &(hitDescription->maxDamage));
+            configGetInt(unarmedConfig.get(), section, "BonusDamage", &(hitDescription->bonusDamage));
+            configGetInt(unarmedConfig.get(), section, "BonusCrit", &(hitDescription->bonusCriticalChance));
+            configGetInt(unarmedConfig.get(), section, "APCost", &(hitDescription->actionPointCost));
+            configGetBool(unarmedConfig.get(), section, "BonusDamage", &(hitDescription->isPenetrate));
+            configGetBool(unarmedConfig.get(), section, "Secondary", &(hitDescription->isSecondary));
 
-                for (Stat stat = STAT_FIRST; stat < PRIMARY_STAT_COUNT; stat++) {
-                    snprintf(statKey, sizeof(statKey), "Stat%d", stat);
-                    configGetInt(&unarmedConfig, section, statKey, &(hitDescription->requiredStats[stat]));
-                }
+            for (Stat stat = STAT_FIRST; stat < PRIMARY_STAT_COUNT; stat++) {
+                snprintf(statKey, sizeof(statKey), "Stat%d", stat);
+                configGetInt(unarmedConfig.get(), section, statKey, &(hitDescription->requiredStats[stat]));
             }
         }
-
-        configFree(&unarmedConfig);
     }
 }
 

--- a/src/combat_ai.cc
+++ b/src/combat_ai.cc
@@ -378,81 +378,77 @@ int aiInit()
 
     gAiPacketsLength = 0;
 
-    Config config;
-    if (!configInit(&config)) {
+    ScopedConfig config("data\\ai.txt", true);
+    if (!config) {
         return -1;
     }
 
-    if (!configRead(&config, "data\\ai.txt", true)) {
-        return -1;
-    }
-
-    gAiPackets = (AiPacket*)internal_malloc(sizeof(*gAiPackets) * config.entriesLength);
+    gAiPackets = (AiPacket*)internal_malloc(sizeof(*gAiPackets) * config.get()->entriesLength);
     if (gAiPackets == nullptr) {
         goto err;
     }
 
-    for (index = 0; index < config.entriesLength; index++) {
+    for (index = 0; index < config.get()->entriesLength; index++) {
         aiPacketInit(&(gAiPackets[index]));
     }
 
-    for (index = 0; index < config.entriesLength; index++) {
-        DictionaryEntry* sectionEntry = &(config.entries[index]);
+    for (index = 0; index < config.get()->entriesLength; index++) {
+        DictionaryEntry* sectionEntry = &(config.get()->entries[index]);
         AiPacket* ai = &(gAiPackets[index]);
         char* stringValue;
 
         ai->name = internal_strdup(sectionEntry->key);
 
-        if (!configGetInt(&config, sectionEntry->key, "packet_num", &(ai->packet_num))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "max_dist", &(ai->max_dist))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "min_to_hit", &(ai->min_to_hit))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "min_hp", &(ai->min_hp))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "aggression", &(ai->aggression))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "packet_num", &(ai->packet_num))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "max_dist", &(ai->max_dist))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "min_to_hit", &(ai->min_to_hit))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "min_hp", &(ai->min_hp))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "aggression", &(ai->aggression))) goto err;
 
-        if (configGetString(&config, sectionEntry->key, "hurt_too_much", &stringValue)) {
+        if (configGetString(config.get(), sectionEntry->key, "hurt_too_much", &stringValue)) {
             _parse_hurt_str(stringValue, &(ai->hurt_too_much));
         }
 
-        if (!configGetInt(&config, sectionEntry->key, "secondary_freq", &(ai->secondary_freq))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "called_freq", &(ai->called_freq))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "font", &(ai->font))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "color", &(ai->color))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "outline_color", &(ai->outline_color))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "chance", &(ai->chance))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "run_start", &(ai->run.start))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "run_end", &(ai->run.end))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "move_start", &(ai->move.start))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "move_end", &(ai->move.end))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "attack_start", &(ai->attack.start))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "attack_end", &(ai->attack.end))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "miss_start", &(ai->miss.start))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "miss_end", &(ai->miss.end))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_head_start", &(ai->hit[HIT_LOCATION_HEAD].start))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_head_end", &(ai->hit[HIT_LOCATION_HEAD].end))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_left_arm_start", &(ai->hit[HIT_LOCATION_LEFT_ARM].start))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_left_arm_end", &(ai->hit[HIT_LOCATION_LEFT_ARM].end))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_right_arm_start", &(ai->hit[HIT_LOCATION_RIGHT_ARM].start))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_right_arm_end", &(ai->hit[HIT_LOCATION_RIGHT_ARM].end))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_torso_start", &(ai->hit[HIT_LOCATION_TORSO].start))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_torso_end", &(ai->hit[HIT_LOCATION_TORSO].end))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_right_leg_start", &(ai->hit[HIT_LOCATION_RIGHT_LEG].start))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_right_leg_end", &(ai->hit[HIT_LOCATION_RIGHT_LEG].end))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_left_leg_start", &(ai->hit[HIT_LOCATION_LEFT_LEG].start))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_left_leg_end", &(ai->hit[HIT_LOCATION_LEFT_LEG].end))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_eyes_start", &(ai->hit[HIT_LOCATION_EYES].start))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_eyes_end", &(ai->hit[HIT_LOCATION_EYES].end))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_groin_start", &(ai->hit[HIT_LOCATION_GROIN].start))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_groin_end", &(ai->hit[HIT_LOCATION_GROIN].end))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "secondary_freq", &(ai->secondary_freq))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "called_freq", &(ai->called_freq))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "font", &(ai->font))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "color", &(ai->color))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "outline_color", &(ai->outline_color))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "chance", &(ai->chance))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "run_start", &(ai->run.start))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "run_end", &(ai->run.end))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "move_start", &(ai->move.start))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "move_end", &(ai->move.end))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "attack_start", &(ai->attack.start))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "attack_end", &(ai->attack.end))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "miss_start", &(ai->miss.start))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "miss_end", &(ai->miss.end))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_head_start", &(ai->hit[HIT_LOCATION_HEAD].start))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_head_end", &(ai->hit[HIT_LOCATION_HEAD].end))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_left_arm_start", &(ai->hit[HIT_LOCATION_LEFT_ARM].start))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_left_arm_end", &(ai->hit[HIT_LOCATION_LEFT_ARM].end))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_right_arm_start", &(ai->hit[HIT_LOCATION_RIGHT_ARM].start))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_right_arm_end", &(ai->hit[HIT_LOCATION_RIGHT_ARM].end))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_torso_start", &(ai->hit[HIT_LOCATION_TORSO].start))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_torso_end", &(ai->hit[HIT_LOCATION_TORSO].end))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_right_leg_start", &(ai->hit[HIT_LOCATION_RIGHT_LEG].start))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_right_leg_end", &(ai->hit[HIT_LOCATION_RIGHT_LEG].end))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_left_leg_start", &(ai->hit[HIT_LOCATION_LEFT_LEG].start))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_left_leg_end", &(ai->hit[HIT_LOCATION_LEFT_LEG].end))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_eyes_start", &(ai->hit[HIT_LOCATION_EYES].start))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_eyes_end", &(ai->hit[HIT_LOCATION_EYES].end))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_groin_start", &(ai->hit[HIT_LOCATION_GROIN].start))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_groin_end", &(ai->hit[HIT_LOCATION_GROIN].end))) goto err;
 
         ai->hit[HIT_LOCATION_GROIN].end++;
 
-        if (configGetString(&config, sectionEntry->key, "area_attack_mode", &stringValue)) {
+        if (configGetString(config.get(), sectionEntry->key, "area_attack_mode", &stringValue)) {
             _cai_match_str_to_list(stringValue, gAreaAttackModeKeys, AREA_ATTACK_MODE_COUNT, &(ai->area_attack_mode));
         } else {
             ai->area_attack_mode = -1;
         }
 
-        if (configGetString(&config, sectionEntry->key, "run_away_mode", &stringValue)) {
+        if (configGetString(config.get(), sectionEntry->key, "run_away_mode", &stringValue)) {
             _cai_match_str_to_list(stringValue, gRunAwayModeKeys, RUN_AWAY_MODE_COUNT, &(ai->run_away_mode));
 
             if (ai->run_away_mode >= 0) {
@@ -460,49 +456,47 @@ int aiInit()
             }
         }
 
-        if (configGetString(&config, sectionEntry->key, "best_weapon", &stringValue)) {
+        if (configGetString(config.get(), sectionEntry->key, "best_weapon", &stringValue)) {
             _cai_match_str_to_list(stringValue, gBestWeaponKeys, BEST_WEAPON_COUNT, &(ai->best_weapon));
         }
 
-        if (configGetString(&config, sectionEntry->key, "distance", &stringValue)) {
+        if (configGetString(config.get(), sectionEntry->key, "distance", &stringValue)) {
             _cai_match_str_to_list(stringValue, gDistanceModeKeys, DISTANCE_COUNT, &(ai->distance));
         }
 
-        if (configGetString(&config, sectionEntry->key, "attack_who", &stringValue)) {
+        if (configGetString(config.get(), sectionEntry->key, "attack_who", &stringValue)) {
             _cai_match_str_to_list(stringValue, gAttackWhoKeys, ATTACK_WHO_COUNT, &(ai->attack_who));
         }
 
-        if (configGetString(&config, sectionEntry->key, "chem_use", &stringValue)) {
+        if (configGetString(config.get(), sectionEntry->key, "chem_use", &stringValue)) {
             _cai_match_str_to_list(stringValue, gChemUseKeys, CHEM_USE_COUNT, &(ai->chem_use));
         }
 
-        configGetIntList(&config, sectionEntry->key, "chem_primary_desire", ai->chem_primary_desire, AI_PACKET_CHEM_PRIMARY_DESIRE_COUNT);
+        configGetIntList(config.get(), sectionEntry->key, "chem_primary_desire", ai->chem_primary_desire, AI_PACKET_CHEM_PRIMARY_DESIRE_COUNT);
 
-        if (configGetString(&config, sectionEntry->key, "disposition", &stringValue)) {
+        if (configGetString(config.get(), sectionEntry->key, "disposition", &stringValue)) {
             _cai_match_str_to_list(stringValue, gDispositionKeys, DISPOSITION_COUNT, &(ai->disposition));
             ai->disposition--;
         }
 
-        if (configGetString(&config, sectionEntry->key, "body_type", &stringValue)) {
+        if (configGetString(config.get(), sectionEntry->key, "body_type", &stringValue)) {
             ai->body_type = internal_strdup(stringValue);
         } else {
             ai->body_type = nullptr;
         }
 
-        if (configGetString(&config, sectionEntry->key, "general_type", &stringValue)) {
+        if (configGetString(config.get(), sectionEntry->key, "general_type", &stringValue)) {
             ai->general_type = internal_strdup(stringValue);
         } else {
             ai->general_type = nullptr;
         }
     }
 
-    if (index < config.entriesLength) {
+    if (index < config.get()->entriesLength) {
         goto err;
     }
 
-    gAiPacketsLength = config.entriesLength;
-
-    configFree(&config);
+    gAiPacketsLength = config.get()->entriesLength;
 
     gAiInitialized = true;
 
@@ -511,7 +505,7 @@ int aiInit()
 err:
 
     if (gAiPackets != nullptr) {
-        for (index = 0; index < config.entriesLength; index++) {
+        for (index = 0; index < config.get()->entriesLength; index++) {
             AiPacket* ai = &(gAiPackets[index]);
             if (ai->name != nullptr) {
                 internal_free(ai->name);
@@ -524,8 +518,6 @@ err:
     }
 
     debugPrint("Error processing ai.txt");
-
-    configFree(&config);
 
     return -1;
 }

--- a/src/combat_ai.cc
+++ b/src/combat_ai.cc
@@ -356,132 +356,126 @@ int aiInit()
 
     gAiPacketsLength = 0;
 
-    Config config;
-    if (!configInit(&config)) {
+    ScopedConfig config("data\\ai.txt", true);
+    if (!config) {
         return -1;
     }
 
-    if (!configRead(&config, "data\\ai.txt", true)) {
-        return -1;
-    }
-
-    gAiPackets = (AiPacket*)internal_malloc(sizeof(*gAiPackets) * config.entriesLength);
+    gAiPackets = (AiPacket*)internal_malloc(sizeof(*gAiPackets) * config.get()->entriesLength);
     if (gAiPackets == nullptr) {
         goto err;
     }
 
-    for (index = 0; index < config.entriesLength; index++) {
+    for (index = 0; index < config.get()->entriesLength; index++) {
         aiPacketInit(&(gAiPackets[index]));
     }
 
-    for (index = 0; index < config.entriesLength; index++) {
-        DictionaryEntry* sectionEntry = &(config.entries[index]);
+    for (index = 0; index < config.get()->entriesLength; index++) {
+        DictionaryEntry* sectionEntry = &(config.get()->entries[index]);
         AiPacket* ai = &(gAiPackets[index]);
         char* stringValue;
 
         ai->name = internal_strdup(sectionEntry->key);
 
-        if (!configGetInt(&config, sectionEntry->key, "packet_num", &(ai->packet_num))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "max_dist", &(ai->max_dist))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "min_to_hit", &(ai->min_to_hit))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "min_hp", &(ai->min_hp))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "aggression", &(ai->aggression))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "packet_num", &(ai->packet_num))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "max_dist", &(ai->max_dist))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "min_to_hit", &(ai->min_to_hit))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "min_hp", &(ai->min_hp))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "aggression", &(ai->aggression))) goto err;
 
-        if (configGetString(&config, sectionEntry->key, "hurt_too_much", &stringValue)) {
+        if (configGetString(config.get(), sectionEntry->key, "hurt_too_much", &stringValue)) {
             _parse_hurt_str(stringValue, &(ai->hurt_too_much));
         }
 
-        if (!configGetInt(&config, sectionEntry->key, "secondary_freq", &(ai->secondary_freq))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "called_freq", &(ai->called_freq))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "font", &(ai->font))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "color", &(ai->color))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "outline_color", &(ai->outline_color))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "chance", &(ai->chance))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "run_start", &(ai->run.start))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "run_end", &(ai->run.end))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "move_start", &(ai->move.start))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "move_end", &(ai->move.end))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "attack_start", &(ai->attack.start))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "attack_end", &(ai->attack.end))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "miss_start", &(ai->miss.start))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "miss_end", &(ai->miss.end))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_head_start", &(ai->hit[HIT_LOCATION_HEAD].start))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_head_end", &(ai->hit[HIT_LOCATION_HEAD].end))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_left_arm_start", &(ai->hit[HIT_LOCATION_LEFT_ARM].start))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_left_arm_end", &(ai->hit[HIT_LOCATION_LEFT_ARM].end))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_right_arm_start", &(ai->hit[HIT_LOCATION_RIGHT_ARM].start))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_right_arm_end", &(ai->hit[HIT_LOCATION_RIGHT_ARM].end))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_torso_start", &(ai->hit[HIT_LOCATION_TORSO].start))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_torso_end", &(ai->hit[HIT_LOCATION_TORSO].end))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_right_leg_start", &(ai->hit[HIT_LOCATION_RIGHT_LEG].start))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_right_leg_end", &(ai->hit[HIT_LOCATION_RIGHT_LEG].end))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_left_leg_start", &(ai->hit[HIT_LOCATION_LEFT_LEG].start))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_left_leg_end", &(ai->hit[HIT_LOCATION_LEFT_LEG].end))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_eyes_start", &(ai->hit[HIT_LOCATION_EYES].start))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_eyes_end", &(ai->hit[HIT_LOCATION_EYES].end))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_groin_start", &(ai->hit[HIT_LOCATION_GROIN].start))) goto err;
-        if (!configGetInt(&config, sectionEntry->key, "hit_groin_end", &(ai->hit[HIT_LOCATION_GROIN].end))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "secondary_freq", &(ai->secondary_freq))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "called_freq", &(ai->called_freq))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "font", &(ai->font))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "color", &(ai->color))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "outline_color", &(ai->outline_color))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "chance", &(ai->chance))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "run_start", &(ai->run.start))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "run_end", &(ai->run.end))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "move_start", &(ai->move.start))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "move_end", &(ai->move.end))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "attack_start", &(ai->attack.start))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "attack_end", &(ai->attack.end))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "miss_start", &(ai->miss.start))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "miss_end", &(ai->miss.end))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_head_start", &(ai->hit[HIT_LOCATION_HEAD].start))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_head_end", &(ai->hit[HIT_LOCATION_HEAD].end))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_left_arm_start", &(ai->hit[HIT_LOCATION_LEFT_ARM].start))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_left_arm_end", &(ai->hit[HIT_LOCATION_LEFT_ARM].end))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_right_arm_start", &(ai->hit[HIT_LOCATION_RIGHT_ARM].start))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_right_arm_end", &(ai->hit[HIT_LOCATION_RIGHT_ARM].end))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_torso_start", &(ai->hit[HIT_LOCATION_TORSO].start))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_torso_end", &(ai->hit[HIT_LOCATION_TORSO].end))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_right_leg_start", &(ai->hit[HIT_LOCATION_RIGHT_LEG].start))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_right_leg_end", &(ai->hit[HIT_LOCATION_RIGHT_LEG].end))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_left_leg_start", &(ai->hit[HIT_LOCATION_LEFT_LEG].start))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_left_leg_end", &(ai->hit[HIT_LOCATION_LEFT_LEG].end))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_eyes_start", &(ai->hit[HIT_LOCATION_EYES].start))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_eyes_end", &(ai->hit[HIT_LOCATION_EYES].end))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_groin_start", &(ai->hit[HIT_LOCATION_GROIN].start))) goto err;
+        if (!configGetInt(config.get(), sectionEntry->key, "hit_groin_end", &(ai->hit[HIT_LOCATION_GROIN].end))) goto err;
 
         ai->hit[HIT_LOCATION_GROIN].end++;
 
-        if (configGetString(&config, sectionEntry->key, "area_attack_mode", &stringValue)) {
+        if (configGetString(config.get(), sectionEntry->key, "area_attack_mode", &stringValue)) {
             _cai_match_str_to_list_enum<AreaAttackMode>(stringValue, gAreaAttackModeKeys, AREA_ATTACK_MODE_COUNT, &(ai->area_attack_mode));
         } else {
             ai->area_attack_mode = AREA_ATTACK_MODE_INVALID;
         }
 
-        if (configGetString(&config, sectionEntry->key, "run_away_mode", &stringValue)) {
+        if (configGetString(config.get(), sectionEntry->key, "run_away_mode", &stringValue)) {
             _cai_match_str_to_list_enum<RunAwayMode>(stringValue, gRunAwayModeKeys, RUN_AWAY_MODE_COUNT, &(ai->run_away_mode));
             if (ai->run_away_mode >= RUN_AWAY_MODE_FIRST) {
                 ai->run_away_mode--;
             }
         }
 
-        if (configGetString(&config, sectionEntry->key, "best_weapon", &stringValue)) {
+        if (configGetString(config.get(), sectionEntry->key, "best_weapon", &stringValue)) {
             _cai_match_str_to_list_enum<BestWeapon>(stringValue, gBestWeaponKeys, BEST_WEAPON_COUNT, &(ai->best_weapon));
         }
 
-        if (configGetString(&config, sectionEntry->key, "distance", &stringValue)) {
+        if (configGetString(config.get(), sectionEntry->key, "distance", &stringValue)) {
             _cai_match_str_to_list_enum<DistanceMode>(stringValue, gDistanceModeKeys, DISTANCE_COUNT, &(ai->distance));
         }
 
-        if (configGetString(&config, sectionEntry->key, "attack_who", &stringValue)) {
+        if (configGetString(config.get(), sectionEntry->key, "attack_who", &stringValue)) {
             _cai_match_str_to_list_enum<AttackWho>(stringValue, gAttackWhoKeys, ATTACK_WHO_COUNT, &(ai->attack_who));
         }
 
-        if (configGetString(&config, sectionEntry->key, "chem_use", &stringValue)) {
+        if (configGetString(config.get(), sectionEntry->key, "chem_use", &stringValue)) {
             _cai_match_str_to_list_enum<ChemUse>(stringValue, gChemUseKeys, CHEM_USE_COUNT, &(ai->chem_use));
         }
 
-        configGetIntList(&config, sectionEntry->key, "chem_primary_desire", ai->chem_primary_desire, AI_PACKET_CHEM_PRIMARY_DESIRE_COUNT);
+        configGetIntList(config.get(), sectionEntry->key, "chem_primary_desire", ai->chem_primary_desire, AI_PACKET_CHEM_PRIMARY_DESIRE_COUNT);
 
-        if (configGetString(&config, sectionEntry->key, "disposition", &stringValue)) {
+        if (configGetString(config.get(), sectionEntry->key, "disposition", &stringValue)) {
             _cai_match_str_to_list_enum<Disposition>(stringValue, gDispositionKeys, DISPOSITION_COUNT, &(ai->disposition));
             if (ai->disposition >= DISPOSITION_FIRST) {
                 ai->disposition--;
             }
         }
 
-        if (configGetString(&config, sectionEntry->key, "body_type", &stringValue)) {
+        if (configGetString(config.get(), sectionEntry->key, "body_type", &stringValue)) {
             ai->body_type = internal_strdup(stringValue);
         } else {
             ai->body_type = nullptr;
         }
 
-        if (configGetString(&config, sectionEntry->key, "general_type", &stringValue)) {
+        if (configGetString(config.get(), sectionEntry->key, "general_type", &stringValue)) {
             ai->general_type = internal_strdup(stringValue);
         } else {
             ai->general_type = nullptr;
         }
     }
 
-    if (index < config.entriesLength) {
+    if (index < config.get()->entriesLength) {
         goto err;
     }
 
-    gAiPacketsLength = config.entriesLength;
-
-    configFree(&config);
+    gAiPacketsLength = config.get()->entriesLength;
 
     gAiInitialized = true;
 
@@ -490,7 +484,7 @@ int aiInit()
 err:
 
     if (gAiPackets != nullptr) {
-        for (index = 0; index < config.entriesLength; index++) {
+        for (index = 0; index < config.get()->entriesLength; index++) {
             AiPacket* ai = &(gAiPackets[index]);
             if (ai->name != nullptr) {
                 internal_free(ai->name);
@@ -503,8 +497,6 @@ err:
     }
 
     debugPrint("Error processing ai.txt");
-
-    configFree(&config);
 
     return -1;
 }

--- a/src/config.cc
+++ b/src/config.cc
@@ -851,6 +851,7 @@ bool configSetBool(Config* config, const char* sectionKey, const char* key, bool
     return configSetInt(config, sectionKey, key, value ? 1 : 0);
 }
 
+// ScopedConfig is a RAII wrapper around Config that makes cleanup easier.
 ScopedConfig::ScopedConfig()
 {
     _loaded = configInit(&_config);

--- a/src/config.cc
+++ b/src/config.cc
@@ -879,6 +879,7 @@ bool configSetBool(Config* config, const char* sectionKey, const char* key, bool
     return configSetInt(config, sectionKey, key, value ? 1 : 0);
 }
 
+// ScopedConfig is a RAII wrapper around Config that makes cleanup easier.
 ScopedConfig::ScopedConfig()
 {
     _loaded = configInit(&_config);

--- a/src/config.cc
+++ b/src/config.cc
@@ -900,11 +900,7 @@ ScopedConfig::~ScopedConfig()
     }
 }
 
-bool ScopedConfig::isInitialized() const
-{
-    return _config.isInitialized();
-}
-
+// get returns a pointer to be useful in the config* API above; it cannot be nullptr
 Config* ScopedConfig::get()
 {
     return &_config;

--- a/src/config.h
+++ b/src/config.h
@@ -89,8 +89,6 @@ public:
     ScopedConfig(const ScopedConfig&) = delete;
     ScopedConfig& operator=(const ScopedConfig&) = delete;
 
-    bool isInitialized() const;
-
     Config* get();
     const Config* get() const;
 

--- a/src/elevator.cc
+++ b/src/elevator.cc
@@ -651,60 +651,56 @@ void elevatorsInit()
 {
     char* elevatorsFileName;
     configGetString(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_ELEVATORS_FILE_KEY, &elevatorsFileName);
-    if (elevatorsFileName != nullptr && *elevatorsFileName == '\0') {
-        elevatorsFileName = nullptr;
+    if (elevatorsFileName == nullptr || *elevatorsFileName == '\0') {
+        return;
     }
 
-    if (elevatorsFileName != nullptr) {
-        Config elevatorsConfig;
-        if (configInit(&elevatorsConfig)) {
-            if (configRead(&elevatorsConfig, elevatorsFileName, false)) {
-                char sectionKey[4];
-                char key[32];
-                for (int index = 0; index < ELEVATORS_MAX; index++) {
-                    snprintf(sectionKey, sizeof(sectionKey), "%d", index);
+    ScopedConfig elevatorsConfig(elevatorsFileName, false);
+    if (!elevatorsConfig) {
+        return;
+    }
 
-                    if (index >= ELEVATOR_COUNT) {
-                        int levels = 0;
-                        configGetInt(&elevatorsConfig, sectionKey, "ButtonCount", &levels);
-                        gElevatorLevels[index] = std::clamp(levels, 2, ELEVATOR_LEVEL_MAX);
-                    }
+    char sectionKey[4];
+    char key[32];
+    for (int index = 0; index < ELEVATORS_MAX; index++) {
+        snprintf(sectionKey, sizeof(sectionKey), "%d", index);
 
-                    configGetInt(&elevatorsConfig, sectionKey, "MainFrm", &(gElevatorBackgrounds[index].backgroundFrmId));
-                    configGetInt(&elevatorsConfig, sectionKey, "ButtonsFrm", &(gElevatorBackgrounds[index].panelFrmId));
+        if (index >= ELEVATOR_COUNT) {
+            int levels = 0;
+            configGetInt(elevatorsConfig.get(), sectionKey, "ButtonCount", &levels);
+            gElevatorLevels[index] = std::clamp(levels, 2, ELEVATOR_LEVEL_MAX);
+        }
 
-                    for (int level = 0; level < ELEVATOR_LEVEL_MAX; level++) {
-                        snprintf(key, sizeof(key), "ID%d", level + 1);
-                        configGetInt(&elevatorsConfig, sectionKey, key, &(gElevatorDescriptions[index][level].map));
+        configGetInt(elevatorsConfig.get(), sectionKey, "MainFrm", &(gElevatorBackgrounds[index].backgroundFrmId));
+        configGetInt(elevatorsConfig.get(), sectionKey, "ButtonsFrm", &(gElevatorBackgrounds[index].panelFrmId));
 
-                        snprintf(key, sizeof(key), "Elevation%d", level + 1);
-                        configGetInt(&elevatorsConfig, sectionKey, key, &(gElevatorDescriptions[index][level].elevation));
+        for (int level = 0; level < ELEVATOR_LEVEL_MAX; level++) {
+            snprintf(key, sizeof(key), "ID%d", level + 1);
+            configGetInt(elevatorsConfig.get(), sectionKey, key, &(gElevatorDescriptions[index][level].map));
 
-                        snprintf(key, sizeof(key), "Tile%d", level + 1);
-                        configGetInt(&elevatorsConfig, sectionKey, key, &(gElevatorDescriptions[index][level].tile));
-                    }
-                }
+            snprintf(key, sizeof(key), "Elevation%d", level + 1);
+            configGetInt(elevatorsConfig.get(), sectionKey, key, &(gElevatorDescriptions[index][level].elevation));
 
-                // NOTE: Sfall implementation is slightly different. It uses one
-                // loop and stores `type` value in a separate lookup table. This
-                // value is then used in the certain places to remap from
-                // requested elevator to the new one.
-                for (int index = 0; index < ELEVATORS_MAX; index++) {
-                    snprintf(sectionKey, sizeof(sectionKey), "%d", index);
+            snprintf(key, sizeof(key), "Tile%d", level + 1);
+            configGetInt(elevatorsConfig.get(), sectionKey, key, &(gElevatorDescriptions[index][level].tile));
+        }
+    }
 
-                    int type;
-                    if (configGetInt(&elevatorsConfig, sectionKey, "Image", &type)) {
-                        type = std::clamp(type, 0, ELEVATORS_MAX - 1);
-                        if (index != type) {
-                            memcpy(&(gElevatorBackgrounds[index]), &(gElevatorBackgrounds[type]), sizeof(*gElevatorBackgrounds));
-                            memcpy(&(gElevatorLevels[index]), &(gElevatorLevels[type]), sizeof(*gElevatorLevels));
-                            memcpy(&(gElevatorLevelLabels[index]), &(gElevatorLevelLabels[type]), sizeof(*gElevatorLevelLabels));
-                        }
-                    }
-                }
+    // NOTE: Sfall implementation is slightly different. It uses one
+    // loop and stores `type` value in a separate lookup table. This
+    // value is then used in the certain places to remap from
+    // requested elevator to the new one.
+    for (int index = 0; index < ELEVATORS_MAX; index++) {
+        snprintf(sectionKey, sizeof(sectionKey), "%d", index);
+
+        int type;
+        if (configGetInt(elevatorsConfig.get(), sectionKey, "Image", &type)) {
+            type = std::clamp(type, 0, ELEVATORS_MAX - 1);
+            if (index != type) {
+                memcpy(&(gElevatorBackgrounds[index]), &(gElevatorBackgrounds[type]), sizeof(*gElevatorBackgrounds));
+                memcpy(&(gElevatorLevels[index]), &(gElevatorLevels[type]), sizeof(*gElevatorLevels));
+                memcpy(&(gElevatorLevelLabels[index]), &(gElevatorLevelLabels[type]), sizeof(*gElevatorLevelLabels));
             }
-
-            configFree(&elevatorsConfig);
         }
     }
 }

--- a/src/elevator.cc
+++ b/src/elevator.cc
@@ -667,59 +667,56 @@ void elevatorsInit()
 {
     char* elevatorsFileName;
     configGetString(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_ELEVATORS_FILE_KEY, &elevatorsFileName);
-    if (elevatorsFileName != nullptr && *elevatorsFileName == '\0') {
-        elevatorsFileName = nullptr;
+    if (elevatorsFileName == nullptr || *elevatorsFileName == '\0') {
+        return;
     }
 
-    if (elevatorsFileName != nullptr) {
-        Config elevatorsConfig;
-        if (configInit(&elevatorsConfig)) {
-            if (configRead(&elevatorsConfig, elevatorsFileName, false)) {
-                char sectionKey[4];
-                char key[32];
-                for (int index = 0; index < ELEVATORS_MAX; index++) {
-                    snprintf(sectionKey, sizeof(sectionKey), "%d", index);
+    ScopedConfig elevatorsConfig(elevatorsFileName, false);
+    if (!elevatorsConfig) {
+        return;
+    }
 
-                    if (index >= ELEVATOR_COUNT) {
-                        int levels = 0;
-                        configGetInt(&elevatorsConfig, sectionKey, "ButtonCount", &levels);
-                        gElevatorLevels[index] = std::clamp(levels, 2, ELEVATOR_LEVEL_MAX);
-                    }
+    char sectionKey[4];
+    char key[32];
+    for (int index = 0; index < ELEVATORS_MAX; index++) {
+        snprintf(sectionKey, sizeof(sectionKey), "%d", index);
 
-                    configGetInt(&elevatorsConfig, sectionKey, "MainFrm", &(gElevatorBackgrounds[index].backgroundFrmId));
-                    configGetInt(&elevatorsConfig, sectionKey, "ButtonsFrm", &(gElevatorBackgrounds[index].panelFrmId));
+        if (index >= ELEVATOR_COUNT) {
+            int levels = 0;
+            configGetInt(elevatorsConfig.get(), sectionKey, "ButtonCount", &levels);
+            gElevatorLevels[index] = std::clamp(levels, 2, ELEVATOR_LEVEL_MAX);
+        }
 
-                    for (int level = 0; level < ELEVATOR_LEVEL_MAX; level++) {
-                        snprintf(key, sizeof(key), "ID%d", level + 1);
-                        configGetEnum<Map>(&elevatorsConfig, sectionKey, key, &(gElevatorDescriptions[index][level].map));
-                        snprintf(key, sizeof(key), "Elevation%d", level + 1);
-                        configGetInt(&elevatorsConfig, sectionKey, key, &(gElevatorDescriptions[index][level].elevation));
+        configGetInt(elevatorsConfig.get(), sectionKey, "MainFrm", &(gElevatorBackgrounds[index].backgroundFrmId));
+        configGetInt(elevatorsConfig.get(), sectionKey, "ButtonsFrm", &(gElevatorBackgrounds[index].panelFrmId));
 
-                        snprintf(key, sizeof(key), "Tile%d", level + 1);
-                        configGetInt(&elevatorsConfig, sectionKey, key, &(gElevatorDescriptions[index][level].tile));
-                    }
-                }
+        for (int level = 0; level < ELEVATOR_LEVEL_MAX; level++) {
+            snprintf(key, sizeof(key), "ID%d", level + 1);
+            configGetEnum<Map>(elevatorsConfig.get(), sectionKey, key, &(gElevatorDescriptions[index][level].map));
 
-                // NOTE: Sfall implementation is slightly different. It uses one
-                // loop and stores `type` value in a separate lookup table. This
-                // value is then used in the certain places to remap from
-                // requested elevator to the new one.
-                for (int index = 0; index < ELEVATORS_MAX; index++) {
-                    snprintf(sectionKey, sizeof(sectionKey), "%d", index);
+            snprintf(key, sizeof(key), "Elevation%d", level + 1);
+            configGetInt(elevatorsConfig.get(), sectionKey, key, &(gElevatorDescriptions[index][level].elevation));
 
-                    int type;
-                    if (configGetInt(&elevatorsConfig, sectionKey, "Image", &type)) {
-                        type = std::clamp(type, 0, ELEVATORS_MAX - 1);
-                        if (index != type) {
-                            memcpy(&(gElevatorBackgrounds[index]), &(gElevatorBackgrounds[type]), sizeof(*gElevatorBackgrounds));
-                            memcpy(&(gElevatorLevels[index]), &(gElevatorLevels[type]), sizeof(*gElevatorLevels));
-                            memcpy(&(gElevatorLevelLabels[index]), &(gElevatorLevelLabels[type]), sizeof(*gElevatorLevelLabels));
-                        }
-                    }
-                }
+            snprintf(key, sizeof(key), "Tile%d", level + 1);
+            configGetInt(elevatorsConfig.get(), sectionKey, key, &(gElevatorDescriptions[index][level].tile));
+        }
+    }
+
+    // NOTE: Sfall implementation is slightly different. It uses one
+    // loop and stores `type` value in a separate lookup table. This
+    // value is then used in the certain places to remap from
+    // requested elevator to the new one.
+    for (int index = 0; index < ELEVATORS_MAX; index++) {
+        snprintf(sectionKey, sizeof(sectionKey), "%d", index);
+
+        int type;
+        if (configGetInt(elevatorsConfig.get(), sectionKey, "Image", &type)) {
+            type = std::clamp(type, 0, ELEVATORS_MAX - 1);
+            if (index != type) {
+                memcpy(&(gElevatorBackgrounds[index]), &(gElevatorBackgrounds[type]), sizeof(*gElevatorBackgrounds));
+                memcpy(&(gElevatorLevels[index]), &(gElevatorLevels[type]), sizeof(*gElevatorLevels));
+                memcpy(&(gElevatorLevelLabels[index]), &(gElevatorLevelLabels[type]), sizeof(*gElevatorLevelLabels));
             }
-
-            configFree(&elevatorsConfig);
         }
     }
 }

--- a/src/game_config_migration.cc
+++ b/src/game_config_migration.cc
@@ -107,25 +107,22 @@ bool gameConfigMigrateFromF2Res(const char* gameConfigFilePath, Config* gameConf
     compat_splitpath(gameConfigFilePath, drive, dir, nullptr, nullptr);
     compat_makepath(f2ResFilePath, drive, dir, F2_RES_CONFIG_FILE_NAME, nullptr);
 
-    Config legacyConfig;
-    if (!configInit(&legacyConfig)) {
+    ScopedConfig legacyConfig(f2ResFilePath, false);
+    if (!legacyConfig) {
         return false;
     }
 
     bool migrated = false;
-    if (configRead(&legacyConfig, f2ResFilePath, false)) {
-        for (const auto& entry : kF2ResMigrationEntries) {
-            if (gameConfigMigrateStringKey(&legacyConfig, gameConfig, entry)) {
-                migrated = true;
-            }
-        }
-
-        if (gameConfigMigrateScaleKey(&legacyConfig, gameConfig)) {
+    for (const auto& entry : kF2ResMigrationEntries) {
+        if (gameConfigMigrateStringKey(legacyConfig.get(), gameConfig, entry)) {
             migrated = true;
         }
     }
 
-    configFree(&legacyConfig);
+    if (gameConfigMigrateScaleKey(legacyConfig.get(), gameConfig)) {
+        migrated = true;
+    }
+
     return migrated;
 }
 
@@ -223,8 +220,8 @@ static bool contentConfigMigrateFromSfall(Config* sfallConfig, const char* conte
         return false;
     }
 
-    Config migratedConfig;
-    if (!configInit(&migratedConfig)) {
+    ScopedConfig migratedConfig;
+    if (!migratedConfig) {
         return false;
     }
 
@@ -235,7 +232,7 @@ static bool contentConfigMigrateFromSfall(Config* sfallConfig, const char* conte
         if (configGetInt(sfallConfig, "Misc", sfallKey, &value) && value >= 0 && value != defaultValue) {
             char buf[32];
             snprintf(buf, sizeof(buf), "%d", value);
-            configSetString(&migratedConfig, CONTENT_CONFIG_START_SECTION, targetKey, buf);
+            configSetString(migratedConfig.get(), CONTENT_CONFIG_START_SECTION, targetKey, buf);
             migrated = true;
         }
     };
@@ -249,7 +246,7 @@ static bool contentConfigMigrateFromSfall(Config* sfallConfig, const char* conte
             if (value[0] == '\0' || entry.defaultValue != nullptr && strcmp(value, entry.defaultValue) == 0) {
                 continue;
             }
-            configSetString(&migratedConfig, entry.targetSection, entry.targetKey, value);
+            configSetString(migratedConfig.get(), entry.targetSection, entry.targetKey, value);
             migrated = true;
         }
     }
@@ -263,12 +260,11 @@ static bool contentConfigMigrateFromSfall(Config* sfallConfig, const char* conte
         compat_makepath(pathWithoutFile, drive, dirPart, nullptr, nullptr);
         compat_mkdir_recursive(pathWithoutFile);
 
-        if (!configWrite(&migratedConfig, contentConfigFilePath, false)) {
+        if (!configWrite(migratedConfig.get(), contentConfigFilePath, false)) {
             debugPrint("Failed to write migrated settings to %s!\n", contentConfigFilePath);
         }
     }
 
-    configFree(&migratedConfig);
     return migrated;
 }
 

--- a/src/game_config_migration.cc
+++ b/src/game_config_migration.cc
@@ -177,29 +177,26 @@ bool gameConfigMigrateFromF2Res(const char* gameConfigFilePath, Config* gameConf
     compat_splitpath(gameConfigFilePath, drive, dir, nullptr, nullptr);
     compat_makepath(f2ResFilePath, drive, dir, F2_RES_CONFIG_FILE_NAME, nullptr);
 
-    Config legacyConfig;
-    if (!configInit(&legacyConfig)) {
+    ScopedConfig legacyConfig(f2ResFilePath, false);
+    if (!legacyConfig) {
         return false;
     }
 
     bool migrated = false;
-    if (configRead(&legacyConfig, f2ResFilePath, false)) {
-        for (const auto& entry : kF2ResMigrationEntries) {
-            if (gameConfigMigrateStringKey(&legacyConfig, gameConfig, entry)) {
-                migrated = true;
-            }
-        }
-
-        if (gameConfigMigrateMainMenuScaleModeKey(&legacyConfig, gameConfig)) {
-            migrated = true;
-        }
-
-        if (gameConfigMigrateScaleKey(&legacyConfig, gameConfig)) {
+    for (const auto& entry : kF2ResMigrationEntries) {
+        if (gameConfigMigrateStringKey(legacyConfig.get(), gameConfig, entry)) {
             migrated = true;
         }
     }
 
-    configFree(&legacyConfig);
+    if (gameConfigMigrateMainMenuScaleModeKey(legacyConfig.get(), gameConfig)) {
+        migrated = true;
+    }
+
+    if (gameConfigMigrateScaleKey(legacyConfig.get(), gameConfig)) {
+        migrated = true;
+    }
+
     return migrated;
 }
 
@@ -378,8 +375,8 @@ static bool contentConfigMigrateFromSfall(Config* sfallConfig, const char* conte
         return false;
     }
 
-    Config migratedConfig;
-    if (!configInit(&migratedConfig)) {
+    ScopedConfig migratedConfig;
+    if (!migratedConfig) {
         return false;
     }
 
@@ -391,7 +388,7 @@ static bool contentConfigMigrateFromSfall(Config* sfallConfig, const char* conte
         int travelDelay = 66;
         configGetInt(sfallConfig, kSfallMisc, "WorldMapDelay2", &travelDelay);
         travelDelay = std::clamp(travelDelay, 1, 150);
-        configSetInt(&migratedConfig, CONTENT_CONFIG_WORLDMAP_SECTION, "travel_delay", travelDelay);
+        configSetInt(migratedConfig.get(), CONTENT_CONFIG_WORLDMAP_SECTION, "travel_delay", travelDelay);
         migrated = true;
     }
 
@@ -400,7 +397,7 @@ static bool contentConfigMigrateFromSfall(Config* sfallConfig, const char* conte
         int value;
         configGetIntBase(sfallConfig, kSfallMisc, sfallKey, &value, -1, 10);
         if (value >= 0 && value != defaultValue) {
-            configSetInt(&migratedConfig, CONTENT_CONFIG_START_SECTION, targetKey, value);
+            configSetInt(migratedConfig.get(), CONTENT_CONFIG_START_SECTION, targetKey, value);
             migrated = true;
         }
     };
@@ -415,16 +412,16 @@ static bool contentConfigMigrateFromSfall(Config* sfallConfig, const char* conte
             if (value[0] == '\0' || entry.defaultValue != nullptr && strcmp(value, entry.defaultValue) == 0) {
                 continue;
             }
-            configSetString(&migratedConfig, entry.targetSection, entry.targetKey, value);
+            configSetString(migratedConfig.get(), entry.targetSection, entry.targetKey, value);
             migrated = true;
         }
     }
 
-    if (contentConfigMigrateSfallMovieOverrides(sfallConfig, &migratedConfig)) {
+    if (contentConfigMigrateSfallMovieOverrides(sfallConfig, migratedConfig.get())) {
         migrated = true;
     }
 
-    if (contentConfigMigrateSfallFallout1MovieBehavior(sfallConfig, &migratedConfig)) {
+    if (contentConfigMigrateSfallFallout1MovieBehavior(sfallConfig, migratedConfig.get())) {
         migrated = true;
     }
 
@@ -437,12 +434,11 @@ static bool contentConfigMigrateFromSfall(Config* sfallConfig, const char* conte
         compat_makepath(pathWithoutFile, drive, dirPart, nullptr, nullptr);
         compat_mkdir_recursive(pathWithoutFile);
 
-        if (!configWrite(&migratedConfig, contentConfigFilePath, false)) {
+        if (!configWrite(migratedConfig.get(), contentConfigFilePath, false)) {
             debugPrint("Failed to write migrated settings to %s!\n", contentConfigFilePath);
         }
     }
 
-    configFree(&migratedConfig);
     return migrated;
 }
 

--- a/src/item.cc
+++ b/src/item.cc
@@ -3388,46 +3388,42 @@ static void booksInitCustom()
 {
     char* booksFilePath;
     configGetString(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_BOOKS_FILE_KEY, &booksFilePath);
-    if (booksFilePath != nullptr && *booksFilePath == '\0') {
-        booksFilePath = nullptr;
+    if (booksFilePath == nullptr || *booksFilePath == '\0') {
+        return;
     }
 
-    if (booksFilePath != nullptr) {
-        Config booksConfig;
-        if (configInit(&booksConfig)) {
-            if (configRead(&booksConfig, booksFilePath, false)) {
-                bool overrideVanilla = false;
-                configGetBool(&booksConfig, "main", "overrideVanilla", &overrideVanilla);
-                if (overrideVanilla) {
-                    gBooks.clear();
-                }
+    ScopedConfig booksConfig(booksFilePath, false);
+    if (!booksConfig) {
+        return;
+    }
 
-                int bookCount = 0;
-                configGetInt(&booksConfig, "main", "count", &bookCount);
-                if (bookCount > BOOKS_MAX) {
-                    bookCount = BOOKS_MAX;
-                }
+    bool overrideVanilla = false;
+    configGetBool(booksConfig.get(), "main", "overrideVanilla", &overrideVanilla);
+    if (overrideVanilla) {
+        gBooks.clear();
+    }
 
-                char sectionKey[4];
-                for (int index = 0; index < bookCount; index++) {
-                    // Books numbering starts with 1.
-                    snprintf(sectionKey, sizeof(sectionKey), "%d", index + 1);
+    int bookCount = 0;
+    configGetInt(booksConfig.get(), "main", "count", &bookCount);
+    if (bookCount > BOOKS_MAX) {
+        bookCount = BOOKS_MAX;
+    }
 
-                    int bookPid;
-                    if (!configGetInt(&booksConfig, sectionKey, "PID", &bookPid)) continue;
+    char sectionKey[4];
+    for (int index = 0; index < bookCount; index++) {
+        // Books numbering starts with 1.
+        snprintf(sectionKey, sizeof(sectionKey), "%d", index + 1);
 
-                    int messageId;
-                    if (!configGetInt(&booksConfig, sectionKey, "TextID", &messageId)) continue;
+        int bookPid;
+        if (!configGetInt(booksConfig.get(), sectionKey, "PID", &bookPid)) continue;
 
-                    int skill;
-                    if (!configGetInt(&booksConfig, sectionKey, "Skill", &skill)) continue;
+        int messageId;
+        if (!configGetInt(booksConfig.get(), sectionKey, "TextID", &messageId)) continue;
 
-                    booksAdd(bookPid, messageId, skill);
-                }
-            }
+        int skill;
+        if (!configGetInt(booksConfig.get(), sectionKey, "Skill", &skill)) continue;
 
-            configFree(&booksConfig);
-        }
+        booksAdd(bookPid, messageId, skill);
     }
 }
 

--- a/src/item.cc
+++ b/src/item.cc
@@ -3424,46 +3424,42 @@ static void booksInitCustom()
 {
     char* booksFilePath;
     configGetString(&gSfallConfig, SFALL_CONFIG_MISC_KEY, SFALL_CONFIG_BOOKS_FILE_KEY, &booksFilePath);
-    if (booksFilePath != nullptr && *booksFilePath == '\0') {
-        booksFilePath = nullptr;
+    if (booksFilePath == nullptr || *booksFilePath == '\0') {
+        return;
     }
 
-    if (booksFilePath != nullptr) {
-        Config booksConfig;
-        if (configInit(&booksConfig)) {
-            if (configRead(&booksConfig, booksFilePath, false)) {
-                bool overrideVanilla = false;
-                configGetBool(&booksConfig, "main", "overrideVanilla", &overrideVanilla);
-                if (overrideVanilla) {
-                    gBooks.clear();
-                }
+    ScopedConfig booksConfig(booksFilePath, false);
+    if (!booksConfig) {
+        return;
+    }
 
-                int bookCount = 0;
-                configGetInt(&booksConfig, "main", "count", &bookCount);
-                if (bookCount > BOOKS_MAX) {
-                    bookCount = BOOKS_MAX;
-                }
+    bool overrideVanilla = false;
+    configGetBool(booksConfig.get(), "main", "overrideVanilla", &overrideVanilla);
+    if (overrideVanilla) {
+        gBooks.clear();
+    }
 
-                char sectionKey[4];
-                for (int index = 0; index < bookCount; index++) {
-                    // Books numbering starts with 1.
-                    snprintf(sectionKey, sizeof(sectionKey), "%d", index + 1);
+    int bookCount = 0;
+    configGetInt(booksConfig.get(), "main", "count", &bookCount);
+    if (bookCount > BOOKS_MAX) {
+        bookCount = BOOKS_MAX;
+    }
 
-                    int bookPid;
-                    if (!configGetInt(&booksConfig, sectionKey, "PID", &bookPid)) continue;
+    char sectionKey[4];
+    for (int index = 0; index < bookCount; index++) {
+        // Books numbering starts with 1.
+        snprintf(sectionKey, sizeof(sectionKey), "%d", index + 1);
 
-                    int messageId;
-                    if (!configGetInt(&booksConfig, sectionKey, "TextID", &messageId)) continue;
+        int bookPid;
+        if (!configGetInt(booksConfig.get(), sectionKey, "PID", &bookPid)) continue;
 
-                    Skill skill;
-                    if (!configGetEnum<Skill>(&booksConfig, sectionKey, "Skill", &skill)) continue;
+        int messageId;
+        if (!configGetInt(booksConfig.get(), sectionKey, "TextID", &messageId)) continue;
 
-                    booksAdd(bookPid, messageId, skill);
-                }
-            }
+        Skill skill;
+        if (!configGetEnum<Skill>(booksConfig.get(), sectionKey, "Skill", &skill)) continue;
 
-            configFree(&booksConfig);
-        }
+        booksAdd(bookPid, messageId, skill);
     }
 }
 

--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -396,7 +396,7 @@ static void loadSavePersistSelectedSlot()
     snprintf(path, sizeof(path), "%s\\%s", _patches, kLoadSaveSlotDataFile);
 
     ScopedConfig config { path, false };
-    if (!config.isInitialized()) {
+    if (!config.get()->isInitialized()) {
         return;
     }
 

--- a/src/movie_effect.cc
+++ b/src/movie_effect.cc
@@ -112,13 +112,6 @@ int movieEffectsLoad(const char* filePath)
         return -1;
     }
 
-    Config config;
-    if (!configInit(&config)) {
-        return -1;
-    }
-
-    int rc = -1;
-
     char path[COMPAT_MAX_PATH];
     strcpy(path, filePath);
 
@@ -129,97 +122,96 @@ int movieEffectsLoad(const char* filePath)
 
     strcpy(path + strlen(path), ".cfg");
 
-    int* movieEffectFrameList;
-
-    if (!configRead(&config, path, true)) {
-        goto out;
+    ScopedConfig config(path, true);
+    if (!config) {
+        return -1;
     }
 
     int movieEffectsLength;
-    if (!configGetInt(&config, "info", "total_effects", &movieEffectsLength)) {
-        goto out;
+    if (!configGetInt(config.get(), "info", "total_effects", &movieEffectsLength)) {
+        return -1;
     }
 
-    movieEffectFrameList = (int*)internal_malloc(sizeof(*movieEffectFrameList) * movieEffectsLength);
+    int* movieEffectFrameList = (int*)internal_malloc(sizeof(*movieEffectFrameList) * movieEffectsLength);
     if (movieEffectFrameList == nullptr) {
-        goto out;
+        return -1;
     }
 
     bool frameListRead;
     if (movieEffectsLength >= 2) {
-        frameListRead = configGetIntList(&config, "info", "effect_frames", movieEffectFrameList, movieEffectsLength);
+        frameListRead = configGetIntList(config.get(), "info", "effect_frames", movieEffectFrameList, movieEffectsLength);
     } else {
-        frameListRead = configGetInt(&config, "info", "effect_frames", &(movieEffectFrameList[0]));
+        frameListRead = configGetInt(config.get(), "info", "effect_frames", &(movieEffectFrameList[0]));
     }
 
-    if (frameListRead) {
-        int movieEffectsCreated = 0;
-        for (int index = 0; index < movieEffectsLength; index++) {
-            char section[20];
-            compat_itoa(movieEffectFrameList[index], section, 10);
+    if (!frameListRead) {
+        internal_free(movieEffectFrameList);
+        return -1;
+    }
 
-            char* fadeTypeString;
-            if (!configGetString(&config, section, "fade_type", &fadeTypeString)) {
-                continue;
-            }
+    int rc = -1;
+    int movieEffectsCreated = 0;
+    for (int index = 0; index < movieEffectsLength; index++) {
+        char section[20];
+        compat_itoa(movieEffectFrameList[index], section, 10);
 
-            int fadeType = MOVIE_EFFECT_TYPE_NONE;
-            if (compat_stricmp(fadeTypeString, "in") == 0) {
-                fadeType = MOVIE_EFFECT_TYPE_FADE_IN;
-            } else if (compat_stricmp(fadeTypeString, "out") == 0) {
-                fadeType = MOVIE_EFFECT_TYPE_FADE_OUT;
-            }
-
-            if (fadeType == MOVIE_EFFECT_TYPE_NONE) {
-                continue;
-            }
-
-            int fadeColor[3];
-            if (!configGetIntList(&config, section, "fade_color", fadeColor, 3)) {
-                continue;
-            }
-
-            int steps;
-            if (!configGetInt(&config, section, "fade_steps", &steps)) {
-                continue;
-            }
-
-            MovieEffect* movieEffect = (MovieEffect*)internal_malloc(sizeof(*movieEffect));
-            if (movieEffect == nullptr) {
-                continue;
-            }
-
-            memset(movieEffect, 0, sizeof(*movieEffect));
-            movieEffect->startFrame = movieEffectFrameList[index];
-            movieEffect->endFrame = movieEffect->startFrame + steps - 1;
-            movieEffect->steps = steps;
-            movieEffect->fadeType = fadeType & 0xFF;
-            movieEffect->r = fadeColor[0] & 0xFF;
-            movieEffect->g = fadeColor[1] & 0xFF;
-            movieEffect->b = fadeColor[2] & 0xFF;
-
-            if (movieEffect->startFrame <= 1) {
-                _inside_fade = true;
-            }
-
-            movieEffect->next = gMovieEffectHead;
-            gMovieEffectHead = movieEffect;
-
-            movieEffectsCreated++;
+        char* fadeTypeString;
+        if (!configGetString(config.get(), section, "fade_type", &fadeTypeString)) {
+            continue;
         }
 
-        if (movieEffectsCreated != 0) {
-            movieSetPaletteProc(_moviefx_callback_func);
-            _movieSetPaletteFunc(_moviefx_palette_func);
-            rc = 0;
+        int fadeType = MOVIE_EFFECT_TYPE_NONE;
+        if (compat_stricmp(fadeTypeString, "in") == 0) {
+            fadeType = MOVIE_EFFECT_TYPE_FADE_IN;
+        } else if (compat_stricmp(fadeTypeString, "out") == 0) {
+            fadeType = MOVIE_EFFECT_TYPE_FADE_OUT;
         }
+
+        if (fadeType == MOVIE_EFFECT_TYPE_NONE) {
+            continue;
+        }
+
+        int fadeColor[3];
+        if (!configGetIntList(config.get(), section, "fade_color", fadeColor, 3)) {
+            continue;
+        }
+
+        int steps;
+        if (!configGetInt(config.get(), section, "fade_steps", &steps)) {
+            continue;
+        }
+
+        MovieEffect* movieEffect = (MovieEffect*)internal_malloc(sizeof(*movieEffect));
+        if (movieEffect == nullptr) {
+            continue;
+        }
+
+        memset(movieEffect, 0, sizeof(*movieEffect));
+        movieEffect->startFrame = movieEffectFrameList[index];
+        movieEffect->endFrame = movieEffect->startFrame + steps - 1;
+        movieEffect->steps = steps;
+        movieEffect->fadeType = fadeType & 0xFF;
+        movieEffect->r = fadeColor[0] & 0xFF;
+        movieEffect->g = fadeColor[1] & 0xFF;
+        movieEffect->b = fadeColor[2] & 0xFF;
+
+        if (movieEffect->startFrame <= 1) {
+            _inside_fade = true;
+        }
+
+        movieEffect->next = gMovieEffectHead;
+        gMovieEffectHead = movieEffect;
+
+        movieEffectsCreated++;
+    }
+
+    if (movieEffectsCreated != 0) {
+        movieSetPaletteProc(_moviefx_callback_func);
+        _movieSetPaletteFunc(_moviefx_palette_func);
+        rc = 0;
     }
 
     internal_free(movieEffectFrameList);
-
-out:
-
-    configFree(&config);
 
     return rc;
 }

--- a/src/movie_effect.cc
+++ b/src/movie_effect.cc
@@ -114,13 +114,6 @@ int movieEffectsLoad(const char* filePath)
         return -1;
     }
 
-    Config config;
-    if (!configInit(&config)) {
-        return -1;
-    }
-
-    int rc = -1;
-
     char path[COMPAT_MAX_PATH];
     strcpy(path, filePath);
 
@@ -131,97 +124,96 @@ int movieEffectsLoad(const char* filePath)
 
     strcpy(path + strlen(path), ".cfg");
 
-    int* movieEffectFrameList;
-
-    if (!configRead(&config, path, true)) {
-        goto out;
+    ScopedConfig config(path, true);
+    if (!config) {
+        return -1;
     }
 
     int movieEffectsLength;
-    if (!configGetInt(&config, "info", "total_effects", &movieEffectsLength)) {
-        goto out;
+    if (!configGetInt(config.get(), "info", "total_effects", &movieEffectsLength)) {
+        return -1;
     }
 
-    movieEffectFrameList = (int*)internal_malloc(sizeof(*movieEffectFrameList) * movieEffectsLength);
+    int* movieEffectFrameList = (int*)internal_malloc(sizeof(*movieEffectFrameList) * movieEffectsLength);
     if (movieEffectFrameList == nullptr) {
-        goto out;
+        return -1;
     }
 
     bool frameListRead;
     if (movieEffectsLength >= 2) {
-        frameListRead = configGetIntList(&config, "info", "effect_frames", movieEffectFrameList, movieEffectsLength);
+        frameListRead = configGetIntList(config.get(), "info", "effect_frames", movieEffectFrameList, movieEffectsLength);
     } else {
-        frameListRead = configGetInt(&config, "info", "effect_frames", &(movieEffectFrameList[0]));
+        frameListRead = configGetInt(config.get(), "info", "effect_frames", &(movieEffectFrameList[0]));
     }
 
-    if (frameListRead) {
-        int movieEffectsCreated = 0;
-        for (int index = 0; index < movieEffectsLength; index++) {
-            char section[20];
-            compat_itoa(movieEffectFrameList[index], section, 10);
+    if (!frameListRead) {
+        internal_free(movieEffectFrameList);
+        return -1;
+    }
 
-            char* fadeTypeString;
-            if (!configGetString(&config, section, "fade_type", &fadeTypeString)) {
-                continue;
-            }
+    int rc = -1;
+    int movieEffectsCreated = 0;
+    for (int index = 0; index < movieEffectsLength; index++) {
+        char section[20];
+        compat_itoa(movieEffectFrameList[index], section, 10);
 
-            int fadeType = MOVIE_EFFECT_TYPE_NONE;
-            if (compat_stricmp(fadeTypeString, "in") == 0) {
-                fadeType = MOVIE_EFFECT_TYPE_FADE_IN;
-            } else if (compat_stricmp(fadeTypeString, "out") == 0) {
-                fadeType = MOVIE_EFFECT_TYPE_FADE_OUT;
-            }
-
-            if (fadeType == MOVIE_EFFECT_TYPE_NONE) {
-                continue;
-            }
-
-            int fadeColor[3];
-            if (!configGetIntList(&config, section, "fade_color", fadeColor, 3)) {
-                continue;
-            }
-
-            int steps;
-            if (!configGetInt(&config, section, "fade_steps", &steps)) {
-                continue;
-            }
-
-            MovieEffect* movieEffect = (MovieEffect*)internal_malloc(sizeof(*movieEffect));
-            if (movieEffect == nullptr) {
-                continue;
-            }
-
-            memset(movieEffect, 0, sizeof(*movieEffect));
-            movieEffect->startFrame = movieEffectFrameList[index];
-            movieEffect->endFrame = movieEffect->startFrame + steps - 1;
-            movieEffect->steps = steps;
-            movieEffect->fadeType = fadeType & 0xFF;
-            movieEffect->r = fadeColor[0] & 0xFF;
-            movieEffect->g = fadeColor[1] & 0xFF;
-            movieEffect->b = fadeColor[2] & 0xFF;
-
-            if (movieEffect->startFrame <= 1) {
-                _inside_fade = true;
-            }
-
-            movieEffect->next = gMovieEffectHead;
-            gMovieEffectHead = movieEffect;
-
-            movieEffectsCreated++;
+        char* fadeTypeString;
+        if (!configGetString(config.get(), section, "fade_type", &fadeTypeString)) {
+            continue;
         }
 
-        if (movieEffectsCreated != 0) {
-            movieSetPaletteProc(_moviefx_callback_func);
-            _movieSetPaletteFunc(_moviefx_palette_func);
-            rc = 0;
+        int fadeType = MOVIE_EFFECT_TYPE_NONE;
+        if (compat_stricmp(fadeTypeString, "in") == 0) {
+            fadeType = MOVIE_EFFECT_TYPE_FADE_IN;
+        } else if (compat_stricmp(fadeTypeString, "out") == 0) {
+            fadeType = MOVIE_EFFECT_TYPE_FADE_OUT;
         }
+
+        if (fadeType == MOVIE_EFFECT_TYPE_NONE) {
+            continue;
+        }
+
+        int fadeColor[3];
+        if (!configGetIntList(config.get(), section, "fade_color", fadeColor, 3)) {
+            continue;
+        }
+
+        int steps;
+        if (!configGetInt(config.get(), section, "fade_steps", &steps)) {
+            continue;
+        }
+
+        MovieEffect* movieEffect = (MovieEffect*)internal_malloc(sizeof(*movieEffect));
+        if (movieEffect == nullptr) {
+            continue;
+        }
+
+        memset(movieEffect, 0, sizeof(*movieEffect));
+        movieEffect->startFrame = movieEffectFrameList[index];
+        movieEffect->endFrame = movieEffect->startFrame + steps - 1;
+        movieEffect->steps = steps;
+        movieEffect->fadeType = fadeType & 0xFF;
+        movieEffect->r = fadeColor[0] & 0xFF;
+        movieEffect->g = fadeColor[1] & 0xFF;
+        movieEffect->b = fadeColor[2] & 0xFF;
+
+        if (movieEffect->startFrame <= 1) {
+            _inside_fade = true;
+        }
+
+        movieEffect->next = gMovieEffectHead;
+        gMovieEffectHead = movieEffect;
+
+        movieEffectsCreated++;
+    }
+
+    if (movieEffectsCreated != 0) {
+        movieSetPaletteProc(_moviefx_callback_func);
+        _movieSetPaletteFunc(_moviefx_palette_func);
+        rc = 0;
     }
 
     internal_free(movieEffectFrameList);
-
-out:
-
-    configFree(&config);
 
     return rc;
 }

--- a/src/party_member.cc
+++ b/src/party_member.cc
@@ -122,57 +122,54 @@ static int _curID = 20000;
 // 0x493BC0 partyMember_init
 int partyMembersInit()
 {
-    Config config;
-
     gPartyMemberDescriptionsLength = 0;
 
-    if (!configInit(&config)) {
+    ScopedConfig config("data\\party.txt", true);
+    if (!config) {
         return -1;
-    }
-
-    if (!configRead(&config, "data\\party.txt", true)) {
-        goto err;
     }
 
     char section[50];
     snprintf(section, sizeof(section), "Party Member %d", gPartyMemberDescriptionsLength);
 
     int partyMemberPid;
-    while (configGetInt(&config, section, "party_member_pid", &partyMemberPid)) {
+    while (configGetInt(config.get(), section, "party_member_pid", &partyMemberPid)) {
         gPartyMemberDescriptionsLength++;
         snprintf(section, sizeof(section), "Party Member %d", gPartyMemberDescriptionsLength);
     }
 
     gPartyMemberPids = (int*)internal_malloc(sizeof(*gPartyMemberPids) * gPartyMemberDescriptionsLength);
     if (gPartyMemberPids == nullptr) {
-        goto err;
+        return -1;
     }
 
     memset(gPartyMemberPids, 0, sizeof(*gPartyMemberPids) * gPartyMemberDescriptionsLength);
 
     gPartyMembers = (PartyMemberListItem*)internal_malloc(sizeof(*gPartyMembers) * (gPartyMemberDescriptionsLength + 20));
     if (gPartyMembers == nullptr) {
-        goto err;
+        return -1;
     }
 
     memset(gPartyMembers, 0, sizeof(*gPartyMembers) * (gPartyMemberDescriptionsLength + 20));
 
     gPartyMemberDescriptions = (PartyMemberDescription*)internal_malloc(sizeof(*gPartyMemberDescriptions) * gPartyMemberDescriptionsLength);
     if (gPartyMemberDescriptions == nullptr) {
-        goto err;
+        return -1;
     }
 
     memset(gPartyMemberDescriptions, 0, sizeof(*gPartyMemberDescriptions) * gPartyMemberDescriptionsLength);
 
     _partyMemberLevelUpInfoList = (PartyMemberLevelUpInfo*)internal_malloc(sizeof(*_partyMemberLevelUpInfoList) * gPartyMemberDescriptionsLength);
-    if (_partyMemberLevelUpInfoList == nullptr) goto err;
+    if (_partyMemberLevelUpInfoList == nullptr) {
+        return -1;
+    }
 
     memset(_partyMemberLevelUpInfoList, 0, sizeof(*_partyMemberLevelUpInfoList) * gPartyMemberDescriptionsLength);
 
     for (int index = 0; index < gPartyMemberDescriptionsLength; index++) {
         snprintf(section, sizeof(section), "Party Member %d", index);
 
-        if (!configGetInt(&config, section, "party_member_pid", &partyMemberPid)) {
+        if (!configGetInt(config.get(), section, "party_member_pid", &partyMemberPid)) {
             break;
         }
 
@@ -184,7 +181,7 @@ int partyMembersInit()
 
         char* string;
 
-        if (configGetString(&config, section, "area_attack_mode", &string)) {
+        if (configGetString(config.get(), section, "area_attack_mode", &string)) {
             while (*string != '\0') {
                 int areaAttackMode;
                 strParseStrFromList(&string, &areaAttackMode, gAreaAttackModeKeys, AREA_ATTACK_MODE_COUNT);
@@ -192,7 +189,7 @@ int partyMembersInit()
             }
         }
 
-        if (configGetString(&config, section, "attack_who", &string)) {
+        if (configGetString(config.get(), section, "attack_who", &string)) {
             while (*string != '\0') {
                 int attachWho;
                 strParseStrFromList(&string, &attachWho, gAttackWhoKeys, ATTACK_WHO_COUNT);
@@ -200,7 +197,7 @@ int partyMembersInit()
             }
         }
 
-        if (configGetString(&config, section, "best_weapon", &string)) {
+        if (configGetString(config.get(), section, "best_weapon", &string)) {
             while (*string != '\0') {
                 int bestWeapon;
                 strParseStrFromList(&string, &bestWeapon, gBestWeaponKeys, BEST_WEAPON_COUNT);
@@ -208,7 +205,7 @@ int partyMembersInit()
             }
         }
 
-        if (configGetString(&config, section, "chem_use", &string)) {
+        if (configGetString(config.get(), section, "chem_use", &string)) {
             while (*string != '\0') {
                 int chemUse;
                 strParseStrFromList(&string, &chemUse, gChemUseKeys, CHEM_USE_COUNT);
@@ -216,7 +213,7 @@ int partyMembersInit()
             }
         }
 
-        if (configGetString(&config, section, "distance", &string)) {
+        if (configGetString(config.get(), section, "distance", &string)) {
             while (*string != '\0') {
                 int distanceMode;
                 strParseStrFromList(&string, &distanceMode, gDistanceModeKeys, DISTANCE_COUNT);
@@ -224,7 +221,7 @@ int partyMembersInit()
             }
         }
 
-        if (configGetString(&config, section, "run_away_mode", &string)) {
+        if (configGetString(config.get(), section, "run_away_mode", &string)) {
             while (*string != '\0') {
                 int runAwayMode;
                 strParseStrFromList(&string, &runAwayMode, gRunAwayModeKeys, RUN_AWAY_MODE_COUNT);
@@ -232,7 +229,7 @@ int partyMembersInit()
             }
         }
 
-        if (configGetString(&config, section, "disposition", &string)) {
+        if (configGetString(config.get(), section, "disposition", &string)) {
             while (*string != '\0') {
                 int disposition;
                 strParseStrFromList(&string, &disposition, gDispositionKeys, DISPOSITION_COUNT);
@@ -241,15 +238,15 @@ int partyMembersInit()
         }
 
         int levelUpEvery;
-        if (configGetInt(&config, section, "level_up_every", &levelUpEvery)) {
+        if (configGetInt(config.get(), section, "level_up_every", &levelUpEvery)) {
             partyMemberDescription->level_up_every = levelUpEvery;
 
             int levelMinimum;
-            if (configGetInt(&config, section, "level_minimum", &levelMinimum)) {
+            if (configGetInt(config.get(), section, "level_minimum", &levelMinimum)) {
                 partyMemberDescription->level_minimum = levelMinimum;
             }
 
-            if (configGetString(&config, section, "level_pids", &string)) {
+            if (configGetString(config.get(), section, "level_pids", &string)) {
                 while (*string != '\0' && partyMemberDescription->level_pids_num < PARTY_MEMBER_MAX_LEVEL) {
                     int levelPid;
                     strParseInt(&string, &levelPid);
@@ -260,15 +257,7 @@ int partyMembersInit()
         }
     }
 
-    configFree(&config);
-
     return 0;
-
-err:
-
-    configFree(&config);
-
-    return -1;
 }
 
 // 0x4940E4 partyMember_reset

--- a/src/party_member.cc
+++ b/src/party_member.cc
@@ -116,57 +116,54 @@ static int _curID = 20000;
 // 0x493BC0 partyMember_init
 int partyMembersInit()
 {
-    Config config;
-
     gPartyMemberDescriptionsLength = 0;
 
-    if (!configInit(&config)) {
+    ScopedConfig config("data\\party.txt", true);
+    if (!config) {
         return -1;
-    }
-
-    if (!configRead(&config, "data\\party.txt", true)) {
-        goto err;
     }
 
     char section[50];
     snprintf(section, sizeof(section), "Party Member %d", gPartyMemberDescriptionsLength);
 
     int partyMemberPid;
-    while (configGetInt(&config, section, "party_member_pid", &partyMemberPid)) {
+    while (configGetInt(config.get(), section, "party_member_pid", &partyMemberPid)) {
         gPartyMemberDescriptionsLength++;
         snprintf(section, sizeof(section), "Party Member %d", gPartyMemberDescriptionsLength);
     }
 
     gPartyMemberPids = (int*)internal_malloc(sizeof(*gPartyMemberPids) * gPartyMemberDescriptionsLength);
     if (gPartyMemberPids == nullptr) {
-        goto err;
+        return -1;
     }
 
     memset(gPartyMemberPids, 0, sizeof(*gPartyMemberPids) * gPartyMemberDescriptionsLength);
 
     gPartyMembers = (PartyMemberListItem*)internal_malloc(sizeof(*gPartyMembers) * (gPartyMemberDescriptionsLength + 20));
     if (gPartyMembers == nullptr) {
-        goto err;
+        return -1;
     }
 
     memset(gPartyMembers, 0, sizeof(*gPartyMembers) * (gPartyMemberDescriptionsLength + 20));
 
     gPartyMemberDescriptions = (PartyMemberDescription*)internal_malloc(sizeof(*gPartyMemberDescriptions) * gPartyMemberDescriptionsLength);
     if (gPartyMemberDescriptions == nullptr) {
-        goto err;
+        return -1;
     }
 
     memset(gPartyMemberDescriptions, 0, sizeof(*gPartyMemberDescriptions) * gPartyMemberDescriptionsLength);
 
     _partyMemberLevelUpInfoList = (PartyMemberLevelUpInfo*)internal_malloc(sizeof(*_partyMemberLevelUpInfoList) * gPartyMemberDescriptionsLength);
-    if (_partyMemberLevelUpInfoList == nullptr) goto err;
+    if (_partyMemberLevelUpInfoList == nullptr) {
+        return -1;
+    }
 
     memset(_partyMemberLevelUpInfoList, 0, sizeof(*_partyMemberLevelUpInfoList) * gPartyMemberDescriptionsLength);
 
     for (int index = 0; index < gPartyMemberDescriptionsLength; index++) {
         snprintf(section, sizeof(section), "Party Member %d", index);
 
-        if (!configGetInt(&config, section, "party_member_pid", &partyMemberPid)) {
+        if (!configGetInt(config.get(), section, "party_member_pid", &partyMemberPid)) {
             break;
         }
 
@@ -178,7 +175,7 @@ int partyMembersInit()
 
         char* string;
 
-        if (configGetString(&config, section, "area_attack_mode", &string)) {
+        if (configGetString(config.get(), section, "area_attack_mode", &string)) {
             while (*string != '\0') {
                 int areaAttackMode;
                 if (strParseStrFromList(&string, &areaAttackMode, gAreaAttackModeKeys, AREA_ATTACK_MODE_COUNT) == 0) {
@@ -187,7 +184,7 @@ int partyMembersInit()
             }
         }
 
-        if (configGetString(&config, section, "attack_who", &string)) {
+        if (configGetString(config.get(), section, "attack_who", &string)) {
             while (*string != '\0') {
                 int attackWho;
                 if (strParseStrFromList(&string, &attackWho, gAttackWhoKeys, ATTACK_WHO_COUNT) == 0) {
@@ -196,7 +193,7 @@ int partyMembersInit()
             }
         }
 
-        if (configGetString(&config, section, "best_weapon", &string)) {
+        if (configGetString(config.get(), section, "best_weapon", &string)) {
             while (*string != '\0') {
                 int bestWeapon;
                 if (strParseStrFromList(&string, &bestWeapon, gBestWeaponKeys, BEST_WEAPON_COUNT) == 0) {
@@ -205,7 +202,7 @@ int partyMembersInit()
             }
         }
 
-        if (configGetString(&config, section, "chem_use", &string)) {
+        if (configGetString(config.get(), section, "chem_use", &string)) {
             while (*string != '\0') {
                 int chemUse;
                 if (strParseStrFromList(&string, &chemUse, gChemUseKeys, CHEM_USE_COUNT) == 0) {
@@ -214,7 +211,7 @@ int partyMembersInit()
             }
         }
 
-        if (configGetString(&config, section, "distance", &string)) {
+        if (configGetString(config.get(), section, "distance", &string)) {
             while (*string != '\0') {
                 int distanceMode;
                 if (strParseStrFromList(&string, &distanceMode, gDistanceModeKeys, DISTANCE_COUNT) == 0) {
@@ -223,7 +220,7 @@ int partyMembersInit()
             }
         }
 
-        if (configGetString(&config, section, "run_away_mode", &string)) {
+        if (configGetString(config.get(), section, "run_away_mode", &string)) {
             while (*string != '\0') {
                 int runAwayMode;
                 if (strParseStrFromList(&string, &runAwayMode, gRunAwayModeKeys, RUN_AWAY_MODE_COUNT) == 0) {
@@ -232,7 +229,7 @@ int partyMembersInit()
             }
         }
 
-        if (configGetString(&config, section, "disposition", &string)) {
+        if (configGetString(config.get(), section, "disposition", &string)) {
             while (*string != '\0') {
                 int disposition;
                 if (strParseStrFromList(&string, &disposition, gDispositionKeys, DISPOSITION_COUNT) == 0) {
@@ -242,15 +239,15 @@ int partyMembersInit()
         }
 
         int levelUpEvery;
-        if (configGetInt(&config, section, "level_up_every", &levelUpEvery)) {
+        if (configGetInt(config.get(), section, "level_up_every", &levelUpEvery)) {
             partyMemberDescription->level_up_every = levelUpEvery;
 
             int levelMinimum;
-            if (configGetInt(&config, section, "level_minimum", &levelMinimum)) {
+            if (configGetInt(config.get(), section, "level_minimum", &levelMinimum)) {
                 partyMemberDescription->level_minimum = levelMinimum;
             }
 
-            if (configGetString(&config, section, "level_pids", &string)) {
+            if (configGetString(config.get(), section, "level_pids", &string)) {
                 while (*string != '\0' && partyMemberDescription->level_pids_num < PARTY_MEMBER_MAX_LEVEL) {
                     int levelPid;
                     strParseInt(&string, &levelPid);
@@ -261,15 +258,7 @@ int partyMembersInit()
         }
     }
 
-    configFree(&config);
-
     return 0;
-
-err:
-
-    configFree(&config);
-
-    return -1;
 }
 
 // 0x4940E4 partyMember_reset

--- a/src/worldmap.cc
+++ b/src/worldmap.cc
@@ -1305,37 +1305,37 @@ static int wmConfigInit()
         return -1;
     }
 
-    Config config;
-    if (!configInit(&config)) {
+    ScopedConfig config;
+    if (!config) {
         return -1;
     }
 
-    if (configRead(&config, "data\\worldmap.txt", true)) {
+    if (configRead(config.get(), "data\\worldmap.txt", true)) {
         for (int index = 0; index < ENCOUNTER_FREQUENCY_TYPE_COUNT; index++) {
-            if (!configGetInt(&config, "data", wmFreqStrs[index], &(wmFreqValues[index]))) {
+            if (!configGetInt(config.get(), "data", wmFreqStrs[index], &(wmFreqValues[index]))) {
                 break;
             }
         }
 
         char* terrainTypes;
-        configGetString(&config, "data", "terrain_types", &terrainTypes);
-        wmParseTerrainTypes(&config, terrainTypes);
+        configGetString(config.get(), "data", "terrain_types", &terrainTypes);
+        wmParseTerrainTypes(config.get(), terrainTypes);
 
         for (int index = 0;; index++) {
             char section[40];
             snprintf(section, sizeof(section), "Encounter Table %d", index);
 
             char* lookupName;
-            if (!configGetString(&config, section, "lookup_name", &lookupName)) {
+            if (!configGetString(config.get(), section, "lookup_name", &lookupName)) {
                 break;
             }
 
-            if (wmReadEncounterType(&config, lookupName, section) == -1) {
+            if (wmReadEncounterType(config.get(), lookupName, section) == -1) {
                 return -1;
             }
         }
 
-        if (!configGetInt(&config, "Tile Data", "num_horizontal_tiles", &wmNumHorizontalTiles)) {
+        if (!configGetInt(config.get(), "Tile Data", "num_horizontal_tiles", &wmNumHorizontalTiles)) {
             showMessageBox("\nwmConfigInit::Error loading tile data!");
             return -1;
         }
@@ -1345,7 +1345,7 @@ static int wmConfigInit()
             snprintf(section, sizeof(section), "Tile %d", tileIndex);
 
             int artIndex;
-            if (!configGetInt(&config, section, "art_idx", &artIndex)) {
+            if (!configGetInt(config.get(), section, "art_idx", &artIndex)) {
                 break;
             }
 
@@ -1367,12 +1367,12 @@ static int wmConfigInit()
             tile->fid = buildFid(OBJ_TYPE_INTERFACE, artIndex, 0, 0, 0);
 
             int encounterDifficulty;
-            if (configGetInt(&config, section, "encounter_difficulty", &encounterDifficulty)) {
+            if (configGetInt(config.get(), section, "encounter_difficulty", &encounterDifficulty)) {
                 tile->encounterDifficultyModifier = encounterDifficulty;
             }
 
             char* walkMaskName;
-            if (configGetString(&config, section, "walk_mask_name", &walkMaskName)) {
+            if (configGetString(config.get(), section, "walk_mask_name", &walkMaskName)) {
                 strncpy(tile->walkMaskName, walkMaskName, TILE_WALK_MASK_NAME_SIZE);
             }
 
@@ -1382,7 +1382,7 @@ static int wmConfigInit()
                     snprintf(key, sizeof(key), "%d_%d", row, column);
 
                     char* subtileProps;
-                    if (!configGetString(&config, section, key, &subtileProps)) {
+                    if (!configGetString(config.get(), section, key, &subtileProps)) {
                         showMessageBox("\nwmConfigInit::Error loading tiles!");
                         exit(1);
                     }
@@ -1395,8 +1395,6 @@ static int wmConfigInit()
             }
         }
     }
-
-    configFree(&config);
 
     return 0;
 }
@@ -2423,7 +2421,7 @@ static int wmAreaSlotInit(CityInfo* area)
 // 0x4BEF68 wmAreaInit
 static int wmAreaInit()
 {
-    Config cfg;
+    ScopedConfig cfg;
     char section[40];
     char key[40];
     int area_idx;
@@ -2437,15 +2435,15 @@ static int wmAreaInit()
         return -1;
     }
 
-    if (!configInit(&cfg)) {
+    if (!cfg) {
         return -1;
     }
 
-    if (configRead(&cfg, "data\\city.txt", true)) {
+    if (configRead(cfg.get(), "data\\city.txt", true)) {
         area_idx = 0;
         do {
             snprintf(section, sizeof(section), "Area %02d", area_idx);
-            if (!configGetInt(&cfg, section, "townmap_art_idx", &num)) {
+            if (!configGetInt(cfg.get(), section, "townmap_art_idx", &num)) {
                 break;
             }
 
@@ -2472,7 +2470,7 @@ static int wmAreaInit()
 
             city->mapFid = num;
 
-            if (configGetInt(&cfg, section, "townmap_label_art_idx", &num)) {
+            if (configGetInt(cfg.get(), section, "townmap_label_art_idx", &num)) {
                 if (num != -1) {
                     num = buildFid(OBJ_TYPE_INTERFACE, num, 0, 0, 0);
                 }
@@ -2480,14 +2478,14 @@ static int wmAreaInit()
                 city->labelFid = num;
             }
 
-            if (!configGetString(&cfg, section, "area_name", &str)) {
+            if (!configGetString(cfg.get(), section, "area_name", &str)) {
                 showMessageBox("\nwmConfigInit::Error loading areas!");
                 exit(1);
             }
 
             strncpy(city->name, str, 40);
 
-            if (!configGetString(&cfg, section, "world_pos", &str)) {
+            if (!configGetString(cfg.get(), section, "world_pos", &str)) {
                 showMessageBox("\nwmConfigInit::Error loading areas!");
                 exit(1);
             }
@@ -2500,7 +2498,7 @@ static int wmAreaInit()
                 return -1;
             }
 
-            if (!configGetString(&cfg, section, "start_state", &str)) {
+            if (!configGetString(cfg.get(), section, "start_state", &str)) {
                 showMessageBox("\nwmConfigInit::Error loading areas!");
                 exit(1);
             }
@@ -2509,13 +2507,13 @@ static int wmAreaInit()
                 return -1;
             }
 
-            if (configGetString(&cfg, section, "lock_state", &str)) {
+            if (configGetString(cfg.get(), section, "lock_state", &str)) {
                 if (strParseStrFromList(&str, &(city->lockState), wmStateStrs, 2) == -1) {
                     return -1;
                 }
             }
 
-            if (!configGetString(&cfg, section, "size", &str)) {
+            if (!configGetString(cfg.get(), section, "size", &str)) {
                 showMessageBox("\nwmConfigInit::Error loading areas!");
                 exit(1);
             }
@@ -2527,7 +2525,7 @@ static int wmAreaInit()
             while (city->entrancesLength < ENTRANCE_LIST_CAPACITY) {
                 snprintf(key, sizeof(key), "entrance_%d", city->entrancesLength);
 
-                if (!configGetString(&cfg, section, key, &str)) {
+                if (!configGetString(cfg.get(), section, key, &str)) {
                     break;
                 }
 
@@ -2570,8 +2568,6 @@ static int wmAreaInit()
             area_idx++;
         } while (area_idx < 5000);
     }
-
-    configFree(&cfg);
 
     // SFALL: CitiesLimitFix (always on)
     /*if (wmMaxAreaNum != CITY_COUNT) {
@@ -2638,17 +2634,17 @@ static int wmMapInit()
     MapInfo* maps;
     MapInfo* map;
 
-    Config config;
-    if (!configInit(&config)) {
+    ScopedConfig config;
+    if (!config) {
         return -1;
     }
 
-    if (configRead(&config, "data\\maps.txt", true)) {
+    if (configRead(config.get(), "data\\maps.txt", true)) {
         for (int mapIdx = 0;; mapIdx++) {
             char section[40];
             snprintf(section, sizeof(section), "Map %03d", mapIdx);
 
-            if (!configGetString(&config, section, "lookup_name", &str)) {
+            if (!configGetString(config.get(), section, "lookup_name", &str)) {
                 break;
             }
 
@@ -2667,7 +2663,7 @@ static int wmMapInit()
 
             strncpy(map->lookupName, str, 40);
 
-            if (!configGetString(&config, section, "map_name", &str)) {
+            if (!configGetString(config.get(), section, "map_name", &str)) {
                 showMessageBox("\nwmConfigInit::Error loading maps!");
                 exit(1);
             }
@@ -2675,11 +2671,11 @@ static int wmMapInit()
             compat_strlwr(str);
             strncpy(map->mapFileName, str, 40);
 
-            if (configGetString(&config, section, "music", &str)) {
+            if (configGetString(config.get(), section, "music", &str)) {
                 strncpy(map->music, str, 40);
             }
 
-            if (configGetString(&config, section, "ambient_sfx", &str)) {
+            if (configGetString(config.get(), section, "ambient_sfx", &str)) {
                 while (str) {
                     MapAmbientSoundEffectInfo* sfx = &(map->ambientSoundEffects[map->ambientSoundEffectsLength]);
                     if (strParseKeyValue(&str, sfx->name, &(sfx->chance), ":") == -1) {
@@ -2701,7 +2697,7 @@ static int wmMapInit()
                 }
             }
 
-            if (configGetString(&config, section, "saved", &str)) {
+            if (configGetString(config.get(), section, "saved", &str)) {
                 if (strParseStrFromList(&str, &num, wmYesNoStrs, 2) == -1) {
                     return -1;
                 }
@@ -2710,7 +2706,7 @@ static int wmMapInit()
                 wmSetFlags(&(map->flags), MAP_SAVED, num);
             }
 
-            if (configGetString(&config, section, "dead_bodies_age", &str)) {
+            if (configGetString(config.get(), section, "dead_bodies_age", &str)) {
                 if (strParseStrFromList(&str, &num, wmYesNoStrs, 2) == -1) {
                     return -1;
                 }
@@ -2719,7 +2715,7 @@ static int wmMapInit()
                 wmSetFlags(&(map->flags), MAP_DEAD_BODIES_AGE, num);
             }
 
-            if (configGetString(&config, section, "can_rest_here", &str)) {
+            if (configGetString(config.get(), section, "can_rest_here", &str)) {
                 if (strParseStrFromList(&str, &num, wmYesNoStrs, 2) == -1) {
                     return -1;
                 }
@@ -2742,7 +2738,7 @@ static int wmMapInit()
                 wmSetFlags(&(map->flags), MAP_CAN_REST_ELEVATION_2, num);
             }
 
-            if (configGetString(&config, section, "pipboy_active", &str)) {
+            if (configGetString(config.get(), section, "pipboy_active", &str)) {
                 if (strParseStrFromList(&str, &num, wmYesNoStrs, 2) == -1) {
                     return -1;
                 }
@@ -2752,7 +2748,7 @@ static int wmMapInit()
             }
 
             // SFALL: Pip-boy automaps patch.
-            if (configGetString(&config, section, "automap", &str)) {
+            if (configGetString(config.get(), section, "automap", &str)) {
                 if (strParseStrFromList(&str, &num, wmYesNoStrs, 2) == -1) {
                     return -1;
                 }
@@ -2760,7 +2756,7 @@ static int wmMapInit()
                 automapSetDisplayMap(mapIdx, num);
             }
 
-            if (configGetString(&config, section, "random_start_point_0", &str)) {
+            if (configGetString(config.get(), section, "random_start_point_0", &str)) {
                 int rspIndex = 0;
                 while (str != nullptr) {
                     while (*str != '\0') {
@@ -2782,15 +2778,13 @@ static int wmMapInit()
                     char key[40];
                     snprintf(key, sizeof(key), "random_start_point_%1d", ++rspIndex);
 
-                    if (!configGetString(&config, section, key, &str)) {
+                    if (!configGetString(config.get(), section, key, &str)) {
                         str = nullptr;
                     }
                 }
             }
         }
     }
-
-    configFree(&config);
 
     return 0;
 }

--- a/src/worldmap.cc
+++ b/src/worldmap.cc
@@ -1646,37 +1646,37 @@ static int wmConfigInit()
         return -1;
     }
 
-    Config config;
-    if (!configInit(&config)) {
+    ScopedConfig config;
+    if (!config) {
         return -1;
     }
 
-    if (configRead(&config, "data\\worldmap.txt", true)) {
+    if (configRead(config.get(), "data\\worldmap.txt", true)) {
         for (int index = 0; index < ENCOUNTER_FREQUENCY_TYPE_COUNT; index++) {
-            if (!configGetInt(&config, "data", wmFreqStrs[index], &(wmFreqValues[index]))) {
+            if (!configGetInt(config.get(), "data", wmFreqStrs[index], &(wmFreqValues[index]))) {
                 break;
             }
         }
 
         char* terrainTypes;
-        configGetString(&config, "data", "terrain_types", &terrainTypes);
-        wmParseTerrainTypes(&config, terrainTypes);
+        configGetString(config.get(), "data", "terrain_types", &terrainTypes);
+        wmParseTerrainTypes(config.get(), terrainTypes);
 
         for (int index = 0;; index++) {
             char section[40];
             snprintf(section, sizeof(section), "Encounter Table %d", index);
 
             char* lookupName;
-            if (!configGetString(&config, section, "lookup_name", &lookupName)) {
+            if (!configGetString(config.get(), section, "lookup_name", &lookupName)) {
                 break;
             }
 
-            if (wmReadEncounterType(&config, lookupName, section) == -1) {
+            if (wmReadEncounterType(config.get(), lookupName, section) == -1) {
                 return -1;
             }
         }
 
-        if (!configGetInt(&config, "Tile Data", "num_horizontal_tiles", &wmNumHorizontalTiles)) {
+        if (!configGetInt(config.get(), "Tile Data", "num_horizontal_tiles", &wmNumHorizontalTiles)) {
             showMessageBox("\nwmConfigInit::Error loading tile data!");
             return -1;
         }
@@ -1686,7 +1686,7 @@ static int wmConfigInit()
             snprintf(section, sizeof(section), "Tile %d", tileIndex);
 
             int artIndex;
-            if (!configGetInt(&config, section, "art_idx", &artIndex)) {
+            if (!configGetInt(config.get(), section, "art_idx", &artIndex)) {
                 break;
             }
 
@@ -1708,12 +1708,12 @@ static int wmConfigInit()
             tile->fid = buildFid(OBJ_TYPE_INTERFACE, artIndex);
 
             int encounterDifficulty;
-            if (configGetInt(&config, section, "encounter_difficulty", &encounterDifficulty)) {
+            if (configGetInt(config.get(), section, "encounter_difficulty", &encounterDifficulty)) {
                 tile->encounterDifficultyModifier = encounterDifficulty;
             }
 
             char* walkMaskName;
-            if (configGetString(&config, section, "walk_mask_name", &walkMaskName)) {
+            if (configGetString(config.get(), section, "walk_mask_name", &walkMaskName)) {
                 strncpy(tile->walkMaskName, walkMaskName, TILE_WALK_MASK_NAME_SIZE);
             }
 
@@ -1723,7 +1723,7 @@ static int wmConfigInit()
                     snprintf(key, sizeof(key), "%d_%d", row, column);
 
                     char* subtileProps;
-                    if (!configGetString(&config, section, key, &subtileProps)) {
+                    if (!configGetString(config.get(), section, key, &subtileProps)) {
                         showMessageBox("\nwmConfigInit::Error loading tiles!");
                         exit(1);
                     }
@@ -1736,8 +1736,6 @@ static int wmConfigInit()
             }
         }
     }
-
-    configFree(&config);
 
     return 0;
 }
@@ -2764,7 +2762,7 @@ static int wmAreaSlotInit(CityInfo* area)
 // 0x4BEF68 wmAreaInit
 static int wmAreaInit()
 {
-    Config cfg;
+    ScopedConfig cfg;
     char section[40];
     char key[40];
     City area_idx;
@@ -2778,15 +2776,15 @@ static int wmAreaInit()
         return -1;
     }
 
-    if (!configInit(&cfg)) {
+    if (!cfg) {
         return -1;
     }
 
-    if (configRead(&cfg, "data\\city.txt", true)) {
+    if (configRead(cfg.get(), "data\\city.txt", true)) {
         area_idx = CITY_FIRST;
         do {
             snprintf(section, sizeof(section), "Area %02d", area_idx);
-            if (!configGetInt(&cfg, section, "townmap_art_idx", &num)) {
+            if (!configGetInt(cfg.get(), section, "townmap_art_idx", &num)) {
                 break;
             }
 
@@ -2813,7 +2811,7 @@ static int wmAreaInit()
 
             city->mapFid = num;
 
-            if (configGetInt(&cfg, section, "townmap_label_art_idx", &num)) {
+            if (configGetInt(cfg.get(), section, "townmap_label_art_idx", &num)) {
                 if (num != -1) {
                     num = buildFid(OBJ_TYPE_INTERFACE, num);
                 }
@@ -2821,14 +2819,14 @@ static int wmAreaInit()
                 city->labelFid = num;
             }
 
-            if (!configGetString(&cfg, section, "area_name", &str)) {
+            if (!configGetString(cfg.get(), section, "area_name", &str)) {
                 showMessageBox("\nwmConfigInit::Error loading areas!");
                 exit(1);
             }
 
             strncpy(city->name, str, 40);
 
-            if (!configGetString(&cfg, section, "world_pos", &str)) {
+            if (!configGetString(cfg.get(), section, "world_pos", &str)) {
                 showMessageBox("\nwmConfigInit::Error loading areas!");
                 exit(1);
             }
@@ -2841,7 +2839,7 @@ static int wmAreaInit()
                 return -1;
             }
 
-            if (!configGetString(&cfg, section, "start_state", &str)) {
+            if (!configGetString(cfg.get(), section, "start_state", &str)) {
                 showMessageBox("\nwmConfigInit::Error loading areas!");
                 exit(1);
             }
@@ -2850,13 +2848,13 @@ static int wmAreaInit()
                 return -1;
             }
 
-            if (configGetString(&cfg, section, "lock_state", &str)) {
+            if (configGetString(cfg.get(), section, "lock_state", &str)) {
                 if (strParseStrFromListEnum<LockState>(&str, &(city->lockState), wmStateStrs, LOCK_STATE_COUNT) == -1) {
                     return -1;
                 }
             }
 
-            if (!configGetString(&cfg, section, "size", &str)) {
+            if (!configGetString(cfg.get(), section, "size", &str)) {
                 showMessageBox("\nwmConfigInit::Error loading areas!");
                 exit(1);
             }
@@ -2868,7 +2866,7 @@ static int wmAreaInit()
             while (city->entrancesLength < ENTRANCE_LIST_CAPACITY) {
                 snprintf(key, sizeof(key), "entrance_%d", city->entrancesLength);
 
-                if (!configGetString(&cfg, section, key, &str)) {
+                if (!configGetString(cfg.get(), section, key, &str)) {
                     break;
                 }
 
@@ -2911,8 +2909,6 @@ static int wmAreaInit()
             area_idx++;
         } while (area_idx < 5000);
     }
-
-    configFree(&cfg);
 
     // SFALL: CitiesLimitFix (always on)
     /*if (wmMaxAreaNum != CITY_COUNT) {
@@ -2979,17 +2975,17 @@ static int wmMapInit()
     MapInfo* maps;
     MapInfo* map;
 
-    Config config;
-    if (!configInit(&config)) {
+    ScopedConfig config;
+    if (!config) {
         return -1;
     }
 
-    if (configRead(&config, "data\\maps.txt", true)) {
+    if (configRead(config.get(), "data\\maps.txt", true)) {
         for (Map mapIdx = MAP_FIRST;; mapIdx++) {
             char section[40];
             snprintf(section, sizeof(section), "Map %03d", mapIdx);
 
-            if (!configGetString(&config, section, "lookup_name", &str)) {
+            if (!configGetString(config.get(), section, "lookup_name", &str)) {
                 break;
             }
 
@@ -3008,7 +3004,7 @@ static int wmMapInit()
 
             strncpy(map->lookupName, str, 40);
 
-            if (!configGetString(&config, section, "map_name", &str)) {
+            if (!configGetString(config.get(), section, "map_name", &str)) {
                 showMessageBox("\nwmConfigInit::Error loading maps!");
                 exit(1);
             }
@@ -3016,11 +3012,11 @@ static int wmMapInit()
             compat_strlwr(str);
             strncpy(map->mapFileName, str, 40);
 
-            if (configGetString(&config, section, "music", &str)) {
+            if (configGetString(config.get(), section, "music", &str)) {
                 strncpy(map->music, str, 40);
             }
 
-            if (configGetString(&config, section, "ambient_sfx", &str)) {
+            if (configGetString(config.get(), section, "ambient_sfx", &str)) {
                 while (str) {
                     MapAmbientSoundEffectInfo* sfx = &(map->ambientSoundEffects[map->ambientSoundEffectsLength]);
                     if (strParseKeyValue(&str, sfx->name, &(sfx->chance), ":") == -1) {
@@ -3042,7 +3038,7 @@ static int wmMapInit()
                 }
             }
 
-            if (configGetString(&config, section, "saved", &str)) {
+            if (configGetString(config.get(), section, "saved", &str)) {
                 if (strParseStrFromList(&str, &num, wmYesNoStrs, 2) == -1) {
                     return -1;
                 }
@@ -3051,7 +3047,7 @@ static int wmMapInit()
                 wmSetFlags(&(map->flags), MAP_SAVED, num);
             }
 
-            if (configGetString(&config, section, "dead_bodies_age", &str)) {
+            if (configGetString(config.get(), section, "dead_bodies_age", &str)) {
                 if (strParseStrFromList(&str, &num, wmYesNoStrs, 2) == -1) {
                     return -1;
                 }
@@ -3060,7 +3056,7 @@ static int wmMapInit()
                 wmSetFlags(&(map->flags), MAP_DEAD_BODIES_AGE, num);
             }
 
-            if (configGetString(&config, section, "can_rest_here", &str)) {
+            if (configGetString(config.get(), section, "can_rest_here", &str)) {
                 if (strParseStrFromList(&str, &num, wmYesNoStrs, 2) == -1) {
                     return -1;
                 }
@@ -3083,7 +3079,7 @@ static int wmMapInit()
                 wmSetFlags(&(map->flags), MAP_CAN_REST_ELEVATION_2, num);
             }
 
-            if (configGetString(&config, section, "pipboy_active", &str)) {
+            if (configGetString(config.get(), section, "pipboy_active", &str)) {
                 if (strParseStrFromList(&str, &num, wmYesNoStrs, 2) == -1) {
                     return -1;
                 }
@@ -3093,7 +3089,7 @@ static int wmMapInit()
             }
 
             // SFALL: Pip-boy automaps patch.
-            if (configGetString(&config, section, "automap", &str)) {
+            if (configGetString(config.get(), section, "automap", &str)) {
                 if (strParseStrFromList(&str, &num, wmYesNoStrs, 2) == -1) {
                     return -1;
                 }
@@ -3101,7 +3097,7 @@ static int wmMapInit()
                 automapSetDisplayMap(mapIdx, num);
             }
 
-            if (configGetString(&config, section, "random_start_point_0", &str)) {
+            if (configGetString(config.get(), section, "random_start_point_0", &str)) {
                 int rspIndex = 0;
                 while (str != nullptr) {
                     while (*str != '\0') {
@@ -3123,15 +3119,13 @@ static int wmMapInit()
                     char key[40];
                     snprintf(key, sizeof(key), "random_start_point_%1d", ++rspIndex);
 
-                    if (!configGetString(&config, section, key, &str)) {
+                    if (!configGetString(config.get(), section, key, &str)) {
                         str = nullptr;
                     }
                 }
             }
         }
     }
-
-    configFree(&config);
 
     return 0;
 }


### PR DESCRIPTION
Eliminates the free, which sometimes required gotos.

Left configRead in a couple places that return different values if the file is missing (0) vs hard error (-1). With more careful analysis it's possible we could fold the read into the ScopeConfig constructor in these cases too.

Also, doing this makes it feel like a ScopeConfig::get(section, value, &out) function would feel nice, as well as iterators for sections/keys.

Note: looks like a lot of code has changed, but the function bodies are mostly just outdented.  Only the first few lines of each function is typically modified, + mechanical changes to retrieving config values
