### PR TITLE
Fix initialized variable comparisons and fileReadInt32

### DIFF
--- a/src/color.cc
+++ b/src/color.cc
@@ -322,7 +322,7 @@ bool colorPaletteLoad(const char* path)
     // NOTE: Uninline.
     fileRead(_colorTable, 0x8000, 1, stream);
 
-    unsigned int type;
+    unsigned int type = 0;
     // NOTE: Uninline.
     fileRead(&type, sizeof(type), 1, stream);
 

--- a/src/db.cc
+++ b/src/db.cc
@@ -316,9 +316,10 @@ int fileReadUInt16(File* stream, unsigned short* valuePtr)
 // 0x4C614C db_freadInt
 int fileReadInt32(File* stream, int* valuePtr)
 {
-    int value;
+    int value = 0;
 
-    if (xfileRead(&value, 4, 1, stream) == -1) {
+    // SFALL: return error on short read
+    if (xfileRead(&value, sizeof(value), 1, stream) != 1) {
         return -1;
     }
 

--- a/src/dfile.cc
+++ b/src/dfile.cc
@@ -448,6 +448,8 @@ int dfileWriteChar(int ch, DFile* stream)
 {
     assert(stream); // "stream", "dfile.c", 437
 
+    // not implemented
+
     return -1;
 }
 
@@ -458,6 +460,8 @@ int dfileWriteString(const char* string, DFile* stream)
 {
     assert(string); // "s", "dfile.c", 448
     assert(stream); // "stream", "dfile.c", 449
+
+    // not implemented
 
     return -1;
 }
@@ -520,6 +524,8 @@ size_t dfileWrite(const void* ptr, size_t size, size_t count, DFile* stream)
 {
     assert(ptr); // "ptr", "dfile.c", 538
     assert(stream); // "stream", "dfile.c", 539
+
+    // not implemented
 
     return count - 1;
 }

--- a/src/xfile.cc
+++ b/src/xfile.cc
@@ -307,8 +307,14 @@ size_t xfileRead(void* ptr, size_t size, size_t count, XFile* stream)
         // [fread] returns number of elements read, but [gzwrite] have no such
         // concept, it works with bytes, and returns number of bytes read.
         // Depending on the [size] and [count] parameters this function can
-        // return wrong result.
-        elementsRead = gzread(stream->gzfile, ptr, size * count);
+        // return wrong result.  We attempt to fix this roughly here.
+        // In practice unlikely to matter since GZFILE type isn't used.
+        if (size == 0 || count == 0) {
+            elementsRead = 0;
+        } else {
+            int bytesRead = gzread(stream->gzfile, ptr, size * count);
+            elementsRead = bytesRead > 0 ? static_cast<size_t>(bytesRead) / size : 0;
+        }
         break;
     default:
         elementsRead = fread(ptr, size, count, stream->file);


### PR DESCRIPTION
Also pulled in an Sfall fix for this function

Fixes https://github.com/fallout2-ce/fallout2-ce/issues/516
