### PR TITLE
[low prio] Complete access to message lists

### DIFF
--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -111,6 +111,8 @@ enum EditorFolder : int {
     EDITOR_FOLDER_KILLS,
 };
 
+static void characterEditorMessageListReset();
+
 enum EditorDerivedStat : int {
     EDITOR_DERIVED_STAT_ARMOR_CLASS,
     EDITOR_DERIVED_STAT_ACTION_POINTS,
@@ -621,6 +623,12 @@ static int gCharacterEditorOptionalTraitBtns[TRAIT_COUNT];
 
 // 0x5700E8 mesg
 static MessageListItem gCharacterEditorMessageListItem;
+
+static void characterEditorMessageListReset()
+{
+    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_EDITOR, nullptr);
+    messageListFree(&gCharacterEditorMessageList);
+}
 
 // 0x5700F8 old_str1
 static char gCharacterEditorCardTitle[48];
@@ -1334,16 +1342,32 @@ static int characterEditorWindowInit()
 
     fid = buildFid(OBJ_TYPE_INTERFACE, (gCharacterEditorIsCreationMode ? 169 : 177));
     if (!_editorBackgroundFrmImage.lock(fid)) {
-        messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_EDITOR, nullptr);
-        messageListFree(&gCharacterEditorMessageList);
+        characterEditorMessageListReset();
         return -1;
     }
 
     if (karmaInit() == -1) {
+        _editorBackgroundFrmImage.unlock();
+        characterEditorMessageListReset();
+        if (gCharacterEditorIsoWasEnabled) {
+            isoEnable();
+        }
+        colorCycleEnable();
+        gameMouseSetCursor(MOUSE_CURSOR_ARROW);
         return -1;
     }
 
     if (genericReputationInit() == -1) {
+        karmaFree();
+        cleanup:
+        _editorBackgroundFrmImage.unlock();
+
+        characterEditorMessageListReset();
+        if (gCharacterEditorIsoWasEnabled) {
+            isoEnable();
+        }
+        colorCycleEnable();
+        gameMouseSetCursor(MOUSE_CURSOR_ARROW);
         return -1;
     }
 
@@ -1366,11 +1390,9 @@ static int characterEditorWindowInit()
         while (--i >= 0) {
             _editorFrmImages[i].unlock();
         }
-        return -1;
-
         _editorBackgroundFrmImage.unlock();
 
-        messageListFree(&gCharacterEditorMessageList);
+        characterEditorMessageListReset();
 
         if (gCharacterEditorIsoWasEnabled) {
             isoEnable();
@@ -1408,8 +1430,7 @@ static int characterEditorWindowInit()
 
         _editorBackgroundFrmImage.unlock();
 
-        messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_EDITOR, nullptr);
-        messageListFree(&gCharacterEditorMessageList);
+        characterEditorMessageListReset();
         if (gCharacterEditorIsoWasEnabled) {
             isoEnable();
         }
@@ -1438,8 +1459,7 @@ static int characterEditorWindowInit()
 
         _editorBackgroundFrmImage.unlock();
 
-        messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_EDITOR, nullptr);
-        messageListFree(&gCharacterEditorMessageList);
+        characterEditorMessageListReset();
         if (gCharacterEditorIsoWasEnabled) {
             isoEnable();
         }
@@ -1931,8 +1951,7 @@ static void characterEditorWindowFree()
     // SFALL: Custom town reputation.
     customTownReputationFree();
 
-    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_EDITOR, nullptr);
-    messageListFree(&gCharacterEditorMessageList);
+    characterEditorMessageListReset();
 
     interfaceBarRefresh();
 

--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -1330,9 +1330,11 @@ static int characterEditorWindowInit()
     if (!messageListLoad(&gCharacterEditorMessageList, path)) {
         return -1;
     }
+    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_EDITOR, &gCharacterEditorMessageList);
 
     fid = buildFid(OBJ_TYPE_INTERFACE, (gCharacterEditorIsCreationMode ? 169 : 177));
     if (!_editorBackgroundFrmImage.lock(fid)) {
+        messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_EDITOR, nullptr);
         messageListFree(&gCharacterEditorMessageList);
         return -1;
     }
@@ -1406,6 +1408,7 @@ static int characterEditorWindowInit()
 
         _editorBackgroundFrmImage.unlock();
 
