### PR TITLE
adds objectIsSavable, objectPrepareWhoHitMeForSave adjustment

### DIFF
--- a/src/combat.cc
+++ b/src/combat.cc
@@ -2221,14 +2221,6 @@ int combatLoad(File* stream)
     return 0;
 }
 
-static bool _combatShouldSaveObject(Object* obj)
-{
-    if (obj == nullptr) return false;
-    if (obj == gDude) return true;
-    if (objectIsPartyMember(obj)) return true;
-    return (obj->flags & OBJECT_NO_SAVE) == 0;
-}
-
 // 0x421244
 int combatSave(File* stream)
 {
@@ -2244,13 +2236,13 @@ int combatSave(File* stream)
     int valid_com = 0;
 
     for (int index = 0; index < _list_com; index++) {
-        if (_combatShouldSaveObject(_combat_list[index])) {
+        if (objectIsSavable(_combat_list[index])) {
             valid_com++;
             valid_total++;
         }
     }
     for (int index = _list_com; index < _list_total; index++) {
-        if (_combatShouldSaveObject(_combat_list[index])) {
+        if (objectIsSavable(_combat_list[index])) {
             valid_noncom++;
             valid_total++;
         }
@@ -2265,14 +2257,14 @@ int combatSave(File* stream)
 
     for (int index = 0; index < _list_total; index++) {
         Object* obj = _combat_list[index];
-        if (_combatShouldSaveObject(obj)) {
+        if (objectIsSavable(obj)) {
             if (fileWriteInt32(stream, obj->cid) == -1) return -1;
         }
     }
 
     for (int index = 0; index < _list_total; index++) {
         Object* obj = _combat_list[index];
-        if (!_combatShouldSaveObject(obj)) continue;
+        if (!objectIsSavable(obj)) continue;
 
         int friendlyId = -1;
         int targetId = -1;
@@ -2281,8 +2273,8 @@ int combatSave(File* stream)
 
         CombatAiInfo* aiInfo = &(_aiInfoList[index]);
 
-        friendlyId = _combatShouldSaveObject(aiInfo->friendlyDead) ? aiInfo->friendlyDead->id : -1;
-        targetId = _combatShouldSaveObject(aiInfo->lastTarget) ? aiInfo->lastTarget->id : -1;
+        friendlyId = objectIsSavable(aiInfo->friendlyDead) ? aiInfo->friendlyDead->id : -1;
+        targetId = objectIsSavable(aiInfo->lastTarget) ? aiInfo->lastTarget->id : -1;
 
         itemId = aiInfo->lastItem != nullptr ? aiInfo->lastItem->id : -1;
         lastMove = aiInfo->lastMove;

--- a/src/object.cc
+++ b/src/object.cc
@@ -237,7 +237,8 @@ static Object* objectPrepareWhoHitMeForSave(CritterCombatData* combatData)
         return whoHitMe;
     }
 
-    combatData->whoHitMeCid = whoHitMe != nullptr ? whoHitMe->cid : -1;
+    combatData->whoHitMeCid = objectShouldSave(whoHitMe) ? whoHitMe->cid : -1;
+
     return whoHitMe;
 }
 
@@ -477,6 +478,15 @@ int objectRead(Object* obj, File* stream)
     }
 
     return 0;
+}
+
+bool objectShouldSave(Object* obj)
+{
+    if (obj == nullptr) return false;
+    if (obj == gDude) return true;
+    if (objectIsPartyMember(obj)) return true;
+
+    return (obj->flags & OBJECT_NO_SAVE) == 0;
 }
 
 // 0x488CE4 obj_load

--- a/src/object.cc
+++ b/src/object.cc
@@ -237,7 +237,7 @@ static Object* objectPrepareWhoHitMeForSave(CritterCombatData* combatData)
         return whoHitMe;
     }
 
-    combatData->whoHitMeCid = objectShouldSave(whoHitMe) ? whoHitMe->cid : -1;
+    combatData->whoHitMeCid = objectIsSavable(whoHitMe) ? whoHitMe->cid : -1;
 
     return whoHitMe;
 }
@@ -480,7 +480,7 @@ int objectRead(Object* obj, File* stream)
     return 0;
 }
 
-bool objectShouldSave(Object* obj)
+bool objectIsSavable(Object* obj)
 {
     if (obj == nullptr) return false;
     if (obj == gDude) return true;

--- a/src/object.cc
+++ b/src/object.cc
@@ -237,8 +237,10 @@ static Object* objectPrepareWhoHitMeForSave(CritterCombatData* combatData)
         return whoHitMe;
     }
 
+    // NOTE: We only clear the cid for non-savable objects to prevent stale
+    // references in the save file. We must NOT nullify `whoHitMe` itself,
+    // otherwise the current combat AI logic will break.
     combatData->whoHitMeCid = objectIsSavable(whoHitMe) ? whoHitMe->cid : -1;
-
     return whoHitMe;
 }
 

--- a/src/object.h
+++ b/src/object.h
@@ -25,7 +25,7 @@ int objectsInit(unsigned char* buf, int width, int height, int pitch);
 void objectsReset();
 void objectsExit();
 int objectRead(Object* obj, File* stream);
-bool objectShouldSave(Object* obj);
+bool objectIsSavable(Object* obj);
 int objectLoadAll(File* stream);
 int objectSaveAll(File* stream);
 void _obj_render_pre_roof(Rect* rect, int elevation);

--- a/src/object.h
+++ b/src/object.h
@@ -25,6 +25,7 @@ int objectsInit(unsigned char* buf, int width, int height, int pitch);
 void objectsReset();
 void objectsExit();
 int objectRead(Object* obj, File* stream);
+bool objectShouldSave(Object* obj);
 int objectLoadAll(File* stream);
 int objectSaveAll(File* stream);
 void _obj_render_pre_roof(Rect* rect, int elevation);


### PR DESCRIPTION
### Follow up PR for OBJECT_NO_SAVE + combat linkage

### Solution

Adds helper function `objectIsSavable(Object* obj)` inside `src/object.cc` and exposes it via `src/object.h`. 

```cpp
bool objectIsSavable(Object* obj)
{
    if (obj == nullptr) return false;
    if (obj == gDude) return true;
    if (objectIsPartyMember(obj)) return true;

    return (obj->flags & OBJECT_NO_SAVE) == 0;
}
```

use cases:
**In `combatSave`**
**In `objectPrepareWhoHitMeForSave`**:

```cpp
static Object* objectPrepareWhoHitMeForSave(CritterCombatData* combatData)
{
    Object* whoHitMe = combatData->whoHitMe;
    if (whoHitMe == (Object*)-1) {
        whoHitMe = nullptr;
    }

    // Match sfall: only preserve whoHitMe in active combat saves.
    if (!isInCombat() || combatData->maneuver == CRITTER_MANEUVER_NONE) {
        combatData->whoHitMeCid = -1;
        return whoHitMe;
    }

    combatData->whoHitMeCid = objectIsSavable(whoHitMe) ? whoHitMe->cid : -1;
    return whoHitMe;
}
```