### PR TITLE
fixes the 'heap use after free' if you push armed mining cart in mari…

### DIFF
--- a/src/proto_instance.cc
+++ b/src/proto_instance.cc
@@ -1483,13 +1483,14 @@ int objectUse(Object* user, Object* targetObj)
     }
 
     bool scriptOverrides = false;
+    int targetObjSid = targetObj->sid;
 
-    if (targetObj->sid != -1) {
-        scriptSetObjects(targetObj->sid, user, targetObj);
-        scriptExecProc(targetObj->sid, SCRIPT_PROC_USE);
+    if (targetObjSid != -1) {
+        scriptSetObjects(targetObjSid, user, targetObj);
+        scriptExecProc(targetObjSid, SCRIPT_PROC_USE);
 
         Script* script;
-        if (scriptGetScript(targetObj->sid, &script) == -1) {
+        if (scriptGetScript(targetObjSid, &script) == -1) {
             return -1;
         }
 


### PR DESCRIPTION
### Description

Another heap use after free issue when pushing armed mining cart to open Mariposa entrance #571 
```gdb
INFO: 
You gain 5250 experience points.
INFO: Script Error: scripts\ESMinCrt.int: op_destroy_object: obj is NULL
=================================================================
==18206==ERROR: AddressSanitizer: heap-use-after-free on address 0x7c81654bbbdc at pc 0x5601574d9af7 bp 0x7ffcb82cfde0 sp 0x7ffcb82cfdd8
READ of size 4 at 0x7c81654bbbdc thread T0
    #0 0x5601574d9af6 in fallout::objectUse(fallout::Object*, fallout::Object*) /home/game/games/fallout2-ce/src/proto_instance.cc:1492
    #1 0x560157271e5c in animationRunSequence /home/game/games/fallout2-ce/src/animation.cc:1470
    #2 0x5601572730b7 in _anim_set_continue /home/game/games/fallout2-ce/src/animation.cc:1593
    #3 0x56015727c454 in fallout::_object_animate() /home/game/games/fallout2-ce/src/animation.cc:2876
    #4 0x56015737bc1b in fallout::tickersExecute() /home/game/games/fallout2-ce/src/input.cc:329
    #5 0x56015737b769 in fallout::_process_bk() /home/game/games/fallout2-ce/src/input.cc:224
    #6 0x56015737b66a in fallout::inputGetInput() /home/game/games/fallout2-ce/src/input.cc:199
    #7 0x56015758d4b8 in mainLoop /home/game/games/fallout2-ce/src/main.cc:385
    #8 0x56015758caa7 in fallout::falloutMain(int, char**) /home/game/games/fallout2-ce/src/main.cc:189
    #9 0x560157539830 in fallout::main(int, char**) /home/game/games/fallout2-ce/src/win32.cc:113
    #10 0x560157539858 in main /home/game/games/fallout2-ce/src/win32.cc:127
    #11 0x7f816602ef76 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #12 0x7f816602f026 in __libc_start_main_impl ../csu/libc-start.c:360
    #13 0x56015725e630 in _start (/home/game/games/fallout2-ce/build/fallout2-ce+0xad630) (BuildId: fd301c8fed6f198e38a6ad1b3e59b0d7863a111c)

0x7c81654bbbdc is located 156 bytes inside of 184-byte region [0x7c81654bbb40,0x7c81654bbbf8)
freed by thread T0 here:
    #0 0x7f816672340f in free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:51
    #1 0x560157430f23 in memoryBlockFreeImpl /home/game/games/fallout2-ce/src/memory.cc:175
    #2 0x560157430e96 in fallout::internal_free(void*) /home/game/games/fallout2-ce/src/memory.cc:160
    #3 0x560157479bed in objectDeallocate /home/game/games/fallout2-ce/src/object.cc:3778
    #4 0x56015747ad79 in _obj_remove /home/game/games/fallout2-ce/src/object.cc:3962
    #5 0x56015746fb76 in fallout::objectDestroy(fallout::Object*, fallout::Rect*) /home/game/games/fallout2-ce/src/object.cc:2005
    #6 0x560157390890 in opDestroyObject /home/game/games/fallout2-ce/src/interpreter_extra.cc:1000
    #7 0x5601573ba2a5 in fallout::programInterpret(fallout::Program*, int) /home/game/games/fallout2-ce/src/interpreter.cc:2704
    #8 0x5601573bb27f in fallout::programExecuteProcedure(fallout::Program*, int) /home/game/games/fallout2-ce/src/interpreter.cc:2899
    #9 0x5601574f73a3 in fallout::scriptExecProc(int, int) /home/game/games/fallout2-ce/src/scripts.cc:1376
    #10 0x5601574d9ab6 in fallout::objectUse(fallout::Object*, fallout::Object*) /home/game/games/fallout2-ce/src/proto_instance.cc:1489
    #11 0x560157271e5c in animationRunSequence /home/game/games/fallout2-ce/src/animation.cc:1470
    #12 0x5601572730b7 in _anim_set_continue /home/game/games/fallout2-ce/src/animation.cc:1593
    #13 0x56015727c454 in fallout::_object_animate() /home/game/games/fallout2-ce/src/animation.cc:2876
    #14 0x56015737bc1b in fallout::tickersExecute() /home/game/games/fallout2-ce/src/input.cc:329
    #15 0x56015737b769 in fallout::_process_bk() /home/game/games/fallout2-ce/src/input.cc:224
    #16 0x56015737b66a in fallout::inputGetInput() /home/game/games/fallout2-ce/src/input.cc:199
    #17 0x56015758d4b8 in mainLoop /home/game/games/fallout2-ce/src/main.cc:385
    #18 0x56015758caa7 in fallout::falloutMain(int, char**) /home/game/games/fallout2-ce/src/main.cc:189
    #19 0x560157539830 in fallout::main(int, char**) /home/game/games/fallout2-ce/src/win32.cc:113
    #20 0x560157539858 in main /home/game/games/fallout2-ce/src/win32.cc:127
    #21 0x7f816602ef76 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

previously allocated by thread T0 here:
    #0 0x7f816672435f in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:67
    #1 0x560157430c3b in memoryBlockMallocImpl /home/game/games/fallout2-ce/src/memory.cc:86
    #2 0x560157430bf9 in fallout::internal_malloc(unsigned long) /home/game/games/fallout2-ce/src/memory.cc:74
    #3 0x56015747990b in objectAllocate /home/game/games/fallout2-ce/src/object.cc:3746
    #4 0x5601574682b0 in fallout::objectCreateWithFidPid(fallout::Object**, int, int) /home/game/games/fallout2-ce/src/object.cc:915
    #5 0x56015738fc1a in opCreateObject /home/game/games/fallout2-ce/src/interpreter_extra.cc:890
    #6 0x5601573ba2a5 in fallout::programInterpret(fallout::Program*, int) /home/game/games/fallout2-ce/src/interpreter.cc:2704
    #7 0x5601573bb27f in fallout::programExecuteProcedure(fallout::Program*, int) /home/game/games/fallout2-ce/src/interpreter.cc:2899
    #8 0x5601574f73a3 in fallout::scriptExecProc(int, int) /home/game/games/fallout2-ce/src/scripts.cc:1376
    #9 0x5601574d8cbf in fallout::objectUseItemOnInternal(fallout::Object*, fallout::Object*, fallout::Object*) /home/game/games/fallout2-ce/src/proto_instance.cc:1339
    #10 0x5601574d90ec in fallout::objectUseItemOn(fallout::Object*, fallout::Object*, fallout::Object*) /home/game/games/fallout2-ce/src/proto_instance.cc:1387
    #11 0x560157271f4a in animationRunSequence /home/game/games/fallout2-ce/src/animation.cc:1476
    #12 0x5601572730b7 in _anim_set_continue /home/game/games/fallout2-ce/src/animation.cc:1593
    #13 0x56015727adbc in _object_move /home/game/games/fallout2-ce/src/animation.cc:2711
    #14 0x56015727bed3 in fallout::_object_animate() /home/game/games/fallout2-ce/src/animation.cc:2838
    #15 0x56015737bc1b in fallout::tickersExecute() /home/game/games/fallout2-ce/src/input.cc:329
    #16 0x56015737b769 in fallout::_process_bk() /home/game/games/fallout2-ce/src/input.cc:224
    #17 0x56015737b66a in fallout::inputGetInput() /home/game/games/fallout2-ce/src/input.cc:199
    #18 0x56015758d4b8 in mainLoop /home/game/games/fallout2-ce/src/main.cc:385
    #19 0x56015758caa7 in fallout::falloutMain(int, char**) /home/game/games/fallout2-ce/src/main.cc:189
    #20 0x560157539830 in fallout::main(int, char**) /home/game/games/fallout2-ce/src/win32.cc:113
    #21 0x560157539858 in main /home/game/games/fallout2-ce/src/win32.cc:127
    #22 0x7f816602ef76 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

SUMMARY: AddressSanitizer: heap-use-after-free /home/game/games/fallout2-ce/src/proto_instance.cc:1492 in fallout::objectUse(fallout::Object*, fallout::Object*)
Shadow bytes around the buggy address:
  0x7c81654bb900: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x7c81654bb980: fd fd fd fd fd fd fd fa fa fa fa fa fa fa fa fa
  0x7c81654bba00: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x7c81654bba80: fd fd fd fd fd fd fd fa fa fa fa fa fa fa fa fa
  0x7c81654bbb00: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
=>0x7c81654bbb80: fd fd fd fd fd fd fd fd fd fd fd[fd]fd fd fd fa
  0x7c81654bbc00: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x7c81654bbc80: fd fd fd fd fd fd fd fa fa fa fa fa fa fa fa fa
  0x7c81654bbd00: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x7c81654bbd80: fd fd fd fd fd fd fd fa fa fa fa fa fa fa fa fa
  0x7c81654bbe00: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
```

### Reproduction Steps and Savefile (if available)

Arm the cart and try to push it..
[SLOT01_mariposa_cart.zip](https://github.com/user-attachments/files/30166801/SLOT01_mariposa_cart.zip)