+        messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_EDITOR, nullptr);
         messageListFree(&gCharacterEditorMessageList);
         if (gCharacterEditorIsoWasEnabled) {
             isoEnable();
@@ -1435,6 +1438,7 @@ static int characterEditorWindowInit()
 
         _editorBackgroundFrmImage.unlock();
 
+        messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_EDITOR, nullptr);
         messageListFree(&gCharacterEditorMessageList);
         if (gCharacterEditorIsoWasEnabled) {
             isoEnable();
@@ -1927,6 +1931,7 @@ static void characterEditorWindowFree()
     // SFALL: Custom town reputation.
     customTownReputationFree();
 
+    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_EDITOR, nullptr);
     messageListFree(&gCharacterEditorMessageList);
 
     interfaceBarRefresh();

--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -736,6 +736,17 @@ static int gCharacterEditorLastLevel;
 // 0x5707B8 fontsave_1
 static int gCharacterEditorOldFont;
 
+static void characterEditorWindowRestoreState()
+{
+    if (gCharacterEditorIsoWasEnabled) {
+        isoEnable();
+    }
+
+    colorCycleEnable();
+    gameMouseSetCursor(MOUSE_CURSOR_ARROW);
+    fontSetCurrent(gCharacterEditorOldFont);
+}
+
 // 0x5707BC kills_count
 static int gCharacterEditorKillsCount;
 
@@ -1330,12 +1341,15 @@ static int characterEditorWindowInit()
     gameMouseSetCursor(MOUSE_CURSOR_ARROW);
 
     if (!messageListInit(&gCharacterEditorMessageList)) {
+        characterEditorWindowRestoreState();
         return -1;
     }
 
     snprintf(path, sizeof(path), "%s%s", asc_5186C8, "editor.msg");
 
     if (!messageListLoad(&gCharacterEditorMessageList, path)) {
+        characterEditorMessageListReset();
+        characterEditorWindowRestoreState();
         return -1;
     }
     messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_EDITOR, &gCharacterEditorMessageList);
@@ -1343,17 +1357,14 @@ static int characterEditorWindowInit()
     fid = buildFid(OBJ_TYPE_INTERFACE, (gCharacterEditorIsCreationMode ? 169 : 177));
     if (!_editorBackgroundFrmImage.lock(fid)) {
         characterEditorMessageListReset();
+        characterEditorWindowRestoreState();
         return -1;
     }
 
     if (karmaInit() == -1) {
         _editorBackgroundFrmImage.unlock();
         characterEditorMessageListReset();
-        if (gCharacterEditorIsoWasEnabled) {
-            isoEnable();
-        }
-        colorCycleEnable();
-        gameMouseSetCursor(MOUSE_CURSOR_ARROW);
+        characterEditorWindowRestoreState();
         return -1;
     }
 
@@ -1362,11 +1373,7 @@ static int characterEditorWindowInit()
         _editorBackgroundFrmImage.unlock();
 
         characterEditorMessageListReset();
-        if (gCharacterEditorIsoWasEnabled) {
-            isoEnable();
-        }
-        colorCycleEnable();
-        gameMouseSetCursor(MOUSE_CURSOR_ARROW);
+        characterEditorWindowRestoreState();
         return -1;
     }
 
@@ -1393,12 +1400,7 @@ static int characterEditorWindowInit()
 
         characterEditorMessageListReset();
 
-        if (gCharacterEditorIsoWasEnabled) {
-            isoEnable();
-        }
-
-        colorCycleEnable();
-        gameMouseSetCursor(MOUSE_CURSOR_ARROW);
+        characterEditorWindowRestoreState();
         return -1;
     }
 
@@ -1430,12 +1432,7 @@ static int characterEditorWindowInit()
         _editorBackgroundFrmImage.unlock();
 
         characterEditorMessageListReset();
-        if (gCharacterEditorIsoWasEnabled) {
-            isoEnable();
-        }
-
-        colorCycleEnable();
-        gameMouseSetCursor(MOUSE_CURSOR_ARROW);
+        characterEditorWindowRestoreState();
 
         return -1;
     }
@@ -1459,12 +1456,7 @@ static int characterEditorWindowInit()
         _editorBackgroundFrmImage.unlock();
 
         characterEditorMessageListReset();
-        if (gCharacterEditorIsoWasEnabled) {
-            isoEnable();
-        }
-
-        colorCycleEnable();
-        gameMouseSetCursor(MOUSE_CURSOR_ARROW);
+        characterEditorWindowRestoreState();
 
         return -1;
     }

