### PR TITLE
ZIP DB archive support

### DIFF
--- a/src/dfile.cc
+++ b/src/dfile.cc
@@ -39,6 +39,7 @@ namespace fallout {
 
 static int dbaseFindEntryByFilePath(const void* file, const void* entryName);
 static int dbaseFindEntryByFilePathForSort(const void* a, const void* b);
+static bool dbaseZipIsEocd(const unsigned char* p);
 static bool dbaseParseZip(DBase* dbase, FILE* stream);
 static DFile* dfileOpenInternal(DBase* dbase, const char* filename, const char* mode, DFile* dfile);
 static int dfileReadCharInternal(DFile* stream);
@@ -679,6 +680,11 @@ static int dbaseFindEntryByFilePathForSort(const void* a, const void* b)
     return compat_stricmp(ea->path, eb->path);
 }
 
+static bool dbaseZipIsEocd(const unsigned char* p)
+{
+    return p[0] == 0x50 && p[1] == 0x4b && p[2] == 0x05 && p[3] == 0x06;
+}
+
 // Parses a ZIP archive's central directory and builds the DBaseEntry array.
 static bool dbaseParseZip(DBase* dbase, FILE* stream)
 {
@@ -690,43 +696,53 @@ static bool dbaseParseZip(DBase* dbase, FILE* stream)
         return false;
     }
 
