### PR TITLE
Fix crash due to corrupted `whoHitMe`

### DIFF
--- a/src/combat.cc
+++ b/src/combat.cc
@@ -3537,7 +3537,7 @@ void attackInit(Attack* attack, Object* attacker, Object* defender, int hitMode,
     attack->defenderFlags = 0;
     attack->defenderKnockback = 0;
     attack->extrasLength = 0;
-    attack->oops = defender;
+    attack->intendedTarget = defender;
 }
 
 // 0x422F3C
@@ -4336,7 +4336,7 @@ static int attackComputeCriticalFailure(Attack* attack)
             int rounds = attackType == ATTACK_TYPE_RANGED ? attack->ammoQuantity : 1;
             attackComputeDamage(attack, rounds, 2);
         } else {
-            attack->defender = attack->oops;
+            attack->defender = attack->intendedTarget;
         }
 
         if (attack->defender != nullptr) {
@@ -4758,31 +4758,28 @@ void _apply_damage(Attack* attack, bool animated)
 {
     Object* attacker = attack->attacker;
     bool attackerIsCritter = attacker != nullptr && FID_TYPE(attacker->fid) == OBJ_TYPE_CRITTER;
-    bool v5 = attack->defender != attack->oops;
+    bool hitUnintendedTarget = attack->defender != attack->intendedTarget;
 
     if (attackerIsCritter && (attacker->data.critter.combat.results & DAM_DEAD) == 0) {
         _set_new_results(attacker, attack->attackerFlags);
-        // TODO: Not sure about "attack->defender == attack->oops".
-        _damage_object(attacker, attack->attackerDamage, animated, attack->defender == attack->oops, attacker);
+        _damage_object(attacker, attack->attackerDamage, animated, hitUnintendedTarget, attacker);
     }
 
-    Object* v7 = attack->oops;
-    if (v7 != nullptr && v7 != attack->defender) {
-        _combatai_notify_onlookers(v7);
+    // bystanders might flee
+    if (attack->intendedTarget != nullptr && hitUnintendedTarget) {
+        _combatai_notify_onlookers(attack->intendedTarget);
     }
 
     Object* defender = attack->defender;
     bool defenderIsCritter = defender != nullptr && FID_TYPE(defender->fid) == OBJ_TYPE_CRITTER;
 
-    if (!defenderIsCritter && !v5) {
-        bool v9 = objectIsPartyMember(attack->defender) && objectIsPartyMember(attack->attacker) ? false : true;
-        if (v9) {
-            if (defender != nullptr) {
-                if (defender->sid != -1) {
-                    scriptSetFixedParam(defender->sid, attack->attackerDamage);
-                    scriptSetObjects(defender->sid, attack->attacker, attack->weapon);
-                    scriptExecProc(defender->sid, SCRIPT_PROC_DAMAGE);
-                }
+    if (!defenderIsCritter && !hitUnintendedTarget) {
+        bool shouldRunDamageProc = !objectIsPartyMember(attack->defender) || !objectIsPartyMember(attack->attacker);
+        if (shouldRunDamageProc) {
+            if (defender != nullptr && defender->sid != -1) {
+                scriptSetFixedParam(defender->sid, attack->attackerDamage);
+                scriptSetObjects(defender->sid, attack->attacker, attack->weapon);
+                scriptExecProc(defender->sid, SCRIPT_PROC_DAMAGE);
             }
         }
     }
@@ -4790,24 +4787,17 @@ void _apply_damage(Attack* attack, bool animated)
     if (defenderIsCritter && (defender->data.critter.combat.results & DAM_DEAD) == 0) {
         _set_new_results(defender, attack->defenderFlags);
 
-        if (defenderIsCritter) {
-            if (defenderIsCritter) {
-                if ((defender->data.critter.combat.results & (DAM_DEAD | DAM_KNOCKED_OUT)) != 0) {
-                    if (!v5 || defender != gDude) {
-                        critterSetWhoHitMe(defender, attack->attacker);
-                    }
-                } else if (defender == attack->oops || defender->data.critter.combat.team != attack->attacker->data.critter.combat.team) {
-                    _combatai_check_retaliation(defender, attack->attacker);
-                }
+        if ((defender->data.critter.combat.results & (DAM_DEAD | DAM_KNOCKED_OUT)) != 0) {
+            if (!hitUnintendedTarget || defender != gDude) {
+                critterSetWhoHitMe(defender, attack->attacker);
             }
+        } else if (attackerIsCritter && (defender == attack->intendedTarget || defender->data.critter.combat.team != attack->attacker->data.critter.combat.team)) {
+            _combatai_check_retaliation(defender, attack->attacker);
         }
 
         scriptSetObjects(defender->sid, attack->attacker, attack->weapon);
-        _damage_object(defender, attack->defenderDamage, animated, attack->defender != attack->oops, attacker);
-
-        if (defenderIsCritter) {
-            _combatai_notify_onlookers(defender);
-        }
+        _damage_object(defender, attack->defenderDamage, animated, hitUnintendedTarget, attacker);
+        _combatai_notify_onlookers(defender);
 
         if (attack->defenderDamage >= 0 && (attack->attackerFlags & DAM_HIT) != 0) {
             scriptSetObjects(attack->attacker->sid, nullptr, attack->defender);
@@ -4824,14 +4814,13 @@ void _apply_damage(Attack* attack, bool animated)
             if (defenderIsCritter) {
                 if ((obj->data.critter.combat.results & (DAM_DEAD | DAM_KNOCKED_OUT)) != 0) {
                     critterSetWhoHitMe(obj, attack->attacker);
-                } else if (obj->data.critter.combat.team != attack->attacker->data.critter.combat.team) {
+                } else if (attackerIsCritter && obj->data.critter.combat.team != attack->attacker->data.critter.combat.team) {
                     _combatai_check_retaliation(obj, attack->attacker);
                 }
             }
 
             scriptSetObjects(obj->sid, attack->attacker, attack->weapon);
-            // TODO: Not sure about defender == oops.
-            _damage_object(obj, attack->extrasDamage[index], animated, attack->defender == attack->oops, attack->attacker);
+            _damage_object(obj, attack->extrasDamage[index], animated, hitUnintendedTarget, attack->attacker);
             _combatai_notify_onlookers(obj);
 
             if (attack->extrasDamage[index] >= 0) {
@@ -4900,18 +4889,18 @@ static void _set_new_results(Object* critter, int flags)
     }
 }
 
-// 0x425020
-static void _damage_object(Object* a1, int damage, bool animated, int a4, Object* a5)
+// 0x425020 damage_object
+static void _damage_object(Object* target, int damage, bool animated, int hitUnintendedTarget, Object* damageSource)
 {
-    if (a1 == nullptr) {
+    if (target == nullptr) {
         return;
     }
 
-    if (FID_TYPE(a1->fid) != OBJ_TYPE_CRITTER) {
+    if (FID_TYPE(target->fid) != OBJ_TYPE_CRITTER) {
         return;
     }
 
-    if (critterFlagCheck(a1->pid, CRITTER_INVULNERABLE)) {
+    if (critterFlagCheck(target->pid, CRITTER_INVULNERABLE)) {
         return;
     }
 
@@ -4919,50 +4908,50 @@ static void _damage_object(Object* a1, int damage, bool animated, int a4, Object
         return;
     }
 
-    critterAdjustHitPoints(a1, -damage);
+    critterAdjustHitPoints(target, -damage);
 
-    if (a1 == gDude) {
+    if (target == gDude) {
         interfaceRenderHitPoints(animated);
     }
 
-    a1->data.critter.combat.damageLastTurn += damage;
+    target->data.critter.combat.damageLastTurn += damage;
 
-    if (!a4) {
+    if (!hitUnintendedTarget) {
         // TODO: Not sure about this one.
-        if (!objectIsPartyMember(a1) || !objectIsPartyMember(a5)) {
-            scriptSetFixedParam(a1->sid, damage);
-            scriptExecProc(a1->sid, SCRIPT_PROC_DAMAGE);
+        if (!objectIsPartyMember(target) || !objectIsPartyMember(damageSource)) {
+            scriptSetFixedParam(target->sid, damage);
+            scriptExecProc(target->sid, SCRIPT_PROC_DAMAGE);
         }
     }
 
-    if ((a1->data.critter.combat.results & DAM_DEAD) != 0) {
-        scriptSetObjects(a1->sid, a1->data.critter.combat.whoHitMe, nullptr);
-        scriptExecProc(a1->sid, SCRIPT_PROC_DESTROY);
-        itemDestroyAllHidden(a1);
+    if ((target->data.critter.combat.results & DAM_DEAD) != 0) {
+        scriptSetObjects(target->sid, target->data.critter.combat.whoHitMe, nullptr);
+        scriptExecProc(target->sid, SCRIPT_PROC_DESTROY);
+        itemDestroyAllHidden(target);
 
-        if (a1 != gDude) {
-            Object* whoHitMe = a1->data.critter.combat.whoHitMe;
+        if (target != gDude) {
+            Object* whoHitMe = target->data.critter.combat.whoHitMe;
             if (whoHitMe == gDude || (whoHitMe != nullptr && whoHitMe->data.critter.combat.team == gDude->data.critter.combat.team)) {
                 bool scriptOverrides = false;
                 Script* scr;
-                if (scriptGetScript(a1->sid, &scr) != -1) {
+                if (scriptGetScript(target->sid, &scr) != -1) {
                     scriptOverrides = scr->scriptOverrides;
                 }
 
                 if (!scriptOverrides) {
-                    _combat_exps += critterGetExp(a1);
-                    killsIncByType(critterGetKillType(a1));
+                    _combat_exps += critterGetExp(target);
+                    killsIncByType(critterGetKillType(target));
                 }
             }
         }
 
-        if (a1->sid != -1) {
-            scriptRemove(a1->sid);
-            a1->sid = -1;
+        if (target->sid != -1) {
+            scriptRemove(target->sid);
+            target->sid = -1;
         }
 
-        partyMemberRemove(a1);
-        scriptHooks_OnDeath(a1);
+        partyMemberRemove(target);
+        scriptHooks_OnDeath(target);
     }
 }
 
@@ -5034,11 +5023,11 @@ void _combat_display(Attack* attack)
 
     char text[280];
     if (attack->defender != nullptr
-        && attack->oops != nullptr
-        && attack->defender != attack->oops
+        && attack->intendedTarget != nullptr
+        && attack->defender != attack->intendedTarget
         && (attack->attackerFlags & DAM_HIT) != 0) {
         if (FID_TYPE(attack->defender->fid) == OBJ_TYPE_CRITTER) {
-            if (attack->oops == gDude) {
+            if (attack->intendedTarget == gDude) {
                 // 608 (male) - Oops! %s was hit instead of you!
                 // 708 (female) - Oops! %s was hit instead of you!
                 messageListItem.num = baseMessageId + 8;
@@ -5048,7 +5037,7 @@ void _combat_display(Attack* attack)
             } else {
                 // 509 (male) - Oops! %s were hit instead of %s!
                 // 559 (female) - Oops! %s were hit instead of %s!
-                const char* name = objectGetName(attack->oops);
+                const char* name = objectGetName(attack->intendedTarget);
                 messageListItem.num = baseMessageId + 9;
                 if (messageListGetItem(&gCombatMessageList, &messageListItem)) {
                     snprintf(text, sizeof(text), messageListItem.text, mainCritterName, name);

--- a/src/combat.cc
+++ b/src/combat.cc
@@ -4931,6 +4931,10 @@ static void _damage_object(Object* target, int damage, bool animated, int hitUni
 
         if (target != gDude) {
             Object* whoHitMe = target->data.critter.combat.whoHitMe;
+            if (whoHitMe != nullptr && FID_TYPE(whoHitMe->fid) != OBJ_TYPE_CRITTER) {
+                // whoHitMe is not guaranteed to be a critter
+                whoHitMe = nullptr;
+            }
             if (whoHitMe == gDude || (whoHitMe != nullptr && whoHitMe->data.critter.combat.team == gDude->data.critter.combat.team)) {
                 bool scriptOverrides = false;
                 Script* scr;

--- a/src/combat.cc
+++ b/src/combat.cc
@@ -4931,11 +4931,7 @@ static void _damage_object(Object* target, int damage, bool animated, int hitUni
 
         if (target != gDude) {
             Object* whoHitMe = target->data.critter.combat.whoHitMe;
-            if (whoHitMe != nullptr && FID_TYPE(whoHitMe->fid) != OBJ_TYPE_CRITTER) {
-                // whoHitMe is not guaranteed to be a critter
-                whoHitMe = nullptr;
-            }
-            if (whoHitMe == gDude || (whoHitMe != nullptr && whoHitMe->data.critter.combat.team == gDude->data.critter.combat.team)) {
+            if (whoHitMe == gDude || (whoHitMe != nullptr && FID_TYPE(whoHitMe->fid) == OBJ_TYPE_CRITTER && whoHitMe->data.critter.combat.team == gDude->data.critter.combat.team)) {
                 bool scriptOverrides = false;
                 Script* scr;
                 if (scriptGetScript(target->sid, &scr) != -1) {

--- a/src/combat.cc
+++ b/src/combat.cc
@@ -4931,7 +4931,7 @@ static void _damage_object(Object* target, int damage, bool animated, int hitUni
 
         if (target != gDude) {
             Object* whoHitMe = target->data.critter.combat.whoHitMe;
-            if (whoHitMe == gDude || (whoHitMe != nullptr && FID_TYPE(whoHitMe->fid) == OBJ_TYPE_CRITTER && whoHitMe->data.critter.combat.team == gDude->data.critter.combat.team)) {
+            if (whoHitMe == gDude || (whoHitMe != nullptr && whoHitMe->data.critter.combat.team == gDude->data.critter.combat.team)) {
                 bool scriptOverrides = false;
                 Script* scr;
                 if (scriptGetScript(target->sid, &scr) != -1) {

--- a/src/combat_defs.h
+++ b/src/combat_defs.h
@@ -103,7 +103,7 @@ typedef struct Attack {
     Object* attacker;
     int hitMode;
     Object* weapon;
-    int attackHitLocation;
+    int attackHitLocation; // UNUSED?
     int attackerDamage;
     int attackerFlags;
     int ammoQuantity;
@@ -114,7 +114,7 @@ typedef struct Attack {
     int defenderDamage;
     int defenderFlags;
     int defenderKnockback;
-    Object* oops;
+    Object* intendedTarget; // mainTarget
     int extrasLength;
     Object* extras[EXPLOSION_TARGET_COUNT];
     int extrasHitLocation[EXPLOSION_TARGET_COUNT];

--- a/src/map.cc
+++ b/src/map.cc
@@ -958,7 +958,8 @@ static int mapLoad(File* stream)
         goto err;
     }
 
-    if ((gMapHeader.flags & 1) == 0) {
+    if (!_isLoadingGame()) {
+        // Fix whoHitMe union.  When loading a saved game, combatLoad is responsible for this fix
         _map_fix_critter_combat_data();
     }
 

--- a/src/object.cc
+++ b/src/object.cc
@@ -227,6 +227,9 @@ static int _cd_order[9] = {
 static Object* objectPrepareWhoHitMeForSave(CritterCombatData* combatData)
 {
     Object* whoHitMe = combatData->whoHitMe;
+    if (whoHitMe == (Object*)-1) {
+        whoHitMe = nullptr;
+    }
 
     // Match sfall: only preserve whoHitMe in active combat saves.
     if (!isInCombat() || combatData->maneuver == CRITTER_MANEUVER_NONE) {

--- a/src/object.cc
+++ b/src/object.cc
@@ -440,10 +440,6 @@ int objectRead(Object* obj, File* stream)
         return -1;
     }
 
-    if (PID_TYPE(obj->pid) == OBJ_TYPE_CRITTER && obj->data.critter.combat.whoHitMeCid == -1) {
-        obj->data.critter.combat.whoHitMe = nullptr;
-    }
-
     if (isExitGridPid(obj->pid)) {
         if (obj->data.misc.map <= 0) {
             if ((obj->fid & 0xFFF) < 33) {

--- a/src/object.cc
+++ b/src/object.cc
@@ -440,6 +440,10 @@ int objectRead(Object* obj, File* stream)
         return -1;
     }
 
+    if (PID_TYPE(obj->pid) == OBJ_TYPE_CRITTER && obj->data.critter.combat.whoHitMeCid == -1) {
+        obj->data.critter.combat.whoHitMe = nullptr;
+    }
+
     if (isExitGridPid(obj->pid)) {
         if (obj->data.misc.map <= 0) {
             if ((obj->fid & 0xFFF) < 33) {

--- a/src/object.cc
+++ b/src/object.cc
@@ -59,6 +59,7 @@ static int _obj_adjust_light(Object* obj, int a2, Rect* rect);
 static void objectDrawOutline(Object* object, Rect* rect);
 static void _obj_render_object(Object* object, Rect* rect, int light);
 static int _obj_preload_sort(const void* a1, const void* a2);
+static Object* objectPrepareWhoHitMeForSave(CritterCombatData* combatData);
 
 // 0x5195F8 objInitialized
 static bool gObjectsInitialized = false;
@@ -222,6 +223,20 @@ static int _cd_order[9] = {
     0,
     0,
 };
+
+static Object* objectPrepareWhoHitMeForSave(CritterCombatData* combatData)
+{
+    Object* whoHitMe = combatData->whoHitMe;
+
+    // Match sfall: only preserve whoHitMe in active combat saves.
+    if (!isInCombat() || combatData->maneuver == CRITTER_MANEUVER_NONE) {
+        combatData->whoHitMeCid = -1;
+        return whoHitMe;
+    }
+
+    combatData->whoHitMeCid = whoHitMe != nullptr ? whoHitMe->cid : -1;
+    return whoHitMe;
+}
 
 // 0x6391D0 light_blocked
 static int _light_blocked[6][36];
@@ -707,14 +722,7 @@ int objectSaveAll(File* stream)
                 Object* whoHitMe = nullptr;
                 if (PID_TYPE(object->pid) == OBJ_TYPE_CRITTER) {
                     combatData = &(object->data.critter.combat);
-                    whoHitMe = combatData->whoHitMe;
-                    if (whoHitMe != nullptr) {
-                        if (combatData->whoHitMeCid != -1) {
-                            combatData->whoHitMeCid = whoHitMe->cid;
-                        }
-                    } else {
-                        combatData->whoHitMeCid = -1;
-                    }
+                    whoHitMe = objectPrepareWhoHitMeForSave(combatData);
                 }
 
                 if (objectWrite(object, stream) == -1) {
@@ -3528,14 +3536,7 @@ static int _obj_save_obj(File* stream, Object* object)
     Object* whoHitMe = nullptr;
     if (PID_TYPE(object->pid) == OBJ_TYPE_CRITTER) {
         combatData = &(object->data.critter.combat);
-        whoHitMe = combatData->whoHitMe;
-        if (whoHitMe != nullptr) {
-            if (combatData->whoHitMeCid != -1) {
-                combatData->whoHitMeCid = whoHitMe->cid;
-            }
-        } else {
-            combatData->whoHitMeCid = -1;
-        }
+        whoHitMe = objectPrepareWhoHitMeForSave(combatData);
     }
 
     if (objectWrite(object, stream) == -1) {


### PR DESCRIPTION
It's possible for some object's `whoHitMe` to contain `-1`.  It's supposed to be resolved to `nullptr`, but doesn't reliably happen in all cases, esp outside of combat.  The main fix here is to normalize to nullptr when loading the object, instead of just map load, or combat paths.

At some point I thought the problem might have been attacker being a non-critter.  Added some guards against that regardless.  Also, found several bugs and messiness in `apply_damage` which are now fixed.

Fixes https://github.com/alexbatalov/fallout2-ce/issues/368

I reliably repro'd the crash before, and verified that it is fixed.  I also repro'd the crash in Vanila+sfall in wine