--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -1359,7 +1359,7 @@ static int characterEditorWindowInit()
 
     if (genericReputationInit() == -1) {
         karmaFree();
-        cleanup:
+    cleanup:
         _editorBackgroundFrmImage.unlock();
 
         characterEditorMessageListReset();

--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -1359,7 +1359,6 @@ static int characterEditorWindowInit()
 
     if (genericReputationInit() == -1) {
         karmaFree();
-    cleanup:
         _editorBackgroundFrmImage.unlock();
 
         characterEditorMessageListReset();

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -87,6 +87,8 @@ typedef enum GameDialogReviewWindowButtonFrm {
     GAME_DIALOG_REVIEW_WINDOW_BUTTON_FRM_COUNT,
 } GameDialogReviewWindowButtonFrm;
 
+static void partyMemberCustomizationMessageListReset();
+
 typedef enum GameDialogReaction {
     GAME_DIALOG_REACTION_GOOD = 49,
     GAME_DIALOG_REACTION_NEUTRAL = 50,
@@ -624,6 +626,12 @@ static int gGameDialogReviewWindowOldFont;
 
 // 0x58F470 gdialog_buttons
 static int _gdialog_buttons[9];
+
+static void partyMemberCustomizationMessageListReset()
+{
+    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_CUSTOM, nullptr);
+    messageListFree(&gCustomMessageList);
+}
 
 // 0x58F4C8 oldFont
 static int _oldFont;
@@ -4047,6 +4055,7 @@ int partyMemberCustomizationWindowInit()
     FrmImage backgroundFrmImage;
     int backgroundFid = buildFid(OBJ_TYPE_INTERFACE, 391);
     if (!backgroundFrmImage.lock(backgroundFid)) {
+        partyMemberCustomizationMessageListReset();
         return -1;
     }
 
@@ -4158,6 +4167,7 @@ int partyMemberCustomizationWindowInit()
 void partyMemberCustomizationWindowFree()
 {
     if (gGameDialogWindow == -1) {
+        partyMemberCustomizationMessageListReset();
         return;
     }
 
@@ -4195,8 +4205,7 @@ void partyMemberCustomizationWindowFree()
     windowDestroy(gGameDialogWindow);
     gGameDialogWindow = -1;
 
-    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_CUSTOM, nullptr);
-    messageListFree(&gCustomMessageList);
+    partyMemberCustomizationMessageListReset();
 }
 
 // 0x449B3C

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -4042,6 +4042,7 @@ int partyMemberCustomizationWindowInit()
     if (!messageListLoad(&gCustomMessageList, "game\\custom.msg")) {
         return -1;
     }
+    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_CUSTOM, &gCustomMessageList);
 
     FrmImage backgroundFrmImage;
     int backgroundFid = buildFid(OBJ_TYPE_INTERFACE, 391);
@@ -4194,6 +4195,7 @@ void partyMemberCustomizationWindowFree()
     windowDestroy(gGameDialogWindow);
     gGameDialogWindow = -1;
 
+    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_CUSTOM, nullptr);
     messageListFree(&gCustomMessageList);
 }
 

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -2654,7 +2654,7 @@ static int inventoryCommonInit()
             gameUiDisable(0);
         }
 
-        messageListFree(&gInventoryMessageList);
+        inventoryMessageListFree();
 
         return -1;
     }

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -1565,6 +1565,7 @@ static int inventoryMessageListInit()
     if (!messageListLoad(&gInventoryMessageList, path))
         return -1;
 
+    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_INVENTORY, &gInventoryMessageList);
     return 0;
 }
 
@@ -1581,6 +1582,7 @@ static void inventoryDisplayMessage(int num)
 // 0x46E7A0
 static int inventoryMessageListFree()
 {
+    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_INVENTORY, nullptr);
     messageListFree(&gInventoryMessageList);
     return 0;
 }

--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -121,6 +121,8 @@ typedef enum LoadSaveScrollDirection {
     LOAD_SAVE_SCROLL_DIRECTION_DOWN,
 } LoadSaveScrollDirection;
 
+static void loadSaveMessageListReset();
+
 typedef struct LoadSaveSlotData {
     char signature[24];
     short versionMinor;
@@ -333,6 +335,12 @@ static char _str1[COMPAT_MAX_PATH];
 // 0x6145FC str
 static char _str[COMPAT_MAX_PATH];
 
+static void loadSaveMessageListReset()
+{
+    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_LSGAME, nullptr);
+    messageListFree(&gLoadSaveMessageList);
+}
+
 // 0x614700 lsgbuf
 static unsigned char* gLoadSaveWindowBuffer;
 
@@ -488,7 +496,7 @@ int lsgSaveGame(int mode)
         gameMouseSetCursor(MOUSE_CURSOR_ARROW);
 
         if (v6 != -1) {
-            // Preserve the loaded list lifetime used by this path.
+            loadSaveMessageListReset();
             return 1;
         }
 
@@ -504,8 +512,7 @@ int lsgSaveGame(int mode)
         };
         showDialogBox(_str0, body, 1, 169, 116, COLOR_AMBER, nullptr, COLOR_AMBER, DIALOG_BOX_LARGE);
 
