### PR TITLE
Fix elevator cancelation in RPU

### DIFF
--- a/src/elevator.cc
+++ b/src/elevator.cc
@@ -473,10 +473,12 @@ int elevatorSelectLevel(int elevator, int* mapPtr, int* elevationPtr, int* tileP
     elevatorWindowFree();
     touch_set_touchscreen_mode(false);
 
-    const ElevatorDescription* description = &(elevatorDescription[keyCode]);
-    *mapPtr = description->map;
-    *elevationPtr = description->elevation;
-    *tilePtr = description->tile;
+    if (keyCode >= 0) {
+        const ElevatorDescription* description = &(elevatorDescription[keyCode]);
+        *mapPtr = description->map;
+        *elevationPtr = description->elevation;
+        *tilePtr = description->tile;
+    }
 
     return 0;
 }
@@ -657,7 +659,7 @@ static int elevatorGetLevelFromEscKey(int elevator, int map)
             return index;
         }
     }
-    return 0;
+    return -1;
 }
 
 void elevatorsInit()

--- a/src/elevator.cc
+++ b/src/elevator.cc
@@ -54,6 +54,7 @@ typedef struct ElevatorDescription {
 static int elevatorWindowInit(int elevator);
 static void elevatorWindowFree();
 static int elevatorGetLevelFromKeyCode(int elevator, int keyCode);
+static int elevatorGetLevelFromEscKey(int elevator, int map);
 
 // 0x43E950 grph_id_2
 static const int gElevatorFrmIds[ELEVATOR_FRM_COUNT] = {
@@ -395,12 +396,15 @@ int elevatorSelectLevel(int elevator, int* mapPtr, int* elevationPtr, int* tileP
     windowRefresh(gElevatorWindow);
 
     bool done = false;
+    bool skipGauge = false;
     int keyCode;
     while (!done) {
         sharedFpsLimiter.mark();
 
         keyCode = inputGetInput();
         if (keyCode == KEY_ESCAPE) {
+            keyCode = elevatorGetLevelFromEscKey(elevator, *mapPtr);
+            skipGauge = true;
             done = true;
         }
 
@@ -420,7 +424,7 @@ int elevatorSelectLevel(int elevator, int* mapPtr, int* elevationPtr, int* tileP
         sharedFpsLimiter.throttle();
     }
 
-    if (keyCode != KEY_ESCAPE) {
+    if (!skipGauge) {
         keyCode -= 500;
 
         if (*elevationPtr != keyCode) {
@@ -468,10 +472,6 @@ int elevatorSelectLevel(int elevator, int* mapPtr, int* elevationPtr, int* tileP
 
     elevatorWindowFree();
     touch_set_touchscreen_mode(false);
-
-    if (keyCode == KEY_ESCAPE) {
-        return -1;
-    }
 
     const ElevatorDescription* description = &(elevatorDescription[keyCode]);
     *mapPtr = description->map;
@@ -644,6 +644,17 @@ static int elevatorGetLevelFromKeyCode(int elevator, int keyCode)
         // consider use std toupper instead of & 0xFF
         if (c == (char)(keyCode & 0xFF)) {
             return index + 1;
+        }
+    }
+    return 0;
+}
+
+static int elevatorGetLevelFromEscKey(int elevator, int map)
+{
+    const ElevatorDescription* exits = gElevatorDescriptions[elevator];
+    for (int index = 0; index < ELEVATOR_LEVEL_MAX; index++) {
+        if (exits[index].map == map && exits[index].elevation == gElevation) {
+            return index;
         }
     }
     return 0;

--- a/src/elevator.cc
+++ b/src/elevator.cc
@@ -469,12 +469,14 @@ int elevatorSelectLevel(int elevator, int* mapPtr, int* elevationPtr, int* tileP
     elevatorWindowFree();
     touch_set_touchscreen_mode(false);
 
-    if (keyCode != KEY_ESCAPE) {
-        const ElevatorDescription* description = &(elevatorDescription[keyCode]);
-        *mapPtr = description->map;
-        *elevationPtr = description->elevation;
-        *tilePtr = description->tile;
+    if (keyCode == KEY_ESCAPE) {
+        return -1;
     }
+
+    const ElevatorDescription* description = &(elevatorDescription[keyCode]);
+    *mapPtr = description->map;
+    *elevationPtr = description->elevation;
+    *tilePtr = description->tile;
 
     return 0;
 }

--- a/src/scripts.cc
+++ b/src/scripts.cc
@@ -1000,6 +1000,10 @@ static int scriptsHandleElevatorRequest(bool closeDoorsBeforeMapTransition)
         return -1;
     }
 
+    if (tile == -1) {
+        return -1;
+    }
+
     automapSaveCurrent();
 
     if (map == gMapHeader.index) {


### PR DESCRIPTION
If you step into an elevator in RPU and cancel the floor selection, the door closes behind you (sometimes with glitchy graphics).  This is a latent bug in the elevators code that vanilla doesn't hit

  - elevator_select_ mutates the caller’s elevation to a UI/display level before the modal loop.
  - Escape/cancel returns 0 without writing a destination tile.
  - Caller then sees map == current map and elevation != current elevation, so it closes the nearby door.
  - tile is still -1.

Fix is by @NovaRain: treat ESC as selecting the current level instead of resulting in an invalid state.

Repro: use save from https://github.com/fallout2-ce/fallout2-ce/issues/543