### PR TITLE
Fix ddraw.ini -> game.cfg migration on unix-y systems

### DIFF
--- a/src/platform_compat.cc
+++ b/src/platform_compat.cc
@@ -161,43 +161,45 @@ void compat_makepath(char* path, const char* drive, const char* dir, const char*
     if (dir != nullptr) {
         if (*dir != '\0') {
             if (!compatIsPathSeparator(*dir) && compatIsPathSeparator(*path)) {
-
-                strcpy(path, dir);
-                path = strchr(path, '\0');
-
-                if (compatIsPathSeparator(path[-1])) {
-                    path--;
-                } else {
-                    *path = '/';
-                }
-            }
-        }
-
-        if (fname != nullptr && *fname != '\0') {
-            if (!compatIsPathSeparator(*fname) && *path == '/') {
                 path++;
             }
 
-            strcpy(path, fname);
+            strcpy(path, dir);
             path = strchr(path, '\0');
-        } else {
-            if (*path == '/') {
-                path++;
+
+            if (compatIsPathSeparator(path[-1])) {
+                path--;
+            } else {
+                *path = '/';
             }
         }
+    }
 
-        if (ext != nullptr) {
-            if (*ext != '\0') {
-                if (*ext != '.') {
-                    *path++ = '.';
-                }
-
-                strcpy(path, ext);
-                path = strchr(path, '\0');
-            }
+    if (fname != nullptr && *fname != '\0') {
+        if (!compatIsPathSeparator(*fname) && compatIsPathSeparator(*path)) {
+            path++;
         }
 
-        *path = '\0';
+        strcpy(path, fname);
+        path = strchr(path, '\0');
+    } else {
+        if (compatIsPathSeparator(*path)) {
+            path++;
+        }
+    }
+
+    if (ext != nullptr) {
+        if (*ext != '\0') {
+            if (*ext != '.') {
+                *path++ = '.';
+            }
+
+            strcpy(path, ext);
+            path = strchr(path, '\0');
+        }
+    }
+
+    *path = '\0';
 #endif
 }
 
@@ -223,7 +225,7 @@ int compat_mkdir(const char* path)
 #ifdef _WIN32
     return mkdir(nativePath);
 #else
-        return mkdir(nativePath, 0755);
+    return mkdir(nativePath, 0755);
 #endif
 }
 
@@ -263,11 +265,11 @@ bool compat_is_dir(const char* path)
     }
     return (info.st_mode & _S_IFDIR) != 0;
 #else
-        struct stat info;
-        if (stat(nativePath, &info) != 0) {
-            return false;
-        }
-        return S_ISDIR(info.st_mode);
+    struct stat info;
+    if (stat(nativePath, &info) != 0) {
+        return false;
+    }
+    return S_ISDIR(info.st_mode);
 #endif
 }
 
@@ -283,11 +285,11 @@ bool compat_file_exists(const char* filePath)
     }
     return (info.st_mode & _S_IFDIR) == 0;
 #else
-        struct stat info;
-        if (stat(nativePath, &info) != 0) {
-            return false;
-        }
-        return !S_ISDIR(info.st_mode);
+    struct stat info;
+    if (stat(nativePath, &info) != 0) {
+        return false;
+    }
+    return !S_ISDIR(info.st_mode);
 #endif
 }
 
@@ -296,9 +298,9 @@ unsigned int compat_timeGetTime()
 #ifdef _WIN32
     return timeGetTime();
 #else
-        static auto start = std::chrono::steady_clock::now();
-        auto now = std::chrono::steady_clock::now();
-        return static_cast<unsigned int>(std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count());
+    static auto start = std::chrono::steady_clock::now();
+    auto now = std::chrono::steady_clock::now();
+    return static_cast<unsigned int>(std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count());
 #endif
 }
 