-        messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_LSGAME, nullptr);
-        messageListFree(&gLoadSaveMessageList);
+        loadSaveMessageListReset();
 
         return -1;
     }
@@ -1116,8 +1123,7 @@ int lsgLoadGame(int mode)
         strcpy(_str1, getmsg(&gLoadSaveMessageList, &messageListItem, 135));
         showDialogBox(_str0, body, 1, 169, 116, COLOR_AMBER, nullptr, COLOR_AMBER, DIALOG_BOX_LARGE);
 
-        messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_LSGAME, nullptr);
-        messageListFree(&gLoadSaveMessageList);
+        loadSaveMessageListReset();
         mapNewMap();
         _game_user_wants_to_quit = GAME_QUIT_REQUEST_MAIN_MENU;
 
@@ -1613,8 +1619,7 @@ static int lsgWindowInit(int windowType)
 
     _snapshot = (unsigned char*)internal_malloc(61632);
     if (_snapshot == nullptr) {
-        messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_LSGAME, nullptr);
-        messageListFree(&gLoadSaveMessageList);
+        loadSaveMessageListReset();
         fontSetCurrent(gLoadSaveWindowOldFont);
         return -1;
     }
@@ -1666,8 +1671,7 @@ static int lsgWindowInit(int windowType)
                 _loadsaveFrmImages[index].unlock();
             }
             internal_free(_snapshot);
-            messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_LSGAME, nullptr);
-            messageListFree(&gLoadSaveMessageList);
+            loadSaveMessageListReset();
             fontSetCurrent(gLoadSaveWindowOldFont);
 
             if (windowType != LOAD_SAVE_WINDOW_TYPE_LOAD_GAME_FROM_MAIN_MENU) {
@@ -1693,8 +1697,7 @@ static int lsgWindowInit(int windowType)
     if (gLoadSaveWindow == -1) {
         // FIXME: Leaking frms.
         internal_free(_snapshot);
-        messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_LSGAME, nullptr);
-        messageListFree(&gLoadSaveMessageList);
+        loadSaveMessageListReset();
         fontSetCurrent(gLoadSaveWindowOldFont);
 
         if (windowType != LOAD_SAVE_WINDOW_TYPE_LOAD_GAME_FROM_MAIN_MENU) {
@@ -1832,8 +1835,7 @@ static int lsgWindowFree(int windowType)
 
     windowDestroy(gLoadSaveWindow);
     fontSetCurrent(gLoadSaveWindowOldFont);
-    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_LSGAME, nullptr);
-    messageListFree(&gLoadSaveMessageList);
+    loadSaveMessageListReset();
 
     for (int index = 0; index < LOAD_SAVE_FRM_COUNT; index++) {
         _loadsaveFrmImages[index].unlock();

--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -470,6 +470,7 @@ int lsgSaveGame(int mode)
         if (!messageListLoad(&gLoadSaveMessageList, path)) {
             return -1;
         }
+        messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_LSGAME, &gLoadSaveMessageList);
 
         _snapshotBuf = nullptr;
         int v6 = _QuickSnapShot();
@@ -487,6 +488,7 @@ int lsgSaveGame(int mode)
         gameMouseSetCursor(MOUSE_CURSOR_ARROW);
 
         if (v6 != -1) {
+            // Preserve the loaded list lifetime used by this path.
             return 1;
         }
 
@@ -502,6 +504,7 @@ int lsgSaveGame(int mode)
         };
         showDialogBox(_str0, body, 1, 169, 116, COLOR_AMBER, nullptr, COLOR_AMBER, DIALOG_BOX_LARGE);
 
+        messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_LSGAME, nullptr);
         messageListFree(&gLoadSaveMessageList);
 
         return -1;
@@ -1101,6 +1104,7 @@ int lsgLoadGame(int mode)
         if (!messageListLoad(&gLoadSaveMessageList, path)) {
             return -1;
         }
+        messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_LSGAME, &gLoadSaveMessageList);
 
         if (window != -1) {
             windowDestroy(window);
@@ -1112,6 +1116,7 @@ int lsgLoadGame(int mode)
         strcpy(_str1, getmsg(&gLoadSaveMessageList, &messageListItem, 135));
         showDialogBox(_str0, body, 1, 169, 116, COLOR_AMBER, nullptr, COLOR_AMBER, DIALOG_BOX_LARGE);
 
+        messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_LSGAME, nullptr);
         messageListFree(&gLoadSaveMessageList);
         mapNewMap();
         _game_user_wants_to_quit = GAME_QUIT_REQUEST_MAIN_MENU;
