### PR TITLE
adds lowercase fallback for sound/music

### DIFF
--- a/src/game_sound.cc
+++ b/src/game_sound.cc
@@ -1,5 +1,6 @@
 #include "game_sound.h"
 
+#include <algorithm>
 #include <stdio.h>
 #include <string.h>
 
@@ -1741,6 +1742,27 @@ int gameSoundFindBackgroundSoundPath(char* dest, const char* src)
 
             snprintf(path, sizeof(path), "%s%s%s", basePath, src, extension);
             int fileSize;
+            if (dbGetFileSize(path, &fileSize) == 0) {
+                strncpy(dest, path, COMPAT_MAX_PATH);
+                dest[COMPAT_MAX_PATH] = '\0';
+                return 0;
+            }
+
+            // lowercase fallback
+            std::string src_lower(src);
+            std::transform(src_lower.begin(), src_lower.end(), src_lower.begin(), [](unsigned char c) {
+                return std::tolower(c);
+            });
+
+            size_t len_lower = src_lower.size() + strlen(extension);
+            if (strlen(basePath) + len_lower > COMPAT_MAX_PATH) {
+                if (gGameSoundDebugEnabled) {
+                    debugPrint("lowercase fallback: Full background path too long.\n");
+                }
+                return -1;
+            }
+
+            snprintf(path, sizeof(path), "%s%s%s", basePath, src_lower.c_str(), extension);
             if (dbGetFileSize(path, &fileSize) == 0) {
                 strncpy(dest, path, COMPAT_MAX_PATH);
                 dest[COMPAT_MAX_PATH] = '\0';

--- a/src/game_sound.cc
+++ b/src/game_sound.cc
@@ -1,6 +1,7 @@
 #include "game_sound.h"
 
 #include <algorithm>
+#include <cctype>
 #include <stdio.h>
 #include <string.h>
 
@@ -1751,7 +1752,7 @@ int gameSoundFindBackgroundSoundPath(char* dest, const char* src)
             // lowercase fallback
             std::string src_lower(src);
             std::transform(src_lower.begin(), src_lower.end(), src_lower.begin(), [](unsigned char c) {
-                return std::tolower(c);
+                return tolower(c);
             });
 
             size_t len_lower = src_lower.size() + strlen(extension);


### PR DESCRIPTION
Fix background music failure on case-sensitive filesystems (GOG installation)
Example for temple of trials:
```
INFO: 
Gsound: playing ambient map sfx: water1
INFO: tile_hires_stencil_on_map_load
INFO: 
WorldMap Error: Couldn't start map Music!
INFO: 
WorldMap Error: Couldn't start map Music!
```

### Problem
On case-sensitive platforms (Linux, macOS, Android), the background music for certain maps (like the Temple of Trials `13CARVRN`) fails to load. This happens because the engine requests uppercase filenames, while modern distributions (like GOG) ship audio files fully lowercased (`sound/music/13carvrn.acm`).

As a result, `dbGetFileSize` fails to locate the file, causing a `WorldMap Error: Couldn't start map Music!` and silence during gameplay.

### Solution
Added a lowercase fallback search to `gameSoundFindBackgroundSoundPath` 

This strictly minimizes changes to the core loop while making the background music fully operational out of the box for the widespread GOG release.