### PR TITLE
Two crash fixes

### DIFF
--- a/src/automap.cc
+++ b/src/automap.cc
@@ -48,6 +48,11 @@ static int _copy_file_data(File* stream1, File* stream2, int length);
 
 static int gAutomapWindow = -1;
 
+static bool automapEntryIsValid(int map, int elevation)
+{
+    return map >= 0 && map < AUTOMAP_MAP_COUNT && elevationIsValid(elevation);
+}
+
 typedef enum AutomapFrm {
     AUTOMAP_FRM_BACKGROUND,
     AUTOMAP_FRM_BUTTON_UP,
@@ -293,6 +298,10 @@ int automapSave(File* stream)
 // 0x41B8B4 automapDisplayMap
 int _automapDisplayMap(int map)
 {
+    if (map < 0 || map >= AUTOMAP_MAP_COUNT) {
+        return -1;
+    }
+
     return _displayMapList[map];
 }
 
@@ -696,6 +705,9 @@ int automapSaveCurrent()
 {
     int map = mapGetCurrentMap();
     int elevation = gElevation;
+    if (!automapEntryIsValid(map, elevation)) {
+        return 0;
+    }
 
     int entryOffset = gAutomapHeader.offsets[map][elevation];
     if (entryOffset < 0) {
@@ -941,6 +953,9 @@ err:
 static int automapLoadEntry(int map, int elevation)
 {
     gAutomapEntry.compressedData = nullptr;
+    if (!automapEntryIsValid(map, elevation)) {
+        return -1;
+    }
 
     char path[COMPAT_MAX_PATH];
     snprintf(path, sizeof(path), "%s\\%s", "MAPS", AUTOMAP_DB);

--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -1190,14 +1190,16 @@ void _gmouse_handle_event(int mouseX, int mouseY, int mouseState)
                         mouseGetPosition(&updatedMouseX, &updatedMouseY);
 
                         if (abs(updatedMouseY - newMouseY) > 10) {
+                            int nextActionIndex;
                             if (newMouseY >= updatedMouseY) {
-                                actionIndex -= 1;
+                                nextActionIndex = actionIndex - 1;
                             } else {
-                                actionIndex += 1;
+                                nextActionIndex = actionIndex + 1;
                             }
 
-                            if (gameMouseHighlightActionMenuItemAtIndex(actionIndex) == 0) {
+                            if (gameMouseHighlightActionMenuItemAtIndex(nextActionIndex) == 0) {
                                 tileWindowRefreshRect(&cursorRect, gElevation);
+                                actionIndex = nextActionIndex;
                             }
                             newMouseY = updatedMouseY;
                         }

--- a/src/pipboy.cc
+++ b/src/pipboy.cc
@@ -1705,6 +1705,10 @@ static int _PrintAMelevList(int selectedMap)
     int totalEntries = 0;
     int elevationsListSize = 0;
     const int maxEntriesPerPage = PIPBOY_AUTOMAP_SUB_LINES;
+    int mapCount = std::min(wmMapMaxCount(), AUTOMAP_MAP_COUNT);
+    if (_amcty_indx < 0 || _amcty_indx >= mapCount) {
+        return 0;
+    }
 
     // First pass: Count total valid entries
     for (int elevation = 0; elevation < ELEVATION_COUNT; elevation++) {
@@ -1713,7 +1717,6 @@ static int _PrintAMelevList(int selectedMap)
         }
     }
 
-    int mapCount = wmMapMaxCount();
     for (int map = 0; map < mapCount; map++) {
         if (map == _amcty_indx || _get_map_idx_same(_amcty_indx, map) == -1) {
             continue;
@@ -1827,7 +1830,7 @@ static int _PrintAMList(int selectedLocation)
 
     int count = 0;
 
-    int mapCount = wmMapMaxCount();
+    int mapCount = std::min(wmMapMaxCount(), AUTOMAP_MAP_COUNT);
     for (int map = 0; map < mapCount; map++) {
         int elevation;
         for (elevation = 0; elevation < ELEVATION_COUNT; elevation++) {


### PR DESCRIPTION
* Sfall fix for > 160 maps for automap code (RPU triggers this)
* Logic fix for action menu, where actionIndex was incremented unconditionally and could go out of bounds.  This was a regression from vanilla

Attempting to fix #548  and #543 