@@ -1604,9 +1609,11 @@ static int lsgWindowInit(int windowType)
     if (!messageListLoad(&gLoadSaveMessageList, _str)) {
         return -1;
     }
+    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_LSGAME, &gLoadSaveMessageList);
 
     _snapshot = (unsigned char*)internal_malloc(61632);
     if (_snapshot == nullptr) {
+        messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_LSGAME, nullptr);
         messageListFree(&gLoadSaveMessageList);
         fontSetCurrent(gLoadSaveWindowOldFont);
         return -1;
@@ -1659,6 +1666,7 @@ static int lsgWindowInit(int windowType)
                 _loadsaveFrmImages[index].unlock();
             }
             internal_free(_snapshot);
+            messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_LSGAME, nullptr);
             messageListFree(&gLoadSaveMessageList);
             fontSetCurrent(gLoadSaveWindowOldFont);
 
@@ -1685,6 +1693,7 @@ static int lsgWindowInit(int windowType)
     if (gLoadSaveWindow == -1) {
         // FIXME: Leaking frms.
         internal_free(_snapshot);
+        messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_LSGAME, nullptr);
         messageListFree(&gLoadSaveMessageList);
         fontSetCurrent(gLoadSaveWindowOldFont);
 
@@ -1823,6 +1832,7 @@ static int lsgWindowFree(int windowType)
 
     windowDestroy(gLoadSaveWindow);
     fontSetCurrent(gLoadSaveWindowOldFont);
