### PR TITLE
Better fix for directory detection

### DIFF
--- a/src/game_config_migration.cc
+++ b/src/game_config_migration.cc
@@ -312,7 +312,7 @@ void contentConfigTryMigrateFromSfall(const char* contentConfigPath)
         return;
     }
     if (!compat_is_dir(masterPatches.c_str())) {
-        // Master patches is pointing to a file instead of a folder. This shouldn't normally happen, so don't migrate in this case.
+        // master_patches must point to an existing folder. Don't migrate when it's missing or not a directory.
         return;
     }
     char contentCfgPath[COMPAT_MAX_PATH];

--- a/src/game_config_migration.cc
+++ b/src/game_config_migration.cc
@@ -311,7 +311,7 @@ void contentConfigTryMigrateFromSfall(const char* contentConfigPath)
         debugPrint("Failed to migrate from ddraw.ini: no master_patches is set.\n");
         return;
     }
-    if (compat_file_exists(masterPatches.c_str())) {
+    if (!compat_is_dir(masterPatches.c_str())) {
         // Master patches is pointing to a file instead of a folder. This shouldn't normally happen, so don't migrate in this case.
         return;
     }

--- a/src/platform_compat.cc
+++ b/src/platform_compat.cc
@@ -7,6 +7,7 @@
 #include <io.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/stat.h>
 #else
 #include <dirent.h>
 #include <sys/stat.h>
@@ -237,6 +238,28 @@ int compat_mkdir_recursive(const char* path)
         }
     }
     return compat_mkdir(path);
+}
+
+bool compat_is_dir(const char* path)
+{
+    char nativePath[COMPAT_MAX_PATH];
+    strcpy(nativePath, path);
+    compat_windows_path_to_native(nativePath);
+    compat_resolve_path(nativePath);
+
+#ifdef _WIN32
+    struct _stat info;
+    if (_stat(nativePath, &info) != 0) {
+        return false;
+    }
+    return (info.st_mode & _S_IFDIR) != 0;
+#else
+    struct stat info;
+    if (stat(nativePath, &info) != 0) {
+        return false;
+    }
+    return S_ISDIR(info.st_mode);
+#endif
 }
 
 bool compat_file_exists(const char* filePath)

