### PR TITLE
Change `use_walk_distance` to match sfall setting

### DIFF
--- a/files/fallout2.cfg
+++ b/files/fallout2.cfg
@@ -132,8 +132,9 @@ main_menu_scale_mode=1
 [qol]
 ; Automatically open doors that are unlocked and has no script attached.
 auto_open_doors=0
-; Overrides distance at which walk animation is used when using an object.
-use_walk_distance=5
+; Overrides distance at which walk animation is used when using an object.  0 disables walking
+; This is the number of empty tiles between the player and the target
+use_walk_distance=3
 ; Allow opening party member inventory from the long-press world menu.
 party_trade_from_menu=1
 ; Allow switching to companions' inventories in loot screens (and barter, in the future)

--- a/src/actions.cc
+++ b/src/actions.cc
@@ -1043,6 +1043,8 @@ int _action_climb_ladder(Object* critter, Object* ladder)
     animationRequestOptions |= ANIMATION_REQUEST_NO_STAND;
     reg_anim_begin(animationRequestOptions);
 
+    // note: distance is checked to ladder tile, but movement is to SE tile, so the walk/run choice
+    // could be slightly off
     int tile = tileGetTileInDirection(ladder->tile, ROTATION_SE, 1);
     if (actionPoints != -1 || objectWithinWalkDistance(critter, ladder)) {
         animationRegisterMoveToTile(critter, tile, ladder->elevation, actionPoints, 0);

--- a/src/object.cc
+++ b/src/object.cc
@@ -2667,15 +2667,16 @@ int objectGetDistanceBetweenTiles(Object* object1, int tile1, Object* object2, i
 
 bool objectWithinWalkDistance(Object* critter, Object* target)
 {
-    int walkDistance = settings.qol.use_walk_distance;
-    if (objectGetDistanceBetween(critter, target) >= walkDistance) {
-        return false;
-    }
     if (critter == nullptr || target == nullptr) {
         return false;
     }
+    int walkDistanceLimit = settings.qol.use_walk_distance + 2;
+    int distance = objectGetDistanceBetween(critter, target);
+    if (distance >= walkDistanceLimit || distance <= 1) {
+        return false;
+    }
 
-    return _make_path(critter, critter->tile, target->tile, nullptr, 0) < walkDistance;
+    return _make_path(critter, critter->tile, target->tile, nullptr, 0) < walkDistanceLimit;
 }
 
 // 0x48BC38 obj_create_list

--- a/src/object.cc
+++ b/src/object.cc
@@ -2672,7 +2672,10 @@ bool objectWithinWalkDistance(Object* critter, Object* target)
     }
     int walkDistanceLimit = settings.qol.use_walk_distance + 2;
     int distance = objectGetDistanceBetween(critter, target);
-    if (distance >= walkDistanceLimit || distance <= 1) {
+    if (distance <= 1) {
+        return true;
+    }
+    if (distance >= walkDistanceLimit) {
         return false;
     }
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -139,7 +139,7 @@ struct DebugSettings {
 };
 
 struct QolSettings {
-    int use_walk_distance = 5;
+    int use_walk_distance = 3;
     bool auto_open_doors = false;
     bool party_trade_from_menu = true;
     bool party_loot_and_barter = false;


### PR DESCRIPTION
It's pointless to set this to 0,1 because you don't move if the target is adjacent or yourself, so sfall changes this to "number of spaces" between player and target.  We were reading the old ddraw.ini setting before, incorrectly.

Also add a small optimization to not compute path for adjacent targets