+    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_LSGAME, nullptr);
     messageListFree(&gLoadSaveMessageList);
 
     for (int index = 0; index < LOAD_SAVE_FRM_COUNT; index++) {

--- a/src/message.cc
+++ b/src/message.cc
@@ -183,13 +183,12 @@ bool messageListInit(MessageList* messageList)
 // 0x484964 message_exit
 bool messageListFree(MessageList* messageList)
 {
-    int i;
-    MessageListItem* entry;
-
     if (messageList == nullptr) {
         return false;
     }
 
+    int i;
+    MessageListItem* entry;
     for (i = 0; i < messageList->entries_num; i++) {
         entry = &(messageList->entries[i]);
 
@@ -212,7 +211,6 @@ bool messageListFree(MessageList* messageList)
     return true;
 }
 
-// message_load
 // 0x484AA4 message_load
 bool messageListLoad(MessageList* messageList, const char* path)
 {

--- a/src/message.h
+++ b/src/message.h
@@ -18,8 +18,8 @@ namespace fallout {
 // always exposes persistent standard message lists and additionally exposes
 // some volatile lists for the duration of their UI lifetime:
 enum StandardMessageList {
-    STANDARD_MESSAGE_LIST_COMBAT, // transient
-    STANDARD_MESSAGE_LIST_COMBAT_AI, // transient
+    STANDARD_MESSAGE_LIST_COMBAT,
+    STANDARD_MESSAGE_LIST_COMBAT_AI,
     STANDARD_MESSAGE_LIST_SCRNAME,
     STANDARD_MESSAGE_LIST_MISC,
     STANDARD_MESSAGE_LIST_CUSTOM, // transient

--- a/src/message.h
+++ b/src/message.h
@@ -14,17 +14,26 @@ namespace fallout {
 // CE: Working with standard message lists is tricky in Sfall. Many message
 // lists are initialized only for the duration of appropriate modal window. This
 // is not documented in Sfall and shifts too much responsibility to scripters
-// (who should check game mode before accessing volatile message lists). For now
-// CE only exposes persistent standard message lists:
+// (who should check game mode before accessing volatile message lists). CE
+// always exposes persistent standard message lists and additionally exposes
+// some volatile lists for the duration of their UI lifetime:
 // - combat.msg
 // - combatai.msg
 // - scrname.msg
 // - misc.msg
+// - custom.msg
+// - editor.msg
+// - inventry.msg
 // - item.msg
+// - lsgame.msg
 // - map.msg
+// - options.msg
+// - pipboy.msg
+// - quests.msg
 // - proto.msg
 // - script.msg
 // - skill.msg
+// - skilldex.msg
 // - stat.msg
 // - trait.msg
 // - worldmap.msg
@@ -49,6 +58,7 @@ enum StandardMessageList {
     STANDARD_MESSAGE_LIST_STAT,
     STANDARD_MESSAGE_LIST_TRAIT,
     STANDARD_MESSAGE_LIST_WORLDMAP,
+    STANDARD_MESSAGE_LIST_EDITOR,
     STANDARD_MESSAGE_LIST_COUNT,
 };
 

--- a/src/message.h
+++ b/src/message.h
@@ -17,48 +17,28 @@ namespace fallout {
 // (who should check game mode before accessing volatile message lists). CE
 // always exposes persistent standard message lists and additionally exposes
 // some volatile lists for the duration of their UI lifetime:
-// - combat.msg
-// - combatai.msg
-// - scrname.msg
-// - misc.msg
-// - custom.msg
-// - editor.msg
-// - inventry.msg
-// - item.msg
-// - lsgame.msg
-// - map.msg
-// - options.msg
-// - pipboy.msg
-// - quests.msg
-// - proto.msg
-// - script.msg
-// - skill.msg
-// - skilldex.msg
-// - stat.msg
-// - trait.msg
-// - worldmap.msg
 enum StandardMessageList {
-    STANDARD_MESSAGE_LIST_COMBAT,
-    STANDARD_MESSAGE_LIST_COMBAT_AI,
+    STANDARD_MESSAGE_LIST_COMBAT, // transient
+    STANDARD_MESSAGE_LIST_COMBAT_AI, // transient
     STANDARD_MESSAGE_LIST_SCRNAME,
     STANDARD_MESSAGE_LIST_MISC,
-    STANDARD_MESSAGE_LIST_CUSTOM,
-    STANDARD_MESSAGE_LIST_INVENTORY,
+    STANDARD_MESSAGE_LIST_CUSTOM, // transient
+    STANDARD_MESSAGE_LIST_INVENTORY, // transient
     STANDARD_MESSAGE_LIST_ITEM,
-    STANDARD_MESSAGE_LIST_LSGAME,
+    STANDARD_MESSAGE_LIST_LSGAME, // transient
     STANDARD_MESSAGE_LIST_MAP,
-    STANDARD_MESSAGE_LIST_OPTIONS,
+    STANDARD_MESSAGE_LIST_OPTIONS, // transient
     STANDARD_MESSAGE_LIST_PERK,
-    STANDARD_MESSAGE_LIST_PIPBOY,
-    STANDARD_MESSAGE_LIST_QUESTS,
+    STANDARD_MESSAGE_LIST_PIPBOY, // transient
+    STANDARD_MESSAGE_LIST_QUESTS, // transient
     STANDARD_MESSAGE_LIST_PROTO,
     STANDARD_MESSAGE_LIST_SCRIPT,
     STANDARD_MESSAGE_LIST_SKILL,
-    STANDARD_MESSAGE_LIST_SKILLDEX,
+    STANDARD_MESSAGE_LIST_SKILLDEX, // transient
     STANDARD_MESSAGE_LIST_STAT,
     STANDARD_MESSAGE_LIST_TRAIT,
     STANDARD_MESSAGE_LIST_WORLDMAP,
-    STANDARD_MESSAGE_LIST_EDITOR,
+    STANDARD_MESSAGE_LIST_EDITOR, // transient; yes, this is supposed to be at the end rather than alphabetical
     STANDARD_MESSAGE_LIST_COUNT,
 };
 

--- a/src/options.cc
+++ b/src/options.cc
@@ -236,6 +236,7 @@ static int optionsWindowInit()
             optionsMenuHelpEnabled = false;
         }
     }
+    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_OPTIONS, &preferencesMessageList);
 
     for (int index = 0; index < OPTIONS_WINDOW_FRM_COUNT; index++) {
         bool loaded = false;
@@ -370,6 +371,7 @@ static void optionsWindowCleanup(bool restoreWorldState)
         optionsWindow = -1;
     }
 
+    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_OPTIONS, nullptr);
     messageListFree(&ceOptionsMessageList);
     messageListFree(&preferencesMessageList);
 
@@ -441,6 +443,7 @@ int showPause(bool preserveWorldState)
         // FIXME: Leaking graphics.
         return -1;
     }
+    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_OPTIONS, &preferencesMessageList);
 
     int pauseWindowX = (screenGetWidth() - frmImages[PAUSE_WINDOW_FRM_BACKGROUND].getWidth()) / 2;
     int pauseWindowY = (screenGetHeight() - frmImages[PAUSE_WINDOW_FRM_BACKGROUND].getHeight()) / 2;
@@ -459,6 +462,7 @@ int showPause(bool preserveWorldState)
         256,
         WINDOW_MODAL | WINDOW_DONT_MOVE_TOP);
     if (window == -1) {
+        messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_OPTIONS, nullptr);
         messageListFree(&preferencesMessageList);
 
         debugPrint("\n** Error opening pause window! **\n");
@@ -556,6 +560,7 @@ int showPause(bool preserveWorldState)
 
     windowDestroy(window);
     pauseWindow = -1;
