### PR TITLE
Mapper EDG support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -626,6 +626,8 @@ if((NOT ANDROID) AND (NOT IOS) AND (NOT CMAKE_SYSTEM_NAME MATCHES "Emscripten"))
         "src/mapper/mp_scrpt.h"
         "src/mapper/mp_targt.cc"
         "src/mapper/mp_targt.h"
+        "src/mapper/mp_utils.cc"
+        "src/mapper/mp_utils.h"
         "src/mapper/mp_text.cc"
         "src/mapper/mp_text.h"
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -614,6 +614,8 @@ if((NOT ANDROID) AND (NOT IOS) AND (NOT CMAKE_SYSTEM_NAME MATCHES "Emscripten"))
     target_sources(mapper-ce PUBLIC
         ${FALLOUT_ENGINE_SOURCES}
         ${FALLOUT_PLATFORM_SOURCES}
+        "src/mapper/map_edge_setup.cc"
+        "src/mapper/map_edge_setup.h"
         "src/mapper/map_func.cc"
         "src/mapper/map_func.h"
         "src/mapper/mapper.cc"

--- a/src/game.cc
+++ b/src/game.cc
@@ -1318,11 +1318,6 @@ int showQuitConfirmationDialog()
     return rc;
 }
 
-bool gameIsMapper()
-{
-    return gIsMapper;
-}
-
 static void TryLoadBaseCEMod()
 {
     bool found = false;

--- a/src/game.cc
+++ b/src/game.cc
@@ -1318,6 +1318,11 @@ int showQuitConfirmationDialog()
     return rc;
 }
 