-    // Search for EOCD signature within the last 65557 bytes of the file.
-    int searchStart = std::max(0, fileSize - kMaxEocdSearch);
-    int searchSize = fileSize - searchStart;
-
-    unsigned char* buf = (unsigned char*)malloc(searchSize);
-    if (!buf) {
+    // Try the common case first: no comment, EOCD is the last 22 bytes.
+    unsigned char tail[22];
+    fseek(stream, -22, SEEK_END);
+    if (fread(tail, sizeof(tail), 1, stream) != 1) {
         return false;
     }
 
-    fseek(stream, searchStart, SEEK_SET);
-    if (fread(buf, searchSize, 1, stream) != 1) {
-        free(buf);
-        return false;
-    }
+    int eocdOffset = fileSize - 22;
+    bool found = dbaseZipIsEocd(tail);
 
-    int eocdOffset = -1;
-    for (int i = searchSize - 22; i >= 0; i--) {
-        if (buf[i] == 0x50 && buf[i + 1] == 0x4b && buf[i + 2] == 0x05 && buf[i + 3] == 0x06) {
-            eocdOffset = searchStart + i;
-            break;
+    // ZIP allows a variable-length comment between the EOCD and end of file.
+    // Search backwards through the last 65557 bytes if not at the expected spot.
+    if (!found) {
+        int searchStart = std::max(0, fileSize - kMaxEocdSearch);
+        int searchSize = fileSize - searchStart;
+
+        unsigned char* buf = (unsigned char*)malloc(searchSize);
+        if (!buf) {
+            return false;
         }
-    }
-    free(buf);
 
-    if (eocdOffset < 0) {
+        fseek(stream, searchStart, SEEK_SET);
+        if (fread(buf, searchSize, 1, stream) != 1) {
+            free(buf);
+            return false;
+        }
+
+        for (int i = searchSize - 22; i >= 0; i--) {
+            if (dbaseZipIsEocd(buf + i)) {
+                eocdOffset = searchStart + i;
+                found = true;
+                break;
+            }
+        }
+        free(buf);
+    }
+
+    if (!found) {
         return false;
     }
 
-    // Read EOCD fields: total entries, central directory offset.
+    // Read EOCD: entries on this disk (skip), total entries, CD size, CD offset.
     if (fseek(stream, eocdOffset + 8, SEEK_SET) != 0) {
         return false;
     }
 
-    unsigned short diskEntries;
-    if (fread(&diskEntries, sizeof(diskEntries), 1, stream) != 1) {
-        return false;
-    }
+    fseek(stream, 2, SEEK_CUR); // entries on this disk
 
     unsigned short totalEntries;
     if (fread(&totalEntries, sizeof(totalEntries), 1, stream) != 1) {
@@ -741,6 +757,13 @@ static bool dbaseParseZip(DBase* dbase, FILE* stream)
     unsigned int centralDirOffset;
     if (fread(&centralDirOffset, sizeof(centralDirOffset), 1, stream) != 1) {
         return false;
+    }
+
+    if (totalEntries == 0xFFFF || centralDirSize == 0xFFFFFFFF || centralDirOffset == 0xFFFFFFFF) {
+        dbase->errorFlags |= DBASE_ERROR_ZIP64;
+        dbase->entriesLength = 0;
+        dbase->entries = nullptr;
+        return true;
     }
 
     if (totalEntries == 0) {
@@ -777,8 +800,11 @@ static bool dbaseParseZip(DBase* dbase, FILE* stream)
             break;
         }
 
+        if (flags & 0x01) {
+            dbase->errorFlags |= DBASE_ERROR_ENCRYPTED;
+        }
         if (flags & 0x08) {
-            dbase->errorFlags = dbase->errorFlags | DBASE_ERROR_DESCRIPTORS;
+            dbase->errorFlags |= DBASE_ERROR_DESCRIPTORS;
         }
 
         unsigned short method;
@@ -813,7 +839,16 @@ static bool dbaseParseZip(DBase* dbase, FILE* stream)
             break;
         }
 
-        fseek(stream, 8, SEEK_CUR); // disk number start, internal attrs, external attrs
+        unsigned short diskNumberStart;
+        if (fread(&diskNumberStart, sizeof(diskNumberStart), 1, stream) != 1) {
+            break;
+        }
+
+        if (diskNumberStart != 0) {
+            dbase->errorFlags |= DBASE_ERROR_MULTI_DISK;
+        }
+
+        fseek(stream, 6, SEEK_CUR); // internal attrs, external attrs
 
         unsigned int localHeaderOffset;
         if (fread(&localHeaderOffset, sizeof(localHeaderOffset), 1, stream) != 1) {
@@ -854,6 +889,7 @@ static bool dbaseParseZip(DBase* dbase, FILE* stream)
         } else if (method == 8) {
             compressed = 1;
         } else {
+            dbase->errorFlags |= DBASE_ERROR_UNSUPPORTED_METHOD;
             free(fileName);
             continue;
         }

--- a/src/dfile.cc
+++ b/src/dfile.cc
@@ -38,12 +38,14 @@ namespace fallout {
 #define DFILE_HAS_COMPRESSED_UNGETC (0x10)
 
 static int dbaseFindEntryByFilePath(const void* file, const void* entryName);
+static int dbaseFindEntryByFilePathForSort(const void* a, const void* b);
+static bool dbaseParseZip(DBase* dbase, FILE* stream);
 static DFile* dfileOpenInternal(DBase* dbase, const char* filename, const char* mode, DFile* dfile);
 static int dfileReadCharInternal(DFile* stream);
 static bool dfileReadCompressed(DFile* stream, void* ptr, size_t size);
 static void dfileUngetCompressed(DFile* stream, int ch);
 
-// Reads .DAT file contents.
+// Reads .DAT or .ZIP file contents.
 //
 // 0x4E4F58 dbase_open
 DBase* dbaseOpen(const char* filePath)
@@ -63,8 +65,28 @@ DBase* dbaseOpen(const char* filePath)
 
     memset(dbase, 0, sizeof(*dbase));
 
-    // Get file size, and reposition stream to read footer, which contains two
-    // 32-bits ints.
+    // Read first 4 bytes to detect ZIP format (local file header signature).
+    unsigned char magic[4];
+    bool isZip = fread(magic, 1, 4, stream) == 4
+        && magic[0] == 0x50 && magic[1] == 0x4B && magic[2] == 0x03 && magic[3] == 0x04;
+
+    if (isZip) {
+        dbase->format = DBaseFormat::ZIP;
+        dbase->dataOffset = 0;
+        dbase->path = compat_strdup(filePath);
+
+        if (!dbaseParseZip(dbase, stream)) {
+            goto err;
+        }
+
+        fclose(stream);
+        return dbase;
+    }
+
+    dbase->format = DBaseFormat::DAT;
+
+    // DAT format: parse footer.
+    // Reposition stream to read footer, which contains two 32-bit ints.
     int fileSize = getFileSize(stream);
     if (fseek(stream, fileSize - sizeof(int) * 2, SEEK_SET) != 0) {
         goto err;
@@ -147,6 +169,11 @@ DBase* dbaseOpen(const char* filePath)
 
     dbase->path = compat_strdup(filePath);
     dbase->dataOffset = fileSize - dbaseDataSize;
+
+    // Normalize entry data offsets to absolute file positions.
+    for (entryIndex = 0; entryIndex < dbase->entriesLength; entryIndex++) {
+        dbase->entries[entryIndex].dataOffset += dbase->dataOffset;
+    }
 
     fclose(stream);
 
@@ -558,7 +585,7 @@ int dfileSeek(DFile* stream, long offset, int origin)
         return 0;
     }
 
-    if (fseek(stream->stream, stream->dbase->dataOffset + stream->entry->dataOffset, SEEK_SET) != 0) {
+    if (fseek(stream->stream, stream->entry->dataOffset, SEEK_SET) != 0) {
         stream->flags |= DFILE_ERROR;
         return 1;
     }
@@ -575,9 +602,16 @@ int dfileSeek(DFile* stream, long offset, int origin)
         stream->decompressionStream->next_in = stream->decompressionBuffer;
         stream->decompressionStream->avail_in = 0;
 
-        if (inflateInit(stream->decompressionStream) != Z_OK) {
-            stream->flags |= DFILE_ERROR;
-            return 1;
+        if (stream->dbase->format == DBaseFormat::ZIP) {
+            if (inflateInit2(stream->decompressionStream, -15) != Z_OK) {
+                stream->flags |= DFILE_ERROR;
+                return 1;
+            }
+        } else {
+            if (inflateInit(stream->decompressionStream) != Z_OK) {
+                stream->flags |= DFILE_ERROR;
+                return 1;
+            }
         }
     } else {
         // FIXME: I'm not sure what this assignment means. This field is
@@ -636,6 +670,233 @@ static int dbaseFindEntryByFilePath(const void* file, const void* entryName)
     return compat_stricmp(filePath, entry->path);
 }
 
+// qsort comparison callback for sorting ZIP entries ascending by path.
+static int dbaseFindEntryByFilePathForSort(const void* a, const void* b)
+{
+    const DBaseEntry* ea = (const DBaseEntry*)a;
+    const DBaseEntry* eb = (const DBaseEntry*)b;
+
+    return compat_stricmp(ea->path, eb->path);
+}
+
+// Parses a ZIP archive's central directory and builds the DBaseEntry array.
+static bool dbaseParseZip(DBase* dbase, FILE* stream)
+{
+    constexpr unsigned int kCentralDirSignature = 0x02014b50;
+    constexpr int kMaxEocdSearch = 65557;
+
+    int fileSize = getFileSize(stream);
+    if (fileSize < 22) {
+        return false;
+    }
+
+    // Search for EOCD signature within the last 65557 bytes of the file.
+    int searchStart = std::max(0, fileSize - kMaxEocdSearch);
+    int searchSize = fileSize - searchStart;
+
+    unsigned char* buf = (unsigned char*)malloc(searchSize);
+    if (!buf) {
+        return false;
+    }
+
+    fseek(stream, searchStart, SEEK_SET);
+    if (fread(buf, searchSize, 1, stream) != 1) {
+        free(buf);
+        return false;
+    }
+
+    int eocdOffset = -1;
+    for (int i = searchSize - 22; i >= 0; i--) {
+        if (buf[i] == 0x50 && buf[i + 1] == 0x4b && buf[i + 2] == 0x05 && buf[i + 3] == 0x06) {
+            eocdOffset = searchStart + i;
+            break;
+        }
+    }
+    free(buf);
+
+    if (eocdOffset < 0) {
+        return false;
+    }
+
+    // Read EOCD fields: total entries, central directory offset.
+    if (fseek(stream, eocdOffset + 8, SEEK_SET) != 0) {
+        return false;
+    }
+
+    unsigned short diskEntries;
+    if (fread(&diskEntries, sizeof(diskEntries), 1, stream) != 1) {
+        return false;
+    }
+
+    unsigned short totalEntries;
+    if (fread(&totalEntries, sizeof(totalEntries), 1, stream) != 1) {
+        return false;
+    }
+
+    unsigned int centralDirSize;
+    if (fread(&centralDirSize, sizeof(centralDirSize), 1, stream) != 1) {
+        return false;
+    }
+
+    unsigned int centralDirOffset;
+    if (fread(&centralDirOffset, sizeof(centralDirOffset), 1, stream) != 1) {
+        return false;
+    }
+
+    if (totalEntries == 0) {
+        dbase->entriesLength = 0;
+        dbase->entries = nullptr;
+        return true;
+    }
+
+    dbase->entries = (DBaseEntry*)malloc(sizeof(*dbase->entries) * totalEntries);
+    if (!dbase->entries) {
+        return false;
+    }
+    memset(dbase->entries, 0, sizeof(*dbase->entries) * totalEntries);
+
+    // Walk central directory entries.
+    if (fseek(stream, centralDirOffset, SEEK_SET) != 0) {
+        return false;
+    }
+
+    int entryCount = 0;
+    for (unsigned short i = 0; i < totalEntries; i++) {
+        unsigned int signature;
+        if (fread(&signature, sizeof(signature), 1, stream) != 1) {
+            break;
+        }
+        if (signature != kCentralDirSignature) {
+            break;
+        }
+
+        fseek(stream, 4, SEEK_CUR); // version made by, version needed to extract
+
+        unsigned short flags;
+        if (fread(&flags, sizeof(flags), 1, stream) != 1) {
+            break;
+        }
+
+        if (flags & 0x08) {
+            dbase->errorFlags = dbase->errorFlags | DBASE_ERROR_DESCRIPTORS;
+        }
+
+        unsigned short method;
+        if (fread(&method, sizeof(method), 1, stream) != 1) {
+            break;
+        }
+
+        fseek(stream, 8, SEEK_CUR); // mod time, mod date, crc32
+
+        unsigned int compressedSize;
+        if (fread(&compressedSize, sizeof(compressedSize), 1, stream) != 1) {
+            break;
+        }
+
+        unsigned int uncompressedSize;
+        if (fread(&uncompressedSize, sizeof(uncompressedSize), 1, stream) != 1) {
+            break;
+        }
+
+        unsigned short fileNameLength;
+        if (fread(&fileNameLength, sizeof(fileNameLength), 1, stream) != 1) {
+            break;
+        }
+
+        unsigned short extraFieldLength;
+        if (fread(&extraFieldLength, sizeof(extraFieldLength), 1, stream) != 1) {
+            break;
+        }
+
+        unsigned short fileCommentLength;
+        if (fread(&fileCommentLength, sizeof(fileCommentLength), 1, stream) != 1) {
+            break;
+        }
+
+        fseek(stream, 8, SEEK_CUR); // disk number start, internal attrs, external attrs
+
+        unsigned int localHeaderOffset;
+        if (fread(&localHeaderOffset, sizeof(localHeaderOffset), 1, stream) != 1) {
+            break;
+        }
+
+        // Read and normalize filename.
+        char* fileName = (char*)malloc(fileNameLength + 1);
+        if (!fileName) {
+            break;
+        }
+        if (fread(fileName, fileNameLength, 1, stream) != 1) {
+            free(fileName);
+            break;
+        }
+        fileName[fileNameLength] = '\0';
+
+        for (unsigned short j = 0; j < fileNameLength; j++) {
+            if (fileName[j] == '/') {
+                fileName[j] = '\\';
+            }
+        }
+
+        // Skip directory entries (trailing slash).
+        if (fileNameLength > 0 && fileName[fileNameLength - 1] == '\\') {
+            free(fileName);
+            fseek(stream, extraFieldLength + fileCommentLength, SEEK_CUR);
+            continue;
+        }
+
+        // Skip extra field and file comment.
+        fseek(stream, extraFieldLength + fileCommentLength, SEEK_CUR);
+
+        // Map compression method: 0=stored, 8=deflated.
+        unsigned char compressed;
+        if (method == 0) {
+            compressed = 0;
+        } else if (method == 8) {
+            compressed = 1;
+        } else {
+            free(fileName);
+            continue;
+        }
+
+        // Read local file header to get actual data offset.
+        long savedPos = ftell(stream);
+        if (fseek(stream, localHeaderOffset + 26, SEEK_SET) != 0) {
+            break;
+        }
+
+        unsigned short localFileNameLength;
+        unsigned short localExtraFieldLength;
+        if (fread(&localFileNameLength, sizeof(localFileNameLength), 1, stream) != 1
+            || fread(&localExtraFieldLength, sizeof(localExtraFieldLength), 1, stream) != 1) {
+            break;
+        }
+
+        if (fseek(stream, savedPos, SEEK_SET) != 0) {
+            break;
+        }
+
+        // Compute absolute offset to file data (past local file header).
+        int dataOffset = static_cast<int>(localHeaderOffset) + 30 + localFileNameLength + localExtraFieldLength;
+
+        DBaseEntry* entry = &dbase->entries[entryCount];
+        entry->path = fileName;
+        entry->compressed = compressed;
+        entry->uncompressedSize = static_cast<int>(uncompressedSize);
+        entry->dataSize = static_cast<int>(compressedSize);
+        entry->dataOffset = dataOffset;
+
+        entryCount++;
+    }
+
+    dbase->entriesLength = entryCount;
+
+    if (entryCount > 1) {
+        qsort(dbase->entries, entryCount, sizeof(*dbase->entries), dbaseFindEntryByFilePathForSort);
+    }
+
+    return true;
+}
+
 // 0x4E5D9C dfile_fopen_helper
 static DFile* dfileOpenInternal(DBase* dbase, const char* filePath, const char* mode, DFile* dfile)
 {
@@ -682,7 +943,7 @@ static DFile* dfileOpenInternal(DBase* dbase, const char* filePath, const char* 
     }
 
     // Relocate stream to the beginning of data for specified entry.
-    if (fseek(dfile->stream, dbase->dataOffset + entry->dataOffset, SEEK_SET) != 0) {
+    if (fseek(dfile->stream, entry->dataOffset, SEEK_SET) != 0) {
         goto err;
     }
 
@@ -709,8 +970,14 @@ static DFile* dfileOpenInternal(DBase* dbase, const char* filePath, const char* 
         dfile->decompressionStream->next_in = dfile->decompressionBuffer;
         dfile->decompressionStream->avail_in = 0;
 
-        if (inflateInit(dfile->decompressionStream) != Z_OK) {
-            goto err;
+        if (dbase->format == DBaseFormat::ZIP) {
+            if (inflateInit2(dfile->decompressionStream, -15) != Z_OK) {
+                goto err;
+            }
+        } else {
+            if (inflateInit(dfile->decompressionStream) != Z_OK) {
+                goto err;
+            }
         }
     } else {
         // Entry is not compressed, there is no need to keep decompression

--- a/src/dfile.cc
+++ b/src/dfile.cc
@@ -41,7 +41,7 @@ static int dbaseFindEntryByFilePath(const void* file, const void* entryName);
 static int dbaseFindEntryByFilePathForSort(const void* a, const void* b);
 static bool dbaseZipIsEocd(const unsigned char* p);
 static bool dfileDecompressInit(z_streamp stream, DBaseFormat format, unsigned char* buffer);
-static bool dbaseParseZip(DBase* dbase, FILE* stream);
+static bool dbaseParseZip(DBase* dbase, FILE* stream, int& errorFlags);
 static DFile* dfileOpenInternal(DBase* dbase, const char* filename, const char* mode, DFile* dfile);
 static int dfileReadCharInternal(DFile* stream);
 static bool dfileReadCompressed(DFile* stream, void* ptr, size_t size);
@@ -50,12 +50,15 @@ static void dfileUngetCompressed(DFile* stream, int ch);
 // Reads .DAT or .ZIP file contents.
 //
 // 0x4E4F58 dbase_open
-DBase* dbaseOpen(const char* filePath)
+DBase* dbaseOpen(const char* filePath, int* errorFlags)
 {
     assert(filePath); // "filename", "dfile.c", 74
 
     FILE* stream = compat_fopen(filePath, "rb");
     if (stream == nullptr) {
+        if (errorFlags != nullptr) {
+            *errorFlags = DBASE_ERROR_NO_FILE;
+        }
         return nullptr;
     }
 
@@ -77,7 +80,12 @@ DBase* dbaseOpen(const char* filePath)
         dbase->dataOffset = 0;
         dbase->path = compat_strdup(filePath);
 
-        if (!dbaseParseZip(dbase, stream)) {
+        int zipErrorFlags = 0;
+        if (!dbaseParseZip(dbase, stream, zipErrorFlags)
+            || zipErrorFlags != 0) {
+            if (errorFlags) {
+                *errorFlags = zipErrorFlags;
+            }
             dbaseClose(dbase);
             fclose(stream);
             return nullptr;
@@ -690,8 +698,13 @@ static bool dfileDecompressInit(z_streamp stream, DBaseFormat format, unsigned c
     return inflateResult == Z_OK;
 }
 
+template <typename T>
+static bool dbaseReadValue(FILE* stream, T* value) {
+    return fread(value, sizeof(T), 1, stream) == 1;
+}
+
 // Parses a ZIP archive's central directory and builds the DBaseEntry array.
-static bool dbaseParseZip(DBase* dbase, FILE* stream)
+static bool dbaseParseZip(DBase* dbase, FILE* stream, int& errorFlags)
 {
     constexpr unsigned int kCentralDirSignature = 0x02014b50;
     constexpr int kMaxEocdSearch = 65557;
@@ -750,22 +763,15 @@ static bool dbaseParseZip(DBase* dbase, FILE* stream)
     fseek(stream, 2, SEEK_CUR); // entries on this disk
 
     unsigned short totalEntries;
-    if (fread(&totalEntries, sizeof(totalEntries), 1, stream) != 1) {
-        return false;
-    }
-
-    unsigned int centralDirSize;
-    if (fread(&centralDirSize, sizeof(centralDirSize), 1, stream) != 1) {
-        return false;
-    }
-
-    unsigned int centralDirOffset;
-    if (fread(&centralDirOffset, sizeof(centralDirOffset), 1, stream) != 1) {
+    unsigned int centralDirSize, centralDirOffset;
+    if (!dbaseReadValue(stream, &totalEntries)
+        || !dbaseReadValue(stream, &centralDirSize)
+        || !dbaseReadValue(stream, &centralDirOffset)) {
         return false;
     }
 
     if (totalEntries == 0xFFFF || centralDirSize == 0xFFFFFFFF || centralDirOffset == 0xFFFFFFFF) {
-        dbase->errorFlags |= DBASE_ERROR_ZIP64;
+        errorFlags |= DBASE_ERROR_ZIP64;
         dbase->entriesLength = 0;
         dbase->entries = nullptr;
         return true;
@@ -791,72 +797,52 @@ static bool dbaseParseZip(DBase* dbase, FILE* stream)
     int entryCount = 0;
     for (unsigned short i = 0; i < totalEntries; i++) {
         unsigned int signature;
-        if (fread(&signature, sizeof(signature), 1, stream) != 1) {
-            break;
-        }
-        if (signature != kCentralDirSignature) {
-            break;
+        if (!dbaseReadValue(stream, &signature) || signature != kCentralDirSignature) {
+            dbase->entriesLength = entryCount;
+            return false;
         }
 
         fseek(stream, 4, SEEK_CUR); // version made by, version needed to extract
 
-        unsigned short flags;
-        if (fread(&flags, sizeof(flags), 1, stream) != 1) {
+        unsigned short flags, method;
+        if (!dbaseReadValue(stream, &flags)
+            || !dbaseReadValue(stream, &method)) {
             break;
         }
 
         if (flags & 0x01) {
-            dbase->errorFlags |= DBASE_ERROR_ENCRYPTED;
+            errorFlags |= DBASE_ERROR_ENCRYPTED;
         }
         if (flags & 0x08) {
-            dbase->errorFlags |= DBASE_ERROR_DESCRIPTORS;
-        }
-
-        unsigned short method;
-        if (fread(&method, sizeof(method), 1, stream) != 1) {
-            break;
+            errorFlags |= DBASE_ERROR_DESCRIPTORS;
         }
 
         fseek(stream, 8, SEEK_CUR); // mod time, mod date, crc32
 
-        unsigned int compressedSize;
-        if (fread(&compressedSize, sizeof(compressedSize), 1, stream) != 1) {
-            break;
-        }
-
-        unsigned int uncompressedSize;
-        if (fread(&uncompressedSize, sizeof(uncompressedSize), 1, stream) != 1) {
-            break;
-        }
-
-        unsigned short fileNameLength;
-        if (fread(&fileNameLength, sizeof(fileNameLength), 1, stream) != 1) {
-            break;
-        }
-
-        unsigned short extraFieldLength;
-        if (fread(&extraFieldLength, sizeof(extraFieldLength), 1, stream) != 1) {
-            break;
-        }
-
-        unsigned short fileCommentLength;
-        if (fread(&fileCommentLength, sizeof(fileCommentLength), 1, stream) != 1) {
-            break;
-        }
-
-        unsigned short diskNumberStart;
-        if (fread(&diskNumberStart, sizeof(diskNumberStart), 1, stream) != 1) {
+        int compressedSize, uncompressedSize;
+        unsigned short fileNameLength, extraFieldLength, fileCommentLength, diskNumberStart;
+        if (!dbaseReadValue(stream, &compressedSize)
+            || !dbaseReadValue(stream, &uncompressedSize)
+            || !dbaseReadValue(stream, &fileNameLength)
+            || !dbaseReadValue(stream, &extraFieldLength)
+            || !dbaseReadValue(stream, &fileCommentLength)
+            || !dbaseReadValue(stream, &diskNumberStart)) {
             break;
         }
 
         if (diskNumberStart != 0) {
-            dbase->errorFlags |= DBASE_ERROR_MULTI_DISK;
+            errorFlags |= DBASE_ERROR_MULTI_DISK;
+        }
+
+        // Skip files larger than 2GB since our DBaseEntry uses signed int
+        if (compressedSize < 0 || uncompressedSize < 0) {
+            continue;
         }
 
         fseek(stream, 6, SEEK_CUR); // internal attrs, external attrs
 
-        unsigned int localHeaderOffset;
-        if (fread(&localHeaderOffset, sizeof(localHeaderOffset), 1, stream) != 1) {
+        int localHeaderOffset;
+        if (!dbaseReadValue(stream, &localHeaderOffset)) {
             break;
         }
 
@@ -894,36 +880,35 @@ static bool dbaseParseZip(DBase* dbase, FILE* stream)
         } else if (method == 8) {
             compressed = 1;
         } else {
-            dbase->errorFlags |= DBASE_ERROR_UNSUPPORTED_METHOD;
+            errorFlags |= DBASE_ERROR_UNSUPPORTED_METHOD;
             free(fileName);
             continue;
         }
 
         // Read local file header to get actual data offset.
         long savedPos = ftell(stream);
-        if (fseek(stream, localHeaderOffset + 26, SEEK_SET) != 0) {
-            break;
-        }
-
         unsigned short localFileNameLength;
         unsigned short localExtraFieldLength;
-        if (fread(&localFileNameLength, sizeof(localFileNameLength), 1, stream) != 1
-            || fread(&localExtraFieldLength, sizeof(localExtraFieldLength), 1, stream) != 1) {
-            break;
-        }
-
-        if (fseek(stream, savedPos, SEEK_SET) != 0) {
+        if (fseek(stream, localHeaderOffset + 26, SEEK_SET) != 0
+            || !dbaseReadValue(stream, &localFileNameLength)
+            || !dbaseReadValue(stream, &localExtraFieldLength)
+            || fseek(stream, savedPos, SEEK_SET) != 0) {
+            free(fileName);
             break;
         }
 
         // Compute absolute offset to file data (past local file header).
-        int dataOffset = static_cast<int>(localHeaderOffset) + 30 + localFileNameLength + localExtraFieldLength;
+        int dataOffset = localHeaderOffset + 30 + localFileNameLength + localExtraFieldLength;
+        if (dataOffset < 0) {
+            free(fileName);
+            continue;
+        }
 
         DBaseEntry* entry = &dbase->entries[entryCount];
         entry->path = fileName;
         entry->compressed = compressed;
-        entry->uncompressedSize = static_cast<int>(uncompressedSize);
-        entry->dataSize = static_cast<int>(compressedSize);
+        entry->uncompressedSize = uncompressedSize;
+        entry->dataSize = compressedSize;
         entry->dataOffset = dataOffset;
 
         entryCount++;

--- a/src/dfile.cc
+++ b/src/dfile.cc
@@ -40,6 +40,7 @@ namespace fallout {
 static int dbaseFindEntryByFilePath(const void* file, const void* entryName);
 static int dbaseFindEntryByFilePathForSort(const void* a, const void* b);
 static bool dbaseZipIsEocd(const unsigned char* p);
+static bool dfileDecompressInit(z_streamp stream, DBaseFormat format, unsigned char* buffer);
 static bool dbaseParseZip(DBase* dbase, FILE* stream);
 static DFile* dfileOpenInternal(DBase* dbase, const char* filename, const char* mode, DFile* dfile);
 static int dfileReadCharInternal(DFile* stream);
@@ -599,22 +600,9 @@ int dfileSeek(DFile* stream, long offset, int origin)
             return 1;
         }
 
-        stream->decompressionStream->zalloc = Z_NULL;
-        stream->decompressionStream->zfree = Z_NULL;
-        stream->decompressionStream->opaque = Z_NULL;
-        stream->decompressionStream->next_in = stream->decompressionBuffer;
-        stream->decompressionStream->avail_in = 0;
-
-        if (stream->dbase->format == DBaseFormat::ZIP) {
-            if (inflateInit2(stream->decompressionStream, -15) != Z_OK) {
-                stream->flags |= DFILE_ERROR;
-                return 1;
-            }
-        } else {
-            if (inflateInit(stream->decompressionStream) != Z_OK) {
-                stream->flags |= DFILE_ERROR;
-                return 1;
-            }
+        if (!dfileDecompressInit(stream->decompressionStream, stream->dbase->format, stream->decompressionBuffer)) {
+            stream->flags |= DFILE_ERROR;
+            return 1;
         }
     } else {
         // FIXME: I'm not sure what this assignment means. This field is
@@ -676,8 +664,8 @@ static int dbaseFindEntryByFilePath(const void* file, const void* entryName)
 // qsort comparison callback for sorting ZIP entries ascending by path.
 static int dbaseFindEntryByFilePathForSort(const void* a, const void* b)
 {
-    const DBaseEntry* ea = (const DBaseEntry*)a;
-    const DBaseEntry* eb = (const DBaseEntry*)b;
+    const auto* ea = static_cast<const DBaseEntry*>(a);
+    const auto* eb = static_cast<const DBaseEntry*>(b);
 
     return compat_stricmp(ea->path, eb->path);
 }
@@ -685,6 +673,21 @@ static int dbaseFindEntryByFilePathForSort(const void* a, const void* b)
 static bool dbaseZipIsEocd(const unsigned char* p)
 {
     return p[0] == 0x50 && p[1] == 0x4b && p[2] == 0x05 && p[3] == 0x06;
+}
+
+static bool dfileDecompressInit(z_streamp stream, DBaseFormat format, unsigned char* buffer)
+{
+    stream->zalloc = Z_NULL;
+    stream->zfree = Z_NULL;
+    stream->opaque = Z_NULL;
+    stream->next_in = buffer;
+    stream->avail_in = 0;
+
+    int inflateResult = format == DBaseFormat::ZIP
+        ? inflateInit2(stream, -15)
+        : inflateInit(stream);
+
+    return inflateResult == Z_OK;
 }
 
 // Parses a ZIP archive's central directory and builds the DBaseEntry array.
@@ -1002,20 +1005,8 @@ static DFile* dfileOpenInternal(DBase* dbase, const char* filePath, const char* 
             }
         }
 
-        dfile->decompressionStream->zalloc = Z_NULL;
-        dfile->decompressionStream->zfree = Z_NULL;
-        dfile->decompressionStream->opaque = Z_NULL;
-        dfile->decompressionStream->next_in = dfile->decompressionBuffer;
-        dfile->decompressionStream->avail_in = 0;
-
-        if (dbase->format == DBaseFormat::ZIP) {
-            if (inflateInit2(dfile->decompressionStream, -15) != Z_OK) {
-                goto err;
-            }
-        } else {
-            if (inflateInit(dfile->decompressionStream) != Z_OK) {
-                goto err;
-            }
+        if (!dfileDecompressInit(dfile->decompressionStream, dbase->format, dfile->decompressionBuffer)) {
+            goto err;
         }
     } else {
         // Entry is not compressed, there is no need to keep decompression

--- a/src/dfile.cc
+++ b/src/dfile.cc
@@ -77,7 +77,9 @@ DBase* dbaseOpen(const char* filePath)
         dbase->path = compat_strdup(filePath);
 
         if (!dbaseParseZip(dbase, stream)) {
-            goto err;
+            dbaseClose(dbase);
+            fclose(stream);
+            return nullptr;
         }
 
         fclose(stream);

--- a/src/dfile.cc
+++ b/src/dfile.cc
@@ -41,7 +41,11 @@ static int dbaseFindEntryByFilePath(const void* file, const void* entryName);
 static int dbaseFindEntryByFilePathForSort(const void* a, const void* b);
 static bool dbaseZipIsEocd(const unsigned char* p);
 
-enum class ZipSignature : int { NOT_ZIP = 0, ZIP = 1, EMPTY = 2 };
+enum class ZipSignature : int {
+    NOT_ZIP = 0,
+    ZIP = 1,
+    EMPTY = 2
+};
 static ZipSignature dbaseCheckZipSignature(FILE* stream);
 static bool dfileDecompressInit(z_streamp stream, DBaseFormat format, unsigned char* buffer);
 static bool dbaseParseZip(DBase* dbase, FILE* stream, int& errorFlags);
@@ -697,7 +701,8 @@ static bool dfileDecompressInit(z_streamp stream, DBaseFormat format, unsigned c
 }
 
 template <typename T>
-static bool dbaseReadValue(FILE* stream, T* value) {
+static bool dbaseReadValue(FILE* stream, T* value)
+{
     return fread(value, sizeof(T), 1, stream) == 1;
 }
 

--- a/src/dfile.cc
+++ b/src/dfile.cc
@@ -40,6 +40,9 @@ namespace fallout {
 static int dbaseFindEntryByFilePath(const void* file, const void* entryName);
 static int dbaseFindEntryByFilePathForSort(const void* a, const void* b);
 static bool dbaseZipIsEocd(const unsigned char* p);
+
+enum class ZipSignature : int { NOT_ZIP = 0, ZIP = 1, EMPTY = 2 };
+static ZipSignature dbaseCheckZipSignature(FILE* stream);
 static bool dfileDecompressInit(z_streamp stream, DBaseFormat format, unsigned char* buffer);
 static bool dbaseParseZip(DBase* dbase, FILE* stream, int& errorFlags);
 static DFile* dfileOpenInternal(DBase* dbase, const char* filename, const char* mode, DFile* dfile);
@@ -56,9 +59,15 @@ DBase* dbaseOpen(const char* filePath, int* errorFlags)
 
     FILE* stream = compat_fopen(filePath, "rb");
     if (stream == nullptr) {
-        if (errorFlags != nullptr) {
-            *errorFlags = DBASE_ERROR_NO_FILE;
+        return nullptr;
+    }
+
+    ZipSignature zipStatus = dbaseCheckZipSignature(stream);
+    if (zipStatus == ZipSignature::EMPTY) {
+        if (errorFlags) {
+            *errorFlags = DBASE_ERROR_EMPTY;
         }
+        fclose(stream);
         return nullptr;
     }
 
@@ -67,15 +76,9 @@ DBase* dbaseOpen(const char* filePath, int* errorFlags)
         fclose(stream);
         return nullptr;
     }
-
     memset(dbase, 0, sizeof(*dbase));
 
-    // Read first 4 bytes to detect ZIP format (local file header signature).
-    unsigned char magic[4];
-    bool isZip = fread(magic, 1, 4, stream) == 4
-        && magic[0] == 0x50 && magic[1] == 0x4B && magic[2] == 0x03 && magic[3] == 0x04;
-
-    if (isZip) {
+    if (zipStatus == ZipSignature::ZIP) {
         dbase->format = DBaseFormat::ZIP;
         dbase->dataOffset = 0;
         dbase->path = compat_strdup(filePath);
@@ -678,11 +681,6 @@ static int dbaseFindEntryByFilePathForSort(const void* a, const void* b)
     return compat_stricmp(ea->path, eb->path);
 }
 
-static bool dbaseZipIsEocd(const unsigned char* p)
-{
-    return p[0] == 0x50 && p[1] == 0x4b && p[2] == 0x05 && p[3] == 0x06;
-}
-
 static bool dfileDecompressInit(z_streamp stream, DBaseFormat format, unsigned char* buffer)
 {
     stream->zalloc = Z_NULL;
@@ -703,6 +701,26 @@ static bool dbaseReadValue(FILE* stream, T* value) {
     return fread(value, sizeof(T), 1, stream) == 1;
 }
 
+static ZipSignature dbaseCheckZipSignature(FILE* stream)
+{
+    unsigned char magic[4];
+    if (fread(magic, 1, 4, stream) != 4 || magic[0] != 0x50 || magic[1] != 0x4B) {
+        return ZipSignature::NOT_ZIP;
+    }
+    if (magic[2] == 0x03 && magic[3] == 0x04) {
+        return ZipSignature::ZIP;
+    }
+    if (magic[2] == 0x05 && magic[3] == 0x06) {
+        return ZipSignature::EMPTY;
+    }
+    return ZipSignature::NOT_ZIP;
+}
+
+static bool dbaseZipIsEocd(const unsigned char* p)
+{
+    return p[0] == 0x50 && p[1] == 0x4b && p[2] == 0x05 && p[3] == 0x06;
+}
+
 // Parses a ZIP archive's central directory and builds the DBaseEntry array.
 static bool dbaseParseZip(DBase* dbase, FILE* stream, int& errorFlags)
 {
@@ -716,8 +734,8 @@ static bool dbaseParseZip(DBase* dbase, FILE* stream, int& errorFlags)
 
     // Try the common case first: no comment, EOCD is the last 22 bytes.
     unsigned char tail[22];
-    fseek(stream, -22, SEEK_END);
-    if (fread(tail, sizeof(tail), 1, stream) != 1) {
+    if (fseek(stream, -22, SEEK_END) != 0
+        || fread(tail, sizeof(tail), 1, stream) != 1) {
         return false;
     }
 
@@ -730,12 +748,14 @@ static bool dbaseParseZip(DBase* dbase, FILE* stream, int& errorFlags)
         int searchStart = std::max(0, fileSize - kMaxEocdSearch);
         int searchSize = fileSize - searchStart;
 
-        unsigned char* buf = (unsigned char*)malloc(searchSize);
+        if (fseek(stream, searchStart, SEEK_SET) != 0) {
+            return false;
+        }
+        auto* buf = static_cast<unsigned char*>(malloc(searchSize));
         if (!buf) {
             return false;
         }
 
-        fseek(stream, searchStart, SEEK_SET);
         if (fread(buf, searchSize, 1, stream) != 1) {
             free(buf);
             return false;
@@ -755,12 +775,10 @@ static bool dbaseParseZip(DBase* dbase, FILE* stream, int& errorFlags)
         return false;
     }
 
-    // Read EOCD: entries on this disk (skip), total entries, CD size, CD offset.
-    if (fseek(stream, eocdOffset + 8, SEEK_SET) != 0) {
+    // Read EOCD: skip signature (4) + disk number (2) + disk with CD (2) + entries on this disk (2).
+    if (fseek(stream, eocdOffset + 10, SEEK_SET) != 0) {
         return false;
     }
-
-    fseek(stream, 2, SEEK_CUR); // entries on this disk
 
     unsigned short totalEntries;
     unsigned int centralDirSize, centralDirOffset;
@@ -772,42 +790,52 @@ static bool dbaseParseZip(DBase* dbase, FILE* stream, int& errorFlags)
 
     if (totalEntries == 0xFFFF || centralDirSize == 0xFFFFFFFF || centralDirOffset == 0xFFFFFFFF) {
         errorFlags |= DBASE_ERROR_ZIP64;
-        dbase->entriesLength = 0;
-        dbase->entries = nullptr;
-        return true;
+        return false;
     }
 
+    // There is no point loading empty ZIP since DBase is read-only.
     if (totalEntries == 0) {
-        dbase->entriesLength = 0;
-        dbase->entries = nullptr;
-        return true;
+        errorFlags |= DBASE_ERROR_EMPTY;
+        return false;
     }
 
-    dbase->entries = (DBaseEntry*)malloc(sizeof(*dbase->entries) * totalEntries);
+    // If any entry is skipped, entries will contain unused elements at the end. But this is acceptable because DBaseEntry is small and both qsort and bsearch use entriesLength.
+    dbase->entries = static_cast<DBaseEntry*>(malloc(sizeof(*dbase->entries) * totalEntries));
     if (!dbase->entries) {
         return false;
     }
     memset(dbase->entries, 0, sizeof(*dbase->entries) * totalEntries);
 
     // Walk central directory entries.
-    if (fseek(stream, centralDirOffset, SEEK_SET) != 0) {
+    if (fseek(stream, static_cast<long>(centralDirOffset), SEEK_SET) != 0) {
         return false;
     }
 
-    int entryCount = 0;
-    for (unsigned short i = 0; i < totalEntries; i++) {
+    dbase->entriesLength = 0;
+
+    for (unsigned short entryIndex = 0; entryIndex < totalEntries; entryIndex++) {
         unsigned int signature;
-        if (!dbaseReadValue(stream, &signature) || signature != kCentralDirSignature) {
-            dbase->entriesLength = entryCount;
-            return false;
-        }
-
-        fseek(stream, 4, SEEK_CUR); // version made by, version needed to extract
-
         unsigned short flags, method;
-        if (!dbaseReadValue(stream, &flags)
-            || !dbaseReadValue(stream, &method)) {
-            break;
+        int compressedSize, uncompressedSize, localHeaderOffset;
+        unsigned short fileNameLength, extraFieldLength, fileCommentLength, diskNumberStart;
+        if (!dbaseReadValue(stream, &signature)
+            || signature != kCentralDirSignature
+            // version made by, version needed to extract
+            || fseek(stream, 4, SEEK_CUR) != 0
+            || !dbaseReadValue(stream, &flags)
+            || !dbaseReadValue(stream, &method)
+            // mod time, mod date, crc32
+            || fseek(stream, 8, SEEK_CUR) != 0
+            || !dbaseReadValue(stream, &compressedSize)
+            || !dbaseReadValue(stream, &uncompressedSize)
+            || !dbaseReadValue(stream, &fileNameLength)
+            || !dbaseReadValue(stream, &extraFieldLength)
+            || !dbaseReadValue(stream, &fileCommentLength)
+            || !dbaseReadValue(stream, &diskNumberStart)
+            // internal attrs, external attrs
+            || fseek(stream, 6, SEEK_CUR) != 0
+            || !dbaseReadValue(stream, &localHeaderOffset)) {
+            return false;
         }
 
         if (flags & 0x01) {
@@ -816,62 +844,37 @@ static bool dbaseParseZip(DBase* dbase, FILE* stream, int& errorFlags)
         if (flags & 0x08) {
             errorFlags |= DBASE_ERROR_DESCRIPTORS;
         }
-
-        fseek(stream, 8, SEEK_CUR); // mod time, mod date, crc32
-
-        int compressedSize, uncompressedSize;
-        unsigned short fileNameLength, extraFieldLength, fileCommentLength, diskNumberStart;
-        if (!dbaseReadValue(stream, &compressedSize)
-            || !dbaseReadValue(stream, &uncompressedSize)
-            || !dbaseReadValue(stream, &fileNameLength)
-            || !dbaseReadValue(stream, &extraFieldLength)
-            || !dbaseReadValue(stream, &fileCommentLength)
-            || !dbaseReadValue(stream, &diskNumberStart)) {
-            break;
-        }
-
         if (diskNumberStart != 0) {
             errorFlags |= DBASE_ERROR_MULTI_DISK;
         }
-
         // Skip files larger than 2GB since our DBaseEntry uses signed int
-        if (compressedSize < 0 || uncompressedSize < 0) {
+        if (compressedSize < 0 || uncompressedSize < 0 || localHeaderOffset < 0) {
             continue;
         }
 
-        fseek(stream, 6, SEEK_CUR); // internal attrs, external attrs
-
-        int localHeaderOffset;
-        if (!dbaseReadValue(stream, &localHeaderOffset)) {
-            break;
-        }
-
         // Read and normalize filename.
-        char* fileName = (char*)malloc(fileNameLength + 1);
-        if (!fileName) {
-            break;
+        auto fileName = static_cast<char*>(malloc(fileNameLength + 1));
+        if (fileName == nullptr) {
+            return false;
         }
-        if (fread(fileName, fileNameLength, 1, stream) != 1) {
+        if (fread(fileName, fileNameLength, 1, stream) != 1
+            // Skip extra field and file comment.
+            || fseek(stream, extraFieldLength + fileCommentLength, SEEK_CUR) != 0) {
             free(fileName);
-            break;
+            return false;
         }
-        fileName[fileNameLength] = '\0';
 
+        fileName[fileNameLength] = '\0';
         for (unsigned short j = 0; j < fileNameLength; j++) {
             if (fileName[j] == '/') {
                 fileName[j] = '\\';
             }
         }
-
         // Skip directory entries (trailing slash).
         if (fileNameLength > 0 && fileName[fileNameLength - 1] == '\\') {
             free(fileName);
-            fseek(stream, extraFieldLength + fileCommentLength, SEEK_CUR);
             continue;
         }
-
-        // Skip extra field and file comment.
-        fseek(stream, extraFieldLength + fileCommentLength, SEEK_CUR);
 
         // Map compression method: 0=stored, 8=deflated.
         unsigned char compressed;
@@ -894,7 +897,7 @@ static bool dbaseParseZip(DBase* dbase, FILE* stream, int& errorFlags)
             || !dbaseReadValue(stream, &localExtraFieldLength)
             || fseek(stream, savedPos, SEEK_SET) != 0) {
             free(fileName);
-            break;
+            return false;
         }
 
         // Compute absolute offset to file data (past local file header).
@@ -904,20 +907,18 @@ static bool dbaseParseZip(DBase* dbase, FILE* stream, int& errorFlags)
             continue;
         }
 
-        DBaseEntry* entry = &dbase->entries[entryCount];
+        DBaseEntry* entry = &dbase->entries[dbase->entriesLength];
         entry->path = fileName;
         entry->compressed = compressed;
         entry->uncompressedSize = uncompressedSize;
         entry->dataSize = compressedSize;
         entry->dataOffset = dataOffset;
 
-        entryCount++;
+        dbase->entriesLength++;
     }
 
-    dbase->entriesLength = entryCount;
-
-    if (entryCount > 1) {
-        qsort(dbase->entries, entryCount, sizeof(*dbase->entries), dbaseFindEntryByFilePathForSort);
+    if (dbase->entriesLength > 1) {
+        qsort(dbase->entries, dbase->entriesLength, sizeof(*dbase->entries), dbaseFindEntryByFilePathForSort);
     }
 
     return true;

--- a/src/dfile.cc
+++ b/src/dfile.cc
@@ -189,11 +189,6 @@ DBase* dbaseOpen(const char* filePath, int* errorFlags)
     dbase->path = compat_strdup(filePath);
     dbase->dataOffset = fileSize - dbaseDataSize;
 
-    // Normalize entry data offsets to absolute file positions.
-    for (entryIndex = 0; entryIndex < dbase->entriesLength; entryIndex++) {
-        dbase->entries[entryIndex].dataOffset += dbase->dataOffset;
-    }
-
     fclose(stream);
 
     return dbase;
@@ -604,7 +599,7 @@ int dfileSeek(DFile* stream, long offset, int origin)
         return 0;
     }
 
-    if (fseek(stream->stream, stream->entry->dataOffset, SEEK_SET) != 0) {
+    if (fseek(stream->stream, stream->dbase->dataOffset + stream->entry->dataOffset, SEEK_SET) != 0) {
         stream->flags |= DFILE_ERROR;
         return 1;
     }
@@ -975,7 +970,7 @@ static DFile* dfileOpenInternal(DBase* dbase, const char* filePath, const char* 
     }
 
     // Relocate stream to the beginning of data for specified entry.
-    if (fseek(dfile->stream, entry->dataOffset, SEEK_SET) != 0) {
+    if (fseek(dfile->stream, dbase->dataOffset + entry->dataOffset, SEEK_SET) != 0) {
         goto err;
     }
 

--- a/src/dfile.h
+++ b/src/dfile.h
@@ -9,17 +9,32 @@
 
 namespace fallout {
 
+enum class DBaseFormat : int {
+    DAT = 0,
+    ZIP = 1,
+};
+
+enum DBaseErrorFlags : int {
+    DBASE_ERROR_DESCRIPTORS = 0x01,
+};
+
 typedef struct DBase DBase;
 typedef struct DBaseEntry DBaseEntry;
 typedef struct DFile DFile;
 
-// A representation of .DAT file.
+// A representation of .DAT or .ZIP file.
 typedef struct DBase {
-    // The path of .DAT file that this structure represents.
+    // The path of archive file that this structure represents.
     char* path;
 
     // The offset to the beginning of data section of .DAT file.
     int dataOffset;
+
+    // The format of this archive.
+    DBaseFormat format;
+
+    // Error flags for ZIP archives.
+    int errorFlags;
 
     // The number of entries.
     int entriesLength;

--- a/src/dfile.h
+++ b/src/dfile.h
@@ -15,7 +15,7 @@ enum class DBaseFormat : int {
 };
 
 enum DBaseErrorFlags : int {
-    DBASE_ERROR_NO_FILE = 1 << 1,
+    DBASE_ERROR_EMPTY = 1 << 1,
     DBASE_ERROR_DESCRIPTORS = 1 << 2,
     DBASE_ERROR_ZIP64 = 1 << 3,
     DBASE_ERROR_ENCRYPTED = 1 << 4,

--- a/src/dfile.h
+++ b/src/dfile.h
@@ -16,6 +16,10 @@ enum class DBaseFormat : int {
 
 enum DBaseErrorFlags : int {
     DBASE_ERROR_DESCRIPTORS = 0x01,
+    DBASE_ERROR_ZIP64 = 0x02,
+    DBASE_ERROR_ENCRYPTED = 0x04,
+    DBASE_ERROR_MULTI_DISK = 0x08,
+    DBASE_ERROR_UNSUPPORTED_METHOD = 0x10,
 };
 
 typedef struct DBase DBase;

--- a/src/dfile.h
+++ b/src/dfile.h
@@ -15,11 +15,12 @@ enum class DBaseFormat : int {
 };
 
 enum DBaseErrorFlags : int {
-    DBASE_ERROR_DESCRIPTORS = 0x01,
-    DBASE_ERROR_ZIP64 = 0x02,
-    DBASE_ERROR_ENCRYPTED = 0x04,
-    DBASE_ERROR_MULTI_DISK = 0x08,
-    DBASE_ERROR_UNSUPPORTED_METHOD = 0x10,
+    DBASE_ERROR_NO_FILE = 1 << 1,
+    DBASE_ERROR_DESCRIPTORS = 1 << 2,
+    DBASE_ERROR_ZIP64 = 1 << 3,
+    DBASE_ERROR_ENCRYPTED = 1 << 4,
+    DBASE_ERROR_MULTI_DISK = 1 << 5,
+    DBASE_ERROR_UNSUPPORTED_METHOD = 1 << 6,
 };
 
 typedef struct DBase DBase;
@@ -36,9 +37,6 @@ typedef struct DBase {
 
     // The format of this archive.
     DBaseFormat format;
-
-    // Error flags for ZIP archives.
-    int errorFlags;
 
     // The number of entries.
     int entriesLength;
@@ -129,7 +127,8 @@ typedef struct DFileFindData {
     int index;
 } DFileFindData;
 
-DBase* dbaseOpen(const char* filename);
+// Reads DAT or ZIP file header and table of entries.
+DBase* dbaseOpen(const char* filename, int* errorFlags = nullptr);
 bool dbaseClose(DBase* dbase);
 bool dbaseFindFirstEntry(DBase* dbase, DFileFindData* findFileData, const char* pattern);
 bool dbaseFindNextEntry(DBase* dbase, DFileFindData* findFileData);

--- a/src/xfile.cc
+++ b/src/xfile.cc
@@ -533,6 +533,9 @@ bool xbaseOpen(const char* path)
     }
 
     if (dbaseErrorFlags != 0) {
+        if (dbaseErrorFlags & DBASE_ERROR_EMPTY) {
+            debugPrint("[xfile] %s: empty archive\n", path);
+        }
         if (dbaseErrorFlags & DBASE_ERROR_ZIP64) {
             debugPrint("[xfile] %s: ZIP64 format (unsupported)\n", path);
         }
@@ -548,29 +551,18 @@ bool xbaseOpen(const char* path)
         if (dbaseErrorFlags & DBASE_ERROR_UNSUPPORTED_METHOD) {
             debugPrint("[xfile] %s: unsupported compression method(s)\n", path);
         }
-        // Don't try mounting as directory if we know this is a file.
-        if ((dbaseErrorFlags & DBASE_ERROR_NO_FILE) == 0) {
-            free(xbase->path);
-            free(xbase);
-            return false;
-        }
     }
 
+    // Try mount as directory
     char workingDirectory[COMPAT_MAX_PATH];
-    if (getcwd(workingDirectory, COMPAT_MAX_PATH) == nullptr) {
-        free(xbase->path);
-        free(xbase);
-        return false;
-    }
-
-    if (chdir(path) == 0) {
+    if (!compat_file_exists(path) && getcwd(workingDirectory, COMPAT_MAX_PATH) != nullptr && chdir(path) == 0) {
         chdir(workingDirectory);
         xbase->next = gXbaseHead;
         gXbaseHead = xbase;
         return true;
     }
 
-    // Cleanup if chdir(path) failed
+    // Cleanup on failure.
     free(xbase->path);
     free(xbase);
     return false; // return false to trigger messages on game load

--- a/src/xfile.cc
+++ b/src/xfile.cc
@@ -11,6 +11,7 @@
 #include <unistd.h>
 #endif
 
+#include "debug.h"
 #include "file_find.h"
 
 namespace fallout {
@@ -525,6 +526,11 @@ bool xbaseOpen(const char* path)
     if (dbase != nullptr) {
         xbase->isDbase = true;
         xbase->dbase = dbase;
+
+        if (dbase->format == DBaseFormat::ZIP && (dbase->errorFlags & DBASE_ERROR_DESCRIPTORS) != 0) {
+            debugPrint("[xfile] %s: ZIP contains entries with data descriptors (unsupported)\n", path);
+        }
+
         xbase->next = gXbaseHead;
         gXbaseHead = xbase;
         return true;

--- a/src/xfile.cc
+++ b/src/xfile.cc
@@ -524,13 +524,31 @@ bool xbaseOpen(const char* path)
 
     DBase* dbase = dbaseOpen(path);
     if (dbase != nullptr) {
-        xbase->isDbase = true;
-        xbase->dbase = dbase;
+        if (dbase->format == DBaseFormat::ZIP && dbase->errorFlags != 0) {
+            if (dbase->errorFlags & DBASE_ERROR_ZIP64) {
+                debugPrint("[xfile] %s: ZIP64 format (unsupported)\n", path);
+            }
+            if (dbase->errorFlags & DBASE_ERROR_MULTI_DISK) {
+                debugPrint("[xfile] %s: multi-disk ZIP (unsupported)\n", path);
+            }
+            if (dbase->errorFlags & DBASE_ERROR_ENCRYPTED) {
+                debugPrint("[xfile] %s: encrypted entries (unsupported)\n", path);
+            }
+            if (dbase->errorFlags & DBASE_ERROR_DESCRIPTORS) {
+                debugPrint("[xfile] %s: data descriptors (unsupported)\n", path);
+            }
+            if (dbase->errorFlags & DBASE_ERROR_UNSUPPORTED_METHOD) {
+                debugPrint("[xfile] %s: unsupported compression method(s)\n", path);
+            }
 
-        if (dbase->format == DBaseFormat::ZIP && (dbase->errorFlags & DBASE_ERROR_DESCRIPTORS) != 0) {
-            debugPrint("[xfile] %s: ZIP contains entries with data descriptors (unsupported)\n", path);
+            dbaseClose(dbase);
+            free(xbase->path);
+            free(xbase);
+            return false;
         }
 
+        xbase->isDbase = true;
+        xbase->dbase = dbase;
         xbase->next = gXbaseHead;
         gXbaseHead = xbase;
         return true;

--- a/src/xfile.cc
+++ b/src/xfile.cc
@@ -522,36 +522,38 @@ bool xbaseOpen(const char* path)
         return false;
     }
 
-    DBase* dbase = dbaseOpen(path);
+    int dbaseErrorFlags = 0;
+    DBase* dbase = dbaseOpen(path, &dbaseErrorFlags);
     if (dbase != nullptr) {
-        if (dbase->format == DBaseFormat::ZIP && dbase->errorFlags != 0) {
-            if (dbase->errorFlags & DBASE_ERROR_ZIP64) {
-                debugPrint("[xfile] %s: ZIP64 format (unsupported)\n", path);
-            }
-            if (dbase->errorFlags & DBASE_ERROR_MULTI_DISK) {
-                debugPrint("[xfile] %s: multi-disk ZIP (unsupported)\n", path);
-            }
-            if (dbase->errorFlags & DBASE_ERROR_ENCRYPTED) {
-                debugPrint("[xfile] %s: encrypted entries (unsupported)\n", path);
-            }
-            if (dbase->errorFlags & DBASE_ERROR_DESCRIPTORS) {
-                debugPrint("[xfile] %s: data descriptors (unsupported)\n", path);
-            }
-            if (dbase->errorFlags & DBASE_ERROR_UNSUPPORTED_METHOD) {
-                debugPrint("[xfile] %s: unsupported compression method(s)\n", path);
-            }
-
-            dbaseClose(dbase);
-            free(xbase->path);
-            free(xbase);
-            return false;
-        }
-
         xbase->isDbase = true;
         xbase->dbase = dbase;
         xbase->next = gXbaseHead;
         gXbaseHead = xbase;
         return true;
+    }
+
+    if (dbaseErrorFlags != 0) {
+        if (dbaseErrorFlags & DBASE_ERROR_ZIP64) {
+            debugPrint("[xfile] %s: ZIP64 format (unsupported)\n", path);
+        }
+        if (dbaseErrorFlags & DBASE_ERROR_MULTI_DISK) {
+            debugPrint("[xfile] %s: multi-disk ZIP (unsupported)\n", path);
+        }
+        if (dbaseErrorFlags & DBASE_ERROR_ENCRYPTED) {
+            debugPrint("[xfile] %s: encrypted entries (unsupported)\n", path);
+        }
+        if (dbaseErrorFlags & DBASE_ERROR_DESCRIPTORS) {
+            debugPrint("[xfile] %s: data descriptors (unsupported)\n", path);
+        }
+        if (dbaseErrorFlags & DBASE_ERROR_UNSUPPORTED_METHOD) {
+            debugPrint("[xfile] %s: unsupported compression method(s)\n", path);
+        }
+        // Don't try mounting as directory if we know this is a file.
+        if ((dbaseErrorFlags & DBASE_ERROR_NO_FILE) == 0) {
+            free(xbase->path);
+            free(xbase);
+            return false;
+        }
     }
 
     char workingDirectory[COMPAT_MAX_PATH];


### PR DESCRIPTION
Allows to use zip for packing mod files instead of DAT, improving quality of life for modders.

- Integrated directly into existing DBase (runtime structure for DAT archives).
- Only store and deflate compression is supported (same as DAT, using the same algorithms).
- None of the fancy unusual features of ZIP format are supported.
- Loading will fail and print to log if the type of ZIP file is not supported.