+    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_OPTIONS, nullptr);
     messageListFree(&preferencesMessageList);
 
     if (!preserveWorldState) {

--- a/src/options.cc
+++ b/src/options.cc
@@ -50,6 +50,7 @@ static int optionsWindowInit();
 static int optionsWindowFree();
 static void optionsWindowCleanup(bool restoreWorldState);
 static void _ShadeScreen(bool preserveWorldState);
+static void optionsMessageListReset();
 
 struct OptionsMenuButtonSpec {
     int eventCode;
@@ -112,6 +113,12 @@ static constexpr int optionsWindowButtonCount = (sizeof(optionsMenuButtonSpecs) 
 
 // 0x663878 opbtns
 static unsigned char* _opbtns[optionsWindowButtonCount];
+
+static void optionsMessageListReset()
+{
+    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_OPTIONS, nullptr);
+    messageListFree(&preferencesMessageList);
+}
 
 // 0x48FC50 do_optionsFunc
 int showOptions()
@@ -371,9 +378,8 @@ static void optionsWindowCleanup(bool restoreWorldState)
         optionsWindow = -1;
     }
 
-    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_OPTIONS, nullptr);
+    optionsMessageListReset();
     messageListFree(&ceOptionsMessageList);
-    messageListFree(&preferencesMessageList);
 
     for (int index = 0; index < optionsWindowButtonCount; index++) {
         if (_opbtns[index] != nullptr) {
@@ -462,8 +468,7 @@ int showPause(bool preserveWorldState)
         256,
         WINDOW_MODAL | WINDOW_DONT_MOVE_TOP);
     if (window == -1) {
-        messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_OPTIONS, nullptr);
-        messageListFree(&preferencesMessageList);
+        optionsMessageListReset();
 
         debugPrint("\n** Error opening pause window! **\n");
         return -1;
@@ -560,8 +565,7 @@ int showPause(bool preserveWorldState)
 
     windowDestroy(window);
     pauseWindow = -1;
-    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_OPTIONS, nullptr);
-    messageListFree(&preferencesMessageList);
+    optionsMessageListReset();
 
     if (!preserveWorldState) {
         if (gameMouseWasVisible) {

--- a/src/options.cc
+++ b/src/options.cc
@@ -171,7 +171,7 @@ int showOptions()
             case OPTIONS_MENU_BUTTON_PREFERENCES:
                 // PREFERENCES
                 doPreferences(false);
-                messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_OPTIONS, &gPreferencesMessageList);
+                messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_OPTIONS, &preferencesMessageList);
                 break;
             case KEY_UPPERCASE_H:
             case KEY_LOWERCASE_H:

--- a/src/options.cc
+++ b/src/options.cc
@@ -171,6 +171,7 @@ int showOptions()
             case OPTIONS_MENU_BUTTON_PREFERENCES:
                 // PREFERENCES
                 doPreferences(false);
+                messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_OPTIONS, &gPreferencesMessageList);
                 break;
             case KEY_UPPERCASE_H:
             case KEY_LOWERCASE_H:

--- a/src/pipboy.cc
+++ b/src/pipboy.cc
@@ -2765,11 +2765,10 @@ static int questInit()
     if (!messageListLoad(&gQuestsMessageList, "game\\quests.msg")) {
         return -1;
     }
-    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_QUESTS, &gQuestsMessageList);
 
     File* stream = fileOpen("data\\quests.txt", "rt");
     if (stream == nullptr) {
-        // Intentionally keep the loaded list registered; questFree clears it.
+        messageListFree(&gQuestsMessageList);
         return -1;
     }
 
@@ -2837,12 +2836,14 @@ static int questInit()
     qsort(gQuestDescriptions, gQuestsCount, sizeof(*gQuestDescriptions), questDescriptionCompare);
 
     fileClose(stream);
+    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_QUESTS, &gQuestsMessageList);
 
     return 0;
 
 err:
 
     fileClose(stream);
+    messageListFree(&gQuestsMessageList);
 
     return -1;
 }

--- a/src/pipboy.cc
+++ b/src/pipboy.cc
@@ -611,6 +611,7 @@ int pipboyMessageListInit()
     if (!(messageListLoad(&gPipboyMessageList, path))) {
         return -1;
     }
+    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_PIPBOY, &gPipboyMessageList);
 
     return 0;
 }
@@ -618,6 +619,7 @@ int pipboyMessageListInit()
 void pipboyMessageListFree()
 {
     if (gPipboyMessageList.entries != nullptr) {
+        messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_PIPBOY, nullptr);
         messageListFree(&gPipboyMessageList);
     }
     messageListInit(&gPipboyMessageList);
@@ -2763,9 +2765,11 @@ static int questInit()
     if (!messageListLoad(&gQuestsMessageList, "game\\quests.msg")) {
         return -1;
     }
