### PR TITLE
Fix start_gdialog talking-head crash

### DIFF
--- a/SFALL_COMPATIBILITY.md
+++ b/SFALL_COMPATIBILITY.md
@@ -38,6 +38,12 @@ The following settings were moved into [`fallout2.cfg`](files/fallout2.cfg) inst
 | `Misc` | `UseWalkDistance` | `qol` | `use_walk_distance` |
 | `Misc` | `AutoOpenDoors` | `qol` | `auto_open_doors` |
 
+The following settings were moved into [`<DAT>/config/game.cfg`](files/ce.dat/config/game.cfg):
+
+| ddraw.ini section | ddraw.ini key | game.cfg section | game.cfg key |
+| --- | --- | --- | --- |
+| `Misc` | `StartGDialogFix` | `dialog` | `start_gdialog_fix` |
+
 ## Opcodes / Metarules
 
 See [`https://sfall-team.github.io/sfall/`](https://sfall-team.github.io/sfall/) for documentation on specific functions.

--- a/files/ce.dat/config/game.cfg
+++ b/files/ce.dat/config/game.cfg
@@ -38,6 +38,9 @@ no_exit_hotkey=1
 ; Set to 1 to allow using '^' in dialog msg files to specify gender-based alternative text.
 ; Text must be enclosed in angle brackets, e.g. <MaleText^FemaleText>.
 gender_words=0
+; Set to 1 to enable the sfall StartGDialogFix behavior: talking-head dialogs honor the start_gdialog mood argument unless it is -1.
+; When set to 0, CE still applies sfall's crash fix for calling start_gdialog outside talk_p_proc.
+start_gdialog_fix=0
 
 [main_menu]
 ; Custom version string shown on the main menu. Supports up to two %d placeholders for the game version numbers.

--- a/src/game_config_migration.cc
+++ b/src/game_config_migration.cc
@@ -186,6 +186,7 @@ namespace {
         // [dialog]
         { kSfallMisc, "DialogueFix", CONTENT_CONFIG_DIALOG_SECTION, "no_exit_hotkey", "1" },
         { kSfallMisc, "DialogGenderWords", CONTENT_CONFIG_DIALOG_SECTION, "gender_words", "0" },
+        { kSfallMisc, "StartGDialogFix", CONTENT_CONFIG_DIALOG_SECTION, "start_gdialog_fix", "0" },
         // [main_menu]
         { kSfallMisc, "VersionString", CONTENT_CONFIG_MAIN_MENU_SECTION, "version_string" },
         { kSfallMisc, "MainMenuFontColour", CONTENT_CONFIG_MAIN_MENU_SECTION, "font_color", "0" },

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -10,6 +10,7 @@
 #include "color.h"
 #include "combat.h"
 #include "combat_ai.h"
+#include "content_config.h"
 #include "critter.h"
 #include "debug.h"
 #include "dialog.h"
@@ -1924,8 +1925,12 @@ static void opStartGameDialog(Program* program)
     gameDialogSetBackground(backgroundId);
     gGameDialogReactionOrFidget = reactionLevel;
 
-    if (gGameDialogHeadFid != -1) {
-        int npcReactionValue = reactionGetValue(gGameDialogSpeaker);
+    // SFALL: Use the start_gdialog target instead of the current dialog target,
+    // which can be null outside talk_p_proc.
+    bool startGameDialogFix = false;
+    configGetBool(&gContentConfig, CONTENT_CONFIG_DIALOG_SECTION, "start_gdialog_fix", &startGameDialogFix);
+    if (gGameDialogHeadFid != -1 && (!startGameDialogFix || reactionLevel == -1)) {
+        int npcReactionValue = reactionGetValue(obj);
         int npcReactionType = reactionTranslateValue(npcReactionValue);
         switch (npcReactionType) {
         case NPC_REACTION_BAD:


### PR DESCRIPTION
Use the start_gdialog target object when deriving talking-head reaction, matching sfall's crash fix for calls outside talk_p_proc. Keep the separate StartGDialogFix behavior as a modder-controlled game.cfg option so mods can opt into honoring explicit mood arguments unless mood is -1.

Fixes #567 

sfall references:

- Crash fix/changelog: https://github.com/sfall-team/sfall/blob/d91d01f6256f083fd80a8b90d2202699f604055d/CHANGELOG.md#L171-L175

- Crash patch and StartGDialogFix hook: https://github.com/sfall-team/sfall/blob/d91d01f6256f083fd80a8b90d2202699f604055d/sfall/Modules/BugFixes.cpp#L4138-L4146

- Optional mood behavior hook: https://github.com/sfall-team/sfall/blob/d91d01f6256f083fd80a8b90d2202699f604055d/sfall/Modules/BugFixes.cpp#L2089-L2099


