### PR TITLE
Fix healing revision op_tokenize

### DIFF
--- a/src/interpreter_lib.cc
+++ b/src/interpreter_lib.cc
@@ -313,7 +313,7 @@ void opTokenize(Program* program)
             }
 
             temp = (char*)internal_calloc_safe(1, length + 1, __FILE__, __LINE__); // "..\\int\\INTLIB.C, 230
-            strncpy(temp, start, length);
+            strncpy(temp, start + 1, length);
             programStackPushString(program, temp);
         } else {
             programStackPushInteger(program, 0);


### PR DESCRIPTION
### Description

Even though all the hooks and metarules are implemented by CE the healing revision `scripts\gl_g_healing_revision.int` doesn't work. See my comment in #378 ..

There seems to be a problem in `opTokenize` itself.
Before the fix there was just this message in the log
```
INFO: 
Error during execution: string expected, got c001
INFO: Current script: scripts\gl_g_healing_revision.int, procedure parse_str_2
INFO: 
 health added!
```

After the fix the script normally works
```
gl_g_healing_revision: user 0x560e8cb9a3b0 target 0x560e8cb9a3b0
gl_g_healing_revision: Last day 14
gl_g_healing_revision: resetting heal arrays
gl_g_healing_revision: user1 0x560e8cb9a3b0 target 0x560e8cb9a3b0
gl_g_healing_revision: Jirik has skill 6 level of 71
gl_g_healing_revision: Jirik has best skill level of 71
gl_g_healing_revision: fa level 71, skill bonus 0, effective 71
gl_g_healing_revision: userfa 0x560e8cb9a3b0 target 0x560e8cb9a3b0
gl_g_healing_revision: missing 70 fa_level 71 healed 0.000000 | 5
gl_g_healing_revision: trying to heal Jirik
Jirik healed for 2 HP.
You receive 20 experience for successful use of First Aid skill.
```

### Reproduction Steps and Savefile (if available)
[SLOT01.zip](https://github.com/user-attachments/files/29901924/SLOT01.zip)

### Screenshots

<img width="640" height="480" alt="scr00005" src="https://github.com/user-attachments/assets/bd390fd5-d5c8-4cfa-b468-65d77f34c39a" />