+    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_QUESTS, &gQuestsMessageList);
 
     File* stream = fileOpen("data\\quests.txt", "rt");
     if (stream == nullptr) {
+        // Intentionally keep the loaded list registered; questFree clears it.
         return -1;
     }
 
@@ -2853,6 +2857,7 @@ static void questFree()
 
     gQuestsCount = 0;
 
+    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_QUESTS, nullptr);
     messageListFree(&gQuestsMessageList);
 }
 

--- a/src/preferences.cc
+++ b/src/preferences.cc
@@ -992,6 +992,7 @@ static int preferencesWindowInit()
     if (!messageListLoad(&gPreferencesMessageList, path)) {
         return -1;
     }
+    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_OPTIONS, &gPreferencesMessageList);
 
     _oldFont = fontGetCurrent();
 
@@ -1212,6 +1213,7 @@ static int preferencesWindowFree()
 
     fontSetCurrent(_oldFont);
 
+    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_OPTIONS, nullptr);
     messageListFree(&gPreferencesMessageList);
     touch_set_touchscreen_mode(false);
 

--- a/src/preferences.cc
+++ b/src/preferences.cc
@@ -116,6 +116,7 @@ static int preferencesWindowInit();
 static int preferencesWindowFree();
 static void _DoThing(int eventCode);
 static int preferencesGetRangeOptionLabelX(int optionIndex, int valuesCount, const char* text);
+static void preferencesMessageListReset();
 
 // 0x48FBD0 row1Ytab
 static const int _row1Ytab[PRIMARY_PREF_COUNT] = {
@@ -231,6 +232,12 @@ static MessageList gPreferencesMessageList;
 
 // 0x663840 optnmesg
 static MessageListItem gPreferencesMessageListItem;
+
+static void preferencesMessageListReset()
+{
+    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_OPTIONS, nullptr);
+    messageListFree(&gPreferencesMessageList);
+}
 
 // 0x6638C8 text_delay_back
 static double gPreferencesTextBaseDelay2;
@@ -1004,6 +1011,7 @@ static int preferencesWindowInit()
             while (--i >= 0) {
                 _preferencesFrmImages[i].unlock();
             }
+            preferencesMessageListReset();
             return -1;
         }
     }
@@ -1022,6 +1030,7 @@ static int preferencesWindowInit()
         for (i = 0; i < PREFERENCES_WINDOW_FRM_COUNT; i++) {
             _preferencesFrmImages[i].unlock();
         }
+        preferencesMessageListReset();
         return -1;
     }
 
@@ -1213,8 +1222,7 @@ static int preferencesWindowFree()
 
     fontSetCurrent(_oldFont);
 
-    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_OPTIONS, nullptr);
-    messageListFree(&gPreferencesMessageList);
+    preferencesMessageListReset();
     touch_set_touchscreen_mode(false);
 
     return 0;

--- a/src/skilldex.cc
+++ b/src/skilldex.cc
@@ -171,6 +171,7 @@ static int skilldexWindowInit()
     if (!messageListLoad(&gSkilldexMessageList, path)) {
         return -1;
     }
+    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_SKILLDEX, &gSkilldexMessageList);
 
     int frmIndex;
     for (frmIndex = 0; frmIndex < SKILLDEX_FRM_COUNT; frmIndex++) {
@@ -185,6 +186,7 @@ static int skilldexWindowInit()
             _skilldexFrmImages[frmIndex].unlock();
         }
 
+        messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_SKILLDEX, nullptr);
         messageListFree(&gSkilldexMessageList);
 
         return -1;
@@ -223,6 +225,7 @@ static int skilldexWindowInit()
             _skilldexFrmImages[index].unlock();
         }
 
+        messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_SKILLDEX, nullptr);
         messageListFree(&gSkilldexMessageList);
 
         return -1;
@@ -246,6 +249,7 @@ static int skilldexWindowInit()
             _skilldexFrmImages[index].unlock();
         }
 
+        messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_SKILLDEX, nullptr);
         messageListFree(&gSkilldexMessageList);
 
         return -1;
@@ -408,6 +412,7 @@ static void skilldexWindowFree()
         _skilldexFrmImages[index].unlock();
     }
 
+    messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_SKILLDEX, nullptr);
     messageListFree(&gSkilldexMessageList);
 
     fontSetCurrent(gSkilldexWindowOldFont);


### PR DESCRIPTION
We were missing exposing some message lists that Sfall exposes.  These are mostly the ones that are only valid while in a specific game mode.  I don't really see it as a large problem as the code comment implies.  At worst, it returns `"Error"` (i.e., does not crash)

Several of these modules need a refactor in their cleanup code, but I decided to not try to do in this PR