### PR TITLE
QoL Stackable empty weapons regardless of the previous ammo type.

### DIFF
--- a/src/item.cc
+++ b/src/item.cc
@@ -695,17 +695,17 @@ static bool _item_identical(Object* item1, Object* item2)
         return false;
     }
 
-    int item2Quantity;
-    if (proto->item.type == ITEM_TYPE_AMMO || item1->pid == PROTO_ID_MONEY) {
-        item2Quantity = item2->data.item.ammo.quantity;
-        item2->data.item.ammo.quantity = item1->data.item.ammo.quantity;
-    }
-
     bool sameFlags = item1->data.flags == item2->data.flags;
 
     // empty weapons of the same types are always considered the same even the ammo was originally different
     if (sameFlags && proto->item.type == ITEM_TYPE_WEAPON && item1->data.item.weapon.ammoQuantity < 1 && item2->data.item.weapon.ammoQuantity < 1) {
         return true;
+    }
+
+    int item2Quantity;
+    if (proto->item.type == ITEM_TYPE_AMMO || item1->pid == PROTO_ID_MONEY) {
+        item2Quantity = item2->data.item.ammo.quantity;
+        item2->data.item.ammo.quantity = item1->data.item.ammo.quantity;
     }
 
     // CE: Original code is different. It compares exactly 32 bytes one by one

--- a/src/item.cc
+++ b/src/item.cc
@@ -695,6 +695,11 @@ static bool _item_identical(Object* item1, Object* item2)
         return false;
     }
 
+    // empty weapons of the same types are always the considered the same even the ammo was originally different
+    if (proto->item.type == ITEM_TYPE_WEAPON && item1->data.item.weapon.ammoQuantity < 1 && item2->data.item.weapon.ammoQuantity < 1) {
+        return true;
+    }
+
     int item2Quantity;
     if (proto->item.type == ITEM_TYPE_AMMO || item1->pid == PROTO_ID_MONEY) {
         item2Quantity = item2->data.item.ammo.quantity;

--- a/src/item.cc
+++ b/src/item.cc
@@ -695,23 +695,24 @@ static bool _item_identical(Object* item1, Object* item2)
         return false;
     }
 
-    // empty weapons of the same types are always considered the same even the ammo was originally different
-    if (proto->item.type == ITEM_TYPE_WEAPON && item1->data.item.weapon.ammoQuantity < 1 && item2->data.item.weapon.ammoQuantity < 1) {
-        return true;
-    }
-
     int item2Quantity;
     if (proto->item.type == ITEM_TYPE_AMMO || item1->pid == PROTO_ID_MONEY) {
         item2Quantity = item2->data.item.ammo.quantity;
         item2->data.item.ammo.quantity = item1->data.item.ammo.quantity;
     }
 
+    bool sameFlags = item1->data.flags == item2->data.flags;
+
+    // empty weapons of the same types are always considered the same even the ammo was originally different
+    if (sameFlags && proto->item.type == ITEM_TYPE_WEAPON && item1->data.item.weapon.ammoQuantity < 1 && item2->data.item.weapon.ammoQuantity < 1) {
+        return true;
+    }
+
     // CE: Original code is different. It compares exactly 32 bytes one by one
     // in the loop starting with `data` (which means it also checks `Inventory`
     // object). Objects with inventories are filtered a moment earlier, so it
     // should be safe to check only the item-specific data.
-    bool same = item1->data.flags == item2->data.flags
-        && memcmp(&(item1->data.item), &(item2->data.item), sizeof(ItemObjectData)) == 0;
+    bool same = sameFlags && memcmp(&(item1->data.item), &(item2->data.item), sizeof(ItemObjectData)) == 0;
 
     if (proto->item.type == ITEM_TYPE_AMMO || item1->pid == PROTO_ID_MONEY) {
         item2->data.item.ammo.quantity = item2Quantity;

--- a/src/item.cc
+++ b/src/item.cc
@@ -695,7 +695,7 @@ static bool _item_identical(Object* item1, Object* item2)
         return false;
     }
 
-    // empty weapons of the same types are always the considered the same even the ammo was originally different
+    // empty weapons of the same types are always considered the same even the ammo was originally different
     if (proto->item.type == ITEM_TYPE_WEAPON && item1->data.item.weapon.ammoQuantity < 1 && item2->data.item.weapon.ammoQuantity < 1) {
         return true;
     }


### PR DESCRIPTION
### Description
CE is behaving like vanilla so if you have in the inventory the empty weapons with the same pid it decides whether to stack them or not based on original ammo pid.

Sfall has fixed that already with hooking up on `add_item_force` and set the ammo proto to be the default in `SetDefaultAmmo`.
```c++
	// Set default ammo pid for unloaded weapons to make them stack regardless of previously loaded ammo
	//if (IniReader::GetConfigInt("Misc", "StackEmptyWeapons", 1)) {
		MakeCall(0x4736C6, inven_action_cursor_hack);
		HookCall(0x4772AA, item_add_mult_hook);
	//}
```
```c++
static __declspec(naked) void item_add_mult_hook() {
	__asm {
		push edx;
		call SetDefaultAmmo;
		pop  edx;
		mov  eax, ecx;    // restore
		jmp  fo::funcoffs::item_add_force_;
	}
}
```
Since there's no need to hook on anything in CE anymore the PR just modifies the `_item_identical` function to check for the empty weapons of the same type. Then it's used in `itemAdd` and `itemReplace` functions.

Beware that if you have already those two different instances of empty weapons within the inventory (like in the attached save file), the stacking will happen only if you move the item out and back (or equip it and unequip). For that purpose  Sfall is hooking up also to `inven_action_cursor_hack` but IMO it's not necessary as correction for existing safe file is trivial. 

### Reproduction Steps and Savefile (if available)
[SLOT01.zip](https://github.com/user-attachments/files/29648033/SLOT01.zip)

### Screenshots
Two empty deagles in the main character inventory.
Before:
<img width="640" height="480" alt="scr00000" src="https://github.com/user-attachments/assets/7b279795-30ad-41d7-ad97-42d26c859991" />
After:
<img width="640" height="480" alt="scr00001" src="https://github.com/user-attachments/assets/29dcacdf-e101-41d4-9d18-c32528a7c707" />