--- a/src/platform_compat.cc
+++ b/src/platform_compat.cc
@@ -29,6 +29,13 @@
 
 namespace fallout {
 
+static void compat_prepare_native_path(char* nativePath, const char* path)
+{
+    strcpy(nativePath, path);
+    compat_windows_path_to_native(nativePath);
+    compat_resolve_path(nativePath);
+}
+
 int compat_stricmp(const char* string1, const char* string2)
 {
     return SDL_strcasecmp(string1, string2);
@@ -205,9 +212,7 @@ long compat_filelength(int fd)
 int compat_mkdir(const char* path)
 {
     char nativePath[COMPAT_MAX_PATH];
-    strcpy(nativePath, path);
-    compat_windows_path_to_native(nativePath);
-    compat_resolve_path(nativePath);
+    compat_prepare_native_path(nativePath, path);
 
 #ifdef _WIN32
     return mkdir(nativePath);
@@ -243,9 +248,7 @@ int compat_mkdir_recursive(const char* path)
 bool compat_is_dir(const char* path)
 {
     char nativePath[COMPAT_MAX_PATH];
-    strcpy(nativePath, path);
-    compat_windows_path_to_native(nativePath);
-    compat_resolve_path(nativePath);
+    compat_prepare_native_path(nativePath, path);
 
 #ifdef _WIN32
     struct _stat info;
@@ -264,11 +267,22 @@ bool compat_is_dir(const char* path)
 
 bool compat_file_exists(const char* filePath)
 {
-    FILE* file = compat_fopen(filePath, "rb");
-    if (file == nullptr) return false;
+    char nativePath[COMPAT_MAX_PATH];
+    compat_prepare_native_path(nativePath, filePath);
 
-    fclose(file);
-    return true;
+#ifdef _WIN32
+    struct _stat info;
+    if (_stat(nativePath, &info) != 0) {
+        return false;
+    }
+    return (info.st_mode & _S_IFDIR) == 0;
+#else
+    struct stat info;
+    if (stat(nativePath, &info) != 0) {
+        return false;
+    }
+    return !S_ISDIR(info.st_mode);
+#endif
 }
 
 unsigned int compat_timeGetTime()
@@ -285,18 +299,14 @@ unsigned int compat_timeGetTime()
 FILE* compat_fopen(const char* path, const char* mode)
 {
     char nativePath[COMPAT_MAX_PATH];
-    strcpy(nativePath, path);
-    compat_windows_path_to_native(nativePath);
-    compat_resolve_path(nativePath);
+    compat_prepare_native_path(nativePath, path);
     return fopen(nativePath, mode);
 }
 
 gzFile compat_gzopen(const char* path, const char* mode)
 {
     char nativePath[COMPAT_MAX_PATH];
-    strcpy(nativePath, path);
-    compat_windows_path_to_native(nativePath);
-    compat_resolve_path(nativePath);
+    compat_prepare_native_path(nativePath, path);
     return gzopen(nativePath, mode);
 }
 
@@ -333,23 +343,17 @@ char* compat_gzgets(gzFile stream, char* buffer, int maxCount)
 int compat_remove(const char* path)
 {
     char nativePath[COMPAT_MAX_PATH];
-    strcpy(nativePath, path);
-    compat_windows_path_to_native(nativePath);
-    compat_resolve_path(nativePath);
+    compat_prepare_native_path(nativePath, path);
     return remove(nativePath);
 }
 
 int compat_rename(const char* oldFileName, const char* newFileName)
 {
     char nativeOldFileName[COMPAT_MAX_PATH];
-    strcpy(nativeOldFileName, oldFileName);
-    compat_windows_path_to_native(nativeOldFileName);
-    compat_resolve_path(nativeOldFileName);
+    compat_prepare_native_path(nativeOldFileName, oldFileName);
 
     char nativeNewFileName[COMPAT_MAX_PATH];
-    strcpy(nativeNewFileName, newFileName);
-    compat_windows_path_to_native(nativeNewFileName);
-    compat_resolve_path(nativeNewFileName);
+    compat_prepare_native_path(nativeNewFileName, newFileName);
 
     return rename(nativeOldFileName, nativeNewFileName);
 }
@@ -424,9 +428,7 @@ void compat_resolve_path(char* path)
 int compat_access(const char* path, int mode)
 {
     char nativePath[COMPAT_MAX_PATH];
-    strcpy(nativePath, path);
-    compat_windows_path_to_native(nativePath);
-    compat_resolve_path(nativePath);
+    compat_prepare_native_path(nativePath, path);
     return access(nativePath, mode);
 }
 

--- a/src/platform_compat.cc
+++ b/src/platform_compat.cc
@@ -31,7 +31,8 @@ namespace fallout {
 
 static void compat_prepare_native_path(char* nativePath, const char* path)
 {
-    strcpy(nativePath, path);
+    strncpy(nativePath, path, COMPAT_MAX_PATH - 1);
+    nativePath[COMPAT_MAX_PATH - 1] = '\0';
     compat_windows_path_to_native(nativePath);
     compat_resolve_path(nativePath);
 }

--- a/src/platform_compat.h
+++ b/src/platform_compat.h
@@ -33,6 +33,7 @@ long compat_tell(int fileHandle);
 long compat_filelength(int fd);
 int compat_mkdir(const char* path);
 int compat_mkdir_recursive(const char* path);
+bool compat_is_dir(const char* path);
 bool compat_file_exists(const char* filePath);
 unsigned int compat_timeGetTime();
 FILE* compat_fopen(const char* path, const char* mode);

--- a/src/xfile.cc
+++ b/src/xfile.cc
@@ -553,12 +553,7 @@ bool xbaseOpen(const char* path)
         }
     }
 
-    // Try mount as directory. On POSIX, fopen() can succeed for directories,
-    // so compat_file_exists() is not a reliable gate here.
-    // XXX: this might need to be also normalized to local path separators
-    char workingDirectory[COMPAT_MAX_PATH];
-    if (getcwd(workingDirectory, COMPAT_MAX_PATH) != nullptr && chdir(path) == 0) {
-        chdir(workingDirectory);
+    if (compat_is_dir(path)) {
         xbase->next = gXbaseHead;
         gXbaseHead = xbase;
         return true;


### PR DESCRIPTION
A couple places we used compat_file_exists to distinguish between files and folders/dirs, but this breaks on POSIX.  This attempts to fix it more holistically

This is a probably better fix for: https://github.com/fallout2-ce/fallout2-ce/pull/484

This seems to work fine on mac.  Haven't tested on windows, nor with .zip archives