### PR TITLE
Fix blue/green channel mixup in PCX reading

### DIFF
--- a/src/datafile.cc
+++ b/src/datafile.cc
@@ -49,10 +49,9 @@ void datafileRemapPixelsRgb8(uint8_t* data, uint8_t* palette, int width, int hei
 
     indexedPalette[0] = 0;
     for (int index = 1; index < INDEXED_PALETTE_MAX; index++) {
-        // TODO: Check.
-        int r = palette[index * 3 + 2] >> 3;
+        int r = palette[index * 3] >> 3;
         int g = palette[index * 3 + 1] >> 3;
-        int b = palette[index * 3] >> 3;
+        int b = palette[index * 3 + 2] >> 3;
         int colorTableIndex = (r << 10) | (g << 5) | b;
         indexedPalette[index] = _colorTable[colorTableIndex];
     }
@@ -72,10 +71,9 @@ void datafileRemapPixelsRgb6(uint8_t* data, uint8_t* palette, int width, int hei
 
     indexedPalette[0] = 0;
     for (int index = 1; index < INDEXED_PALETTE_MAX; index++) {
-        // TODO: Check.
-        int r = palette[index * 3 + 2] >> 1;
+        int r = palette[index * 3] >> 1;
         int g = palette[index * 3 + 1] >> 1;
-        int b = palette[index * 3] >> 1;
+        int b = palette[index * 3 + 2] >> 1;
         int colorTableIndex = (r << 10) | (g << 5) | b;
         indexedPalette[index] = _colorTable[colorTableIndex];
     }


### PR DESCRIPTION
Before:
<img width="429" height="641" alt="image" src="https://github.com/user-attachments/assets/764d1df6-4146-4fc3-81c1-e1cf063f40f8" />

After:
<img width="464" height="691" alt="image" src="https://github.com/user-attachments/assets/7eb89f45-9384-4a3d-ae27-f90b0627afa3" />