+bool gameIsMapper()
+{
+    return gIsMapper;
+}
+
 static void TryLoadBaseCEMod()
 {
     bool found = false;

--- a/src/game.h
+++ b/src/game.h
@@ -47,6 +47,9 @@ int gameRequestState(int newGameState);
 void gameUpdateState();
 int showQuitConfirmationDialog();
 
+// True when running as the mapper rather than the game.
+bool gameIsMapper();
+
 int gameLoadGlobalVars();
 int gameShowDeathDialog(const char* message);
 void gameHandleSkilldexResult(int rc);

--- a/src/game.h
+++ b/src/game.h
@@ -47,9 +47,6 @@ int gameRequestState(int newGameState);
 void gameUpdateState();
 int showQuitConfirmationDialog();
 
-// True when running as the mapper rather than the game.
-bool gameIsMapper();
-
 int gameLoadGlobalVars();
 int gameShowDeathDialog(const char* message);
 void gameHandleSkilldexResult(int rc);

--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -2320,12 +2320,8 @@ int _gmouse_3d_move_to(int x, int y, int elevation, Rect* rect)
             x1 = -8;
             y1 = 13;
 
-            if (compat_stricmp(settings.system.executable.c_str(), "mapper") == 0) {
-                if (tileRoofIsVisible()) {
-                    if ((gDude->flags & OBJECT_HIDDEN) == 0) {
-                        y1 = -83;
-                    }
-                }
+            if (settings.system.executableIsMapper() && tileRoofIsVisible() && (gDude->flags & OBJECT_HIDDEN) == 0) {
+                y1 = -83;
             }
         } else {
             tile = -1;

--- a/src/map.cc
+++ b/src/map.cc
@@ -29,9 +29,7 @@
 #include "map_edge.h"
 #include "memory.h"
 #include "object.h"
-#include "palette.h"
 #include "party_member.h"
-#include "pipboy.h"
 #include "proto.h"
 #include "proto_instance.h"
 #include "queue.h"
@@ -289,7 +287,7 @@ void isoExit()
 // 0x481FB4
 void mapInit()
 {
-    if (compat_stricmp(settings.system.executable.c_str(), "mapper") == 0) {
+    if (settings.system.executableIsMapper()) {
         _map_scroll_refresh = isoWindowRefreshRectMapper;
     }
 
@@ -793,7 +791,7 @@ void mapNewMap()
     tileWindowRefresh();
 }
 
-// 0x482A68
+// 0x482A68 map_load
 int mapLoadByName(char* fileName)
 {
     int rc;
@@ -802,20 +800,22 @@ int mapLoadByName(char* fileName)
 
     rc = -1;
 
-    char* extension = strstr(fileName, ".MAP");
-    if (extension != nullptr) {
-        strcpy(extension, ".SAV");
+    if (!settings.system.executableIsMapper()) {
+        char* extension = strstr(fileName, ".MAP");
+        if (extension != nullptr) {
+            strcpy(extension, ".SAV");
 
-        const char* filePath = mapBuildPath(fileName);
+            const char* filePath = mapBuildPath(fileName);
 
-        File* stream = fileOpen(filePath, "rb");
+            File* stream = fileOpen(filePath, "rb");
 
-        strcpy(extension, ".MAP");
+            strcpy(extension, ".MAP");
 
-        if (stream != nullptr) {
-            fileClose(stream);
-            rc = mapLoadSaved(fileName);
-            wmMapMusicStart();
+            if (stream != nullptr) {
+                fileClose(stream);
+                rc = mapLoadSaved(fileName);
+                wmMapMusicStart();
+            }
         }
     }
 
@@ -855,15 +855,17 @@ int mapLoadById(int map)
     return rc;
 }
 
-// 0x482B74
+// 0x482B74 map_load_file
 static int mapLoad(File* stream)
 {
-    _map_save_in_game(true);
     int mapLoadSoundId = 0;
-    if (backgoundSoundIsPlaying()) {
-        // Use the sfall sound path so the map-loading ambience does not depend
-        // on the native background music loader.
-        mapLoadSoundId = scriptSoundPlay("sound\\music\\WIND2.ACM", SCRIPT_SOUND_MODE_LOOP);
+    if (!settings.system.executableIsMapper()) {
+        _map_save_in_game(true);
+        if (backgoundSoundIsPlaying()) {
+            // Use the sfall sound path so the map-loading ambience does not depend
+            // on the native background music loader.
+            mapLoadSoundId = scriptSoundPlay("sound\\music\\WIND2.ACM", SCRIPT_SOUND_MODE_LOOP);
+        }
     }
     isoDisable();
     _partyMemberPrepLoad();
@@ -967,7 +969,7 @@ static int mapLoad(File* stream)
         goto err;
     }
 
-    if (gameIsMapper()) {
+    if (settings.system.executableIsMapper()) {
         mapEdgeLoad(gMapHeader.name);
     } else if (settings.ui.edg_support && !settings.ui.ignore_map_edges) {
         mapEdgeLoad(gMapHeader.name);
@@ -1118,7 +1120,7 @@ err:
     return rc;
 }
 
-// 0x483188
+// 0x483188 map_load_in_game
 int mapLoadSaved(char* fileName)
 {
     debugPrint("\nMAP: Loading SAVED map.");

--- a/src/map.cc
+++ b/src/map.cc
@@ -967,8 +967,11 @@ static int mapLoad(File* stream)
         goto err;
     }
 
-    if (settings.ui.edg_support && !settings.ui.ignore_map_edges) {
+    if (gameIsMapper()) {
         mapEdgeLoad(gMapHeader.name);
+    } else if (settings.ui.edg_support && !settings.ui.ignore_map_edges) {
+        mapEdgeLoad(gMapHeader.name);
+        mapEdgeSetEnabled(true);
     }
 
     error = "Error setting tile center";
@@ -1390,6 +1393,9 @@ int _map_save()
 
         if (rc == 0) {
             debugPrint("%s saved.", gMapHeader.name);
+
+            // Write the edge (.EDG) sidecar alongside the map.
+            mapEdgeSave(gMapHeader.name);
         }
     } else {
         debugPrint("\nError: map_save: map header corrupt!");
@@ -1624,6 +1630,8 @@ static void isoWindowRefreshRectMapper(Rect* rect)
     if (!hasVisArea) {
         tile_hires_stencil_draw(&rectToUpdate, gIsoWindowBuffer, rectGetWidth(&gIsoWindowRect), rectGetHeight(&gIsoWindowRect));
     }
+
+    tileMapperOverlayRender(gIsoWindowBuffer, rectGetWidth(&gIsoWindowRect), gElevation, &rectToUpdate);
 }
 
 // NOTE: Inlined.

--- a/src/map.cc
+++ b/src/map.cc
@@ -969,11 +969,8 @@ static int mapLoad(File* stream)
         goto err;
     }
 
-    if (settings.system.executableIsMapper()) {
+    if (settings.system.executableIsMapper() || settings.ui.edg_support) {
         mapEdgeLoad(gMapHeader.name);
-    } else if (settings.ui.edg_support && !settings.ui.ignore_map_edges) {
-        mapEdgeLoad(gMapHeader.name);
-        mapEdgeSetEnabled(true);
     }
 
     error = "Error setting tile center";

--- a/src/map.cc
+++ b/src/map.cc
@@ -725,6 +725,38 @@ const char* mapBuildPath(const char* name)
     return name;
 }
 
+const char* mapBuildDataSavePath(const char* relativePath)
+{
+    static char path[COMPAT_MAX_PATH];
+
+    // Save root: the validated mapper dev_path when set, otherwise the master patches path.
+    const std::string& devPath = settings.mapper.dev_path;
+    const char* root = !devPath.empty() ? devPath.c_str() : settings.system.master_patches_path.c_str();
+
+    // Join root + relativePath, tolerating a trailing separator on the root.
+    size_t rootLen = strlen(root);
+    bool rootHasSeparator = rootLen > 0 && (root[rootLen - 1] == '\\' || root[rootLen - 1] == '/');
+    snprintf(path, sizeof(path), "%s%s%s", root, rootHasSeparator ? "" : "\\", relativePath);
+
+    // Ensure the directory portion exists.
+    char dir[COMPAT_MAX_PATH];
+    snprintf(dir, sizeof(dir), "%s", path);
+    char* separator = strrchr(dir, '\\');
+    if (separator != nullptr) {
+        *separator = '\0';
+        compat_mkdir_recursive(dir);
+    }
+
+    return path;
+}
+
+const char* mapBuildSavePath(const char* name)
+{
+    char relativePath[COMPAT_MAX_PATH];
+    snprintf(relativePath, sizeof(relativePath), "MAPS\\%s", name);
+    return mapBuildDataSavePath(relativePath);
+}
+
 // 0x482924
 int mapSetEnteringLocation(int elevation, int tile_num, int orientation)
 {
@@ -1345,30 +1377,19 @@ static void _map_fix_critter_combat_data()
 // 0x483850
 int _map_save()
 {
-    char temp[80];
-    temp[0] = '\0';
-
-    strcat(temp, settings.system.master_patches_path.c_str());
-    compat_mkdir(temp);
-
-    strcat(temp, "\\MAPS");
-    compat_mkdir(temp);
-
     int rc = -1;
     if (gMapHeader.name[0] != '\0') {
-        const char* mapFileName = mapBuildPath(gMapHeader.name);
-        File* stream = fileOpen(mapFileName, "wb");
+        const char* mapFilePath = mapBuildSavePath(gMapHeader.name);
+        File* stream = fileOpen(mapFilePath, "wb");
         if (stream != nullptr) {
             rc = _map_save_file(stream);
             fileClose(stream);
         } else {
-            snprintf(temp, sizeof(temp), "Unable to open %s to write!", gMapHeader.name);
-            debugPrint(temp);
+            debugPrint("Unable to open %s to write!", gMapHeader.name);
         }
 
         if (rc == 0) {
-            snprintf(temp, sizeof(temp), "%s saved.", gMapHeader.name);
-            debugPrint(temp);
+            debugPrint("%s saved.", gMapHeader.name);
         }
     } else {
         debugPrint("\nError: map_save: map header corrupt!");

--- a/src/map.cc
+++ b/src/map.cc
@@ -727,10 +727,9 @@ const char* mapBuildDataSavePath(const char* relativePath)
 {
     static char path[COMPAT_MAX_PATH];
 
-    // Save root: the validated mapper dev_path when set, otherwise the master patches path.
+    // Save root: the validated mapper dev_path when set (mapper only), otherwise the master patches path.
     const std::string& devPath = settings.mapper.dev_path;
-    const char* root = !devPath.empty() ? devPath.c_str() : settings.system.master_patches_path.c_str();
-
+    const char* root = (settings.system.executableIsMapper() && !devPath.empty()) ? devPath.c_str() : settings.system.master_patches_path.c_str();
     // Join root + relativePath, tolerating a trailing separator on the root.
     size_t rootLen = strlen(root);
     bool rootHasSeparator = rootLen > 0 && (root[rootLen - 1] == '\\' || root[rootLen - 1] == '/');

--- a/src/map.cc
+++ b/src/map.cc
@@ -53,7 +53,7 @@ static int mapLoad(File* stream);
 static int _map_age_dead_critters();
 static void _map_fix_critter_combat_data();
 static int _map_save_file(File* stream);
-int _map_save();
+int _map_save(bool isInGame);
 static void mapMakeMapsDirectory();
 static void isoWindowRefreshRect(Rect* rect);
 static void isoWindowRefreshRectGame(Rect* rect);
@@ -1376,7 +1376,7 @@ static void _map_fix_critter_combat_data()
 
 // map_save
 // 0x483850
-int _map_save()
+int _map_save(bool isInGame)
 {
     int rc = -1;
     if (gMapHeader.name[0] != '\0') {
@@ -1392,8 +1392,10 @@ int _map_save()
         if (rc == 0) {
             debugPrint("%s saved.", gMapHeader.name);
 
-            // Write the edge (.EDG) sidecar alongside the map.
-            mapEdgeSave(gMapHeader.name);
+            if (!isInGame) {
+                // Write the edge (.EDG) alongside the map.
+                mapEdgeSave(gMapHeader.name);
+            }
         }
     } else {
         debugPrint("\nError: map_save: map header corrupt!");
@@ -1527,7 +1529,7 @@ int _map_save_in_game(bool isLeavingMap)
 
         strcpy(name, gMapHeader.name);
         _strmfe(gMapHeader.name, name, "SAV");
-        if (_map_save() == -1) {
+        if (_map_save(true) == -1) {
             return -1;
         }
 

--- a/src/map.h
+++ b/src/map.h
@@ -117,7 +117,7 @@ int mapGetLoadedAreaId();
 int mapSetTransition(MapTransition* transition);
 int mapHandleTransition();
 int _map_save_in_game(bool isLeavingMap);
-int _map_save();
+int _map_save(bool isInGame = false);
 
 } // namespace fallout
 

--- a/src/map.h
+++ b/src/map.h
@@ -106,6 +106,12 @@ void mapNewMap();
 int mapLoadByName(char* fileName);
 int mapLoadById(int map_index);
 const char* mapBuildPath(const char* name);
+// Resolves a VFS-relative data path (e.g. "MAPS\\ARROYO.MAP") to a writable path, creating its directory.
+// Save root is the validated mapper dev_path when set, otherwise the master patches path.
+const char* mapBuildDataSavePath(const char* relativePath);
+// Convenience wrapper around mapBuildDataSavePath for files under MAPS\, mirroring
+// mapBuildPath semantics: name is the bare filename, e.g. "ARROYO.MAP".
+const char* mapBuildSavePath(const char* name);
 int mapLoadSaved(char* fileName);
 int mapGetLoadedAreaId();
 int mapSetTransition(MapTransition* transition);

--- a/src/map_edge.cc
+++ b/src/map_edge.cc
@@ -11,7 +11,6 @@
 #include "window_manager.h"
 
 #include <cassert>
-#include <memory>
 
 namespace fallout {
 
@@ -19,8 +18,10 @@ namespace fallout {
 constexpr int kTileWidth = 32;
 constexpr int kTileHeight = 24;
 
-static std::unique_ptr<EdgeZone> edgeZones[ELEVATION_COUNT];
+static EdgeElevationData edgeData[ELEVATION_COUNT];
 static bool edgeDataLoaded = false;
+// Whether edges constrain scrolling/clipping. Enabled in play mode, disabled in the mapper.
+static bool edgeEnabled = false;
 static bool edgeVersion2 = false;
 static EdgeZone* currentEdgeZone = nullptr;
 
@@ -152,30 +153,62 @@ static void calcEdgeData(EdgeZone* zone)
 // none contains it.
 static EdgeZone* findZoneByPixel(int px, int py, int elevation)
 {
-    EdgeZone* zone = edgeZones[elevation].get();
-    if (zone == nullptr) {
+    std::vector<EdgeZone>& zones = edgeData[elevation].zones;
+    if (zones.empty()) {
         return nullptr;
     }
 
-    // Multi-edge: advance while target is outside current zone.
+    // Multi-edge: advance while target is outside current zone, stopping at the last.
     // width/height in original are half-window values (winHalfWidth-1, winHalfHeight+1),
     // so window size cancels out of the condition — only pixelRect ± small constants remain.
     constexpr int kZoneMarginY = 2;
 
-    while (zone->next != nullptr) {
+    size_t index = 0;
+    while (index + 1 < zones.size()) {
+        const EdgeZone& zone = zones[index];
         // Point is inside current zone.
-        if (px < zone->pixelRect.left && px > zone->pixelRect.right
-            && py > zone->pixelRect.top - kZoneMarginY && py < zone->pixelRect.bottom - kZoneMarginY) {
+        if (px < zone.pixelRect.left && px > zone.pixelRect.right
+            && py > zone.pixelRect.top - kZoneMarginY && py < zone.pixelRect.bottom - kZoneMarginY) {
             break;
         }
-        zone = zone->next.get();
+        index++;
     }
 
-    return zone;
+    return &zones[index];
 }
 
-// Load EDG file, populate edgeZones, and compute pixel-space fields.
-// EDG files use big-endian byte order (like all Fallout 2 files).
+// Build the "<name>.EDG" name.
+static void buildEdgeFileName(const char* mapName, char* outPath, size_t outSize)
+{
+    char fname[COMPAT_MAX_FNAME];
+    compat_splitpath(mapName, nullptr, nullptr, fname, nullptr);
+    snprintf(outPath, outSize, "%s.EDG", fname);
+}
+
+// Unpacks the EDG clip-sides bitfield (per-elevation in v2).
+static EdgeZone::ClipSides unpackClipSides(int raw)
+{
+    EdgeZone::ClipSides clip;
+    clip.bottom = (raw & 1) != 0;
+    clip.right = ((raw >> 8) & 1) != 0;
+    clip.top = ((raw >> 16) & 1) != 0;
+    clip.left = ((raw >> 24) & 1) != 0;
+    return clip;
+}
+
+// Packs clip-sides into the EDG bitfield (inverse of unpackClipSides).
+static int packClipSides(const EdgeZone::ClipSides& clip)
+{
+    int value = 0;
+    if (clip.bottom) value |= 1;
+    if (clip.right) value |= 1 << 8;
+    if (clip.top) value |= 1 << 16;
+    if (clip.left) value |= 1 << 24;
+    return value;
+}
+
+// Parse an EDG stream into edgeData / edgeVersion2 (big-endian byte order), computing
+// the runtime pixel-space fields for each zone.
 static bool mapEdgeLoadFromStream(File* stream)
 {
     int magic;
@@ -192,27 +225,23 @@ static bool mapEdgeLoadFromStream(File* stream)
     int levelIndicator = 0;
 
     for (int elev = 0; elev < ELEVATION_COUNT; elev++) {
-        int sqLeft = SQUARE_GRID_WIDTH - 1, sqTop = 0, sqRight = 0, sqBottom = SQUARE_GRID_HEIGHT - 1;
-        int sqClipData = 0;
+        EdgeElevationData& data = edgeData[elev];
+        data.squareRect = { SQUARE_GRID_WIDTH - 1, 0, 0, SQUARE_GRID_HEIGHT - 1 };
+        data.clipSides = { };
 
         if (edgeVersion2) {
             int sqRect[4];
-            if (fileReadInt32List(stream, sqRect, 4) == -1
-                || fileReadInt32(stream, &sqClipData) == -1) {
+            int sqClipData;
+            if (fileReadInt32List(stream, sqRect, 4) == -1 || fileReadInt32(stream, &sqClipData) == -1) {
                 return false;
             }
-            sqLeft = sqRect[0];
-            sqTop = sqRect[1];
-            sqRight = sqRect[2];
-            sqBottom = sqRect[3];
+            data.squareRect = { sqRect[0], sqRect[1], sqRect[2], sqRect[3] };
+            data.clipSides = unpackClipSides(sqClipData);
         }
 
         if (levelIndicator != elev) {
             continue; // no tileRect data for this elevation
         }
-
-        auto tail = &edgeZones[elev];
-        bool isFirstZone = true;
 
         while (true) {
             int tileRect[4];
@@ -220,29 +249,11 @@ static bool mapEdgeLoadFromStream(File* stream)
                 return elev == ELEVATION_COUNT - 1;
             }
 
-            auto zone = std::make_unique<EdgeZone>();
             // File stores RECT order: [0]=left, [1]=top, [2]=right, [3]=bottom.
-            zone->tileRect.left = tileRect[0];
-            zone->tileRect.top = tileRect[1];
-            zone->tileRect.right = tileRect[2];
-            zone->tileRect.bottom = tileRect[3];
-
-            zone->squareRect.left = sqLeft;
-            zone->squareRect.top = sqTop;
-            zone->squareRect.right = sqRight;
-            zone->squareRect.bottom = sqBottom;
-            int rawClip = isFirstZone ? sqClipData : 0;
-            zone->clipSides.bottom = (rawClip & 1) != 0;
-            zone->clipSides.right = ((rawClip >> 8) & 1) != 0;
-            zone->clipSides.top = ((rawClip >> 16) & 1) != 0;
-            zone->clipSides.left = ((rawClip >> 24) & 1) != 0;
-            zone->next = nullptr;
-
-            calcEdgeData(zone.get());
-
-            *tail = std::move(zone);
-            tail = &(*tail)->next;
-            isFirstZone = false;
+            EdgeZone zone{};
+            zone.tileRect = { tileRect[0], tileRect[1], tileRect[2], tileRect[3] };
+            calcEdgeData(&zone);
+            data.zones.push_back(zone);
 
             if (fileReadInt32(stream, &levelIndicator) == -1) {
                 return elev == ELEVATION_COUNT - 1;
@@ -261,11 +272,9 @@ void mapEdgeLoad(const char* mapName)
 {
     mapEdgeFree();
 
-    char fname[COMPAT_MAX_FNAME];
-    compat_splitpath(mapName, nullptr, nullptr, fname, nullptr);
-
-    char edgPath[COMPAT_MAX_PATH];
-    snprintf(edgPath, sizeof(edgPath), "MAPS\\%s.EDG", fname);
+    char edgName[COMPAT_MAX_PATH];
+    buildEdgeFileName(mapName, edgName, sizeof(edgName));
+    const char* edgPath = mapBuildPath(edgName);
 
     File* stream = fileOpen(edgPath, "rb");
     if (stream == nullptr) {
@@ -284,12 +293,87 @@ void mapEdgeLoad(const char* mapName)
     }
 }
 
+// Index of the next elevation (>= from) that has zones, or ELEVATION_COUNT if none.
+// Used as the level indicator that advances the loader past empty elevations.
+static int nextElevationWithZones(int from)
+{
+    for (int elev = from; elev < ELEVATION_COUNT; elev++) {
+        if (!edgeData[elev].zones.empty()) {
+            return elev;
+        }
+    }
+    return ELEVATION_COUNT;
+}
+
+// Writes edgeData to an EDG stream, mirroring mapEdgeLoadFromStream's byte layout.
+static bool writeEdgStream(File* stream)
+{
+    if (fileWriteInt32(stream, 'EDGE') == -1) return false;
+    if (fileWriteInt32(stream, edgeVersion2 ? 2 : 1) == -1) return false;
+    if (fileWriteInt32(stream, 0) == -1) return false; // reserved
+
+    for (int elev = 0; elev < ELEVATION_COUNT; elev++) {
+        const EdgeElevationData& data = edgeData[elev];
+
+        if (edgeVersion2) {
+            int sqRect[4] = { data.squareRect.left, data.squareRect.top, data.squareRect.right, data.squareRect.bottom };
+            if (fileWriteInt32List(stream, sqRect, 4) == -1) return false;
+            if (fileWriteInt32(stream, packClipSides(data.clipSides)) == -1) return false;
+        }
+
+        const int zoneCount = static_cast<int>(data.zones.size());
+        for (int i = 0; i < zoneCount; i++) {
+            const Rect& r = data.zones[i].tileRect;
+            int tileRect[4] = { r.left, r.top, r.right, r.bottom };
+            if (fileWriteInt32List(stream, tileRect, 4) == -1) return false;
+
+            // Level indicator: same elevation while more zones follow, otherwise the
+            // index of the next elevation that has zones (so the loader advances to it).
+            int levelIndicator = (i + 1 < zoneCount) ? elev : nextElevationWithZones(elev + 1);
+            if (fileWriteInt32(stream, levelIndicator) == -1) return false;
+        }
+    }
+
+    return true;
+}
+
+void mapEdgeSave(const char* mapName)
+{
+    int totalZones = 0;
+    for (const EdgeElevationData& data : edgeData) {
+        totalZones += static_cast<int>(data.zones.size());
+    }
+    if (totalZones == 0) {
+        return; // nothing to write
+    }
+
+    char edgName[COMPAT_MAX_PATH];
+    buildEdgeFileName(mapName, edgName, sizeof(edgName));
+    const char* edgPath = mapBuildSavePath(edgName);
+
+    File* stream = fileOpen(edgPath, "wb");
+    if (stream == nullptr) {
+        debugPrint("mapEdgeSave: unable to open %s for writing\n", edgPath);
+        return;
+    }
+
+    bool ok = writeEdgStream(stream);
+    fileClose(stream);
+    debugPrint("mapEdgeSave: %s %s\n", ok ? "wrote" : "error writing", edgPath);
+}
+
+EdgeElevationData& mapEdgeGetElevationData(int elevation)
+{
+    return edgeData[elevation];
+}
+
 void mapEdgeFree()
 {
-    for (auto& gEdgeZone : edgeZones) {
-        gEdgeZone.reset();
+    for (auto& data : edgeData) {
+        data = EdgeElevationData { };
     }
     edgeDataLoaded = false;
+    edgeEnabled = false;
     currentEdgeZone = nullptr;
     currentTileXAlignment = 0;
     currentTileYAlignment = 0;
@@ -301,6 +385,17 @@ void mapEdgeFree()
 bool mapEdgeIsLoaded()
 {
     return edgeDataLoaded;
+}
+
+void mapEdgeSetEnabled(bool enabled)
+{
+    edgeEnabled = enabled;
+}
+
+bool mapEdgeIsEnabled()
+{
+    // Edges can only be enabled when data is actually loaded.
+    return edgeDataLoaded && edgeEnabled;
 }
 
 bool mapEdgeZoneIsSelected()
@@ -393,36 +488,32 @@ int mapEdgeGetTileYAlignment() { return currentTileYAlignment; }
 
 bool mapEdgeHasSquareRect(int elevation)
 {
-    const auto& zone = edgeZones[elevation];
-    return edgeVersion2 && zone != nullptr && zone->squareRect.left >= 0;
+    const EdgeElevationData& data = edgeData[elevation];
+    return edgeVersion2 && !data.zones.empty() && data.squareRect.left >= 0;
 }
 
 void mapEdgeGetSquareRect(int elevation, Rect* outRect)
 {
-    const auto& zone = edgeZones[elevation];
-    *outRect = zone->squareRect;
+    *outRect = edgeData[elevation].squareRect;
 }
 
 EdgeZone::ClipSides mapEdgeGetClipSides(int elevation)
 {
-    const auto& zone = edgeZones[elevation];
-    return zone ? zone->clipSides : EdgeZone::ClipSides {};
+    return edgeData[elevation].clipSides;
 }
 
 void mapEdgeRecalc()
 {
-    for (auto& gEdgeZone : edgeZones) {
-        const auto* zone = &gEdgeZone;
-        while (zone != nullptr) {
-            calcEdgeData(zone->get());
-            zone = &zone->get()->next;
+    for (auto& data : edgeData) {
+        for (auto& zone : data.zones) {
+            calcEdgeData(&zone);
         }
     }
 }
 
 bool mapEdgeComputeVisibleArea(int elevation, Rect* outRect)
 {
-    if (!edgeDataLoaded) return false;
+    if (!mapEdgeIsEnabled()) return false;
 
     int px, py;
     tileToPixelOffset(gCenterTile, px, py);
@@ -453,7 +544,7 @@ bool mapEdgeComputeVisibleArea(int elevation, Rect* outRect)
 
 bool mapEdgeIsOverClippedArea(int screenX, int screenY)
 {
-    if (!edgeDataLoaded) return false;
+    if (!mapEdgeIsEnabled()) return false;
 
     if (screenX >= gMapVisibleArea.left && screenX <= gMapVisibleArea.right && screenY >= gMapVisibleArea.top && screenY < gMapVisibleArea.bottom) return false;
 

--- a/src/map_edge.cc
+++ b/src/map_edge.cc
@@ -227,7 +227,7 @@ static bool mapEdgeLoadFromStream(File* stream)
     for (int elev = 0; elev < ELEVATION_COUNT; elev++) {
         EdgeElevationData& data = edgeData[elev];
         data.squareRect = { SQUARE_GRID_WIDTH - 1, 0, 0, SQUARE_GRID_HEIGHT - 1 };
-        data.clipSides = { };
+        data.clipSides = {};
 
         if (edgeVersion2) {
             int sqRect[4];
@@ -370,7 +370,7 @@ EdgeElevationData& mapEdgeGetElevationData(int elevation)
 void mapEdgeFree()
 {
     for (auto& data : edgeData) {
-        data = EdgeElevationData { };
+        data = EdgeElevationData {};
     }
     edgeDataLoaded = false;
     edgeEnabled = false;

--- a/src/map_edge.cc
+++ b/src/map_edge.cc
@@ -250,7 +250,7 @@ static bool mapEdgeLoadFromStream(File* stream)
             }
 
             // File stores RECT order: [0]=left, [1]=top, [2]=right, [3]=bottom.
-            EdgeZone zone{};
+            EdgeZone zone {};
             zone.tileRect = { tileRect[0], tileRect[1], tileRect[2], tileRect[3] };
             calcEdgeData(&zone);
             data.zones.push_back(zone);
@@ -396,6 +396,11 @@ bool mapEdgeIsEnabled()
 {
     // Edges can only be enabled when data is actually loaded.
     return edgeDataLoaded && edgeEnabled;
+}
+
+void mapEdgeUpgradeToVersion2()
+{
+    edgeVersion2 = true;
 }
 
 bool mapEdgeZoneIsSelected()

--- a/src/map_edge.cc
+++ b/src/map_edge.cc
@@ -6,6 +6,7 @@
 #include "map.h"
 #include "map_defs.h"
 #include "platform_compat.h"
+#include "settings.h"
 #include "svga.h"
 #include "tile.h"
 #include "window_manager.h"
@@ -20,8 +21,7 @@ constexpr int kTileHeight = 24;
 
 static EdgeElevationData edgeData[ELEVATION_COUNT];
 static bool edgeDataLoaded = false;
-// Whether edges constrain scrolling/clipping. Enabled in play mode, disabled in the mapper.
-static bool edgeEnabled = false;
+static bool mapperMode = false;
 static bool edgeVersion2 = false;
 static EdgeZone* currentEdgeZone = nullptr;
 
@@ -373,7 +373,6 @@ void mapEdgeFree()
         data = EdgeElevationData {};
     }
     edgeDataLoaded = false;
-    edgeEnabled = false;
     currentEdgeZone = nullptr;
     currentTileXAlignment = 0;
     currentTileYAlignment = 0;
@@ -387,15 +386,20 @@ bool mapEdgeIsLoaded()
     return edgeDataLoaded;
 }
 
-void mapEdgeSetEnabled(bool enabled)
+void mapEdgeSetMapperMode(bool enabled)
 {
-    edgeEnabled = enabled;
+    mapperMode = enabled;
+}
+
+bool mapEdgeIsMapperMode()
+{
+    return mapperMode;
 }
 
 bool mapEdgeIsEnabled()
 {
-    // Edges can only be enabled when data is actually loaded.
-    return edgeDataLoaded && edgeEnabled;
+    // Enforced when data is loaded, we're not editing in the mapper, and the user enabled it.
+    return edgeDataLoaded && !mapperMode && settings.ui.edg_support && !settings.ui.ignore_map_edges;
 }
 
 void mapEdgeUpgradeToVersion2()

--- a/src/map_edge.h
+++ b/src/map_edge.h
@@ -64,6 +64,9 @@ bool mapEdgeIsLoaded();
 void mapEdgeSetEnabled(bool enabled);
 bool mapEdgeIsEnabled();
 
+// Marks edge data as version 2 so squareRect/clipSides are written on save.
+void mapEdgeUpgradeToVersion2();
+
 // Returns true if a zone was selected on last tileSetCenter call.
 bool mapEdgeZoneIsSelected();
 

--- a/src/map_edge.h
+++ b/src/map_edge.h
@@ -1,7 +1,7 @@
 #ifndef MAP_EDGE_H
 #define MAP_EDGE_H
 
-#include <memory>
+#include <vector>
 
 #include "geometry.h"
 
@@ -19,6 +19,7 @@ struct EdgeZone {
     Rect tileRect;
 
     // Pixel-space rect from tileRect corner conversion (before contraction).
+    // Runtime-calculated by calcEdgeData(); stale while the editor mutates tileRect.
     Rect pixelRect;
 
     // Pixel-space boundary for center-tile scroll blocking (screen-size dependent).
@@ -26,27 +27,42 @@ struct EdgeZone {
     // X axis is inverted: left > right (smaller tile index → larger pixel X).
     // Y axis is normal: bottom > top.
     Rect scrollBorderRect;
+};
 
-    // Square-grid clip rect for floor/roof rendering (v2 EDG only).
-    // Valid when left >= 0.
+// All edge data for a single elevation. squareRect/clipSides are per-elevation (v2 EDG),
+// matching the file format; zones is the list of edge rects (one per zone).
+struct EdgeElevationData {
+    std::vector<EdgeZone> zones;
+
+    // Square-grid clip rect for floor/roof rendering (v2 EDG only). Valid when left >= 0.
     Rect squareRect;
 
     // Per-side clip flags unpacked from EDG v2. True means the black square overlay
     // for that side is drawn on top of (after) non-flat objects.
-    ClipSides clipSides;
-
-    std::unique_ptr<EdgeZone> next;
+    EdgeZone::ClipSides clipSides;
 };
 
 // Load EDG file for a map. mapName is the raw map filename e.g. "ARROYO.MAP".
 // Silently does nothing if no .edg file is found.
 void mapEdgeLoad(const char* mapName);
 
+// Writes the current in-memory edge data to the map's EDG file (mapper save path).
+// Does nothing when there are no edge zones. Used by the mapper map-save flow.
+void mapEdgeSave(const char* mapName);
+
+// Mutable access to a single elevation's edge data. Used by the mapper edge editor,
+// which edits this data in place; the disk write happens later via mapEdgeSave.
+EdgeElevationData& mapEdgeGetElevationData(int elevation);
+
 // Free all loaded EDG data. Safe to call when nothing is loaded.
 void mapEdgeFree();
 
 // Returns true if EDG data was successfully loaded for the current map.
 bool mapEdgeIsLoaded();
+
+// Enables/disables edge constraints (scroll blocking, view clipping). Independent of loading.
+void mapEdgeSetEnabled(bool enabled);
+bool mapEdgeIsEnabled();
 
 // Returns true if a zone was selected on last tileSetCenter call.
 bool mapEdgeZoneIsSelected();

--- a/src/map_edge.h
+++ b/src/map_edge.h
@@ -60,8 +60,13 @@ void mapEdgeFree();
 // Returns true if EDG data was successfully loaded for the current map.
 bool mapEdgeIsLoaded();
 
-// Enables/disables edge constraints (scroll blocking, view clipping). Independent of loading.
-void mapEdgeSetEnabled(bool enabled);
+// Mapper-editing mode: when enabled, loaded EDG data is not enforced so edges can be edited.
+// The game leaves this off; the mapper turns it off only while play-testing.
+void mapEdgeSetMapperMode(bool enabled);
+bool mapEdgeIsMapperMode();
+
+// True when edge constraints are actively enforced: data loaded, not in mapper-editing mode,
+// and enabled by user settings (edg_support on, ignore_map_edges off).
 bool mapEdgeIsEnabled();
 
 // Marks edge data as version 2 so squareRect/clipSides are written on save.

--- a/src/mapper/map_edge_setup.cc
+++ b/src/mapper/map_edge_setup.cc
@@ -1,0 +1,515 @@
+#include "mapper/map_edge_setup.h"
+
+#include <algorithm>
+#include <vector>
+
+#include "color.h"
+#include "draw.h"
+#include "geometry.h"
+#include "input.h"
+#include "kb.h"
+#include "map.h"
+#include "map_defs.h"
+#include "map_edge.h"
+#include "mouse.h"
+#include "svga.h"
+#include "text_font.h"
+#include "tile.h"
+#include "window_manager.h"
+
+namespace fallout {
+
+// Palette indices for the iso overlay (15-bit RGB lookups into _colorTable).
+constexpr int kActiveRectColor = 30720; // red
+constexpr int kMoveSideColor = 783; // green
+
+// A side of the active edge rect that can be moved.
+enum class EdgeSide {
+    None,
+    Left,
+    Top,
+    Right,
+    Bottom,
+};
+
+static bool active = false; // dialog open → draw the overlay
+static bool showAllRects = false; // persistent overlay toggle (Settings menu)
+static int workingElevation = 0;
+static int activeRect = -1;
+static EdgeSide moveSide = EdgeSide::None;
+static int moveOrigValue = 0; // side value to restore on Cancel move
+
+// Snapshot of all edge data taken when the dialog opens, restored on Cancel.
+static EdgeElevationData backup[ELEVATION_COUNT];
+
+static std::vector<EdgeZone>& currentZones()
+{
+    return mapEdgeGetElevationData(workingElevation).zones;
+}
+
+// Computes the tileRect (corners as tile indices) that covers the whole hex grid.
+static Rect fullGridTileRect()
+{
+    const int corners[4] = {
+        0,
+        HEX_GRID_WIDTH - 1,
+        (HEX_GRID_HEIGHT - 1) * HEX_GRID_WIDTH,
+        HEX_GRID_SIZE - 1,
+    };
+
+    Rect result { };
+    int maxPx = 0;
+    int minPx = 0;
+    int minPy = 0;
+    int maxPy = 0;
+    for (int i = 0; i < 4; i++) {
+        int px;
+        int py;
+        tileToPixelOffset(corners[i], px, py);
+        if (i == 0 || px > maxPx) {
+            maxPx = px;
+            result.left = corners[i]; // X inverted: left has the larger pixel X
+        }
+        if (i == 0 || px < minPx) {
+            minPx = px;
+            result.right = corners[i];
+        }
+        if (i == 0 || py < minPy) {
+            minPy = py;
+            result.top = corners[i];
+        }
+        if (i == 0 || py > maxPy) {
+            maxPy = py;
+            result.bottom = corners[i];
+        }
+    }
+    return result;
+}
+
+static void editorOpen(int elevation)
+{
+    for (int elev = 0; elev < ELEVATION_COUNT; elev++) {
+        backup[elev] = mapEdgeGetElevationData(elev);
+    }
+
+    workingElevation = elevation;
+    active = true;
+    moveSide = EdgeSide::None;
+    activeRect = currentZones().empty() ? -1 : 0;
+}
+
+static void editorClose(bool save)
+{
+    if (!save) {
+        for (int elev = 0; elev < ELEVATION_COUNT; elev++) {
+            mapEdgeGetElevationData(elev) = backup[elev];
+        }
+    }
+    active = false;
+    moveSide = EdgeSide::None;
+}
+
+static void editorAddRect()
+{
+    currentZones().push_back(EdgeZone { fullGridTileRect() });
+    activeRect = static_cast<int>(currentZones().size()) - 1;
+}
+
+static void editorDeleteRect()
+{
+    std::vector<EdgeZone>& zones = currentZones();
+    if (activeRect < 0 || activeRect >= static_cast<int>(zones.size())) {
+        return;
+    }
+
+    zones.erase(zones.begin() + activeRect);
+    if (zones.empty()) {
+        activeRect = -1;
+    } else if (activeRect > 0) {
+        activeRect--; // previous one
+    }
+    // else (was first): keep index 0, now pointing at the next one.
+}
+
+static void editorNextRect()
+{
+    int count = static_cast<int>(currentZones().size());
+    if (count > 0 && activeRect < count - 1) {
+        activeRect++;
+    }
+}
+
+static void editorPrevRect()
+{
+    if (activeRect > 0) {
+        activeRect--;
+    }
+}
+
+// Returns a writable pointer to the active rect's side value, or nullptr.
+static int* activeSideValue(EdgeSide side)
+{
+    std::vector<EdgeZone>& zones = currentZones();
+    if (activeRect < 0 || activeRect >= static_cast<int>(zones.size())) {
+        return nullptr;
+    }
+    Rect& r = zones[activeRect].tileRect;
+    switch (side) {
+    case EdgeSide::Left:
+        return &r.left;
+    case EdgeSide::Top:
+        return &r.top;
+    case EdgeSide::Right:
+        return &r.right;
+    case EdgeSide::Bottom:
+        return &r.bottom;
+    default:
+        return nullptr;
+    }
+}
+
+static void editorBeginMove(EdgeSide side)
+{
+    int* value = activeSideValue(side);
+    if (value == nullptr) {
+        return;
+    }
+    moveSide = side;
+    moveOrigValue = *value;
+}
+
+static void editorCommitMove()
+{
+    moveSide = EdgeSide::None;
+}
+
+static void editorCancelMove()
+{
+    int* value = activeSideValue(moveSide);
+    if (value != nullptr) {
+        *value = moveOrigValue;
+    }
+    moveSide = EdgeSide::None;
+}
+
+// Moves the selected side to match a screen position over the iso grid (live preview).
+// Returns true if the value changed and the views should refresh.
+static bool editorUpdateMoveFromScreen(int screenX, int screenY)
+{
+    int* value = activeSideValue(moveSide);
+    if (value == nullptr) {
+        return false;
+    }
+
+    int tile = tileFromScreenXY(screenX, screenY, true);
+    if (!hexGridTileIsValid(tile) || tile == *value) {
+        return false;
+    }
+
+    *value = tile;
+    return true;
+}
+
+// Clips an axis-aligned line to clip and draws it; skips lines fully outside.
+static void drawClippedHLine(unsigned char* buffer, int pitch, const Rect* clip, int y, int x0, int x1, int color)
+{
+    if (y < clip->top || y > clip->bottom) return;
+    int left = std::max(std::min(x0, x1), clip->left);
+    int right = std::min(std::max(x0, x1), clip->right);
+    if (left > right) return;
+    bufferDrawLine(buffer, pitch, left, y, right, y, color);
+}
+
+static void drawClippedVLine(unsigned char* buffer, int pitch, const Rect* clip, int x, int y0, int y1, int color)
+{
+    if (x < clip->left || x > clip->right) return;
+    int top = std::max(std::min(y0, y1), clip->top);
+    int bottom = std::min(std::max(y0, y1), clip->bottom);
+    if (top > bottom) return;
+    bufferDrawLine(buffer, pitch, x, top, x, bottom, color);
+}
+
+// Screen-space rect (normalized left<=right, top<=bottom) of a zone's tile corners.
+static Rect tileRectToScreenRect(const Rect& tileRect)
+{
+    int lx, ly, rx, ry, tx, ty, bx, by;
+    tileToScreenXY(tileRect.left, &lx, &ly);
+    tileToScreenXY(tileRect.right, &rx, &ry);
+    tileToScreenXY(tileRect.top, &tx, &ty);
+    tileToScreenXY(tileRect.bottom, &bx, &by);
+    return Rect { std::min(lx, rx), std::min(ty, by), std::max(lx, rx), std::max(ty, by) };
+}
+
+static void drawScreenRectOutline(unsigned char* buffer, int pitch, const Rect* clip, const Rect& s, int color)
+{
+    drawClippedHLine(buffer, pitch, clip, s.top, s.left, s.right, color);
+    drawClippedHLine(buffer, pitch, clip, s.bottom, s.left, s.right, color);
+    drawClippedVLine(buffer, pitch, clip, s.left, s.top, s.bottom, color);
+    drawClippedVLine(buffer, pitch, clip, s.right, s.top, s.bottom, color);
+}
+
+// Registered as the tile renderer's overlay hook. While the dialog is open, only the active
+// rect is drawn (plus the moving side in green). Otherwise the persistent toggle outlines
+// every rect. Never drawn in play mode (edges enabled).
+static void renderOverlay(unsigned char* buffer, int pitch, int elevation, const Rect* clip)
+{
+    if (mapEdgeIsEnabled()) {
+        return;
+    }
+
+    const int red = _colorTable[kActiveRectColor];
+
+    if (!active) {
+        if (showAllRects) {
+            for (const EdgeZone& zone : mapEdgeGetElevationData(elevation).zones) {
+                drawScreenRectOutline(buffer, pitch, clip, tileRectToScreenRect(zone.tileRect), red);
+            }
+        }
+        return;
+    }
+
+    if (elevation != workingElevation) {
+        return;
+    }
+
+    std::vector<EdgeZone>& zones = currentZones();
+    if (activeRect < 0 || activeRect >= static_cast<int>(zones.size())) {
+        return;
+    }
+
+    const Rect s = tileRectToScreenRect(zones[activeRect].tileRect);
+    drawScreenRectOutline(buffer, pitch, clip, s, red);
+
+    if (moveSide != EdgeSide::None) {
+        const int green = _colorTable[kMoveSideColor];
+        switch (moveSide) {
+        case EdgeSide::Left:
+            drawClippedVLine(buffer, pitch, clip, s.left, s.top, s.bottom, green);
+            break;
+        case EdgeSide::Right:
+            drawClippedVLine(buffer, pitch, clip, s.right, s.top, s.bottom, green);
+            break;
+        case EdgeSide::Top:
+            drawClippedHLine(buffer, pitch, clip, s.top, s.left, s.right, green);
+            break;
+        case EdgeSide::Bottom:
+            drawClippedHLine(buffer, pitch, clip, s.bottom, s.left, s.right, green);
+            break;
+        default:
+            break;
+        }
+    }
+}
+
+void mapEdgeSetupInit()
+{
+    tileSetMapperOverlayProc(renderOverlay);
+}
+
+void mapEdgeSetupToggleOverlay()
+{
+    showAllRects = !showAllRects;
+    tileWindowRefresh();
+}
+
+void mapEdgeSetupDialog()
+{
+    constexpr int kWinWidth = 230;
+    constexpr int kWinHeight = 250;
+
+    // Button event codes (kept clear of real key/mouse codes).
+    constexpr int kEvAddRect = 0x3201;
+    constexpr int kEvDelRect = 0x3202;
+    constexpr int kEvPrevRect = 0x3203;
+    constexpr int kEvNextRect = 0x3204;
+    constexpr int kEvSideTop = 0x3205;
+    constexpr int kEvSideBottom = 0x3206;
+    constexpr int kEvSideLeft = 0x3207;
+    constexpr int kEvSideRight = 0x3208;
+    constexpr int kEvCancel = 0x3209;
+    constexpr int kEvSave = 0x320A;
+
+    // Reference diagram box; sides are highlighted green while being moved.
+    constexpr int kBoxLeft = 60;
+    constexpr int kBoxTop = 128;
+    constexpr int kBoxRight = 170;
+    constexpr int kBoxBottom = 186;
+
+    const int winBgColor = _colorTable[3082]; // dark blue
+    const int textColor = _colorTable[16344]; // lighter gray
+    // const int buttonTextColor = _colorTable[20052] | FONT_SHADOW | FONT_MONO; // grey
+    const int titleColor = _colorTable[32767]; // white
+    const int rectColor = _colorTable[kActiveRectColor]; // red
+    const int highlightColor = _colorTable[kMoveSideColor]; // green
+
+    const int winX = (rectGetWidth(&_scr_size) - kWinWidth) / 2;
+    const int winY = (rectGetHeight(&_scr_size) - kWinHeight) / 2;
+
+    int win = windowCreate(winX, winY, kWinWidth, kWinHeight, winBgColor, WINDOW_MOVE_ON_TOP);
+    if (win == -1) {
+        return;
+    }
+
+    unsigned char* buf = windowGetBuffer(win);
+    const int pitch = windowGetWidth(win);
+    const int lineHeight = fontGetLineHeight();
+
+    editorOpen(gElevation);
+
+    auto centeredX = [&](const char* text) { return (kWinWidth - fontGetStringWidth(text)) / 2; };
+
+    ScopedFont font(1);
+
+    // Static chrome and labels drawn once; buttons are themed and registered once.
+    windowDrawBorder(win);
+    windowDrawText(win, "MAP EDGE SETUP", 0, centeredX("MAP EDGE SETUP"), 8, titleColor);
+
+    windowDrawText(win, gMapHeader.name[0] != '\0' ? gMapHeader.name : "<unnamed>", 130, 12, 26, textColor);
+
+    char tmp[64];
+    snprintf(tmp, sizeof(tmp), "Elev: %d", workingElevation);
+    windowDrawText(win, tmp, 0, 168, 26, textColor);
+
+    _win_register_text_button(win, 12, 58, -1, -1, -1, kEvAddRect, "Add Rect", 0);
+    _win_register_text_button(win, 120, 58, -1, -1, -1, kEvDelRect, "Delete Rect", 0);
+    _win_register_text_button(win, 12, 86, -1, -1, -1, kEvPrevRect, "<<", 0);
+    _win_register_text_button(win, 180, 86, -1, -1, -1, kEvNextRect, ">>", 0);
+    _win_register_text_button(win, 96, 108, -1, -1, -1, kEvSideTop, "Top", 0);
+    _win_register_text_button(win, 90, 190, -1, -1, -1, kEvSideBottom, "Bottom", 0);
+    _win_register_text_button(win, 12, 148, -1, -1, -1, kEvSideLeft, "Left", 0);
+    _win_register_text_button(win, 174, 148, -1, -1, -1, kEvSideRight, "Right", 0);
+    _win_register_text_button(win, 12, 222, -1, -1, -1, kEvCancel, "Cancel", 0);
+    _win_register_text_button(win, 160, 222, -1, -1, -1, kEvSave, "Save", 0);
+
+    // Repaints only the parts that change with editor state, then blits the window.
+    auto render = [&]() {
+        char buffer[64];
+
+        snprintf(buffer, sizeof(buffer), "Num Rects: %d", static_cast<int>(currentZones().size()));
+        bufferFill(buf + 40 * pitch + 10, kWinWidth - 20, lineHeight, pitch, winBgColor);
+        windowDrawText(win, buffer, 0, centeredX(buffer), 40, textColor);
+
+        snprintf(buffer, sizeof(buffer), "Rect: %d", activeRect >= 0 ? activeRect + 1 : 0);
+        bufferFill(buf + 90 * pitch + 50, kWinWidth - 100, lineHeight, pitch, winBgColor);
+        windowDrawText(win, buffer, 0, centeredX(buffer), 90, textColor);
+
+        // Reference diagram: red rect, with the side under edit drawn green.
+        bufferFill(buf + (kBoxTop - 1) * pitch + (kBoxLeft - 1), kBoxRight - kBoxLeft + 3, kBoxBottom - kBoxTop + 3, pitch, winBgColor);
+        bufferDrawRect(buf, pitch, kBoxLeft, kBoxTop, kBoxRight, kBoxBottom, rectColor);
+        switch (moveSide) {
+        case EdgeSide::Top:
+            bufferDrawLine(buf, pitch, kBoxLeft, kBoxTop, kBoxRight, kBoxTop, highlightColor);
+            break;
+        case EdgeSide::Bottom:
+            bufferDrawLine(buf, pitch, kBoxLeft, kBoxBottom, kBoxRight, kBoxBottom, highlightColor);
+            break;
+        case EdgeSide::Left:
+            bufferDrawLine(buf, pitch, kBoxLeft, kBoxTop, kBoxLeft, kBoxBottom, highlightColor);
+            break;
+        case EdgeSide::Right:
+            bufferDrawLine(buf, pitch, kBoxRight, kBoxTop, kBoxRight, kBoxBottom, highlightColor);
+            break;
+        default:
+            break;
+        }
+
+        windowRefresh(win);
+    };
+
+    // Repaint both the iso overlay and the dialog after a state change.
+    auto refreshAll = [&]() {
+        tileWindowRefresh();
+        render();
+    };
+
+    refreshAll(); // initial draw of dialog + iso overlay
+
+    bool done = false;
+    while (!done) {
+        sharedFpsLimiter.mark();
+        int keyCode = inputGetInput();
+
+        int mx, my;
+        mouseGetPosition(&mx, &my);
+        bool overDialog = mx >= winX && mx < winX + kWinWidth && my >= winY && my < winY + kWinHeight;
+        bool moving = moveSide != EdgeSide::None;
+
+        // Live-track the selected side under the cursor while over the iso view.
+        if (moving && !overDialog) {
+            if (editorUpdateMoveFromScreen(mx, my)) {
+                tileWindowRefresh();
+            }
+        }
+
+        if (keyCode == KEY_ESCAPE) {
+            if (moving) {
+                editorCancelMove();
+                refreshAll();
+            } else {
+                editorClose(false);
+                done = true;
+            }
+        } else if (keyCode == -2) {
+            int buttons = mouseGetEvent();
+            if (moving && (buttons & MOUSE_EVENT_LEFT_BUTTON_DOWN) && !overDialog) {
+                editorCommitMove();
+                refreshAll();
+            } else if (moving && (buttons & MOUSE_EVENT_RIGHT_BUTTON_DOWN)) {
+                editorCancelMove();
+                refreshAll();
+            }
+        } else if (keyCode != -1) {
+            bool refresh = true;
+            switch (keyCode) {
+            case kEvAddRect:
+                editorAddRect();
+                break;
+            case kEvDelRect:
+                editorDeleteRect();
+                break;
+            case kEvPrevRect:
+                editorPrevRect();
+                break;
+            case kEvNextRect:
+                editorNextRect();
+                break;
+            case kEvSideTop:
+                editorBeginMove(EdgeSide::Top);
+                break;
+            case kEvSideBottom:
+                editorBeginMove(EdgeSide::Bottom);
+                break;
+            case kEvSideLeft:
+                editorBeginMove(EdgeSide::Left);
+                break;
+            case kEvSideRight:
+                editorBeginMove(EdgeSide::Right);
+                break;
+            case kEvCancel:
+                editorClose(false);
+                done = true;
+                refresh = false;
+                break;
+            case kEvSave:
+                editorClose(true);
+                done = true;
+                refresh = false;
+                break;
+            default:
+                refresh = false;
+                break;
+            }
+            if (refresh) {
+                refreshAll();
+            }
+        }
+
+        renderPresent();
+        sharedFpsLimiter.throttle();
+    }
+
+    windowDestroy(win);
+    tileWindowRefresh(); // repaint the iso view without the overlay
+}
+
+} // namespace fallout

--- a/src/mapper/map_edge_setup.cc
+++ b/src/mapper/map_edge_setup.cc
@@ -1,6 +1,7 @@
 #include "mapper/map_edge_setup.h"
 
 #include <algorithm>
+#include <functional>
 #include <vector>
 
 #include "color.h"
@@ -22,8 +23,10 @@ namespace fallout {
 // Palette indices for the iso overlay (15-bit RGB lookups into _colorTable).
 constexpr int kActiveRectColor = 30720; // red
 constexpr int kMoveSideColor = 783; // green
+constexpr int kClipAllColor = 29386; // square side clips all objects
+constexpr int kClipLowColor = 25120; // square side clips low objects only
 
-// A side of the active edge rect that can be moved.
+// A side of the active rect that can be moved.
 enum class EdgeSide {
     None,
     Left,
@@ -32,12 +35,29 @@ enum class EdgeSide {
     Bottom,
 };
 
+// Which rect the open dialog edits: per-zone tileRect or the per-elevation squareRect.
+enum class EditMode {
+    Tiles,
+    Squares,
+};
+
 static bool active = false; // dialog open → draw the overlay
 static bool showAllRects = false; // persistent overlay toggle (Settings menu)
+static EditMode editMode = EditMode::Tiles;
 static int workingElevation = 0;
 static int activeRect = -1;
 static EdgeSide moveSide = EdgeSide::None;
 static int moveOrigValue = 0; // side value to restore on Cancel move
+
+// Square-grid basis vectors in screen space (one step along column / row axis).
+constexpr int kSquareColDx = -48;
+constexpr int kSquareColDy = 12;
+constexpr int kSquareRowDx = 32;
+constexpr int kSquareRowDy = 24;
+
+// squareTileToScreenXY returns the tile's bounding-box top-left; the cell parallelogram's
+// top corner sits this far to the right of it.
+constexpr int kSquareOriginDx = -kSquareColDx;
 
 // Snapshot of all edge data taken when the dialog opens, restored on Cancel.
 static EdgeElevationData backup[ELEVATION_COUNT];
@@ -86,12 +106,13 @@ static Rect fullGridTileRect()
     return result;
 }
 
-static void editorOpen(int elevation)
+static void editorOpen(int elevation, EditMode mode)
 {
     for (int elev = 0; elev < ELEVATION_COUNT; elev++) {
         backup[elev] = mapEdgeGetElevationData(elev);
     }
 
+    editMode = mode;
     workingElevation = elevation;
     active = true;
     moveSide = EdgeSide::None;
@@ -100,7 +121,12 @@ static void editorOpen(int elevation)
 
 static void editorClose(bool save)
 {
-    if (!save) {
+    if (save) {
+        if (editMode == EditMode::Squares) {
+            mapEdgeUpgradeToVersion2();
+        }
+        mapEdgeRecalc();
+    } else {
         for (int elev = 0; elev < ELEVATION_COUNT; elev++) {
             mapEdgeGetElevationData(elev) = backup[elev];
         }
@@ -146,14 +172,27 @@ static void editorPrevRect()
     }
 }
 
-// Returns a writable pointer to the active rect's side value, or nullptr.
-static int* activeSideValue(EdgeSide side)
+// The rect being edited: the active zone's tileRect, or the elevation's squareRect.
+static Rect* activeTargetRect()
 {
+    if (editMode == EditMode::Squares) {
+        return &mapEdgeGetElevationData(workingElevation).squareRect;
+    }
     std::vector<EdgeZone>& zones = currentZones();
     if (activeRect < 0 || activeRect >= static_cast<int>(zones.size())) {
         return nullptr;
     }
-    Rect& r = zones[activeRect].tileRect;
+    return &zones[activeRect].tileRect;
+}
+
+// Returns a writable pointer to the active rect's side value, or nullptr.
+static int* activeSideValue(EdgeSide side)
+{
+    Rect* target = activeTargetRect();
+    if (target == nullptr) {
+        return nullptr;
+    }
+    Rect& r = *target;
     switch (side) {
     case EdgeSide::Left:
         return &r.left;
@@ -163,6 +202,24 @@ static int* activeSideValue(EdgeSide side)
         return &r.right;
     case EdgeSide::Bottom:
         return &r.bottom;
+    default:
+        return nullptr;
+    }
+}
+
+// Mutable clip flag for a square side at the working elevation.
+static bool* squareClipSideFlag(EdgeSide side)
+{
+    EdgeZone::ClipSides& clip = mapEdgeGetElevationData(workingElevation).clipSides;
+    switch (side) {
+    case EdgeSide::Left:
+        return &clip.left;
+    case EdgeSide::Top:
+        return &clip.top;
+    case EdgeSide::Right:
+        return &clip.right;
+    case EdgeSide::Bottom:
+        return &clip.bottom;
     default:
         return nullptr;
     }
@@ -201,13 +258,42 @@ static bool editorUpdateMoveFromScreen(int screenX, int screenY)
         return false;
     }
 
-    int tile = tileFromScreenXY(screenX, screenY, true);
-    if (!hexGridTileIsValid(tile) || tile == *value) {
+    int newValue;
+    if (editMode == EditMode::Squares) {
+        int square = squareTileFromScreenXY(screenX, screenY, workingElevation);
+        if (square < 0) {
+            return false;
+        }
+        bool horizontal = moveSide == EdgeSide::Left || moveSide == EdgeSide::Right;
+        newValue = horizontal ? square % SQUARE_GRID_WIDTH : square / SQUARE_GRID_WIDTH;
+    } else {
+        newValue = tileFromScreenXY(screenX, screenY, true);
+        if (!hexGridTileIsValid(newValue)) {
+            return false;
+        }
+    }
+
+    if (newValue == *value) {
         return false;
     }
 
-    *value = tile;
+    *value = newValue;
     return true;
+}
+
+static void editorToggleClip(EdgeSide side)
+{
+    bool* flag = squareClipSideFlag(side);
+    if (flag != nullptr) {
+        *flag = !*flag;
+    }
+}
+
+static void editorResetSquare()
+{
+    EdgeElevationData& data = mapEdgeGetElevationData(workingElevation);
+    data.squareRect = { SQUARE_GRID_WIDTH - 1, 0, 0, SQUARE_GRID_HEIGHT - 1 };
+    data.clipSides = { };
 }
 
 // Clips an axis-aligned line to clip and draws it; skips lines fully outside.
@@ -229,6 +315,58 @@ static void drawClippedVLine(unsigned char* buffer, int pitch, const Rect* clip,
     bufferDrawLine(buffer, pitch, x, top, x, bottom, color);
 }
 
+// Clips an arbitrary line to clip (Liang-Barsky) and draws it; bufferDrawLine does not clip.
+static void drawClippedLine(unsigned char* buffer, int pitch, const Rect* clip, int x0, int y0, int x1, int y1, int color)
+{
+    float t0 = 0.0f;
+    float t1 = 1.0f;
+    int dx = x1 - x0;
+    int dy = y1 - y0;
+    const int p[4] = { -dx, dx, -dy, dy };
+    const int q[4] = { x0 - clip->left, clip->right - x0, y0 - clip->top, clip->bottom - y0 };
+
+    for (int i = 0; i < 4; i++) {
+        if (p[i] == 0) {
+            if (q[i] < 0) return; // parallel and outside
+            continue;
+        }
+        float t = static_cast<float>(q[i]) / p[i];
+        if (p[i] < 0) {
+            if (t > t1) return;
+            if (t > t0) t0 = t;
+        } else {
+            if (t < t0) return;
+            if (t < t1) t1 = t;
+        }
+    }
+
+    // Clamp against float-truncation landing a pixel outside the clip rect (OOB write).
+    auto clampX = [&](int x) { return std::min(std::max(x, clip->left), clip->right); };
+    auto clampY = [&](int y) { return std::min(std::max(y, clip->top), clip->bottom); };
+
+    bufferDrawLine(buffer, pitch,
+        clampX(x0 + static_cast<int>(t0 * dx)), clampY(y0 + static_cast<int>(t0 * dy)),
+        clampX(x0 + static_cast<int>(t1 * dx)), clampY(y0 + static_cast<int>(t1 * dy)), color);
+}
+
+// Screen positions of the four outline vertices enclosing the visible squares of sr.
+// Indices: 0 top, 1 left, 2 bottom, 3 right (each offset to a cell corner by the basis).
+static void squareRectScreenCorners(const Rect& sr, int elevation, int outX[4], int outY[4])
+{
+    auto corner = [&](int col, int row, int dx, int dy, int index) {
+        int x;
+        int y;
+        squareTileToScreenXY(col + SQUARE_GRID_WIDTH * row, &x, &y, elevation);
+        outX[index] = x + kSquareOriginDx + dx;
+        outY[index] = y + dy;
+    };
+
+    corner(sr.right, sr.top, 0, 0, 0);
+    corner(sr.left, sr.top, kSquareColDx, kSquareColDy, 1);
+    corner(sr.left, sr.bottom, kSquareColDx + kSquareRowDx, kSquareColDy + kSquareRowDy, 2);
+    corner(sr.right, sr.bottom, kSquareRowDx, kSquareRowDy, 3);
+}
+
 // Screen-space rect (normalized left<=right, top<=bottom) of a zone's tile corners.
 static Rect tileRectToScreenRect(const Rect& tileRect)
 {
@@ -248,9 +386,33 @@ static void drawScreenRectOutline(unsigned char* buffer, int pitch, const Rect* 
     drawClippedVLine(buffer, pitch, clip, s.right, s.top, s.bottom, color);
 }
 
-// Registered as the tile renderer's overlay hook. While the dialog is open, only the active
-// rect is drawn (plus the moving side in green). Otherwise the persistent toggle outlines
-// every rect. Never drawn in play mode (edges enabled).
+// Display color of a square side: green while moving, else its clip-mode color.
+static int squareSideColor(EdgeSide side)
+{
+    if (side == moveSide) {
+        return _colorTable[kMoveSideColor];
+    }
+    bool* flag = squareClipSideFlag(side);
+    return _colorTable[(flag != nullptr && *flag) ? kClipAllColor : kClipLowColor];
+}
+
+// Outlines the squareRect over the iso view, one diagonal edge per side.
+static void drawSquareOverlay(unsigned char* buffer, int pitch, int elevation, const Rect* clip)
+{
+    int cx[4];
+    int cy[4];
+    squareRectScreenCorners(mapEdgeGetElevationData(elevation).squareRect, elevation, cx, cy);
+
+    const EdgeSide sides[4] = { EdgeSide::Top, EdgeSide::Left, EdgeSide::Bottom, EdgeSide::Right };
+    for (int i = 0; i < 4; i++) {
+        int j = (i + 1) % 4;
+        drawClippedLine(buffer, pitch, clip, cx[i], cy[i], cx[j], cy[j], squareSideColor(sides[i]));
+    }
+}
+
+// Registered as the tile renderer's overlay hook. While a dialog is open, only the active
+// rect is drawn (plus the moving side highlighted). Otherwise the persistent toggle outlines
+// every edge rect. Never drawn in play mode (edges enabled).
 static void renderOverlay(unsigned char* buffer, int pitch, int elevation, const Rect* clip)
 {
     if (mapEdgeIsEnabled()) {
@@ -264,11 +426,19 @@ static void renderOverlay(unsigned char* buffer, int pitch, int elevation, const
             for (const EdgeZone& zone : mapEdgeGetElevationData(elevation).zones) {
                 drawScreenRectOutline(buffer, pitch, clip, tileRectToScreenRect(zone.tileRect), red);
             }
+            if (mapEdgeHasSquareRect(elevation)) {
+                drawSquareOverlay(buffer, pitch, elevation, clip);
+            }
         }
         return;
     }
 
     if (elevation != workingElevation) {
+        return;
+    }
+
+    if (editMode == EditMode::Squares) {
+        drawSquareOverlay(buffer, pitch, elevation, clip);
         return;
     }
 
@@ -301,6 +471,106 @@ static void renderOverlay(unsigned char* buffer, int pitch, int elevation, const
     }
 }
 
+// Dialog button event codes (kept clear of real key/mouse codes).
+constexpr int kEvSideTop = 0x3205;
+constexpr int kEvSideBottom = 0x3206;
+constexpr int kEvSideLeft = 0x3207;
+constexpr int kEvSideRight = 0x3208;
+constexpr int kEvCancel = 0x3209;
+constexpr int kEvSave = 0x320A;
+constexpr int kEvAddRect = 0x3201;
+constexpr int kEvDelRect = 0x3202;
+constexpr int kEvPrevRect = 0x3203;
+constexpr int kEvNextRect = 0x3204;
+constexpr int kEvClipTop = 0x3211;
+constexpr int kEvClipBottom = 0x3212;
+constexpr int kEvClipLeft = 0x3213;
+constexpr int kEvClipRight = 0x3214;
+constexpr int kEvDefaultReset = 0x3215;
+
+// Shared modal loop. ESC, mouse, side-move and Cancel/Save are common; dispatch handles
+// dialog-specific button codes and reports whether the change needs a refresh.
+static void runEditLoop(int win, int winX, int winY, int winW, int winH,
+    const std::function<void()>& render, const std::function<bool(int)>& dispatch)
+{
+    auto refreshAll = [&]() {
+        tileWindowRefresh();
+        render();
+    };
+
+    refreshAll();
+
+    bool done = false;
+    while (!done) {
+        sharedFpsLimiter.mark();
+        int keyCode = inputGetInput();
+
+        int mx;
+        int my;
+        mouseGetPosition(&mx, &my);
+        bool overDialog = mx >= winX && mx < winX + winW && my >= winY && my < winY + winH;
+        bool moving = moveSide != EdgeSide::None;
+
+        if (moving && !overDialog && editorUpdateMoveFromScreen(mx, my)) {
+            tileWindowRefresh();
+        }
+
+        if (keyCode == KEY_ESCAPE) {
+            if (moving) {
+                editorCancelMove();
+                refreshAll();
+            } else {
+                editorClose(false);
+                done = true;
+            }
+        } else if (keyCode == -2) {
+            int buttons = mouseGetEvent();
+            if (moving && (buttons & MOUSE_EVENT_LEFT_BUTTON_DOWN) && !overDialog) {
+                editorCommitMove();
+                refreshAll();
+            } else if (moving && (buttons & MOUSE_EVENT_RIGHT_BUTTON_DOWN)) {
+                editorCancelMove();
+                refreshAll();
+            }
+        } else if (keyCode != -1) {
+            bool refresh = true;
+            switch (keyCode) {
+            case kEvSideTop:
+                editorBeginMove(EdgeSide::Top);
+                break;
+            case kEvSideBottom:
+                editorBeginMove(EdgeSide::Bottom);
+                break;
+            case kEvSideLeft:
+                editorBeginMove(EdgeSide::Left);
+                break;
+            case kEvSideRight:
+                editorBeginMove(EdgeSide::Right);
+                break;
+            case kEvCancel:
+                editorClose(false);
+                done = true;
+                refresh = false;
+                break;
+            case kEvSave:
+                editorClose(true);
+                done = true;
+                refresh = false;
+                break;
+            default:
+                refresh = dispatch(keyCode);
+                break;
+            }
+            if (refresh) {
+                refreshAll();
+            }
+        }
+
+        renderPresent();
+        sharedFpsLimiter.throttle();
+    }
+}
+
 void mapEdgeSetupInit()
 {
     tileSetMapperOverlayProc(renderOverlay);
@@ -312,63 +582,73 @@ void mapEdgeSetupToggleOverlay()
     tileWindowRefresh();
 }
 
+// Shared dialog palette indices.
+constexpr int kWinBgColor = 3082; // dark blue
+constexpr int kTextColor = 16344; // lighter gray
+constexpr int kTitleColor = 32767; // white
+
+constexpr int kDialogWidth = 230;
+constexpr int kDialogHeight = 250;
+
+// Created window plus the handles both dialogs need for rendering.
+struct SetupWindow {
+    int win;
+    int x;
+    int y;
+    unsigned char* buf;
+    int pitch;
+};
+
+// Creates the centered setup window and draws its border, title, map name and elevation.
+// Requires a font to be active. Returns win == -1 on failure.
+static SetupWindow openSetupWindow(const char* title, int elevation)
+{
+    int x = (rectGetWidth(&_scr_size) - kDialogWidth) / 2;
+    int y = (rectGetHeight(&_scr_size) - kDialogHeight) / 2;
+
+    int win = windowCreate(x, y, kDialogWidth, kDialogHeight, _colorTable[kWinBgColor], WINDOW_MOVE_ON_TOP);
+    if (win == -1) {
+        return { -1, 0, 0, nullptr, 0 };
+    }
+
+    windowDrawBorder(win);
+    windowDrawText(win, title, 0, (kDialogWidth - fontGetStringWidth(title)) / 2, 8, _colorTable[kTitleColor]);
+    windowDrawText(win, gMapHeader.name[0] != '\0' ? gMapHeader.name : "<unnamed>", 130, 13, 30, _colorTable[kTextColor]);
+
+    char elev[32];
+    snprintf(elev, sizeof(elev), "Elev: %d", elevation);
+    windowDrawText(win, elev, 0, 157, 30, _colorTable[kTextColor]);
+
+    return { win, x, y, windowGetBuffer(win), windowGetWidth(win) };
+}
+
 void mapEdgeSetupDialog()
 {
-    constexpr int kWinWidth = 230;
-    constexpr int kWinHeight = 250;
-
-    // Button event codes (kept clear of real key/mouse codes).
-    constexpr int kEvAddRect = 0x3201;
-    constexpr int kEvDelRect = 0x3202;
-    constexpr int kEvPrevRect = 0x3203;
-    constexpr int kEvNextRect = 0x3204;
-    constexpr int kEvSideTop = 0x3205;
-    constexpr int kEvSideBottom = 0x3206;
-    constexpr int kEvSideLeft = 0x3207;
-    constexpr int kEvSideRight = 0x3208;
-    constexpr int kEvCancel = 0x3209;
-    constexpr int kEvSave = 0x320A;
-
     // Reference diagram box; sides are highlighted green while being moved.
     constexpr int kBoxLeft = 60;
     constexpr int kBoxTop = 128;
     constexpr int kBoxRight = 170;
     constexpr int kBoxBottom = 186;
 
-    const int winBgColor = _colorTable[3082]; // dark blue
-    const int textColor = _colorTable[16344]; // lighter gray
-    // const int buttonTextColor = _colorTable[20052] | FONT_SHADOW | FONT_MONO; // grey
-    const int titleColor = _colorTable[32767]; // white
+    const int winBgColor = _colorTable[kWinBgColor];
+    const int textColor = _colorTable[kTextColor];
     const int rectColor = _colorTable[kActiveRectColor]; // red
     const int highlightColor = _colorTable[kMoveSideColor]; // green
 
-    const int winX = (rectGetWidth(&_scr_size) - kWinWidth) / 2;
-    const int winY = (rectGetHeight(&_scr_size) - kWinHeight) / 2;
+    ScopedFont font(1);
 
-    int win = windowCreate(winX, winY, kWinWidth, kWinHeight, winBgColor, WINDOW_MOVE_ON_TOP);
-    if (win == -1) {
+    editorOpen(gElevation, EditMode::Tiles);
+
+    SetupWindow w = openSetupWindow("MAP EDGE SETUP", workingElevation);
+    if (w.win == -1) {
         return;
     }
 
-    unsigned char* buf = windowGetBuffer(win);
-    const int pitch = windowGetWidth(win);
+    const int win = w.win;
+    unsigned char* buf = w.buf;
+    const int pitch = w.pitch;
     const int lineHeight = fontGetLineHeight();
-
-    editorOpen(gElevation);
-
-    auto centeredX = [&](const char* text) { return (kWinWidth - fontGetStringWidth(text)) / 2; };
-
-    ScopedFont font(1);
-
-    // Static chrome and labels drawn once; buttons are themed and registered once.
-    windowDrawBorder(win);
-    windowDrawText(win, "MAP EDGE SETUP", 0, centeredX("MAP EDGE SETUP"), 8, titleColor);
-
-    windowDrawText(win, gMapHeader.name[0] != '\0' ? gMapHeader.name : "<unnamed>", 130, 12, 26, textColor);
-
-    char tmp[64];
-    snprintf(tmp, sizeof(tmp), "Elev: %d", workingElevation);
-    windowDrawText(win, tmp, 0, 168, 26, textColor);
+    auto centeredX = [&](const char* text) { return (kDialogWidth - fontGetStringWidth(text)) / 2; };
 
     _win_register_text_button(win, 12, 58, -1, -1, -1, kEvAddRect, "Add Rect", 0);
     _win_register_text_button(win, 120, 58, -1, -1, -1, kEvDelRect, "Delete Rect", 0);
@@ -386,11 +666,11 @@ void mapEdgeSetupDialog()
         char buffer[64];
 
         snprintf(buffer, sizeof(buffer), "Num Rects: %d", static_cast<int>(currentZones().size()));
-        bufferFill(buf + 40 * pitch + 10, kWinWidth - 20, lineHeight, pitch, winBgColor);
+        bufferFill(buf + 40 * pitch + 10, kDialogWidth - 20, lineHeight, pitch, winBgColor);
         windowDrawText(win, buffer, 0, centeredX(buffer), 40, textColor);
 
         snprintf(buffer, sizeof(buffer), "Rect: %d", activeRect >= 0 ? activeRect + 1 : 0);
-        bufferFill(buf + 90 * pitch + 50, kWinWidth - 100, lineHeight, pitch, winBgColor);
+        bufferFill(buf + 90 * pitch + 50, kDialogWidth - 100, lineHeight, pitch, winBgColor);
         windowDrawText(win, buffer, 0, centeredX(buffer), 90, textColor);
 
         // Reference diagram: red rect, with the side under edit drawn green.
@@ -416,97 +696,111 @@ void mapEdgeSetupDialog()
         windowRefresh(win);
     };
 
-    // Repaint both the iso overlay and the dialog after a state change.
-    auto refreshAll = [&]() {
-        tileWindowRefresh();
-        render();
+    runEditLoop(win, w.x, w.y, kDialogWidth, kDialogHeight, render, [](int keyCode) {
+        switch (keyCode) {
+        case kEvAddRect:
+            editorAddRect();
+            return true;
+        case kEvDelRect:
+            editorDeleteRect();
+            return true;
+        case kEvPrevRect:
+            editorPrevRect();
+            return true;
+        case kEvNextRect:
+            editorNextRect();
+            return true;
+        default:
+            return false;
+        }
+    });
+
+    windowDestroy(win);
+    tileWindowRefresh(); // repaint the iso view without the overlay
+}
+
+void mapEdgeSquareSetupDialog()
+{
+    // Fixed diagram parallelogram, skewed like the iso square grid.
+    // Vertices: 0 top, 1 left, 2 bottom, 3 right. Edge i..i+1 maps to a rect side.
+    constexpr int kDiagX[4] = { 136, 10, 99, 227 };
+    constexpr int kDiagY[4] = { 107, 141, 207, 174 };
+    const EdgeSide kDiagSides[4] = { EdgeSide::Top, EdgeSide::Left, EdgeSide::Bottom, EdgeSide::Right };
+
+    const int winBgColor = _colorTable[kWinBgColor];
+    const int textColor = _colorTable[kTextColor];
+
+    ScopedFont font(1);
+
+    editorOpen(gElevation, EditMode::Squares);
+
+    SetupWindow w = openSetupWindow("MAP ANGLED EDGE SETUP", workingElevation);
+    if (w.win == -1) {
+        return;
+    }
+
+    const int win = w.win;
+    unsigned char* buf = w.buf;
+    const int pitch = w.pitch;
+    const int lineHeight = fontGetLineHeight();
+    auto centeredX = [&](const char* text) { return (kDialogWidth - fontGetStringWidth(text)) / 2; };
+
+    windowDrawText(win, "Clip Objects (clip)", 0, 12, 50, textColor);
+    windowDrawText(win, "All Objects", 0, 12, 62, _colorTable[kClipAllColor]);
+    windowDrawText(win, "Low Objects", 0, 12, 74, _colorTable[kClipLowColor]);
+
+    _win_register_text_button(win, 113, 64, -1, -1, -1, kEvDefaultReset, "Default Reset", 0);
+
+    _win_register_text_button(win, 51, 114, -1, -1, -1, kEvSideTop, "mv", 0);
+    _win_register_text_button(win, 88, 137, -1, -1, -1, kEvClipTop, "clp", 0);
+    _win_register_text_button(win, 43, 167, -1, -1, -1, kEvSideLeft, "mv", 0);
+    _win_register_text_button(win, 78, 156, -1, -1, -1, kEvClipLeft, "clp", 0);
+    _win_register_text_button(win, 166, 131, -1, -1, -1, kEvSideRight, "mv", 0);
+    _win_register_text_button(win, 125, 143, -1, -1, -1, kEvClipRight, "clp", 0);
+    _win_register_text_button(win, 138, 184, -1, -1, -1, kEvSideBottom, "mv", 0);
+    _win_register_text_button(win, 114, 161, -1, -1, -1, kEvClipBottom, "clp", 0);
+
+    _win_register_text_button(win, 30, 224, -1, -1, -1, kEvCancel, "Cancel", 0);
+    _win_register_text_button(win, 143, 224, -1, -1, -1, kEvSave, "Save", 0);
+
+    auto render = [&]() {
+        // Skewed diagram: fixed edges colored by clip mode (green while moving). Repainted
+        // on refresh; same pixels overwrite the previous colors, so no clear is needed.
+        for (int i = 0; i < 4; i++) {
+            int j = (i + 1) % 4;
+            bufferDrawLine(buf, pitch, kDiagX[i], kDiagY[i], kDiagX[j], kDiagY[j], squareSideColor(kDiagSides[i]));
+        }
+
+        const Rect& sr = mapEdgeGetElevationData(workingElevation).squareRect;
+        char status[64];
+        snprintf(status, sizeof(status), "col %d-%d  row %d-%d", sr.right, sr.left, sr.top, sr.bottom);
+        bufferFill(buf + 91 * pitch + 10, kDialogWidth - 20, lineHeight, pitch, winBgColor);
+        windowDrawText(win, status, 0, centeredX(status), 91, textColor);
+
+        windowRefresh(win);
     };
 
-    refreshAll(); // initial draw of dialog + iso overlay
-
-    bool done = false;
-    while (!done) {
-        sharedFpsLimiter.mark();
-        int keyCode = inputGetInput();
-
-        int mx, my;
-        mouseGetPosition(&mx, &my);
-        bool overDialog = mx >= winX && mx < winX + kWinWidth && my >= winY && my < winY + kWinHeight;
-        bool moving = moveSide != EdgeSide::None;
-
-        // Live-track the selected side under the cursor while over the iso view.
-        if (moving && !overDialog) {
-            if (editorUpdateMoveFromScreen(mx, my)) {
-                tileWindowRefresh();
-            }
+    runEditLoop(win, w.x, w.y, kDialogWidth, kDialogHeight, render, [](int keyCode) {
+        switch (keyCode) {
+        case kEvClipTop:
+            editorToggleClip(EdgeSide::Top);
+            return true;
+        case kEvClipBottom:
+            editorToggleClip(EdgeSide::Bottom);
+            return true;
+        case kEvClipLeft:
+            editorToggleClip(EdgeSide::Left);
+            return true;
+        case kEvClipRight:
+            editorToggleClip(EdgeSide::Right);
+            return true;
+        case kEvDefaultReset:
+            editorResetSquare();
+            return true;
+        default:
+            return false;
         }
-
-        if (keyCode == KEY_ESCAPE) {
-            if (moving) {
-                editorCancelMove();
-                refreshAll();
-            } else {
-                editorClose(false);
-                done = true;
-            }
-        } else if (keyCode == -2) {
-            int buttons = mouseGetEvent();
-            if (moving && (buttons & MOUSE_EVENT_LEFT_BUTTON_DOWN) && !overDialog) {
-                editorCommitMove();
-                refreshAll();
-            } else if (moving && (buttons & MOUSE_EVENT_RIGHT_BUTTON_DOWN)) {
-                editorCancelMove();
-                refreshAll();
-            }
-        } else if (keyCode != -1) {
-            bool refresh = true;
-            switch (keyCode) {
-            case kEvAddRect:
-                editorAddRect();
-                break;
-            case kEvDelRect:
-                editorDeleteRect();
-                break;
-            case kEvPrevRect:
-                editorPrevRect();
-                break;
-            case kEvNextRect:
-                editorNextRect();
-                break;
-            case kEvSideTop:
-                editorBeginMove(EdgeSide::Top);
-                break;
-            case kEvSideBottom:
-                editorBeginMove(EdgeSide::Bottom);
-                break;
-            case kEvSideLeft:
-                editorBeginMove(EdgeSide::Left);
-                break;
-            case kEvSideRight:
-                editorBeginMove(EdgeSide::Right);
-                break;
-            case kEvCancel:
-                editorClose(false);
-                done = true;
-                refresh = false;
-                break;
-            case kEvSave:
-                editorClose(true);
-                done = true;
-                refresh = false;
-                break;
-            default:
-                refresh = false;
-                break;
-            }
-            if (refresh) {
-                refreshAll();
-            }
-        }
-
-        renderPresent();
-        sharedFpsLimiter.throttle();
-    }
+    });
 
     windowDestroy(win);
     tileWindowRefresh(); // repaint the iso view without the overlay

--- a/src/mapper/map_edge_setup.cc
+++ b/src/mapper/map_edge_setup.cc
@@ -412,10 +412,10 @@ static void drawSquareOverlay(unsigned char* buffer, int pitch, int elevation, c
 
 // Registered as the tile renderer's overlay hook. While a dialog is open, only the active
 // rect is drawn (plus the moving side highlighted). Otherwise the persistent toggle outlines
-// every edge rect. Never drawn in play mode (edges enabled).
+// every edge rect. Never drawn in play mode.
 static void renderOverlay(unsigned char* buffer, int pitch, int elevation, const Rect* clip)
 {
-    if (mapEdgeIsEnabled()) {
+    if (!mapEdgeIsMapperMode()) {
         return;
     }
 

--- a/src/mapper/map_edge_setup.cc
+++ b/src/mapper/map_edge_setup.cc
@@ -77,7 +77,7 @@ static Rect fullGridTileRect()
         HEX_GRID_SIZE - 1,
     };
 
-    Rect result { };
+    Rect result {};
     int maxPx = 0;
     int minPx = 0;
     int minPy = 0;
@@ -293,7 +293,7 @@ static void editorResetSquare()
 {
     EdgeElevationData& data = mapEdgeGetElevationData(workingElevation);
     data.squareRect = { SQUARE_GRID_WIDTH - 1, 0, 0, SQUARE_GRID_HEIGHT - 1 };
-    data.clipSides = { };
+    data.clipSides = {};
 }
 
 // Clips an axis-aligned line to clip and draws it; skips lines fully outside.

--- a/src/mapper/map_edge_setup.h
+++ b/src/mapper/map_edge_setup.h
@@ -1,0 +1,18 @@
+#ifndef MAPPER_MAP_EDGE_SETUP_H
+#define MAPPER_MAP_EDGE_SETUP_H
+
+namespace fallout {
+
+// Registers the iso-view overlay hook with the tile renderer. Call once at mapper init.
+void mapEdgeSetupInit();
+
+// Opens the Map Edge Setup dialog to edit the current map's edge rects.
+// Edits the in-memory edge data; the disk write happens on the next map save.
+void mapEdgeSetupDialog();
+
+// Toggles the persistent edge-rects overlay shown over the iso view while editing.
+void mapEdgeSetupToggleOverlay();
+
+} // namespace fallout
+
+#endif /* MAPPER_MAP_EDGE_SETUP_H */

--- a/src/mapper/map_edge_setup.h
+++ b/src/mapper/map_edge_setup.h
@@ -10,6 +10,10 @@ void mapEdgeSetupInit();
 // Edits the in-memory edge data; the disk write happens on the next map save.
 void mapEdgeSetupDialog();
 
+// Opens the Map Angled Edge Setup dialog to edit the current elevation's squareRect/clipSides.
+// Edits the in-memory edge data; the disk write happens on the next map save.
+void mapEdgeSquareSetupDialog();
+
 // Toggles the persistent edge-rects overlay shown over the iso view while editing.
 void mapEdgeSetupToggleOverlay();
 

--- a/src/mapper/map_func.cc
+++ b/src/mapper/map_func.cc
@@ -18,6 +18,7 @@
 #include "kb.h"
 #include "map.h"
 #include "mapper/mapper.h"
+#include "mapper/mp_utils.h"
 #include "memory.h"
 #include "mouse.h"
 #include "object.h"

--- a/src/mapper/mapper.cc
+++ b/src/mapper/mapper.cc
@@ -139,6 +139,7 @@ static char kArtToProtos[] = " Art => New Protos ";
 static char kSwapPrototypse[] = " Swap Prototypes ";
 
 static char kHiResMapEdges[] = " Hi-Res Map Edges Setup ";
+static char kSetAngledEdges[] = " Set Hi-Res Angled Edges ";
 static char kToggleMapEdgesOverlay[] = " Toggle Map Edges Overlay ";
 
 static char kTmpMapName[] = "TMP$MAP#.MAP";
@@ -228,6 +229,7 @@ char* menu_3[] = {
 
 char* menuNamesSettings[] = {
     kHiResMapEdges,
+    kSetAngledEdges,
     kToggleMapEdgesOverlay,
 };
 
@@ -297,7 +299,7 @@ int menu_val_2[8];
 
 int menu_val_3[7];
 
-int menu_val_4[2];
+int menu_val_4[3];
 
 // 0x6EAA80
 unsigned char e_num[4][19 * 26];
@@ -577,6 +579,7 @@ constexpr int kBtnClearMapLevel = 5666;
 constexpr int kBtnCreateAllMapTexts = 5406;
 constexpr int kBtnRebuildAllMaps = 5405;
 constexpr int kBtnHiResMapEdges = 0x3101;
+constexpr int kBtnSetAngledEdges = 0x3103;
 constexpr int kBtnToggleMapEdgesOverlay = 0x3102;
 
 // FILE menu pulldown keycodes
@@ -738,7 +741,8 @@ void MapperInit()
     menu_val_3[6] = kBtnLibrarianSwapProtos;
 
     menu_val_4[0] = kBtnHiResMapEdges;
-    menu_val_4[1] = kBtnToggleMapEdgesOverlay;
+    menu_val_4[1] = kBtnSetAngledEdges;
+    menu_val_4[2] = kBtnToggleMapEdgesOverlay;
 }
 
 static int loadMapperLbm(int lbmBufWidth, int lbmBufHeight)
@@ -782,7 +786,7 @@ static void initMenuBar(const int screenWidth)
     _win_register_menu_pulldown(menu_bar, 8, "FILE", kBtnMenuHeaderFile, 8, menu_names[0], foregroundColor, backgroundColor);
     _win_register_menu_pulldown(menu_bar, 40, "TOOLS", kBtnMenuHeaderTools, 21, menu_names[1], foregroundColor, backgroundColor);
     _win_register_menu_pulldown(menu_bar, 80, "SCRIPTS", kBtnMenuHeaderScripts, 8, menu_names[2], foregroundColor, backgroundColor);
-    _win_register_menu_pulldown(menu_bar, 130, "SETTINGS", kBtnMenuHeaderSettings, 2, menu_names[4], foregroundColor, backgroundColor);
+    _win_register_menu_pulldown(menu_bar, 130, "SETTINGS", kBtnMenuHeaderSettings, 3, menu_names[4], foregroundColor, backgroundColor);
     if (can_modify_protos) {
         _win_register_menu_pulldown(menu_bar, 180, "LIBRARIAN", kBtnMenuHeaderLibrarian, 7, menu_names[3], foregroundColor, backgroundColor);
     }
@@ -1575,6 +1579,13 @@ void edit_mapper()
                 break;
             }
             mapEdgeSetupDialog();
+            break;
+        case kBtnSetAngledEdges:
+            if (map_entered) {
+                mapperShowTimedMsg("This map has been Entered.  Can't edit edges.");
+                break;
+            }
+            mapEdgeSquareSetupDialog();
             break;
         case kBtnToggleMapEdgesOverlay:
             mapEdgeSetupToggleOverlay();

--- a/src/mapper/mapper.cc
+++ b/src/mapper/mapper.cc
@@ -1012,6 +1012,7 @@ int mapper_edit_init(int argc, char** argv)
     mouseShowCursor();
     mapperValidateDevPath();
     mapEdgeSetupInit();
+    mapEdgeSetMapperMode(true);
 
     if (settings.mapper.rebuild_protos) {
         proto_build_all_texts();
@@ -1024,10 +1025,7 @@ int mapper_edit_init(int argc, char** argv)
 // 0x48752C
 void mapper_edit_exit()
 {
-    remove(mapBuildPath("TMP$MAP#.MAP"));
-    remove(mapBuildPath("TMP$MAP#.CFG"));
-
-    MapDirErase("MAPS\\", "SAV");
+    mapper_remove_tmp_map_files();
 
     if (can_modify_protos) {
         copy_proto_lists();
@@ -2715,8 +2713,12 @@ int mapper_mark_exit_grid()
 // and on editor shutdown if the user quit while still in play mode.
 static void mapper_remove_tmp_map_files()
 {
-    remove(mapBuildPath(tmp_map_name));
-    remove(mapBuildPath("TMP$MAP#.CFG"));
+    remove(mapBuildSavePath(kTmpMapName));
+    remove(mapBuildSavePath("TMP$MAP#.EDG"));
+
+    char cfgPath[COMPAT_MAX_PATH];
+    snprintf(cfgPath, sizeof(cfgPath), "%s\\MAPS\\TMP$MAP#.CFG", settings.system.master_patches_path.c_str());
+    remove(cfgPath);
     MapDirErase("MAPS\\", "SAV");
 }
 
@@ -2782,10 +2784,8 @@ static void mapper_enter_play_mode(Object** pHlObj1)
     tileScrollBlockingEnable();
     tileScrollLimitingEnable();
 
-    // Edges are loaded but disabled while editing; enable them to mirror play behavior.
-    if (settings.ui.edg_support && !settings.ui.ignore_map_edges) {
-        mapEdgeSetEnabled(true);
-    }
+    // Leave mapper-editing mode so loaded edges behave as in the game (subject to settings).
+    mapEdgeSetMapperMode(false);
 
     if (settings.mapper.run_mapper_as_game) {
         scriptExecProc(gMapSid, SCRIPT_PROC_MAP_ENTER);
@@ -2849,6 +2849,9 @@ static void mapper_exit_play_mode(int* pCurrentType, int* pScrollOffset, Object*
 
     tileScrollBlockingDisable();
     tileScrollLimitingDisable();
+
+    // Back to editing: loaded edges are kept but no longer enforced.
+    mapEdgeSetMapperMode(true);
 
     // Match the original: if click-to-scroll was on during play, force it off on exit.
     if (_gmouse_get_click_to_scroll()) {

--- a/src/mapper/mapper.cc
+++ b/src/mapper/mapper.cc
@@ -32,6 +32,8 @@
 #include "light.h"
 #include "loadsave.h"
 #include "map.h"
+#include "map_edge.h"
+#include "mapper/map_edge_setup.h"
 #include "mapper/map_func.h"
 #include "mapper/mp_instance.h"
 #include "mapper/mp_proto.h"
@@ -52,6 +54,7 @@
 #include "window_manager.h"
 #include "window_manager_private.h"
 #include "worldmap.h"
+#include "xfile.h"
 
 namespace fallout {
 
@@ -134,6 +137,9 @@ static char kRebuildAll[] = " Rebuild ALL ";
 static char kRebuildBinary[] = " Rebuild Binary ";
 static char kArtToProtos[] = " Art => New Protos ";
 static char kSwapPrototypse[] = " Swap Prototypes ";
+
+static char kHiResMapEdges[] = " Hi-Res Map Edges Setup ";
+static char kToggleMapEdgesOverlay[] = " Toggle Map Edges Overlay ";
 
 static char kTmpMapName[] = "TMP$MAP#.MAP";
 
@@ -220,12 +226,18 @@ char* menu_3[] = {
     kSwapPrototypse,
 };
 
+char* menuNamesSettings[] = {
+    kHiResMapEdges,
+    kToggleMapEdgesOverlay,
+};
+
 // 0x5596F8
 char** menu_names[] = {
     menu_0,
     menu_1,
     menu_2,
     menu_3,
+    menuNamesSettings,
 };
 
 // 0x559748
@@ -284,6 +296,8 @@ int menu_val_0[8];
 int menu_val_2[8];
 
 int menu_val_3[7];
+
+int menu_val_4[2];
 
 // 0x6EAA80
 unsigned char e_num[4][19 * 26];
@@ -546,6 +560,7 @@ constexpr int kBtnMenuHeaderFile = KEY_ALT_F;
 constexpr int kBtnMenuHeaderTools = KEY_ALT_V;
 constexpr int kBtnMenuHeaderScripts = KEY_ALT_T;
 constexpr int kBtnMenuHeaderLibrarian = KEY_ALT_J;
+constexpr int kBtnMenuHeaderSettings = KEY_ALT_X;
 
 constexpr int kBtnPlayMode = KEY_F8;
 constexpr int kBtnRebuildProtoList = KEY_F10;
@@ -561,6 +576,8 @@ constexpr int kBtnMarkAllExitGrids = 5679;
 constexpr int kBtnClearMapLevel = 5666;
 constexpr int kBtnCreateAllMapTexts = 5406;
 constexpr int kBtnRebuildAllMaps = 5405;
+constexpr int kBtnHiResMapEdges = 0x3101;
+constexpr int kBtnToggleMapEdgesOverlay = 0x3102;
 
 // FILE menu pulldown keycodes
 constexpr int kBtnNew = KEY_ALT_N;
@@ -719,6 +736,9 @@ void MapperInit()
     menu_val_3[4] = KEY_ESCAPE;
     menu_val_3[5] = kBtnLibrarianArtToProtos;
     menu_val_3[6] = kBtnLibrarianSwapProtos;
+
+    menu_val_4[0] = kBtnHiResMapEdges;
+    menu_val_4[1] = kBtnToggleMapEdgesOverlay;
 }
 
 static int loadMapperLbm(int lbmBufWidth, int lbmBufHeight)
@@ -730,6 +750,42 @@ static int loadMapperLbm(int lbmBufWidth, int lbmBufHeight)
         0,
         lbmBufWidth - 1,
         lbmBufHeight - 1);
+}
+
+// Validates the configurable mapper dev_path: it must be an existing folder mounted in the
+// VFS. When invalid, it is cleared (so saves fall back to the patches path) and the user is warned.
+static void mapperValidateDevPath()
+{
+    std::string& devPath = settings.mapper.dev_path;
+    if (devPath.empty()) {
+        return;
+    }
+
+    if (compat_is_dir(devPath.c_str()) && xbaseIsValidDirectory(devPath.c_str())) {
+        return;
+    }
+
+    char msg[COMPAT_MAX_PATH + 128];
+    snprintf(msg, sizeof(msg), "Mapper dev_path \"%s\" is not a valid mounted data folder. Ignoring it.", devPath.c_str());
+
+    showMessageBox(msg);
+    devPath.clear();
+}
+
+static void initMenuBar(const int screenWidth)
+{
+    int foregroundColor = _colorTable[20052];
+    int backgroundColor = _colorTable[8456];
+
+    menu_bar = windowCreate(0, 0, screenWidth, 16, _colorTable[0], WINDOW_HIDDEN);
+    _win_register_menu_bar(menu_bar, 0, 0, screenWidth, 16, foregroundColor, backgroundColor);
+    _win_register_menu_pulldown(menu_bar, 8, "FILE", kBtnMenuHeaderFile, 8, menu_names[0], foregroundColor, backgroundColor);
+    _win_register_menu_pulldown(menu_bar, 40, "TOOLS", kBtnMenuHeaderTools, 21, menu_names[1], foregroundColor, backgroundColor);
+    _win_register_menu_pulldown(menu_bar, 80, "SCRIPTS", kBtnMenuHeaderScripts, 8, menu_names[2], foregroundColor, backgroundColor);
+    _win_register_menu_pulldown(menu_bar, 130, "SETTINGS", kBtnMenuHeaderSettings, 2, menu_names[4], foregroundColor, backgroundColor);
+    if (can_modify_protos) {
+        _win_register_menu_pulldown(menu_bar, 180, "LIBRARIAN", kBtnMenuHeaderLibrarian, 7, menu_names[3], foregroundColor, backgroundColor);
+    }
 }
 
 // 0x485F94
@@ -770,54 +826,7 @@ int mapper_edit_init(int argc, char** argv)
 
     max_art_buttons = (screenWidth - 135) / 50;
 
-    menu_bar = windowCreate(0,
-        0,
-        screenWidth,
-        16,
-        _colorTable[0],
-        WINDOW_HIDDEN);
-    _win_register_menu_bar(menu_bar,
-        0,
-        0,
-        screenWidth,
-        16,
-        260,
-        _colorTable[8456]);
-    _win_register_menu_pulldown(menu_bar,
-        8,
-        "FILE",
-        kBtnMenuHeaderFile,
-        8,
-        menu_names[0],
-        260,
-        _colorTable[8456]);
-    _win_register_menu_pulldown(menu_bar,
-        40,
-        "TOOLS",
-        kBtnMenuHeaderTools,
-        21,
-        menu_names[1],
-        260,
-        _colorTable[8456]);
-    _win_register_menu_pulldown(menu_bar,
-        80,
-        "SCRIPTS",
-        kBtnMenuHeaderScripts,
-        8,
-        menu_names[2],
-        260,
-        _colorTable[8456]);
-
-    if (can_modify_protos) {
-        _win_register_menu_pulldown(menu_bar,
-            130,
-            "LIBRARIAN",
-            kBtnMenuHeaderLibrarian,
-            7,
-            menu_names[3],
-            260,
-            _colorTable[8456]);
-    }
+    initMenuBar(screenWidth);
 
     tool_win = windowCreate(0,
         _scr_size.bottom - 99,
@@ -997,6 +1006,8 @@ int mapper_edit_init(int argc, char** argv)
     mapInit();
     target_init();
     mouseShowCursor();
+    mapperValidateDevPath();
+    mapEdgeSetupInit();
 
     if (settings.mapper.rebuild_protos) {
         proto_build_all_texts();
@@ -1316,7 +1327,7 @@ void edit_mapper()
                     int tile = gGameMouseBouncingCursor->tile;
 
                     if (settings.debug.show_tile_num) {
-                        debugPrint("tilenum = %d ", tile);
+                        debugPrint("\ntilenum = %d ", tile);
                     }
                     // Display tile number on toolbar (vanilla: x=7, y=27, maxWidth=260, color=35)
                     char tileNumStr[32];
@@ -1415,6 +1426,10 @@ void edit_mapper()
             int index = inputGetInput();
             if (index == -1) continue;
             keyCode = menu_val_3[index];
+        } else if (keyCode == kBtnMenuHeaderSettings) {
+            int index = inputGetInput();
+            if (index == -1) continue;
+            keyCode = menu_val_4[index];
         }
 
         // Toolbar art-slot left-click: select proto from toolbar
@@ -1551,6 +1566,16 @@ void edit_mapper()
         }
         case kBtnInfo:
             // No op, matching original.
+            break;
+        case kBtnHiResMapEdges:
+            if (map_entered) {
+                mapperShowTimedMsg("This map has been Entered.  Can't edit edges.");
+                break;
+            }
+            mapEdgeSetupDialog();
+            break;
+        case kBtnToggleMapEdgesOverlay:
+            mapEdgeSetupToggleOverlay();
             break;
         case kBtnSaveAs: {
             if (map_entered) {
@@ -2743,6 +2768,11 @@ static void mapper_enter_play_mode(Object** pHlObj1)
 
     tileScrollBlockingEnable();
     tileScrollLimitingEnable();
+
+    // Edges are loaded but disabled while editing; enable them to mirror play behavior.
+    if (settings.ui.edg_support && !settings.ui.ignore_map_edges) {
+        mapEdgeSetEnabled(true);
+    }
 
     if (settings.mapper.run_mapper_as_game) {
         scriptExecProc(gMapSid, SCRIPT_PROC_MAP_ENTER);

--- a/src/mapper/mapper.cc
+++ b/src/mapper/mapper.cc
@@ -1,5 +1,7 @@
 #include "mapper/mapper.h"
 
+#include "mapper/mp_utils.h"
+
 #include <algorithm>
 #include <ctype.h>
 #include <stdio.h>
@@ -2833,16 +2835,6 @@ static void mapper_mark_all_exit_grids()
         }
         obj = objectFindNextAtElevation();
     }
-}
-
-void mapperShowTimedMsg(const char* msg)
-{
-    win_timed_msg(msg, _colorTable[31744] | FONT_SHADOW);
-}
-
-bool mapperYesNoDialog(const char* msg)
-{
-    return win_yes_no(msg, 80, 80, 0x104 | FONT_SHADOW) > 0;
 }
 
 } // namespace fallout

--- a/src/mapper/mapper.cc
+++ b/src/mapper/mapper.cc
@@ -1502,7 +1502,8 @@ void edit_mapper()
             if (mapperYesNoDialog("Erase this map?")) {
                 bool wasBlockOn = map_toggle_block_obj_viewing_on();
                 if (wasBlockOn) map_toggle_block_obj_viewing(0);
-                mapper_destroy_highlight_obj(&hl_obj1, &_screen_obj);
+                mapper_destroy_highlight_obj(&hl_obj1, nullptr);
+                _screen_obj = nullptr;
                 mapNewMap();
                 handle_new_map(&currentType, &scrollOffset);
                 interfaceBarHide();
@@ -1518,7 +1519,8 @@ void edit_mapper()
                 if (settings.mapper.use_art_not_protos) {
                     mapperShowTimedMsg("WARNING!  You are loading ART, not PROTOS!!!");
                 }
-                mapper_destroy_highlight_obj(&hl_obj1, &_screen_obj);
+                mapper_destroy_highlight_obj(&hl_obj1, nullptr);
+                _screen_obj = nullptr;
                 bool wasBlockOn = map_toggle_block_obj_viewing_on();
                 if (wasBlockOn) {
                     map_toggle_block_obj_viewing(0);

--- a/src/mapper/mapper.h
+++ b/src/mapper/mapper.h
@@ -18,9 +18,6 @@ extern unsigned char e_num[4][19 * 26];
 int mapper_main(int argc, char** argv);
 void print_toolbar_name(int object_type);
 int mapper_inven_unwield(Object* obj, int right_hand);
-void mapperShowTimedMsg(const char* msg);
-bool mapperYesNoDialog(const char* msg);
-
 } // namespace fallout
 
 #endif /* FALLOUT_MAPPER_MAPPER_H_ */

--- a/src/mapper/mp_text.cc
+++ b/src/mapper/mp_text.cc
@@ -3,8 +3,8 @@
 #include "color.h"
 #include "input.h"
 #include "kb.h"
-#include "mapper/mp_utils.h"
 #include "mapper/mp_proto.h"
+#include "mapper/mp_utils.h"
 #include "obj_types.h"
 #include "window_manager_private.h"
 

--- a/src/mapper/mp_text.cc
+++ b/src/mapper/mp_text.cc
@@ -3,7 +3,7 @@
 #include "color.h"
 #include "input.h"
 #include "kb.h"
-#include "mapper/mapper.h"
+#include "mapper/mp_utils.h"
 #include "mapper/mp_proto.h"
 #include "obj_types.h"
 #include "window_manager_private.h"

--- a/src/mapper/mp_utils.cc
+++ b/src/mapper/mp_utils.cc
@@ -1,0 +1,24 @@
+#include "mapper/mp_utils.h"
+
+#include "color.h"
+#include "text_font.h"
+#include "window_manager_private.h"
+
+namespace fallout {
+
+void mapperShowTimedMsg(const char* msg)
+{
+    win_timed_msg(msg, _colorTable[31744] | FONT_SHADOW);
+}
+
+bool mapperYesNoDialog(const char* msg)
+{
+    return win_yes_no(msg, 80, 80, 0x104 | FONT_SHADOW) > 0;
+}
+
+void mapperShowMessage(const char* msg)
+{
+    _win_msg(msg, 80, 80, _colorTable[31744] | FONT_SHADOW);
+}
+
+} // namespace fallout

--- a/src/mapper/mp_utils.h
+++ b/src/mapper/mp_utils.h
@@ -1,0 +1,12 @@
+#ifndef FALLOUT_MAPPER_MP_UTILS_H_
+#define FALLOUT_MAPPER_MP_UTILS_H_
+
+namespace fallout {
+
+void mapperShowTimedMsg(const char* msg);
+bool mapperYesNoDialog(const char* msg);
+void mapperShowMessage(const char* msg);
+
+} // namespace fallout
+
+#endif /* FALLOUT_MAPPER_MP_UTILS_H_ */

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -11,6 +11,8 @@
 
 namespace fallout {
 
+bool SystemSettings::executableIsMapper() const { return compat_stricmp(executable.c_str(), "mapper") == 0; }
+
 struct SettingDescriptor {
     std::function<void()> read;
     std::function<void(bool onlyAdd)> write;

--- a/src/settings.h
+++ b/src/settings.h
@@ -24,6 +24,8 @@ struct SystemSettings {
     int free_space = 20480;
     int times_run = 0;
     std::string screenshots_format = "png";
+
+    bool executableIsMapper() const;
 };
 
 struct ScreenSettings {

--- a/src/settings.h
+++ b/src/settings.h
@@ -165,8 +165,7 @@ struct MapperSettings {
     // CE: switch between vanilla grid item picker and simpler list-based one.
     bool use_grid_item_picker = true;
     // CE: change mapper path for saving various data.
-    // TODO: use
-    std::string dev_path = R"(\fallout\cd\)";
+    std::string dev_path;
 };
 
 struct Settings {

--- a/src/text_font.h
+++ b/src/text_font.h
@@ -56,6 +56,26 @@ int fontManagerAdd(FontManager* fontManager);
 int fontGetCurrent();
 void fontSetCurrent(int font);
 
+class ScopedFont {
+public:
+    ScopedFont(int font)
+        : _previousFont(fontGetCurrent())
+    {
+        fontSetCurrent(font);
+    }
+
+    ~ScopedFont()
+    {
+        fontSetCurrent(_previousFont);
+    }
+
+    ScopedFont(const ScopedFont&) = delete;
+    ScopedFont& operator=(const ScopedFont&) = delete;
+
+private:
+    int _previousFont;
+};
+
 } // namespace fallout
 
 #endif /* TEXT_FONT_H */

--- a/src/tile.cc
+++ b/src/tile.cc
@@ -287,6 +287,21 @@ static int gTileWindowWidth;
 // 0x66BE34 tile_center_tile
 int gCenterTile;
 
+// Optional mapper overlay drawn over the iso view each refresh (edge editor). Null when unused.
+static TileMapperOverlayProc* gTileMapperOverlayProc = nullptr;
+
+void tileSetMapperOverlayProc(TileMapperOverlayProc* proc)
+{
+    gTileMapperOverlayProc = proc;
+}
+
+void tileMapperOverlayRender(unsigned char* buffer, int pitch, int elevation, const Rect* clip)
+{
+    if (gTileMapperOverlayProc != nullptr) {
+        gTileMapperOverlayProc(buffer, pitch, elevation, clip);
+    }
+}
+
 // 0x4B0C40 tile_init
 int tileInit(TileData** squareGrid, int squareGridWidth, int squareGridHeight, int hexGridWidth, int hexGridHeight, unsigned char* buf, int windowWidth, int windowHeight, int windowPitch, TileWindowRefreshProc* windowRefreshProc)
 {
@@ -544,7 +559,7 @@ int tileSetCenter(int tile, int flags)
     }
 
     bool boundaryModsSet = false;
-    if (mapEdgeIsLoaded() && !settings.ui.ignore_map_edges) {
+    if (mapEdgeIsEnabled() && !settings.ui.ignore_map_edges) {
         bool isScroll = flags == 0;
         if (!isScroll) {
             // Forced positioning (teleport, initial load, etc.): clamp to edge boundary.
@@ -590,7 +605,7 @@ int tileSetCenter(int tile, int flags)
 
         // Scroll-blocker object check only runs when no EDG is loaded.
         // EDG clamping above already enforces the boundary.
-        if ((!mapEdgeIsLoaded() || !mapEdgeZoneIsSelected()) && gTileScrollBlockingEnabled) {
+        if ((!mapEdgeIsEnabled() || !mapEdgeZoneIsSelected()) && gTileScrollBlockingEnabled) {
             if (_obj_scroll_blocking_at(tile, gElevation) == 0) {
                 return -1;
             }
@@ -711,6 +726,8 @@ static void tileRefreshMapper(Rect* rect, int elevation)
     if (!hasVisArea) {
         tile_hires_stencil_draw(&rectToUpdate, gTileWindowBuffer, gTileWindowWidth, gTileWindowHeight);
     }
+
+    tileMapperOverlayRender(gTileWindowBuffer, gTileWindowPitch, elevation, &rectToUpdate);
 
     gTileWindowRefreshProc(&rectToUpdate);
 }

--- a/src/tile.cc
+++ b/src/tile.cc
@@ -469,7 +469,7 @@ int tileInit(TileData** squareGrid, int squareGridWidth, int squareGridHeight, i
 
     tileSetCenter(hexGridWidth * (hexGridHeight / 2) + hexGridWidth / 2, TILE_SET_CENTER_FLAG_IGNORE_SCROLL_RESTRICTIONS);
 
-    if (compat_stricmp(settings.system.executable.c_str(), "mapper") == 0) {
+    if (settings.system.executableIsMapper()) {
         gTileWindowRefreshElevationProc = tileRefreshMapper;
     }
 

--- a/src/tile.cc
+++ b/src/tile.cc
@@ -558,7 +558,7 @@ int tileSetCenter(int tile, int flags)
         return -1;
     }
 
-    const bool edgeActive = mapEdgeIsEnabled() && !settings.ui.ignore_map_edges;
+    const bool edgeActive = mapEdgeIsEnabled();
     const bool isScroll = flags == 0;
 
     if (edgeActive && !isScroll) {

--- a/src/tile.cc
+++ b/src/tile.cc
@@ -558,30 +558,16 @@ int tileSetCenter(int tile, int flags)
         return -1;
     }
 
-    bool boundaryModsSet = false;
-    if (mapEdgeIsEnabled() && !settings.ui.ignore_map_edges) {
-        bool isScroll = flags == 0;
-        if (!isScroll) {
-            // Forced positioning (teleport, initial load, etc.): clamp to edge boundary.
-            tile = mapEdgeSelectZoneAndClamp(tile, gElevation);
-            if (!tileIsValid(tile)) return -1;
-        } else if (mapEdgeZoneIsSelected()) {
-            // Normal scroll: block if tile is outside boundary (matching sfall CheckBorder).
-            // Clamping here would move the center slightly and cause mapScroll's buffer
-            // copy to produce visual artifacts; blocking preserves the current view.
-            if (!mapEdgeTileInBounds(tile)) {
-                return -1;
-            }
-            // Tile is in bounds; set sub-tile boundary mods if tile is on the edge.
-            // If the tile is exactly on a boundary edge, force a full redraw
-            // (matching sfall's CheckBorder returning 1 → modeFlags |= 1).
-            if (mapEdgeSetBoundaryMods(tile)) {
-                boundaryModsSet = true;
-                flags |= TILE_SET_CENTER_REFRESH_WINDOW;
-            }
-        }
+    const bool edgeActive = mapEdgeIsEnabled() && !settings.ui.ignore_map_edges;
+    const bool isScroll = flags == 0;
+
+    if (edgeActive && !isScroll) {
+        // Forced positioning (teleport, load): clamp to edge boundary.
+        tile = mapEdgeSelectZoneAndClamp(tile, gElevation);
+        if (!tileIsValid(tile)) return -1;
     }
 
+    bool boundaryModsSet = false;
     if ((flags & TILE_SET_CENTER_FLAG_IGNORE_SCROLL_RESTRICTIONS) == 0) {
         if (gTileScrollLimitingEnabled) {
             int tileScreenX;
@@ -603,9 +589,21 @@ int tileSetCenter(int tile, int flags)
             }
         }
 
-        // Scroll-blocker object check only runs when no EDG is loaded.
-        // EDG clamping above already enforces the boundary.
-        if ((!mapEdgeIsEnabled() || !mapEdgeZoneIsSelected()) && gTileScrollBlockingEnabled) {
+        // Must run after scroll limiting: mapEdgeSetBoundaryMods mutates the persistent
+        // alignment mods, so a scroll the limiter rejects must not touch them.
+        if (edgeActive && isScroll && mapEdgeZoneIsSelected()) {
+            // Block instead of clamp: clamping would shift the center and make
+            // mapScroll's buffer copy produce artifacts.
+            if (!mapEdgeTileInBounds(tile)) {
+                return -1;
+            }
+            // On a boundary edge: set sub-tile mods and force a full redraw.
+            if (mapEdgeSetBoundaryMods(tile)) {
+                boundaryModsSet = true;
+                flags |= TILE_SET_CENTER_REFRESH_WINDOW;
+            }
+        } else if ((!edgeActive || !mapEdgeZoneIsSelected()) && gTileScrollBlockingEnabled) {
+            // Object scroll-blocker only applies when EDG isn't enforcing the boundary.
             if (_obj_scroll_blocking_at(tile, gElevation) == 0) {
                 return -1;
             }

--- a/src/tile.cc
+++ b/src/tile.cc
@@ -1545,7 +1545,7 @@ void tileRenderFloorsInRect(Rect* rect, int elevation)
 // Port of sfall HRP ViewMap::square_obj_render
 void tileRenderEdgeBlackSquares(Rect* rect, int elevation, bool drawOnTop)
 {
-    if (!mapEdgeHasSquareRect(elevation)) {
+    if (!mapEdgeIsEnabled() || !mapEdgeHasSquareRect(elevation)) {
         return;
     }
 

--- a/src/tile.h
+++ b/src/tile.h
@@ -12,6 +12,12 @@ namespace fallout {
 typedef void(TileWindowRefreshProc)(Rect* rect);
 typedef void(TileWindowRefreshElevationProc)(Rect* rect, int elevation);
 
+// Optional overlay drawn over the mapper iso view each refresh (e.g. the edge editor).
+// clip is the region being refreshed. Set to nullptr to disable.
+typedef void(TileMapperOverlayProc)(unsigned char* buffer, int pitch, int elevation, const Rect* clip);
+void tileSetMapperOverlayProc(TileMapperOverlayProc* proc);
+void tileMapperOverlayRender(unsigned char* buffer, int pitch, int elevation, const Rect* clip);
+
 extern const int _off_tile[6];
 extern const int dword_51D984[6];
 extern int gHexGridSize;

--- a/src/tile_hires_stencil.cc
+++ b/src/tile_hires_stencil.cc
@@ -397,7 +397,7 @@ void tile_hires_stencil_draw(Rect* rect, unsigned char* buffer, int windowWidth,
 
 void tile_hires_stencil_init()
 {
-    gIsTileHiresStencilEnabled = !gameIsMapper() && settings.ui.enable_high_resolution_stencil;
+    gIsTileHiresStencilEnabled = !settings.system.executableIsMapper() && settings.ui.enable_high_resolution_stencil;
     if (!gIsTileHiresStencilEnabled) {
         return;
     }

--- a/src/tile_hires_stencil.cc
+++ b/src/tile_hires_stencil.cc
@@ -1,6 +1,7 @@
 #include "tile_hires_stencil.h"
 #include "debug.h"
 #include "draw.h"
+#include "game.h"
 #include "geometry.h"
 #include "map_edge.h"
 #include "settings.h"
@@ -65,7 +66,7 @@ static_assert(screen_view_width % (2 * square_width) == 0);
 // which is covered by squares but theoretically could be seen in the original game
 static_assert(screen_view_height % (2 * square_height) == 20);
 
-static bool gIsTileHiresStencilEnabled = true;
+static bool gIsTileHiresStencilEnabled = false;
 
 static void clean_cache()
 {
@@ -213,7 +214,7 @@ void tile_hires_stencil_on_center_tile_or_elevation_change()
     }
     // With EDG loaded, the EdgeClipping path handles blackening via ClearRect/CheckRect.
     // The stencil used as a backup when no EDG is present.
-    if (mapEdgeIsLoaded() || !gTileBorderInitialized || visited_tiles[gElevation][gCenterTile]) {
+    if (mapEdgeIsEnabled() || !gTileBorderInitialized || visited_tiles[gElevation][gCenterTile]) {
         return;
     }
 
@@ -396,7 +397,7 @@ void tile_hires_stencil_draw(Rect* rect, unsigned char* buffer, int windowWidth,
 
 void tile_hires_stencil_init()
 {
-    gIsTileHiresStencilEnabled = settings.ui.enable_high_resolution_stencil;
+    gIsTileHiresStencilEnabled = !gameIsMapper() && settings.ui.enable_high_resolution_stencil;
     if (!gIsTileHiresStencilEnabled) {
         return;
     }
@@ -416,6 +417,9 @@ void tile_hires_stencil_init()
 
 void tile_hires_stencil_on_map_load()
 {
+    if (!gIsTileHiresStencilEnabled) {
+        return;
+    }
     clean_cache();
     tile_hires_stencil_on_center_tile_or_elevation_change();
     tileWindowRefresh();

--- a/src/xfile.cc
+++ b/src/xfile.cc
@@ -565,6 +565,33 @@ bool xbaseOpen(const char* path)
     return false; // return false to trigger messages on game load
 }
 
+bool xbaseIsValidDirectory(const char* path)
+{
+    if (path == nullptr || path[0] == '\0') {
+        return false;
+    }
+
+    auto trimmedLength = [](const char* p) {
+        size_t len = strlen(p);
+        while (len > 0 && (p[len - 1] == '\\' || p[len - 1] == '/')) {
+            len--;
+        }
+        return len;
+    };
+
+    size_t targetLen = trimmedLength(path);
+    for (XBase* curr = gXbaseHead; curr != nullptr; curr = curr->next) {
+        if (curr->isDbase || curr->path == nullptr) {
+            continue;
+        }
+        size_t currLen = trimmedLength(curr->path);
+        if (currLen == targetLen && compat_strnicmp(curr->path, path, targetLen) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
 // 0x4DFB3C xenumfiles
 static bool xlistEnumerate(const char* pattern, XListEnumerationHandler* handler, XList* xlist)
 {

--- a/src/xfile.h
+++ b/src/xfile.h
@@ -65,6 +65,10 @@ int xfileEof(XFile* stream);
 long xfileGetSize(XFile* stream);
 bool xbaseReopenAll(char* paths);
 bool xbaseOpen(const char* path);
+
+// Returns true if path is currently mounted as a directory-based VFS xbase
+// (comparison ignores case and a trailing path separator).
+bool xbaseIsValidDirectory(const char* path);
 bool xlistInit(const char* pattern, XList* xlist);
 void xlistFree(XList* xlist);
 


### PR DESCRIPTION
Adds basic EDG editing support to mapper, matching HRP functionality.

Note: this wasn't based on reverse engineering but purely a re-implementation based on observed behavior.

Additionally fixes and improvements:

- Implements dev_path that allows to save edited maps directly to mounted mod folder (this unlocks editing folder-based setups without external VFS solution or maintaining a copy of game resources just for the mapper)
- SAV files were spamming the output folder when opening a map in mapper
- Corrupted view in a corner case where scroll limiting kicks in exactly at the border with modded EDG tile offset
- Selected object was deleted in mapper when opening Load Map dialog, potentially leading to it being lost in the sav file
