### PR TITLE
Support for EPA gender change operation

### DIFF
--- a/src/sfall_opcodes.cc
+++ b/src/sfall_opcodes.cc
@@ -1832,6 +1832,19 @@ static void op_fs_create(Program* program)
     programStackPushInteger(program, -1);
 }
 
+static void op_set_hero_style(Program* program)
+{
+    int style = programStackPopInteger(program);
+    programPrintError("set_hero_style: not implemented!");
+    programStackPushInteger(program, 0);
+}
+
+static void op_set_hero_race(Program* program)
+{
+    int race = programStackPopInteger(program);
+    programPrintError("set_hero_race: not implemented!");
+}
+
 // Note: opcodes should pop arguments off the stack in reverse order
 void sfallOpcodesInit()
 {
@@ -2214,7 +2227,9 @@ void sfallOpcodesInit()
 
     // 0x8213 - void hero_select_win(int)
     // 0x8214 - void set_hero_race(int style)
+    interpreterRegisterOpcode(0x8214, op_set_hero_race);
     // 0x8215 - void set_hero_style(int style)
+    interpreterRegisterOpcode(0x8215, op_set_hero_style);
 
     // 0x8216 - void set_critter_burst_disable(object critter, int disable)
     interpreterRegisterOpcode(0x8216, op_set_critter_burst_disable);

--- a/src/sfall_opcodes.cc
+++ b/src/sfall_opcodes.cc
@@ -1836,7 +1836,6 @@ static void op_set_hero_style(Program* program)
 {
     int style = programStackPopInteger(program);
     programPrintError("set_hero_style: not implemented!");
-    programStackPushInteger(program, 0);
 }
 
 static void op_set_hero_race(Program* program)


### PR DESCRIPTION
### Description
There was a nasty behavior in `epai37.ssl`  that when you tried to change a gender or change a race/hair then the game faded out to black screen and then the script crashed on unimplemented opcode `set_hero_style` or `set_hero_race` and it never faded in so you would have to kill the game or quick reload.
```
INFO: 
Error during execution: Undefined opcode 8215.
INFO: Current script: scripts\epai37.int, procedure Node900
```
```pascal
procedure Node900 begin
   //gender alterations
   gfade_out(ONE_GAME_SECOND);
   //game_time_advance(4*ONE_GAME_WEEK);
   remove_armor(dude_obj)
   set_hero_style(0);
   if (dude_is_male) then begin
      set_pc_base_stat(STAT_gender, GENDER_FEMALE);
      art_change_fid_num(dude_obj, FID_HFJMPS);
   end else begin
      set_pc_base_stat(STAT_gender, GENDER_MALE);
      art_change_fid_num(dude_obj, FID_HMJMPS);
   end
   set_global_var(GVAR_CHAR_MOD,GENDER);
   refresh_pc_art;
   gfade_in(ONE_GAME_SECOND);
   call Node007;

end
```
Procedure `Node900` which is responsible for switching gender was not working just because of the `set_hero_style(0)` which does the reset of the style to default (and that's the only mode CE supports anyway).

So this PR introduces the dummy implementations for `set_hero_style` and `set_hero_race` to enable the gender change and fix the missing fade in for the style/race operations if selected. 

```
gl_g_unlimited_party: talking to Auto-Doc
INFO: 
gl_g_unlimited_party: Auto-Doc is not a joinable NPC, skipping
INFO: Dialogue Reaction: 
INFO: Said Neutral
INFO: Dialogue Reaction: 
INFO: Said Neutral
INFO: Dialogue Reaction: 
INFO: Said Neutral
INFO: 
epai37: armour pid == 232
INFO: 
gl_g_ammobox: apcost
INFO: 
Error during execution: set_hero_style: not implemented!
INFO: Current script: scripts\epai37.int, procedure Node900
INFO: Dialogue Reaction: 
INFO: Said Neutral
```

### Reproduction Steps and Savefile (if available)

Try the gender change within auto doc dialog.
[SLOT03.zip](https://github.com/user-attachments/files/29943003/SLOT03.zip)

### Screenshots
Recorded gender change option after the fix.

https://github.com/user-attachments/assets/d1724b3b-78d0-4fd8-a949-ad8e12a76979



