### PR TITLE
Allow compat_resolve_path to handle duplicate path separators

### DIFF
--- a/src/platform_compat.cc
+++ b/src/platform_compat.cc
@@ -393,6 +393,15 @@ void compat_resolve_path(char* path)
     }
 
     while (dir != nullptr) {
+        while (*pch == '/') {
+            pch++;
+        }
+
+        if (*pch == '\0') {
+            closedir(dir);
+            break;
+        }
+
         char* sep = strchr(pch, '/');
         size_t length;
         if (sep != nullptr) {


### PR DESCRIPTION
Alternate fix for https://github.com/fallout2-ce/fallout2-ce/pull/563.

