### PR TITLE
Handle unimplemented fs_copy/fs_create/fs_find more gracefully in scripts

### DIFF
--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -4896,8 +4896,8 @@ static void opGetPcStat(Program* program)
 // op_fs_copy
 static void opFileSystemCopy(Program* program)
 {
-    char * source = programStackPopString(program);
-    char * path = programStackPopString(program);
+    char* source = programStackPopString(program);
+    char* path = programStackPopString(program);
     scriptPredefinedError(program, "fs_copy", SCRIPT_ERROR_NOT_IMPLEMENTED);
     programStackPushInteger(program, -1);
 }
@@ -4905,7 +4905,7 @@ static void opFileSystemCopy(Program* program)
 // op_fs_find
 static void opFileSystemFind(Program* program)
 {
-    char * path = programStackPopString(program);
+    char* path = programStackPopString(program);
     scriptPredefinedError(program, "fs_find", SCRIPT_ERROR_NOT_IMPLEMENTED);
     programStackPushInteger(program, -1);
 }
@@ -4914,7 +4914,7 @@ static void opFileSystemFind(Program* program)
 static void opFileSystemCreate(Program* program)
 {
     int size = programStackPopInteger(program);
-    char * path = programStackPopString(program);
+    char* path = programStackPopString(program);
     scriptPredefinedError(program, "fs_create", SCRIPT_ERROR_NOT_IMPLEMENTED);
     programStackPushInteger(program, -1);
 }

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -333,9 +333,6 @@ static void opCritterStopAttacking(Program* program);
 static void opTileGetObjectWithPid(Program* program);
 static void opGetObjectName(Program* program);
 static void opGetPcStat(Program* program);
-static void opFileSystemCreate(Program* program);
-static void opFileSystemCopy(Program* program);
-static void opFileSystemFind(Program* program);
 
 // 0x504B0C aCritter
 static char _aCritter[] = "<Critter>";
@@ -4893,32 +4890,6 @@ static void opGetPcStat(Program* program)
     programStackPushInteger(program, value);
 }
 
-// op_fs_copy
-static void opFileSystemCopy(Program* program)
-{
-    char* source = programStackPopString(program);
-    char* path = programStackPopString(program);
-    scriptPredefinedError(program, "fs_copy", SCRIPT_ERROR_NOT_IMPLEMENTED);
-    programStackPushInteger(program, -1);
-}
-
-// op_fs_find
-static void opFileSystemFind(Program* program)
-{
-    char* path = programStackPopString(program);
-    scriptPredefinedError(program, "fs_find", SCRIPT_ERROR_NOT_IMPLEMENTED);
-    programStackPushInteger(program, -1);
-}
-
-// op_fs_create
-static void opFileSystemCreate(Program* program)
-{
-    int size = programStackPopInteger(program);
-    char* path = programStackPopString(program);
-    scriptPredefinedError(program, "fs_create", SCRIPT_ERROR_NOT_IMPLEMENTED);
-    programStackPushInteger(program, -1);
-}
-
 // 0x45CDD4
 void _intExtraClose_()
 {
@@ -5109,9 +5080,6 @@ void _initIntExtra()
     interpreterRegisterOpcode(0x8153, opTerminateCombat); // op_terminate_combat
     interpreterRegisterOpcode(0x8154, opDebugMessage); // op_debug_msg
     interpreterRegisterOpcode(0x8155, opCritterStopAttacking); // op_critter_stop_attacking
-    interpreterRegisterOpcode(0x81f7, opFileSystemCreate); // op_fs_create
-    interpreterRegisterOpcode(0x81f8, opFileSystemCopy); // op_fs_copy
-    interpreterRegisterOpcode(0x81f9, opFileSystemFind); // op_fs_find
 
     sfallOpcodesInit();
 }

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -333,6 +333,9 @@ static void opCritterStopAttacking(Program* program);
 static void opTileGetObjectWithPid(Program* program);
 static void opGetObjectName(Program* program);
 static void opGetPcStat(Program* program);
+static void opFileSystemCreate(Program* program);
+static void opFileSystemCopy(Program* program);
+static void opFileSystemFind(Program* program);
 
 // 0x504B0C aCritter
 static char _aCritter[] = "<Critter>";
@@ -4890,6 +4893,32 @@ static void opGetPcStat(Program* program)
     programStackPushInteger(program, value);
 }
 
