### PR TITLE
Fix an opposite scroll direction in towns list when using the mouse wheel

### DIFF
--- a/src/worldmap.cc
+++ b/src/worldmap.cc
@@ -3323,7 +3323,7 @@ static int wmWorldMapFunc(int a1)
                            WM_TOWN_LIST_X + WM_TOWN_LIST_WIDTH,
                            WM_TOWN_LIST_Y + WM_TOWN_LIST_HEIGHT)) {
                 if (wheelY != 0) {
-                    wmInterfaceScrollTabsStart(wheelY > 0 ? WM_TOWN_LIST_SLOT_HEIGHT : -WM_TOWN_LIST_SLOT_HEIGHT);
+                    wmInterfaceScrollTabsStart(wheelY > 0 ? -WM_TOWN_LIST_SLOT_HEIGHT : WM_TOWN_LIST_SLOT_HEIGHT);
                 }
             }
         }


### PR DESCRIPTION
### Description

The town panel in the worldmap is scrolling in opposite direction if you use the mouse wheel.

### Reproduction Steps and Savefile (if available)
Just open the world map and use the mouse wheel, before the fix if you would like to scroll down the town list you would have to turn the mouse wheel in opposite direction (from bottom to top)

[SLOT01_mouse_wheel.zip](https://github.com/user-attachments/files/29979250/SLOT01_mouse_wheel.zip)

