### PR TITLE
Fix possible double-free in animation_free

### DIFF
--- a/src/animation.cc
+++ b/src/animation.cc
@@ -78,6 +78,11 @@ typedef enum AnimationKind {
     ANIM_KIND_SET_LIGHT_INTENSITY,
 } AnimationKind;
 
+static bool animationKindIsCallback(int kind)
+{
+    return kind == ANIM_KIND_CALLBACK || kind == ANIM_KIND_CALLBACK3;
+}
+
 typedef enum AnimationSequenceFlags {
     // Specifies that the animation sequence has high priority, it cannot be
     // cleared.
@@ -475,7 +480,7 @@ int reg_anim_clear(Object* a1)
         int animationDescriptionIndex;
         for (animationDescriptionIndex = 0; animationDescriptionIndex < animationSequence->length; animationDescriptionIndex++) {
             AnimationDescription* animationDescription = &(animationSequence->animations[animationDescriptionIndex]);
-            if (a1 != animationDescription->owner || animationDescription->kind == ANIM_KIND_CALLBACK) { // ANIM_KIND_CALLBACK3?
+            if (a1 != animationDescription->owner || animationKindIsCallback(animationDescription->kind)) {
                 continue;
             }
 
@@ -589,7 +594,7 @@ static int _check_registry(Object* obj)
         if (animationSequenceIndex != gAnimationSequenceCurrentIndex && animationSequence->step != ANIM_COMPLETE) {
             for (int animationDescriptionIndex = 0; animationDescriptionIndex < animationSequence->length; animationDescriptionIndex++) {
                 AnimationDescription* animationDescription = &(animationSequence->animations[animationDescriptionIndex]);
-                if (obj == animationDescription->owner && animationDescription->kind != ANIM_KIND_CALLBACK) { // ANIM_KIND_CALLBACK3?
+                if (obj == animationDescription->owner && !animationKindIsCallback(animationDescription->kind)) {
                     if ((animationSequence->flags & ANIM_SEQ_INSIGNIFICANT) == 0) {
                         return -1;
                     }
@@ -621,7 +626,7 @@ int animationIsBusy(Object* a1)
                     continue;
                 }
 
-                if (animationDescription->kind == ANIM_KIND_CALLBACK) {
+                if (animationKindIsCallback(animationDescription->kind)) {
                     continue;
                 }
 
@@ -1641,7 +1646,7 @@ static int _anim_set_end(int animationSequenceIndex)
             animationDescription->artCacheKey = nullptr;
         }
 
-        if (animationDescription->kind != ANIM_KIND_CALLBACK && animationDescription->kind != ANIM_KIND_CALLBACK3) {
+        if (!animationKindIsCallback(animationDescription->kind)) {
             // TODO: Check.
             if (animationDescription->kind != ANIM_KIND_PING) {
                 Object* owner = animationDescription->owner;
@@ -1654,7 +1659,7 @@ static int _anim_set_end(int animationSequenceIndex)
                     for (; j < i; j++) {
                         AnimationDescription* ad = &(animationSequence->animations[j]);
                         if (owner == ad->owner) {
-                            if (ad->kind != ANIM_KIND_CALLBACK && ad->kind != ANIM_KIND_CALLBACK3) {
+                            if (!animationKindIsCallback(ad->kind)) {
                                 break;
                             }
                         }

--- a/src/animation.cc
+++ b/src/animation.cc
@@ -1,6 +1,8 @@
 #include "animation.h"
 
 #include <algorithm>
+#include <array>
+#include <cstddef>
 #include <stdio.h>
 #include <string.h>
 
@@ -473,7 +475,7 @@ int reg_anim_clear(Object* a1)
         int animationDescriptionIndex;
         for (animationDescriptionIndex = 0; animationDescriptionIndex < animationSequence->length; animationDescriptionIndex++) {
             AnimationDescription* animationDescription = &(animationSequence->animations[animationDescriptionIndex]);
-            if (a1 != animationDescription->owner || animationDescription->kind == 11) {
+            if (a1 != animationDescription->owner || animationDescription->kind == ANIM_KIND_CALLBACK) { // ANIM_KIND_CALLBACK3?
                 continue;
             }
 
@@ -587,7 +589,7 @@ static int _check_registry(Object* obj)
         if (animationSequenceIndex != gAnimationSequenceCurrentIndex && animationSequence->step != ANIM_COMPLETE) {
             for (int animationDescriptionIndex = 0; animationDescriptionIndex < animationSequence->length; animationDescriptionIndex++) {
                 AnimationDescription* animationDescription = &(animationSequence->animations[animationDescriptionIndex]);
-                if (obj == animationDescription->owner && animationDescription->kind != 11) {
+                if (obj == animationDescription->owner && animationDescription->kind != ANIM_KIND_CALLBACK) { // ANIM_KIND_CALLBACK3?
                     if ((animationSequence->flags & ANIM_SEQ_INSIGNIFICANT) == 0) {
                         return -1;
                     }
@@ -1609,12 +1611,25 @@ static int _anim_set_end(int animationSequenceIndex)
         }
     }
 
+    std::array<Object*, ANIMATION_DESCRIPTION_LIST_CAPACITY> destroyedOwners = {};
+    std::size_t destroyedOwnersLength = 0;
+    auto ownerWasDestroyed = [&destroyedOwners, &destroyedOwnersLength](Object* owner) {
+        return std::find(destroyedOwners.begin(), destroyedOwners.begin() + destroyedOwnersLength, owner) != destroyedOwners.begin() + destroyedOwnersLength;
+    };
+
     for (i = 0; i < animationSequence->length; i++) {
         animationDescription = &(animationSequence->animations[i]);
         if (animationDescription->kind == ANIM_KIND_HIDE && ((i < animationSequence->animationIndex) || (animationDescription->extendedFlags & ANIMATION_SEQUENCE_FORCED))) {
+            Object* owner = animationDescription->owner;
+            if (ownerWasDestroyed(owner)) {
+                continue;
+            }
+
+            destroyedOwners[destroyedOwnersLength++] = owner;
+
             Rect rect;
-            int elevation = animationDescription->owner->elevation;
-            objectDestroy(animationDescription->owner, &rect);
+            int elevation = owner->elevation;
+            objectDestroy(owner, &rect);
             tileWindowRefreshRect(&rect, elevation);
         }
     }
@@ -1623,12 +1638,17 @@ static int _anim_set_end(int animationSequenceIndex)
         animationDescription = &(animationSequence->animations[i]);
         if (animationDescription->artCacheKey) {
             artUnlock(animationDescription->artCacheKey);
+            animationDescription->artCacheKey = nullptr;
         }
 
-        if (animationDescription->kind != 11 && animationDescription->kind != 12) {
+        if (animationDescription->kind != ANIM_KIND_CALLBACK && animationDescription->kind != ANIM_KIND_CALLBACK3) {
             // TODO: Check.
             if (animationDescription->kind != ANIM_KIND_PING) {
                 Object* owner = animationDescription->owner;
+                if (ownerWasDestroyed(owner)) {
+                    continue;
+                }
+
                 if (FID_TYPE(owner->fid) == OBJ_TYPE_CRITTER) {
                     int j = 0;
                     for (; j < i; j++) {


### PR DESCRIPTION
Port of roughly: https://github.com/cambragol/fission-ce/commit/7fafbb11c7daf5fe7f5ae05b92a3bffaaaa7b5a4

Not sure how to trigger it in CE, but seems plausibly possible.

While I was at it, deobfuscated anim constants and make ANIM_CALLBACK{3} handling consistent.  It was missing in a few places