--- a/src/platform_compat.cc
+++ b/src/platform_compat.cc
@@ -29,6 +29,11 @@
 
 namespace fallout {
 
+static bool compatIsPathSeparator(char ch)
+{
+    return ch == '/' || ch == '\\';
+}
+
 static void compat_prepare_native_path(char* nativePath, const char* path)
 {
     strncpy(nativePath, path, COMPAT_MAX_PATH - 1);
@@ -68,46 +73,45 @@ void compat_splitpath(const char* path, char* drive, char* dir, char* fname, cha
     _splitpath(path, drive, dir, fname, ext);
 #else
     const char* driveStart = path;
-    if (path[0] == '/' && path[1] == '/') {
-        path += 2;
-        while (*path != '\0' && *path != '/' && *path != '.') {
-            path++;
+    const char* pathAfterDrive = path;
+    if (compatIsPathSeparator(pathAfterDrive[0]) && compatIsPathSeparator(pathAfterDrive[1])) {
+        pathAfterDrive += 2;
+        while (*pathAfterDrive != '\0' && !compatIsPathSeparator(*pathAfterDrive) && *pathAfterDrive != '.') {
+            pathAfterDrive++;
         }
     }
 
     if (drive != nullptr) {
-        size_t driveSize = path - driveStart;
+        size_t driveSize = pathAfterDrive - driveStart;
         if (driveSize > COMPAT_MAX_DRIVE - 1) {
             driveSize = COMPAT_MAX_DRIVE - 1;
         }
-        strncpy(drive, path, driveSize);
+        strncpy(drive, driveStart, driveSize);
         drive[driveSize] = '\0';
     }
 
-    const char* dirStart = path;
-    const char* fnameStart = path;
-    const char* extStart = nullptr;
-
-    const char* end = path;
-    while (*end != '\0') {
-        if (*end == '/') {
-            fnameStart = end + 1;
-        } else if (*end == '.') {
-            extStart = end;
+    const char* fnameStart = pathAfterDrive;
+    for (const char* pch = pathAfterDrive; *pch != '\0'; pch++) {
+        if (compatIsPathSeparator(*pch)) {
+            fnameStart = pch + 1;
         }
-        end++;
     }
 
-    if (extStart == nullptr) {
-        extStart = end;
+    const char* end = pathAfterDrive + strlen(pathAfterDrive);
+    const char* extStart = end;
+    for (const char* pch = end; pch != fnameStart; pch--) {
+        if (pch[-1] == '.') {
+            extStart = pch - 1;
+            break;
+        }
     }
 
     if (dir != nullptr) {
-        size_t dirSize = fnameStart - dirStart;
+        size_t dirSize = fnameStart - pathAfterDrive;
         if (dirSize > COMPAT_MAX_DIR - 1) {
             dirSize = COMPAT_MAX_DIR - 1;
         }
-        strncpy(dir, path, dirSize);
+        strncpy(dir, pathAfterDrive, dirSize);
         dir[dirSize] = '\0';
     }
 
@@ -143,7 +147,7 @@ void compat_makepath(char* path, const char* drive, const char* dir, const char*
             strcpy(path, drive);
             path = strchr(path, '\0');
 
-            if (path[-1] == '/') {
+            if (compatIsPathSeparator(path[-1])) {
                 path--;
             } else {
                 *path = '/';
@@ -153,14 +157,14 @@ void compat_makepath(char* path, const char* drive, const char* dir, const char*
 
     if (dir != nullptr) {
         if (*dir != '\0') {
-            if (*dir != '/' && *path == '/') {
+            if (!compatIsPathSeparator(*dir) && *path == '/') {
                 path++;
             }
 
             strcpy(path, dir);
             path = strchr(path, '\0');
 
-            if (path[-1] == '/') {
+            if (compatIsPathSeparator(path[-1])) {
                 path--;
             } else {
                 *path = '/';
@@ -169,7 +173,7 @@ void compat_makepath(char* path, const char* drive, const char* dir, const char*
     }
 
     if (fname != nullptr && *fname != '\0') {
-        if (*fname != '/' && *path == '/') {
+        if (!compatIsPathSeparator(*fname) && *path == '/') {
             path++;
         }
 

--- a/src/platform_compat.cc
+++ b/src/platform_compat.cc
@@ -162,42 +162,42 @@ void compat_makepath(char* path, const char* drive, const char* dir, const char*
         if (*dir != '\0') {
             if (!compatIsPathSeparator(*dir) && compatIsPathSeparator(*path)) {
 
-            strcpy(path, dir);
-            path = strchr(path, '\0');
+                strcpy(path, dir);
+                path = strchr(path, '\0');
 
-            if (compatIsPathSeparator(path[-1])) {
-                path--;
-            } else {
-                *path = '/';
+                if (compatIsPathSeparator(path[-1])) {
+                    path--;
+                } else {
+                    *path = '/';
+                }
             }
         }
-    }
 
-    if (fname != nullptr && *fname != '\0') {
-        if (!compatIsPathSeparator(*fname) && *path == '/') {
-            path++;
-        }
-
-        strcpy(path, fname);
-        path = strchr(path, '\0');
-    } else {
-        if (*path == '/') {
-            path++;
-        }
-    }
-
-    if (ext != nullptr) {
-        if (*ext != '\0') {
-            if (*ext != '.') {
-                *path++ = '.';
+        if (fname != nullptr && *fname != '\0') {
+            if (!compatIsPathSeparator(*fname) && *path == '/') {
+                path++;
             }
 
-            strcpy(path, ext);
+            strcpy(path, fname);
             path = strchr(path, '\0');
+        } else {
+            if (*path == '/') {
+                path++;
+            }
         }
-    }
 
-    *path = '\0';
+        if (ext != nullptr) {
+            if (*ext != '\0') {
+                if (*ext != '.') {
+                    *path++ = '.';
+                }
+
+                strcpy(path, ext);
+                path = strchr(path, '\0');
+            }
+        }
+
+        *path = '\0';
 #endif
 }
 
@@ -223,7 +223,7 @@ int compat_mkdir(const char* path)
 #ifdef _WIN32
     return mkdir(nativePath);
 #else
-    return mkdir(nativePath, 0755);
+        return mkdir(nativePath, 0755);
 #endif
 }
 
@@ -263,11 +263,11 @@ bool compat_is_dir(const char* path)
     }
     return (info.st_mode & _S_IFDIR) != 0;
 #else
-    struct stat info;
-    if (stat(nativePath, &info) != 0) {
-        return false;
-    }
-    return S_ISDIR(info.st_mode);
+        struct stat info;
+        if (stat(nativePath, &info) != 0) {
+            return false;
+        }
+        return S_ISDIR(info.st_mode);
 #endif
 }
 
@@ -283,11 +283,11 @@ bool compat_file_exists(const char* filePath)
     }
     return (info.st_mode & _S_IFDIR) == 0;
 #else
-    struct stat info;
-    if (stat(nativePath, &info) != 0) {
-        return false;
-    }
-    return !S_ISDIR(info.st_mode);
+        struct stat info;
+        if (stat(nativePath, &info) != 0) {
+            return false;
+        }
+        return !S_ISDIR(info.st_mode);
 #endif
 }
 
@@ -296,9 +296,9 @@ unsigned int compat_timeGetTime()
 #ifdef _WIN32
     return timeGetTime();
 #else
-    static auto start = std::chrono::steady_clock::now();
-    auto now = std::chrono::steady_clock::now();
-    return static_cast<unsigned int>(std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count());
+        static auto start = std::chrono::steady_clock::now();
+        auto now = std::chrono::steady_clock::now();
+        return static_cast<unsigned int>(std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count());
 #endif
 }
 

--- a/src/platform_compat.cc
+++ b/src/platform_compat.cc
@@ -74,7 +74,10 @@ void compat_splitpath(const char* path, char* drive, char* dir, char* fname, cha
 #else
     const char* driveStart = path;
     const char* pathAfterDrive = path;
-    if (compatIsPathSeparator(pathAfterDrive[0]) && compatIsPathSeparator(pathAfterDrive[1])) {
+    if (pathAfterDrive[0] != '\0'
+        && pathAfterDrive[1] != '\0'
+        && compatIsPathSeparator(pathAfterDrive[0])
+        && compatIsPathSeparator(pathAfterDrive[1])) {
         pathAfterDrive += 2;
         while (*pathAfterDrive != '\0' && !compatIsPathSeparator(*pathAfterDrive) && *pathAfterDrive != '.') {
             pathAfterDrive++;
@@ -157,9 +160,7 @@ void compat_makepath(char* path, const char* drive, const char* dir, const char*
 
     if (dir != nullptr) {
         if (*dir != '\0') {
-            if (!compatIsPathSeparator(*dir) && *path == '/') {
-                path++;
-            }
+            if (!compatIsPathSeparator(*dir) && compatIsPathSeparator(*path)) {
 
             strcpy(path, dir);
             path = strchr(path, '\0');


### PR DESCRIPTION
We were using `compat_splitpath` on a windows path.  We want to work on windows paths, so that's good.  This fixes compat_splitpath so that it works with both folder separators.  Also tweak `compat_makepath` to recognize both, for consistency.

This means that filenames with `\` will be broken, but I think we can (and should) live with that)
