### PR TITLE
Fix possible division by zero in objectExamineFunc

### DIFF
--- a/src/proto_instance.cc
+++ b/src/proto_instance.cc
@@ -380,14 +380,14 @@ int objectExamineFunc(Object* critter, Object* target, void (*fn)(const char* st
             int crippledMsgIdOffset = critterIsCrippled(target) ? -2 : 0;
             int healthLevel;
 
-            const int maxiumHitPoints = critterGetStat(target, STAT_MAXIMUM_HIT_POINTS);
+            const int maximumHitPoints = critterGetStat(target, STAT_MAXIMUM_HIT_POINTS);
             const int currentHitPoints = critterGetStat(target, STAT_CURRENT_HIT_POINTS);
-            if (currentHitPoints <= 0 || critterIsDead(target)) {
+            if (maximumHitPoints <= 0 || currentHitPoints <= 0 || critterIsDead(target)) {
                 healthLevel = 0;
-            } else if (currentHitPoints == maxiumHitPoints) {
+            } else if (currentHitPoints == maximumHitPoints) {
                 healthLevel = 4;
             } else {
-                healthLevel = (currentHitPoints * 3) / maxiumHitPoints + 1;
+                healthLevel = (currentHitPoints * 3) / maximumHitPoints + 1;
             }
 
             MessageListItem hpMessageListItem;


### PR DESCRIPTION
### Description

Somehow got Suliks proto corrupted and the `critterGetStat(target, STAT_MAXIMUM_HIT_POINTS);` returns  `0` on multiple places for him. Raw value in Suliks proto is huge negative number but it's getting normalized in `critterGetStat` method to zero.  Most of `maxHp = 0` cases are handled properly but found an unhandled error in `objectExamineFunc`.

I'll try to reproduce this savefile corruption but meanwhile here's the simple `maximumHitPoints` check to prevent the division by zero.

After the fix the `objectExamineFunc` evaluates Suliks as he's dead already but at least doesn't crash.

<img width="1920" height="1032" alt="Screenshot from 2026-07-12 06-06-47" src="https://github.com/user-attachments/assets/e427daf8-bcf9-4531-88c7-6739cdd51071" />

### Reproduction Steps and Savefile (if available)

Just use the looking glass context menu on Sulik.
[SLOT05.zip](https://github.com/user-attachments/files/29937950/SLOT05.zip)

### Screenshots
<img width="640" height="480" alt="scr00009" src="https://github.com/user-attachments/assets/4255b3c6-517a-48ed-8978-1d631cf77f62" />