+// op_fs_copy
+static void opFileSystemCopy(Program* program)
+{
+    char * source = programStackPopString(program);
+    char * path = programStackPopString(program);
+    scriptPredefinedError(program, "fs_copy", SCRIPT_ERROR_NOT_IMPLEMENTED);
+    programStackPushInteger(program, -1);
+}
+
+// op_fs_find
+static void opFileSystemFind(Program* program)
+{
+    char * path = programStackPopString(program);
+    scriptPredefinedError(program, "fs_find", SCRIPT_ERROR_NOT_IMPLEMENTED);
+    programStackPushInteger(program, -1);
+}
+
+// op_fs_create
+static void opFileSystemCreate(Program* program)
+{
+    int size = programStackPopInteger(program);
+    char * path = programStackPopString(program);
+    scriptPredefinedError(program, "fs_create", SCRIPT_ERROR_NOT_IMPLEMENTED);
+    programStackPushInteger(program, -1);
+}
+
 // 0x45CDD4
 void _intExtraClose_()
 {
@@ -5080,6 +5109,9 @@ void _initIntExtra()
     interpreterRegisterOpcode(0x8153, opTerminateCombat); // op_terminate_combat
     interpreterRegisterOpcode(0x8154, opDebugMessage); // op_debug_msg
     interpreterRegisterOpcode(0x8155, opCritterStopAttacking); // op_critter_stop_attacking
+    interpreterRegisterOpcode(0x81f7, opFileSystemCreate); // op_fs_create
+    interpreterRegisterOpcode(0x81f8, opFileSystemCopy); // op_fs_copy
+    interpreterRegisterOpcode(0x81f9, opFileSystemFind); // op_fs_find
 
     sfallOpcodesInit();
 }

--- a/src/sfall_opcodes.cc
+++ b/src/sfall_opcodes.cc
@@ -1809,6 +1809,29 @@ static void op_set_sfall_return(Program* program)
     hookCall->addReturnValueFromScript(value);
 }
 
+static void op_fs_copy(Program* program)
+{
+    char* source = programStackPopString(program);
+    char* path = programStackPopString(program);
+    programPrintError("fs_copy: not implemented!");
+    programStackPushInteger(program, -1);
+}
+
+static void op_fs_find(Program* program)
+{
+    char* path = programStackPopString(program);
+    programPrintError("fs_find: not implemented!");
+    programStackPushInteger(program, -1);
+}
+
+static void op_fs_create(Program* program)
+{
+    int size = programStackPopInteger(program);
+    char* path = programStackPopString(program);
+    programPrintError("fs_create: not implemented!");
+    programStackPushInteger(program, -1);
+}
+
 // Note: opcodes should pop arguments off the stack in reverse order
 void sfallOpcodesInit()
 {
@@ -2142,8 +2165,11 @@ void sfallOpcodesInit()
     // 0x81f6 - int nb_create_char() // deprecated; do not implement
 
     // 0x81f7 - int   fs_create(string path, int size)
+    interpreterRegisterOpcode(0x81f7, op_fs_create);
     // 0x81f8 - int   fs_copy(string path, string source)
+    interpreterRegisterOpcode(0x81f8, op_fs_copy);
     // 0x81f9 - int   fs_find(string path)
+    interpreterRegisterOpcode(0x81f9, op_fs_find);
     // 0x81fa - void  fs_write_byte(int id, int data)
     // 0x81fb - void  fs_write_short(int id, int data)
     // 0x81fc - void  fs_write_int(int id, int data)


### PR DESCRIPTION
### Description

This PR handles the unimplemented Sfall opcodes `fs_copy fs_create fs_find` more gracefully from the script point of view.
Instead of crashing the script the opcodes return `-1` same as in Sfall when error.
```c++
DWORD __stdcall FScopy(const char* path, const char* source) {
	int result = FSfind(path);
	if (result != -1) return result;
...
}
DWORD __stdcall FScreate(const char* path, int size) {
	if (size > MAX_FILE_SIZE) return -1;  // size limit 10Mb
...
}
DWORD __stdcall FSfind(const char* path) {
	if (!*path) return -1;
...
}
```

### Reproduction Steps and Savefile (if available)

Have been testing that on modified vccasidy.int which didn't work at all before as per #510
[save_and_script.zip](https://github.com/user-attachments/files/29729970/save_and_script.zip)
```
INFO: 
Error during execution: fs_copy: not implemented!
INFO: Current script: scripts\VCCasidy.int, procedure has_head
INFO: 
Error during execution: fs_create: not implemented!
INFO: Current script: scripts\VCCasidy.int, procedure has_head
INFO: 
Error during execution: fs_find: not implemented!
INFO: Current script: scripts\VCCasidy.int, procedure has_head
```
```pascal
procedure has_head
begin
	variable LVar0 := 0;
	LVar0 := fs_copy("art\\heads\\casdybf1.frm", "art\\heads\\casdybf1.frm");
	if (LVar0 == -1) then begin
		LVar0 := fs_create("art\\heads\\casdybf2.frm", 10);
		if (LVar0 == -1) then begin
			LVar0 := fs_find("art\\heads\\casdybf3.frm");
		end
		return 0;
	end
	return 1;
end

```
After this implementation the dialog window opens and Cassidy can be talked to again even without the latest RPU fix which changed the opcode to art_frame_data to mitigate #510 

<img width="640" height="517" alt="image" src="https://github.com/user-attachments/assets/5e851ea3-df1c-4253-9754-bb1897ca775f" />

