### PR TITLE
Typesafe combat_defs.h enum usages

### DIFF
--- a/src/animation.cc
+++ b/src/animation.cc
@@ -3019,7 +3019,7 @@ int _check_move(int* actionPointsPtr)
     if (isInCombat()) {
         if (*actionPointsPtr != -1) {
             if (gPressedPhysicalKeys[SDL_SCANCODE_RCTRL] || gPressedPhysicalKeys[SDL_SCANCODE_LCTRL]) {
-                int hitMode;
+                HitMode hitMode;
                 bool aiming;
                 interfaceGetCurrentHitMode(&hitMode, &aiming);
 

--- a/src/combat.cc
+++ b/src/combat.cc
@@ -93,7 +93,7 @@ typedef struct DamageCalculationContext {
     int difficultyDamagePercent;
 } DamageCalculationContext;
 
-static bool _combat_safety_invalidate_weapon_func(Object* attacker, Object* weapon, int hitMode, Object* defender, int* safeDistancePtr, Object* attackerFriend);
+static bool _combat_safety_invalidate_weapon_func(Object* attacker, Object* weapon, HitMode hitMode, Object* defender, int* safeDistancePtr, Object* attackerFriend);
 static void _combatInitAIInfoList();
 static int aiInfoCopy(int srcIndex, int destIndex);
 static int _combatAIInfoSetLastMove(Object* object, int move);
@@ -122,7 +122,7 @@ static int attackComputeCriticalHit(Attack* a1);
 static int _attackFindInvalidFlags(Object* a1, Object* a2);
 static int attackComputeCriticalFailure(Attack* attack);
 static void _do_random_cripple(int* flagsPtr);
-static int attackDetermineToHit(Object* attacker, int tile, Object* defender, int hitLocation, int hitMode, bool useDistance);
+static int attackDetermineToHit(Object* attacker, int tile, Object* defender, HitLocation hitLocation, HitMode hitMode, bool useDistance);
 static void attackComputeDamage(Attack* attack, int numRounds, int baseDamageMult);
 static void _check_for_death(Object* a1, int a2, int* a3);
 static void _set_new_results(Object* a1, int a2);
@@ -131,11 +131,11 @@ static void combatCopyDamageAmountDescription(char* dest, size_t size, Object* c
 static void combatAddDamageFlagsDescription(char* a1, int flags, Object* a3);
 static void _combat_standup(Object* a1);
 static void _print_tohit(unsigned char* dest, int dest_pitch, int a3);
-static char* hitLocationGetName(Object* critter, int hitLocation);
+static char* hitLocationGetName(Object* critter, HitLocation hitLocation);
 static void _draw_loc_off(int a1, int a2);
 static void _draw_loc_on_(int a1, int a2);
 static void _draw_loc_(int eventCode, int color);
-static int calledShotSelectHitLocation(Object* critter, int* hitLocation, int hitMode);
+static int calledShotSelectHitLocation(Object* critter, HitLocation* hitLocation, HitMode hitMode);
 
 static void criticalsInit();
 static void criticalsReset();
@@ -145,7 +145,7 @@ static int burstModComputeRounds(int totalRounds, int* centerRoundsPtr, int* lef
 static void unarmedInit();
 static void unarmedInitVanilla();
 static void unarmedInitCustom();
-static int unarmedGetHitModeInRange(int firstHitMode, int lastHitMode, bool isSecondary);
+static HitMode unarmedGetHitModeInRange(HitMode firstHitMode, HitMode lastHitMode, bool isSecondary);
 static void damageModInit();
 static void damageModCalculateGlovz(DamageCalculationContext* context);
 static int damageModGlovzDivRound(int dividend, int divisor);
@@ -1899,7 +1899,7 @@ static const int _call_ty[4] = {
 };
 
 // 0x51803C hit_loc_left
-static const int _hit_loc_left[4] = {
+static const HitLocation _hit_loc_left[4] = {
     HIT_LOCATION_HEAD,
     HIT_LOCATION_EYES,
     HIT_LOCATION_RIGHT_ARM,
@@ -1907,7 +1907,7 @@ static const int _hit_loc_left[4] = {
 };
 
 // 0x51804C hit_loc_right
-static const int _hit_loc_right[4] = {
+static const HitLocation _hit_loc_right[4] = {
     HIT_LOCATION_TORSO,
     HIT_LOCATION_GROIN,
     HIT_LOCATION_LEFT_ARM,
@@ -2297,13 +2297,13 @@ int combatSave(File* stream)
 }
 
 // 0x4213E8
-bool _combat_safety_invalidate_weapon(Object* attacker, Object* weapon, int hitMode, Object* defender, int* safeDistancePtr)
+bool _combat_safety_invalidate_weapon(Object* attacker, Object* weapon, HitMode hitMode, Object* defender, int* safeDistancePtr)
 {
     return _combat_safety_invalidate_weapon_func(attacker, weapon, hitMode, defender, safeDistancePtr, nullptr);
 }
 
 // 0x4213FC
-static bool _combat_safety_invalidate_weapon_func(Object* attacker, Object* weapon, int hitMode, Object* defender, int* safeDistancePtr, Object* attackerFriend)
+static bool _combat_safety_invalidate_weapon_func(Object* attacker, Object* weapon, HitMode hitMode, Object* defender, int* safeDistancePtr, Object* attackerFriend)
 {
     if (safeDistancePtr != nullptr) {
         *safeDistancePtr = 0;
@@ -2680,7 +2680,7 @@ static void _combat_begin_extra(Object* attacker)
         _combat_update_critter_outline_for_los(_combat_list[index], 0);
     }
 
-    attackInit(&_main_ctd, attacker, nullptr, 4, 3);
+    attackInit(&_main_ctd, attacker, nullptr, HIT_MODE_PUNCH, HIT_LOCATION_TORSO);
 
     _combat_turn_obj = attacker;
 
@@ -3566,7 +3566,7 @@ void _combat(CombatStartData* csd)
 }
 
 // 0x422EC4
-void attackInit(Attack* attack, Object* attacker, Object* defender, int hitMode, int hitLocation)
+void attackInit(Attack* attack, Object* attacker, Object* defender, HitMode hitMode, HitLocation hitLocation)
 {
     attack->attacker = attacker;
     attack->hitMode = hitMode;
@@ -3587,7 +3587,7 @@ void attackInit(Attack* attack, Object* attacker, Object* defender, int hitMode,
 }
 
 // 0x422F3C
-int _combat_attack(Object* attacker, Object* defender, int hitMode, int hitLocation)
+int _combat_attack(Object* attacker, Object* defender, HitMode hitMode, HitLocation hitLocation)
 {
     if (attacker != gDude && hitMode == HIT_MODE_PUNCH && randomBetween(1, 4) == 1) {
         int fid = buildFid(OBJ_TYPE_CRITTER, attacker->fid & 0xFFF, ANIM_KICK_LEG, (attacker->fid & 0xF000) >> 12, FID_ROTATION(attacker->fid));
@@ -4415,26 +4415,26 @@ static void _do_random_cripple(int* flagsPtr)
 }
 
 // 0x42436C
-int _determine_to_hit(Object* attacker, Object* defender, int hitLocation, int hitMode)
+int _determine_to_hit(Object* attacker, Object* defender, HitLocation hitLocation, HitMode hitMode)
 {
     return attackDetermineToHit(attacker, attacker->tile, defender, hitLocation, hitMode, true);
 }
 
 // 0x424380
-int _determine_to_hit_no_range(Object* attacker, Object* defender, int hitLocation, int hitMode, unsigned char* a5)
+int _determine_to_hit_no_range(Object* attacker, Object* defender, HitLocation hitLocation, HitMode hitMode, unsigned char* a5)
 {
     return attackDetermineToHit(attacker, attacker->tile, defender, hitLocation, hitMode, false);
 }
 
 // 0x424394
-int _determine_to_hit_from_tile(Object* attacker, int tile, Object* defender, int hitLocation, int hitMode)
+int _determine_to_hit_from_tile(Object* attacker, int tile, Object* defender, HitLocation hitLocation, HitMode hitMode)
 {
     return attackDetermineToHit(attacker, tile, defender, hitLocation, hitMode, true);
 }
 
 // determine_to_hit
 // 0x4243A8
-static int attackDetermineToHit(Object* attacker, int tile, Object* defender, int hitLocation, int hitMode, bool useDistance)
+static int attackDetermineToHit(Object* attacker, int tile, Object* defender, HitLocation hitLocation, HitMode hitMode, bool useDistance)
 {
     Object* weapon = critterGetWeaponForHitMode(attacker, hitMode);
 
@@ -5553,7 +5553,7 @@ static void _print_tohit(unsigned char* dest, int destPitch, int accuracy)
 }
 
 // 0x42612C
-static char* hitLocationGetName(Object* critter, int hitLocation)
+static char* hitLocationGetName(Object* critter, HitLocation hitLocation)
 {
     MessageListItem messageListItem;
     messageListItem.num = 1000 + 10 * _art_alias_num(critter->fid & 0xFFF) + hitLocation;
@@ -5592,7 +5592,7 @@ static void _draw_loc_(int eventCode, int color)
 }
 
 // 0x426218
-static int calledShotSelectHitLocation(Object* critter, int* hitLocation, int hitMode)
+static int calledShotSelectHitLocation(Object* critter, HitLocation* hitLocation, HitMode hitMode)
 {
     *hitLocation = HIT_LOCATION_TORSO;
 
@@ -5760,7 +5760,7 @@ static int calledShotSelectHitLocation(Object* critter, int* hitLocation, int hi
 
 // check for possibility of performing attacking
 // 0x426614
-int _combat_check_bad_shot(Object* attacker, Object* defender, int hitMode, bool aiming)
+CombatBadShot _combat_check_bad_shot(Object* attacker, Object* defender, HitMode hitMode, bool aiming)
 {
     int range = 1;
     int tile = -1;
@@ -5816,7 +5816,7 @@ int _combat_check_bad_shot(Object* attacker, Object* defender, int hitMode, bool
 // 0x426744
 bool _combat_to_hit(Object* target, int* accuracy)
 {
-    int hitMode;
+    HitMode hitMode;
     bool aiming;
     if (interfaceGetCurrentHitMode(&hitMode, &aiming) == -1) {
         return false;
@@ -5842,7 +5842,7 @@ void _combat_attack_this(Object* target)
         return;
     }
 
-    int hitMode;
+    HitMode hitMode;
     bool aiming;
     if (interfaceGetCurrentHitMode(&hitMode, &aiming) == -1) {
         return;
@@ -5853,7 +5853,7 @@ void _combat_attack_this(Object* target)
     char formattedText[80];
     const char* sfx;
 
-    int rc = _combat_check_bad_shot(gDude, target, hitMode, aiming);
+    CombatBadShot rc = _combat_check_bad_shot(gDude, target, hitMode, aiming);
     switch (rc) {
     case COMBAT_BAD_SHOT_NO_AMMO:
         item = critterGetWeaponForHitMode(gDude, hitMode);
@@ -5925,7 +5925,7 @@ void _combat_attack_this(Object* target)
         debugPrint("Bad called shot value %d\n", aiming);
     }
 
-    int hitLocation;
+    HitLocation hitLocation;
     if (calledShotSelectHitLocation(target, &hitLocation, hitMode) != -1) {
         _combat_attack(gDude, target, hitMode, hitLocation);
     }
@@ -6303,13 +6303,13 @@ static void criticalsInit()
 
                     // Read original kill types (19) plus one for the player.
                     for (int killType = 0; killType < KILL_TYPE_COUNT + 1; killType++) {
-                        for (int hitLocation = 0; hitLocation < HIT_LOCATION_COUNT; hitLocation++) {
+                        for (HitLocation hitLocation = HIT_LOCATION_HEAD; hitLocation < HIT_LOCATION_COUNT; hitLocation++) {
                             for (int effect = 0; effect < CRTICIAL_EFFECT_COUNT; effect++) {
                                 snprintf(sectionKey, sizeof(sectionKey), "c_%02d_%d_%d", killType, hitLocation, effect);
 
                                 // Update player kill type if needed.
                                 int newKillType = killType == KILL_TYPE_COUNT ? SFALL_KILL_TYPE_COUNT : killType;
-                                for (int dataMember = 0; dataMember < CRIT_DATA_MEMBER_COUNT; dataMember++) {
+                                for (CriticalHitDescriptionDataMember dataMember = CRIT_DATA_MEMBER_DAMAGE_MULTIPLIER; dataMember < CRIT_DATA_MEMBER_COUNT; dataMember++) {
                                     int value = criticalsGetValue(newKillType, hitLocation, effect, dataMember);
                                     if (configGetInt(&criticalsConfig, sectionKey, gCritDataMemberKeys[dataMember], &value)) {
                                         criticalsSetValue(newKillType, hitLocation, effect, dataMember, value);
@@ -6333,7 +6333,7 @@ static void criticalsInit()
                             continue;
                         }
 
-                        for (int hitLocation = 0; hitLocation < HIT_LOCATION_COUNT; hitLocation++) {
+                        for (HitLocation hitLocation = HIT_LOCATION_HEAD; hitLocation < HIT_LOCATION_COUNT; hitLocation++) {
                             if (enabled < 2) {
                                 bool hitLocationChanged = false;
 
@@ -6348,7 +6348,7 @@ static void criticalsInit()
                             snprintf(hitLocationSectionKey, sizeof(hitLocationSectionKey), "c_%02d_%d", killType, hitLocation);
 
                             for (int effect = 0; effect < CRTICIAL_EFFECT_COUNT; effect++) {
-                                for (int dataMember = 0; dataMember < CRIT_DATA_MEMBER_COUNT; dataMember++) {
+                                for (CriticalHitDescriptionDataMember dataMember = CRIT_DATA_MEMBER_DAMAGE_MULTIPLIER; dataMember < CRIT_DATA_MEMBER_COUNT; dataMember++) {
                                     int value = criticalsGetValue(killType, hitLocation, effect, dataMember);
                                     snprintf(key, sizeof(key), "e%d_%s", effect, gCritDataMemberKeys[dataMember]);
                                     if (configGetInt(&criticalsConfig, hitLocationSectionKey, key, &value)) {
@@ -6380,7 +6380,7 @@ static void criticalsExit()
     criticalsReset();
 }
 
-int criticalsGetValue(int killType, int hitLocation, int effect, int dataMember)
+int criticalsGetValue(int killType, HitLocation hitLocation, int effect, CriticalHitDescriptionDataMember dataMember)
 {
     if (killType == SFALL_KILL_TYPE_COUNT) {
         return gPlayerCriticalHitTable[hitLocation][effect].values[dataMember];
@@ -6389,7 +6389,7 @@ int criticalsGetValue(int killType, int hitLocation, int effect, int dataMember)
     }
 }
 
-void criticalsSetValue(int killType, int hitLocation, int effect, int dataMember, int value)
+void criticalsSetValue(int killType, HitLocation hitLocation, int effect, CriticalHitDescriptionDataMember dataMember, int value)
 {
     if (killType == SFALL_KILL_TYPE_COUNT) {
         gPlayerCriticalHitTable[hitLocation][effect].values[dataMember] = value;
@@ -6398,7 +6398,7 @@ void criticalsSetValue(int killType, int hitLocation, int effect, int dataMember
     }
 }
 
-void criticalsResetValue(int killType, int hitLocation, int effect, int dataMember)
+void criticalsResetValue(int killType, HitLocation hitLocation, int effect, CriticalHitDescriptionDataMember dataMember)
 {
     if (killType == SFALL_KILL_TYPE_COUNT) {
         gPlayerCriticalHitTable[hitLocation][effect].values[dataMember] = gBasePlayerCriticalHitTable[hitLocation][effect].values[dataMember];
@@ -6649,7 +6649,7 @@ static void unarmedInitCustom()
             char section[4];
             char statKey[6];
 
-            for (int hitMode = 0; hitMode < HIT_MODE_COUNT; hitMode++) {
+            for (HitMode hitMode = HIT_MODE_LEFT_WEAPON_PRIMARY; hitMode < HIT_MODE_COUNT; hitMode++) {
                 if (!isUnarmedHitMode(hitMode)) {
                     continue;
                 }
@@ -6678,7 +6678,7 @@ static void unarmedInitCustom()
     }
 }
 
-int unarmedGetDamage(int hitMode, int* minDamagePtr, int* maxDamagePtr)
+int unarmedGetDamage(HitMode hitMode, int* minDamagePtr, int* maxDamagePtr)
 {
     UnarmedHitDescription* hitDescription = &(gUnarmedHitDescriptions[hitMode]);
     *minDamagePtr = hitDescription->minDamage;
@@ -6686,45 +6686,45 @@ int unarmedGetDamage(int hitMode, int* minDamagePtr, int* maxDamagePtr)
     return hitDescription->bonusDamage;
 }
 
-int unarmedGetBonusCriticalChance(int hitMode)
+int unarmedGetBonusCriticalChance(HitMode hitMode)
 {
     UnarmedHitDescription* hitDescription = &(gUnarmedHitDescriptions[hitMode]);
     return hitDescription->bonusCriticalChance;
 }
 
-int unarmedGetActionPointCost(int hitMode)
+int unarmedGetActionPointCost(HitMode hitMode)
 {
     UnarmedHitDescription* hitDescription = &(gUnarmedHitDescriptions[hitMode]);
     return hitDescription->actionPointCost;
 }
 
-bool unarmedIsPenetrating(int hitMode)
+bool unarmedIsPenetrating(HitMode hitMode)
 {
     UnarmedHitDescription* hitDescription = &(gUnarmedHitDescriptions[hitMode]);
     return hitDescription->isPenetrate;
 }
 
-int unarmedGetPunchHitMode(bool isSecondary)
+HitMode unarmedGetPunchHitMode(bool isSecondary)
 {
-    int hitMode = unarmedGetHitModeInRange(FIRST_ADVANCED_PUNCH_HIT_MODE, LAST_ADVANCED_PUNCH_HIT_MODE, isSecondary);
-    if (hitMode == -1) {
+    HitMode hitMode = unarmedGetHitModeInRange(FIRST_ADVANCED_PUNCH_HIT_MODE, LAST_ADVANCED_PUNCH_HIT_MODE, isSecondary);
+    if (hitMode == HIT_MODE_INVALID) {
         hitMode = HIT_MODE_PUNCH;
     }
     return hitMode;
 }
 
-int unarmedGetKickHitMode(bool isSecondary)
+HitMode unarmedGetKickHitMode(bool isSecondary)
 {
-    int hitMode = unarmedGetHitModeInRange(FIRST_ADVANCED_KICK_HIT_MODE, LAST_ADVANCED_KICK_HIT_MODE, isSecondary);
-    if (hitMode == -1) {
+    HitMode hitMode = unarmedGetHitModeInRange(FIRST_ADVANCED_KICK_HIT_MODE, LAST_ADVANCED_KICK_HIT_MODE, isSecondary);
+    if (hitMode == HIT_MODE_INVALID) {
         hitMode = HIT_MODE_KICK;
     }
     return hitMode;
 }
 
-static int unarmedGetHitModeInRange(int firstHitMode, int lastHitMode, bool isSecondary)
+static HitMode unarmedGetHitModeInRange(HitMode firstHitMode, HitMode lastHitMode, bool isSecondary)
 {
-    int hitMode = -1;
+    HitMode hitMode = HIT_MODE_INVALID;
 
     int unarmed = skillGetValue(gDude, SKILL_UNARMED);
     int level = pcGetStat(PC_STAT_LEVEL);
@@ -6733,7 +6733,7 @@ static int unarmedGetHitModeInRange(int firstHitMode, int lastHitMode, bool isSe
         stats[stat] = critterGetStat(gDude, stat);
     }
 
-    for (int candidateHitMode = firstHitMode; candidateHitMode <= lastHitMode; candidateHitMode++) {
+    for (HitMode candidateHitMode = firstHitMode; candidateHitMode <= lastHitMode; candidateHitMode++) {
         UnarmedHitDescription* hitDescription = &(gUnarmedHitDescriptions[candidateHitMode]);
         if (isSecondary != hitDescription->isSecondary) {
             continue;
@@ -6940,26 +6940,26 @@ static void damageModCalculateYaam(DamageCalculationContext* context)
     }
 }
 
-int combat_get_hit_location_penalty(int hit_location)
+int combat_get_hit_location_penalty(HitLocation hitLocation)
 {
-    if (hit_location >= 0 && hit_location < HIT_LOCATION_COUNT) {
-        return hit_location_penalty[hit_location];
+    if (hitLocation >= 0 && hitLocation < HIT_LOCATION_COUNT) {
+        return hit_location_penalty[hitLocation];
     } else {
         return 0;
     }
 }
 
-void combat_set_hit_location_penalty(int hit_location, int penalty)
+void combat_set_hit_location_penalty(HitLocation hitLocation, int penalty)
 {
-    if (hit_location >= 0 && hit_location < HIT_LOCATION_COUNT) {
-        hit_location_penalty[hit_location] = penalty;
+    if (hitLocation >= 0 && hitLocation < HIT_LOCATION_COUNT) {
+        hit_location_penalty[hitLocation] = penalty;
     }
 }
 
 void combat_reset_hit_location_penalty()
 {
-    for (int hit_location = 0; hit_location < HIT_LOCATION_COUNT; hit_location++) {
-        hit_location_penalty[hit_location] = hit_location_penalty_default[hit_location];
+    for (int hitLocation = 0; hitLocation < HIT_LOCATION_COUNT; hitLocation++) {
+        hit_location_penalty[hitLocation] = hit_location_penalty_default[hitLocation];
     }
 }
 

--- a/src/combat.cc
+++ b/src/combat.cc
@@ -163,7 +163,7 @@ int _combatNumTurns = 0;
 static int combatTurnHookResult = 0;
 
 // 0x510944 combat_state
-unsigned int gCombatState = COMBAT_STATE_PLAYER_TURN;
+CombatState gCombatState = COMBAT_STATE_PLAYER_TURN;
 
 // 0x510948 aiInfoList
 static CombatAiInfo* _aiInfoList = nullptr;
@@ -2103,7 +2103,7 @@ int _find_cid(int a1, int cid, Object** critterList, int critterListLength)
 // 0x420E4C
 int combatLoad(File* stream)
 {
-    if (fileReadUInt32(stream, &gCombatState) == -1) return -1;
+    if (fileReadUInt32(stream, reinterpret_cast<unsigned int*>(&gCombatState)) == -1) return -1;
 
     if (!isInCombat()) {
         Object* obj = objectFindFirst();
@@ -2874,7 +2874,7 @@ static void _combat_over()
 void _combat_over_from_load()
 {
     _combat_over();
-    gCombatState = 0;
+    gCombatState = COMBAT_STATE_OUT_COMBAT;
     _combat_end_due_to_load = 1;
 }
 
@@ -3468,7 +3468,7 @@ void _combat(CombatStartData* csd)
     if (csd == nullptr
         || (csd->attacker == nullptr || csd->attacker->elevation == gElevation)
         || (csd->defender == nullptr || csd->defender->elevation == gElevation)) {
-        bool wasInCombat = (gCombatState & COMBAT_STATE_IN_COMBAT) != 0;
+        bool wasInCombat = isInCombat();
 
         _combat_begin(nullptr);
 
@@ -5976,7 +5976,7 @@ void _combat_outline_off()
     int v5;
     Object** v9;
 
-    if ((gCombatState & COMBAT_STATE_IN_COMBAT) != 0) {
+    if (isInCombat()) {
         for (i = 0; i < _list_total; i++) {
             objectDisableOutline(_combat_list[i], nullptr);
         }

--- a/src/combat.cc
+++ b/src/combat.cc
@@ -6309,7 +6309,7 @@ static void criticalsInit()
 
                                 // Update player kill type if needed.
                                 int newKillType = killType == KILL_TYPE_COUNT ? SFALL_KILL_TYPE_COUNT : killType;
-                                for (CriticalHitDescriptionDataMember dataMember = CRIT_DATA_MEMBER_DAMAGE_MULTIPLIER; dataMember < CRIT_DATA_MEMBER_COUNT; dataMember++) {
+                                for (CriticalHitDataMember dataMember = CRIT_DATA_MEMBER_DAMAGE_MULTIPLIER; dataMember < CRIT_DATA_MEMBER_COUNT; dataMember++) {
                                     int value = criticalsGetValue(newKillType, hitLocation, effect, dataMember);
                                     if (configGetInt(&criticalsConfig, sectionKey, gCritDataMemberKeys[dataMember], &value)) {
                                         criticalsSetValue(newKillType, hitLocation, effect, dataMember, value);
@@ -6348,7 +6348,7 @@ static void criticalsInit()
                             snprintf(hitLocationSectionKey, sizeof(hitLocationSectionKey), "c_%02d_%d", killType, hitLocation);
 
                             for (int effect = 0; effect < CRTICIAL_EFFECT_COUNT; effect++) {
-                                for (CriticalHitDescriptionDataMember dataMember = CRIT_DATA_MEMBER_DAMAGE_MULTIPLIER; dataMember < CRIT_DATA_MEMBER_COUNT; dataMember++) {
+                                for (CriticalHitDataMember dataMember = CRIT_DATA_MEMBER_DAMAGE_MULTIPLIER; dataMember < CRIT_DATA_MEMBER_COUNT; dataMember++) {
                                     int value = criticalsGetValue(killType, hitLocation, effect, dataMember);
                                     snprintf(key, sizeof(key), "e%d_%s", effect, gCritDataMemberKeys[dataMember]);
                                     if (configGetInt(&criticalsConfig, hitLocationSectionKey, key, &value)) {
@@ -6380,7 +6380,7 @@ static void criticalsExit()
     criticalsReset();
 }
 
-int criticalsGetValue(int killType, HitLocation hitLocation, int effect, CriticalHitDescriptionDataMember dataMember)
+int criticalsGetValue(int killType, HitLocation hitLocation, int effect, CriticalHitDataMember dataMember)
 {
     if (killType == SFALL_KILL_TYPE_COUNT) {
         return gPlayerCriticalHitTable[hitLocation][effect].values[dataMember];
@@ -6389,7 +6389,7 @@ int criticalsGetValue(int killType, HitLocation hitLocation, int effect, Critica
     }
 }
 
-void criticalsSetValue(int killType, HitLocation hitLocation, int effect, CriticalHitDescriptionDataMember dataMember, int value)
+void criticalsSetValue(int killType, HitLocation hitLocation, int effect, CriticalHitDataMember dataMember, int value)
 {
     if (killType == SFALL_KILL_TYPE_COUNT) {
         gPlayerCriticalHitTable[hitLocation][effect].values[dataMember] = value;
@@ -6398,7 +6398,7 @@ void criticalsSetValue(int killType, HitLocation hitLocation, int effect, Critic
     }
 }
 
-void criticalsResetValue(int killType, HitLocation hitLocation, int effect, CriticalHitDescriptionDataMember dataMember)
+void criticalsResetValue(int killType, HitLocation hitLocation, int effect, CriticalHitDataMember dataMember)
 {
     if (killType == SFALL_KILL_TYPE_COUNT) {
         gPlayerCriticalHitTable[hitLocation][effect].values[dataMember] = gBasePlayerCriticalHitTable[hitLocation][effect].values[dataMember];
@@ -6942,23 +6942,23 @@ static void damageModCalculateYaam(DamageCalculationContext* context)
 
 int combat_get_hit_location_penalty(HitLocation hitLocation)
 {
-    if (hitLocation >= 0 && hitLocation < HIT_LOCATION_COUNT) {
+    if (hitLocationIsValid(hitLocation)) {
         return hit_location_penalty[hitLocation];
-    } else {
-        return 0;
     }
+
+    return 0;
 }
 
 void combat_set_hit_location_penalty(HitLocation hitLocation, int penalty)
 {
-    if (hitLocation >= 0 && hitLocation < HIT_LOCATION_COUNT) {
+    if (hitLocationIsValid(hitLocation)) {
         hit_location_penalty[hitLocation] = penalty;
     }
 }
 
 void combat_reset_hit_location_penalty()
 {
-    for (int hitLocation = 0; hitLocation < HIT_LOCATION_COUNT; hitLocation++) {
+    for (HitLocation hitLocation = HIT_LOCATION_HEAD; hitLocation < HIT_LOCATION_COUNT; hitLocation++) {
         hit_location_penalty[hitLocation] = hit_location_penalty_default[hitLocation];
     }
 }

--- a/src/combat.h
+++ b/src/combat.h
@@ -59,9 +59,9 @@ void _combat_delete_critter(Object* obj);
 void _combatKillCritterOutsideCombat(Object* critter_obj, char* msg);
 
 int combatGetTargetHighlight();
-int criticalsGetValue(int killType, HitLocation hitLocation, int effect, CriticalHitDescriptionDataMember dataMember);
-void criticalsSetValue(int killType, HitLocation hitLocation, int effect, CriticalHitDescriptionDataMember dataMember, int value);
-void criticalsResetValue(int killType, HitLocation hitLocation, int effect, CriticalHitDescriptionDataMember dataMember);
+int criticalsGetValue(int killType, HitLocation hitLocation, int effect, CriticalHitDataMember dataMember);
+void criticalsSetValue(int killType, HitLocation hitLocation, int effect, CriticalHitDataMember dataMember, int value);
+void criticalsResetValue(int killType, HitLocation hitLocation, int effect, CriticalHitDataMember dataMember);
 bool criticalsNoTimeLimits();
 int unarmedGetDamage(HitMode hitMode, int* minDamagePtr, int* maxDamagePtr);
 int unarmedGetBonusCriticalChance(HitMode hitMode);

--- a/src/combat.h
+++ b/src/combat.h
@@ -9,7 +9,7 @@
 namespace fallout {
 
 extern int _combatNumTurns;
-extern unsigned int gCombatState;
+extern CombatState gCombatState;
 
 extern int _combat_free_move;
 

--- a/src/combat.h
+++ b/src/combat.h
@@ -19,7 +19,7 @@ void combatExit();
 int _find_cid(int a1, int a2, Object** a3, int a4);
 int combatLoad(File* stream);
 int combatSave(File* stream);
-bool _combat_safety_invalidate_weapon(Object* attacker, Object* weapon, int hitMode, Object* defender, int* safeDistancePtr);
+bool _combat_safety_invalidate_weapon(Object* attacker, Object* weapon, HitMode hitMode, Object* defender, int* safeDistancePtr);
 bool _combatTestIncidentalHit(Object* attacker, Object* defender, Object* attackerFriend, Object* weapon);
 Object* _combat_whose_turn();
 void _combat_data_init(Object* obj);
@@ -34,19 +34,19 @@ void _combat_over_from_load();
 void _combat_give_exps(int exp_points);
 void _combat_turn_run();
 void _combat(CombatStartData* csd);
-void attackInit(Attack* attack, Object* attacker, Object* defender, int hitMode, int hitLocation);
-int _combat_attack(Object* attacker, Object* defender, int hitMode, int hitLocation);
+void attackInit(Attack* attack, Object* attacker, Object* defender, HitMode hitMode, HitLocation hitLocation);
+int _combat_attack(Object* attacker, Object* defender, HitMode hitMode, HitLocation hitLocation);
 int _combat_bullet_start(const Object* attacker, const Object* target);
 void _compute_explosion_on_extras(Attack* attack, bool isFromAttacker, bool isGrenade, bool noDamage);
-int _determine_to_hit(Object* a1, Object* a2, int hitLocation, int hitMode);
-int _determine_to_hit_no_range(Object* attacker, Object* defender, int hitLocation, int hitMode, unsigned char* a5);
-int _determine_to_hit_from_tile(Object* attacker, int tile, Object* defender, int hitLocation, int hitMode);
+int _determine_to_hit(Object* a1, Object* a2, HitLocation hitLocation, HitMode hitMode);
+int _determine_to_hit_no_range(Object* attacker, Object* defender, HitLocation hitLocation, HitMode hitMode, unsigned char* a5);
+int _determine_to_hit_from_tile(Object* attacker, int tile, Object* defender, HitLocation hitLocation, HitMode hitMode);
 void attackComputeDeathFlags(Attack* attack);
 void _apply_damage(Attack* attack, bool animated);
 void _combat_display(Attack* attack);
 void _combat_anim_begin();
 void _combat_anim_finished();
-int _combat_check_bad_shot(Object* attacker, Object* defender, int hitMode, bool aiming);
+CombatBadShot _combat_check_bad_shot(Object* attacker, Object* defender, HitMode hitMode, bool aiming);
 bool _combat_to_hit(Object* target, int* accuracy);
 void _combat_attack_this(Object* target);
 void _combat_outline_on();
@@ -59,21 +59,21 @@ void _combat_delete_critter(Object* obj);
 void _combatKillCritterOutsideCombat(Object* critter_obj, char* msg);
 
 int combatGetTargetHighlight();
-int criticalsGetValue(int killType, int hitLocation, int effect, int dataMember);
-void criticalsSetValue(int killType, int hitLocation, int effect, int dataMember, int value);
-void criticalsResetValue(int killType, int hitLocation, int effect, int dataMember);
+int criticalsGetValue(int killType, HitLocation hitLocation, int effect, CriticalHitDescriptionDataMember dataMember);
+void criticalsSetValue(int killType, HitLocation hitLocation, int effect, CriticalHitDescriptionDataMember dataMember, int value);
+void criticalsResetValue(int killType, HitLocation hitLocation, int effect, CriticalHitDescriptionDataMember dataMember);
 bool criticalsNoTimeLimits();
-int unarmedGetDamage(int hitMode, int* minDamagePtr, int* maxDamagePtr);
-int unarmedGetBonusCriticalChance(int hitMode);
-int unarmedGetActionPointCost(int hitMode);
-bool unarmedIsPenetrating(int hitMode);
-int unarmedGetPunchHitMode(bool isSecondary);
-int unarmedGetKickHitMode(bool isSecondary);
-bool unarmedIsPenetrating(int hitMode);
+int unarmedGetDamage(HitMode hitMode, int* minDamagePtr, int* maxDamagePtr);
+int unarmedGetBonusCriticalChance(HitMode hitMode);
+int unarmedGetActionPointCost(HitMode hitMode);
+bool unarmedIsPenetrating(HitMode hitMode);
+HitMode unarmedGetPunchHitMode(bool isSecondary);
+HitMode unarmedGetKickHitMode(bool isSecondary);
+bool unarmedIsPenetrating(HitMode hitMode);
 bool damageModGetBonusHthDamageFix();
 bool damageModGetDisplayBonusDamage();
-int combat_get_hit_location_penalty(int hit_location);
-void combat_set_hit_location_penalty(int hit_location, int penalty);
+int combat_get_hit_location_penalty(HitLocation hitLocation);
+void combat_set_hit_location_penalty(HitLocation hitLocation, int penalty);
 void combat_reset_hit_location_penalty();
 Attack* combat_get_data();
 
@@ -82,7 +82,7 @@ static inline bool isInCombat()
     return (gCombatState & COMBAT_STATE_IN_COMBAT) != 0;
 }
 
-static inline bool isUnarmedHitMode(int hitMode)
+static inline bool isUnarmedHitMode(HitMode hitMode)
 {
     return hitMode == HIT_MODE_PUNCH
         || hitMode == HIT_MODE_KICK

--- a/src/combat_ai.cc
+++ b/src/combat_ai.cc
@@ -93,19 +93,19 @@ static Object* _ai_danger_source(Object* a1);
 static bool aiHaveAmmo(Object* critter, Object* weapon, Object** ammoPtr);
 static bool _caiHasWeapPrefType(AiPacket* ai, int attackType);
 static Object* _ai_best_weapon(Object* a1, Object* a2, Object* a3, Object* a4);
-static bool _ai_can_use_weapon(Object* critter, Object* weapon, int hitMode);
+static bool _ai_can_use_weapon(Object* critter, Object* weapon, HitMode hitMode);
 static bool aiCanUseItem(Object* obj, Object* a2);
 static Object* _ai_search_environ(Object* critter, int itemType);
 static Object* _ai_retrieve_object(Object* critter, Object* item);
-static int _ai_pick_hit_mode(Object* attacker, Object* weapon, Object* defender);
+static HitMode _ai_pick_hit_mode(Object* attacker, Object* weapon, Object* defender);
 static int _ai_move_steps_closer(Object* a1, Object* a2, int actionPoints, bool taunt);
 static int _ai_move_closer(Object* a1, Object* a2, bool taunt);
 static int _cai_retargetTileFromFriendlyFire(Object* source, Object* target, int* tilePtr);
 static int _cai_retargetTileFromFriendlyFireSubFunc(AiRetargetData* aiRetargetData, int tile);
 static bool _cai_attackWouldIntersect(Object* attacker, Object* defender, Object* attackerFriend, int tile, int* distance);
-static int _ai_switch_weapons(Object* a1, int* hitMode, Object** weapon, Object* a4);
-static int _ai_called_shot(Object* attacker, Object* defender, int hitMode);
-static int _ai_attack(Object* attacker, Object* defender, int hitMode);
+static int _ai_switch_weapons(Object* a1, HitMode* hitMode, Object** weapon, Object* a4);
+static HitLocation _ai_called_shot(Object* attacker, Object* defender, HitMode hitMode);
+static int _ai_attack(Object* attacker, Object* defender, HitMode hitMode);
 static int _ai_try_attack(Object* a1, Object* a2);
 static int _cai_get_min_hp(AiPacket* ai);
 static int _ai_print_msg(Object* critter, int type);
@@ -1619,7 +1619,7 @@ static Object* _ai_danger_source(Object* a1)
                             // Check if we can attack it. No ammo and out of
                             // range are ok results, since we can reload weapon
                             // move closer if necessary.
-                            int badShot = _combat_check_bad_shot(a1, critter, HIT_MODE_RIGHT_WEAPON_PRIMARY, false);
+                            CombatBadShot badShot = _combat_check_bad_shot(a1, critter, HIT_MODE_RIGHT_WEAPON_PRIMARY, false);
                             if (badShot != COMBAT_BAD_SHOT_OK
                                 && badShot != COMBAT_BAD_SHOT_NO_AMMO
                                 && badShot != COMBAT_BAD_SHOT_OUT_OF_RANGE) {
@@ -1975,7 +1975,7 @@ static Object* _ai_best_weapon(Object* attacker, Object* weapon1, Object* weapon
 }
 
 // 0x4298EC
-static bool _ai_can_use_weapon(Object* critter, Object* weapon, int hitMode)
+static bool _ai_can_use_weapon(Object* critter, Object* weapon, HitMode hitMode)
 {
     bool result = critterCanUseWeapon(critter, weapon, hitMode);
 
@@ -2260,7 +2260,7 @@ static Object* _ai_retrieve_object(Object* critter, Object* item)
 }
 
 // 0x429DB4
-static int _ai_pick_hit_mode(Object* attacker, Object* weapon, Object* defender)
+static HitMode _ai_pick_hit_mode(Object* attacker, Object* weapon, Object* defender)
 {
     if (weapon == nullptr) {
         return HIT_MODE_PUNCH;
@@ -2302,19 +2302,19 @@ static int _ai_pick_hit_mode(Object* attacker, Object* weapon, Object* defender)
             break;
         case AREA_ATTACK_MODE_BE_SURE:
             if (_determine_to_hit(attacker, defender, HIT_LOCATION_TORSO, HIT_MODE_RIGHT_WEAPON_SECONDARY) >= 85
-                && !_combat_safety_invalidate_weapon(attacker, weapon, 3, defender, nullptr)) {
+                && !_combat_safety_invalidate_weapon(attacker, weapon, HIT_MODE_RIGHT_WEAPON_SECONDARY, defender, nullptr)) {
                 useSecondaryMode = true;
             }
             break;
         case AREA_ATTACK_MODE_BE_CAREFUL:
             if (_determine_to_hit(attacker, defender, HIT_LOCATION_TORSO, HIT_MODE_RIGHT_WEAPON_SECONDARY) >= 50
-                && !_combat_safety_invalidate_weapon(attacker, weapon, 3, defender, nullptr)) {
+                && !_combat_safety_invalidate_weapon(attacker, weapon, HIT_MODE_RIGHT_WEAPON_SECONDARY, defender, nullptr)) {
                 useSecondaryMode = true;
             }
             break;
         case AREA_ATTACK_MODE_BE_ABSOLUTELY_SURE:
             if (_determine_to_hit(attacker, defender, HIT_LOCATION_TORSO, HIT_MODE_RIGHT_WEAPON_SECONDARY) >= 95
-                && !_combat_safety_invalidate_weapon(attacker, weapon, 3, defender, nullptr)) {
+                && !_combat_safety_invalidate_weapon(attacker, weapon, HIT_MODE_RIGHT_WEAPON_SECONDARY, defender, nullptr)) {
                 useSecondaryMode = true;
             }
             break;
@@ -2574,7 +2574,7 @@ static int _cai_retargetTileFromFriendlyFireSubFunc(AiRetargetData* aiRetargetDa
 // 0x42A518
 static bool _cai_attackWouldIntersect(Object* attacker, Object* defender, Object* attackerFriend, int tile, int* distance)
 {
-    int hitMode = HIT_MODE_RIGHT_WEAPON_PRIMARY;
+    HitMode hitMode = HIT_MODE_RIGHT_WEAPON_PRIMARY;
     bool aiming = false;
     if (attacker == gDude) {
         interfaceGetCurrentHitMode(&hitMode, &aiming);
@@ -2601,7 +2601,7 @@ static bool _cai_attackWouldIntersect(Object* attacker, Object* defender, Object
 }
 
 // 0x42A5B8
-static int _ai_switch_weapons(Object* attacker, int* hitMode, Object** weapon, Object* defender)
+static int _ai_switch_weapons(Object* attacker, HitMode* hitMode, Object** weapon, Object* defender)
 {
     *weapon = nullptr;
     *hitMode = HIT_MODE_PUNCH;
@@ -2639,9 +2639,9 @@ static int _ai_switch_weapons(Object* attacker, int* hitMode, Object** weapon, O
 }
 
 // 0x42A670
-static int _ai_called_shot(Object* attacker, Object* defender, int hitMode)
+static HitLocation _ai_called_shot(Object* attacker, Object* defender, HitMode hitMode)
 {
-    int hitLocation = HIT_LOCATION_TORSO;
+    HitLocation hitLocation = HIT_LOCATION_TORSO;
 
     if (weaponGetActionPointCost(attacker, hitMode, true) <= attacker->data.critter.combat.ap) {
         if (critterCanAim(attacker, hitMode)) {
@@ -2661,8 +2661,8 @@ static int _ai_called_shot(Object* attacker, Object* defender, int hitMode)
                 }
 
                 if (critterGetStat(attacker, STAT_INTELLIGENCE) >= intelligenceRequired) {
-                    hitLocation = randomBetween(0, HIT_LOCATION_SPECIFIC_COUNT);
-                    int chanceToHit = _determine_to_hit(attacker, defender, hitMode, hitLocation);
+                    hitLocation = static_cast<HitLocation>(randomBetween(HIT_LOCATION_HEAD, HIT_LOCATION_SPECIFIC_COUNT));                 
+                    int chanceToHit = _determine_to_hit(attacker, defender, hitLocation, hitMode);
                     if (chanceToHit < ai->min_to_hit) {
                         hitLocation = HIT_LOCATION_TORSO;
                     }
@@ -2675,7 +2675,7 @@ static int _ai_called_shot(Object* attacker, Object* defender, int hitMode)
 }
 
 // 0x42A748
-static int _ai_attack(Object* attacker, Object* defender, int hitMode)
+static int _ai_attack(Object* attacker, Object* defender, HitMode hitMode)
 {
     if (attacker->data.critter.combat.maneuver & CRITTER_MANUEVER_FLEEING) {
         return -1;
@@ -2686,7 +2686,7 @@ static int _ai_attack(Object* attacker, Object* defender, int hitMode)
     reg_anim_end();
     _combat_turn_run();
 
-    int hitLocation = _ai_called_shot(attacker, defender, hitMode);
+    HitLocation hitLocation = _ai_called_shot(attacker, defender, hitMode);
     if (_combat_attack(attacker, defender, hitMode, hitLocation)) {
         return -1;
     }
@@ -2709,7 +2709,7 @@ static int _ai_try_attack(Object* attacker, Object* defender)
         weapon = nullptr;
     }
 
-    int hitMode = _ai_pick_hit_mode(attacker, weapon, defender);
+    HitMode hitMode = _ai_pick_hit_mode(attacker, weapon, defender);
     int minToHit = aiGetPacket(attacker)->min_to_hit;
 
     int actionPoints = attacker->data.critter.combat.ap;
@@ -2736,7 +2736,7 @@ static int _ai_try_attack(Object* attacker, Object* defender)
             break;
         }
 
-        int reason = _combat_check_bad_shot(attacker, defender, hitMode, false);
+        CombatBadShot reason = _combat_check_bad_shot(attacker, defender, hitMode, false);
         if (reason == COMBAT_BAD_SHOT_NO_AMMO) {
             // If the secondary attack (for example, burst fire) does not have enough ammo,
             // try the primary attack, which may have a lower ammo cost.
@@ -2821,9 +2821,6 @@ static int _ai_try_attack(Object* attacker, Object* defender)
                 }
             }
         } else if (reason == COMBAT_BAD_SHOT_NOT_ENOUGH_AP || reason == COMBAT_BAD_SHOT_ARM_CRIPPLED || reason == COMBAT_BAD_SHOT_BOTH_ARMS_CRIPPLED) {
-            // 3 - not enough action points
-            // 6 - crippled one arm for two-handed weapon
-            // 7 - both hands crippled
             if (_ai_switch_weapons(attacker, &hitMode, &weapon, defender) == -1) {
                 return -1;
             }

--- a/src/combat_ai.cc
+++ b/src/combat_ai.cc
@@ -2661,7 +2661,7 @@ static HitLocation _ai_called_shot(Object* attacker, Object* defender, HitMode h
                 }
 
                 if (critterGetStat(attacker, STAT_INTELLIGENCE) >= intelligenceRequired) {
-                    hitLocation = static_cast<HitLocation>(randomBetween(HIT_LOCATION_HEAD, HIT_LOCATION_SPECIFIC_COUNT));                 
+                    hitLocation = static_cast<HitLocation>(randomBetween(HIT_LOCATION_HEAD, HIT_LOCATION_SPECIFIC_COUNT));
                     int chanceToHit = _determine_to_hit(attacker, defender, hitLocation, hitMode);
                     if (chanceToHit < ai->min_to_hit) {
                         hitLocation = HIT_LOCATION_TORSO;

--- a/src/combat_defs.h
+++ b/src/combat_defs.h
@@ -18,7 +18,8 @@ typedef enum CombatState {
     COMBAT_STATE_EXIT_REQUESTED = 0x08,
 } CombatState;
 
-typedef enum HitMode {
+enum HitMode : int {
+    HIT_MODE_INVALID = -1,
     HIT_MODE_LEFT_WEAPON_PRIMARY = 0,
     HIT_MODE_LEFT_WEAPON_SECONDARY = 1,
     HIT_MODE_RIGHT_WEAPON_PRIMARY = 2,
@@ -70,21 +71,47 @@ typedef enum HitMode {
     LAST_ADVANCED_KICK_HIT_MODE = HIT_MODE_PIERCING_KICK,
     FIRST_ADVANCED_UNARMED_HIT_MODE = FIRST_ADVANCED_PUNCH_HIT_MODE,
     LAST_ADVANCED_UNARMED_HIT_MODE = LAST_ADVANCED_KICK_HIT_MODE,
-} HitMode;
+};
 
-typedef enum HitLocation {
-    HIT_LOCATION_HEAD,
-    HIT_LOCATION_LEFT_ARM,
-    HIT_LOCATION_RIGHT_ARM,
-    HIT_LOCATION_TORSO,
-    HIT_LOCATION_RIGHT_LEG,
-    HIT_LOCATION_LEFT_LEG,
-    HIT_LOCATION_EYES,
-    HIT_LOCATION_GROIN,
-    HIT_LOCATION_UNCALLED,
-    HIT_LOCATION_COUNT,
+// Overload the prefix increment: ++val
+inline HitMode& operator++(HitMode& e) {
+    e = static_cast<HitMode>(static_cast<int>(e) + 1);
+    return e;
+}
+
+// Overload the postfix increment: val++
+inline HitMode operator++(HitMode& e, int) {
+    HitMode result = e;
+    ++e;
+    return result;
+}
+
+enum HitLocation : int {
+    HIT_LOCATION_HEAD = 0,
+    HIT_LOCATION_LEFT_ARM = 1,
+    HIT_LOCATION_RIGHT_ARM = 2,
+    HIT_LOCATION_TORSO = 3,
+    HIT_LOCATION_RIGHT_LEG = 4,
+    HIT_LOCATION_LEFT_LEG = 5,
+    HIT_LOCATION_EYES = 6,
+    HIT_LOCATION_GROIN = 7,
+    HIT_LOCATION_UNCALLED = 8,
+    HIT_LOCATION_COUNT = 9,
     HIT_LOCATION_SPECIFIC_COUNT = HIT_LOCATION_COUNT - 1,
-} HitLocation;
+};
+
+// Overload the prefix increment: ++val
+inline HitLocation& operator++(HitLocation& e) {
+    e = static_cast<HitLocation>(static_cast<int>(e) + 1);
+    return e;
+}
+
+// Overload the postfix increment: val++
+inline HitLocation operator++(HitLocation& e, int) {
+    HitLocation result = e;
+    ++e;
+    return result;
+}
 
 typedef struct CombatStartData {
     Object* attacker;
@@ -101,16 +128,16 @@ typedef struct CombatStartData {
 
 typedef struct Attack {
     Object* attacker;
-    int hitMode;
+    HitMode hitMode;
     Object* weapon;
-    int attackHitLocation; // UNUSED?
+    HitLocation attackHitLocation; // UNUSED?
     int attackerDamage;
     int attackerFlags;
     int ammoQuantity;
     int criticalMessageId;
     Object* defender;
     int tile;
-    int defenderHitLocation;
+    HitLocation defenderHitLocation;
     int defenderDamage;
     int defenderFlags;
     int defenderKnockback;
@@ -123,16 +150,30 @@ typedef struct Attack {
     int extrasKnockback[EXPLOSION_TARGET_COUNT];
 } Attack;
 
-typedef enum CriticalHitDescriptionDataMember {
-    CRIT_DATA_MEMBER_DAMAGE_MULTIPLIER,
-    CRIT_DATA_MEMBER_FLAGS,
-    CRIT_DATA_MEMBER_MASSIVE_CRITICAL_STAT,
-    CRIT_DATA_MEMBER_MASSIVE_CRITICAL_STAT_MODIFIER,
-    CRIT_DATA_MEMBER_MASSIVE_CRITICAL_FLAGS,
-    CRIT_DATA_MEMBER_MESSAGE_ID,
-    CRIT_DATA_MEMBER_MASSIVE_CRITICAL_MESSAGE_ID,
-    CRIT_DATA_MEMBER_COUNT,
-} CriticalHitDescriptionDataMember;
+enum CriticalHitDescriptionDataMember : int {
+    CRIT_DATA_MEMBER_DAMAGE_MULTIPLIER = 0,
+    CRIT_DATA_MEMBER_FLAGS = 1,
+    CRIT_DATA_MEMBER_MASSIVE_CRITICAL_STAT = 2,
+    CRIT_DATA_MEMBER_MASSIVE_CRITICAL_STAT_MODIFIER = 3,
+    CRIT_DATA_MEMBER_MASSIVE_CRITICAL_FLAGS = 4,
+    CRIT_DATA_MEMBER_MESSAGE_ID = 5,
+    CRIT_DATA_MEMBER_MASSIVE_CRITICAL_MESSAGE_ID = 6,
+    CRIT_DATA_MEMBER_COUNT = 7,
+};
+
+
+// Overload the prefix increment: ++val
+inline CriticalHitDescriptionDataMember& operator++(CriticalHitDescriptionDataMember& e) {
+    e = static_cast<CriticalHitDescriptionDataMember>(static_cast<int>(e) + 1);
+    return e;
+}
+
+// Overload the postfix increment: val++
+inline CriticalHitDescriptionDataMember operator++(CriticalHitDescriptionDataMember& e, int) {
+    CriticalHitDescriptionDataMember result = e;
+    ++e;
+    return result;
+}
 
 // Provides metadata about critical hit effect.
 typedef union CriticalHitDescription {
@@ -160,7 +201,7 @@ typedef union CriticalHitDescription {
     int values[CRIT_DATA_MEMBER_COUNT];
 } CriticalHitDescription;
 
-typedef enum CombatBadShot {
+enum CombatBadShot : int {
     COMBAT_BAD_SHOT_OK = 0,
     COMBAT_BAD_SHOT_NO_AMMO = 1,
     COMBAT_BAD_SHOT_OUT_OF_RANGE = 2,
@@ -169,7 +210,7 @@ typedef enum CombatBadShot {
     COMBAT_BAD_SHOT_AIM_BLOCKED = 5,
     COMBAT_BAD_SHOT_ARM_CRIPPLED = 6,
     COMBAT_BAD_SHOT_BOTH_ARMS_CRIPPLED = 7,
-} CombatBadShot;
+};
 
 } // namespace fallout
 

--- a/src/combat_defs.h
+++ b/src/combat_defs.h
@@ -12,11 +12,31 @@
 
 namespace fallout {
 
-typedef enum CombatState {
+enum CombatState : unsigned int {
+    COMBAT_STATE_OUT_COMBAT = 0x00,
     COMBAT_STATE_IN_COMBAT = 0x01,
     COMBAT_STATE_PLAYER_TURN = 0x02,
     COMBAT_STATE_EXIT_REQUESTED = 0x08,
-} CombatState;
+};
+
+inline fallout::CombatState& operator&=(fallout::CombatState& lhs, unsigned int rhs) {
+    lhs = static_cast<fallout::CombatState>(static_cast<unsigned int>(lhs) & rhs);
+    return lhs;
+}
+
+inline constexpr CombatState operator~(CombatState rhs) {
+    return static_cast<CombatState>(~static_cast<unsigned int>(rhs));
+}
+
+inline CombatState& operator&=(CombatState& lhs, CombatState rhs) {
+    lhs = static_cast<CombatState>(static_cast<unsigned int>(lhs) & static_cast<unsigned int>(rhs));
+    return lhs;
+}
+
+inline CombatState& operator|=(CombatState& lhs, CombatState rhs) {
+    lhs = static_cast<CombatState>(static_cast<unsigned int>(lhs) | static_cast<unsigned int>(rhs));
+    return lhs;
+}
 
 enum HitMode : int {
     HIT_MODE_INVALID = -1,

--- a/src/combat_defs.h
+++ b/src/combat_defs.h
@@ -19,21 +19,25 @@ enum CombatState : unsigned int {
     COMBAT_STATE_EXIT_REQUESTED = 0x08,
 };
 
-inline fallout::CombatState& operator&=(fallout::CombatState& lhs, unsigned int rhs) {
+inline fallout::CombatState& operator&=(fallout::CombatState& lhs, unsigned int rhs)
+{
     lhs = static_cast<fallout::CombatState>(static_cast<unsigned int>(lhs) & rhs);
     return lhs;
 }
 
-inline constexpr CombatState operator~(CombatState rhs) {
+inline constexpr CombatState operator~(CombatState rhs)
+{
     return static_cast<CombatState>(~static_cast<unsigned int>(rhs));
 }
 
-inline CombatState& operator&=(CombatState& lhs, CombatState rhs) {
+inline CombatState& operator&=(CombatState& lhs, CombatState rhs)
+{
     lhs = static_cast<CombatState>(static_cast<unsigned int>(lhs) & static_cast<unsigned int>(rhs));
     return lhs;
 }
 
-inline CombatState& operator|=(CombatState& lhs, CombatState rhs) {
+inline CombatState& operator|=(CombatState& lhs, CombatState rhs)
+{
     lhs = static_cast<CombatState>(static_cast<unsigned int>(lhs) | static_cast<unsigned int>(rhs));
     return lhs;
 }

--- a/src/combat_defs.h
+++ b/src/combat_defs.h
@@ -229,14 +229,8 @@ enum CombatBadShot : int {
     COMBAT_BAD_SHOT_ALREADY_DEAD = 4,
     COMBAT_BAD_SHOT_AIM_BLOCKED = 5,
     COMBAT_BAD_SHOT_ARM_CRIPPLED = 6,
-    COMBAT_BAD_SHOT_BOTH_ARMS_CRIPPLED = 7,
-    COMBAT_BAD_SHOT_COUNT = 8,
+    COMBAT_BAD_SHOT_BOTH_ARMS_CRIPPLED = 7
 };
-
-inline static bool combatBadShotIsValid(int combatBadShot)
-{
-    return combatBadShot >= COMBAT_BAD_SHOT_OK && combatBadShot < COMBAT_BAD_SHOT_COUNT;
-}
 
 } // namespace fallout
 

--- a/src/combat_defs.h
+++ b/src/combat_defs.h
@@ -73,18 +73,15 @@ enum HitMode : int {
     LAST_ADVANCED_UNARMED_HIT_MODE = LAST_ADVANCED_KICK_HIT_MODE,
 };
 
-// Overload the prefix increment: ++val
-inline HitMode& operator++(HitMode& e)
+inline static bool hitModeIsValid(int hitMode)
 {
-    e = static_cast<HitMode>(static_cast<int>(e) + 1);
-    return e;
+    return hitMode >= HIT_MODE_LEFT_WEAPON_PRIMARY && hitMode < HIT_MODE_COUNT;
 }
 
-// Overload the postfix increment: val++
 inline HitMode operator++(HitMode& e, int)
 {
     HitMode result = e;
-    ++e;
+    e = static_cast<HitMode>(static_cast<int>(e) + 1);
     return result;
 }
 
@@ -102,18 +99,15 @@ enum HitLocation : int {
     HIT_LOCATION_SPECIFIC_COUNT = HIT_LOCATION_COUNT - 1,
 };
 
-// Overload the prefix increment: ++val
-inline HitLocation& operator++(HitLocation& e)
+inline static bool hitLocationIsValid(int hitLocation)
 {
-    e = static_cast<HitLocation>(static_cast<int>(e) + 1);
-    return e;
+    return hitLocation >= HIT_LOCATION_HEAD && hitLocation < HIT_LOCATION_COUNT;
 }
 
-// Overload the postfix increment: val++
 inline HitLocation operator++(HitLocation& e, int)
 {
     HitLocation result = e;
-    ++e;
+    e = static_cast<HitLocation>(static_cast<int>(e) + 1);
     return result;
 }
 
@@ -154,7 +148,7 @@ typedef struct Attack {
     int extrasKnockback[EXPLOSION_TARGET_COUNT];
 } Attack;
 
-enum CriticalHitDescriptionDataMember : int {
+enum CriticalHitDataMember : int {
     CRIT_DATA_MEMBER_DAMAGE_MULTIPLIER = 0,
     CRIT_DATA_MEMBER_FLAGS = 1,
     CRIT_DATA_MEMBER_MASSIVE_CRITICAL_STAT = 2,
@@ -165,18 +159,15 @@ enum CriticalHitDescriptionDataMember : int {
     CRIT_DATA_MEMBER_COUNT = 7,
 };
 
-// Overload the prefix increment: ++val
-inline CriticalHitDescriptionDataMember& operator++(CriticalHitDescriptionDataMember& e)
+inline static bool criticalHitDataMemberIsValid(int criticalHitDataMember)
 {
-    e = static_cast<CriticalHitDescriptionDataMember>(static_cast<int>(e) + 1);
-    return e;
+    return criticalHitDataMember >= CRIT_DATA_MEMBER_DAMAGE_MULTIPLIER && criticalHitDataMember < CRIT_DATA_MEMBER_COUNT;
 }
 
-// Overload the postfix increment: val++
-inline CriticalHitDescriptionDataMember operator++(CriticalHitDescriptionDataMember& e, int)
+inline CriticalHitDataMember operator++(CriticalHitDataMember& e, int)
 {
-    CriticalHitDescriptionDataMember result = e;
-    ++e;
+    CriticalHitDataMember result = e;
+    e = static_cast<CriticalHitDataMember>(static_cast<int>(e) + 1);
     return result;
 }
 
@@ -215,7 +206,13 @@ enum CombatBadShot : int {
     COMBAT_BAD_SHOT_AIM_BLOCKED = 5,
     COMBAT_BAD_SHOT_ARM_CRIPPLED = 6,
     COMBAT_BAD_SHOT_BOTH_ARMS_CRIPPLED = 7,
+    COMBAT_BAD_SHOT_COUNT = 8,
 };
+
+inline static bool combatBadShotIsValid(int combatBadShot)
+{
+    return combatBadShot >= COMBAT_BAD_SHOT_OK && combatBadShot < COMBAT_BAD_SHOT_COUNT;
+}
 
 } // namespace fallout
 

--- a/src/combat_defs.h
+++ b/src/combat_defs.h
@@ -74,13 +74,15 @@ enum HitMode : int {
 };
 
 // Overload the prefix increment: ++val
-inline HitMode& operator++(HitMode& e) {
+inline HitMode& operator++(HitMode& e)
+{
     e = static_cast<HitMode>(static_cast<int>(e) + 1);
     return e;
 }
 
 // Overload the postfix increment: val++
-inline HitMode operator++(HitMode& e, int) {
+inline HitMode operator++(HitMode& e, int)
+{
     HitMode result = e;
     ++e;
     return result;
@@ -101,13 +103,15 @@ enum HitLocation : int {
 };
 
 // Overload the prefix increment: ++val
-inline HitLocation& operator++(HitLocation& e) {
+inline HitLocation& operator++(HitLocation& e)
+{
     e = static_cast<HitLocation>(static_cast<int>(e) + 1);
     return e;
 }
 
 // Overload the postfix increment: val++
-inline HitLocation operator++(HitLocation& e, int) {
+inline HitLocation operator++(HitLocation& e, int)
+{
     HitLocation result = e;
     ++e;
     return result;
@@ -161,15 +165,16 @@ enum CriticalHitDescriptionDataMember : int {
     CRIT_DATA_MEMBER_COUNT = 7,
 };
 
-
 // Overload the prefix increment: ++val
-inline CriticalHitDescriptionDataMember& operator++(CriticalHitDescriptionDataMember& e) {
+inline CriticalHitDescriptionDataMember& operator++(CriticalHitDescriptionDataMember& e)
+{
     e = static_cast<CriticalHitDescriptionDataMember>(static_cast<int>(e) + 1);
     return e;
 }
 
 // Overload the postfix increment: val++
-inline CriticalHitDescriptionDataMember operator++(CriticalHitDescriptionDataMember& e, int) {
+inline CriticalHitDescriptionDataMember operator++(CriticalHitDescriptionDataMember& e, int)
+{
     CriticalHitDescriptionDataMember result = e;
     ++e;
     return result;

--- a/src/critter.cc
+++ b/src/critter.cc
@@ -1024,7 +1024,7 @@ int critterGetBodyType(Object* critter)
     return proto->critter.data.bodyType;
 }
 
-bool critterCanUseWeapon(Object* critter, Object* weapon, int hitMode)
+bool critterCanUseWeapon(Object* critter, Object* weapon, HitMode hitMode)
 {
     if (critter == nullptr || weapon == nullptr || itemGetType(weapon) != ITEM_TYPE_WEAPON) {
         return false;

--- a/src/critter.h
+++ b/src/critter.h
@@ -1,6 +1,7 @@
 #ifndef CRITTER_H
 #define CRITTER_H
 
+#include "combat_defs.h"
 #include "db.h"
 #include "obj_types.h"
 #include "proto_types.h"
@@ -56,7 +57,7 @@ bool critterIsProne(Object* critter);
 int critterGetBodyType(Object* critter);
 // Checks physical/art capability only. Callers that expose weapon usability
 // decisions must still call scriptHooks_CanUseWeapon with the final result.
-bool critterCanUseWeapon(Object* critter, Object* weapon, int hitMode);
+bool critterCanUseWeapon(Object* critter, Object* weapon, HitMode hitMode);
 int critterBuildGorisFid(Object* critter, int frmId);
 int gcdLoad(const char* path);
 int protoCritterDataRead(File* stream, CritterProtoData* critterData);

--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -1062,7 +1062,7 @@ void _gmouse_handle_event(int mouseX, int mouseY, int mouseState)
                 Object* weapon;
                 if (interfaceGetActiveItem(&weapon) != -1) {
                     if (isInCombat()) {
-                        int hitMode = interfaceGetCurrentHand()
+                        HitMode hitMode = interfaceGetCurrentHand()
                             ? HIT_MODE_RIGHT_WEAPON_PRIMARY
                             : HIT_MODE_LEFT_WEAPON_PRIMARY;
 

--- a/src/game_sound.cc
+++ b/src/game_sound.cc
@@ -1366,7 +1366,7 @@ char* gameSoundBuildInterfaceName(const char* a1)
 
 // sfx_build_weapon_name
 // 0x451760
-char* sfxBuildWeaponName(int effectType, Object* weapon, int hitMode, Object* target)
+char* sfxBuildWeaponName(int effectType, Object* weapon, HitMode hitMode, Object* target)
 {
     int soundVariant;
     char weaponSoundCode;

--- a/src/game_sound.h
+++ b/src/game_sound.h
@@ -1,6 +1,7 @@
 #ifndef GAME_SOUND_H
 #define GAME_SOUND_H
 
+#include "combat_defs.h"
 #include "obj_types.h"
 #include "sound.h"
 
@@ -102,7 +103,7 @@ int _gsound_compute_relative_volume(Object* obj);
 char* sfxBuildCharName(Object* object, int anim, int weaponAnimationCode);
 char* gameSoundBuildAmbientSoundEffectName(const char* name);
 char* gameSoundBuildInterfaceName(const char* name);
-char* sfxBuildWeaponName(int effectType, Object* weapon, int hitMode, Object* target);
+char* sfxBuildWeaponName(int effectType, Object* weapon, HitMode hitMode, Object* target);
 char* sfxBuildSceneryName(int actionType, int action, const char* name);
 char* sfxBuildOpenName(Object* object, int action);
 void _gsound_red_butt_press(int btn, int keyCode);

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -99,8 +99,8 @@ typedef struct InterfaceItemState {
     Object* item;
     unsigned char isDisabled;
     unsigned char isWeapon;
-    int primaryHitMode;
-    int secondaryHitMode;
+    HitMode primaryHitMode;
+    HitMode secondaryHitMode;
     int action;
     int itemFid;
 } InterfaceItemState;
@@ -1086,7 +1086,7 @@ void interfaceRenderActionPoints(int actionPointsLeft, int bonusActionPoints)
 }
 
 // 0x45EF6C intface_get_attack
-int interfaceGetCurrentHitMode(int* hitMode, bool* aiming)
+int interfaceGetCurrentHitMode(HitMode* hitMode, bool* aiming)
 {
     if (gInterfaceBarWindow == -1) {
         return -1;
@@ -1350,7 +1350,7 @@ void _intface_use_item()
     if (ptr->isWeapon != 0) {
         if (ptr->action == INTERFACE_ITEM_ACTION_RELOAD) {
             if (isInCombat()) {
-                int hitMode = gInterfaceCurrentHand == HAND_LEFT
+                HitMode hitMode = gInterfaceCurrentHand == HAND_LEFT
                     ? HIT_MODE_LEFT_WEAPON_RELOAD
                     : HIT_MODE_RIGHT_WEAPON_RELOAD;
 
@@ -1668,7 +1668,7 @@ static int interfaceBarRefreshMainAction()
         } else {
             int primaryFid = -1;
             int bullseyeFid = -1;
-            int hitMode = -1;
+            HitMode hitMode = HIT_MODE_INVALID;
 
             // NOTE: This value is decremented at 0x45FEAC, probably to build
             // jump table.
@@ -2943,7 +2943,7 @@ static void sidePanelsDraw(const char* path, int win, bool isLeading)
 // modes, the default is `punch`).
 //
 // 0x45EF6C intface_get_attack
-bool interface_get_current_attack_mode(int* hit_mode)
+bool interface_get_current_attack_mode(HitMode* hitMode)
 {
     if (gInterfaceBarWindow == -1) {
         return false;
@@ -2952,19 +2952,19 @@ bool interface_get_current_attack_mode(int* hit_mode)
     switch (gInterfaceItemStates[gInterfaceCurrentHand].action) {
     case INTERFACE_ITEM_ACTION_PRIMARY_AIMING:
     case INTERFACE_ITEM_ACTION_PRIMARY:
-        *hit_mode = gInterfaceItemStates[gInterfaceCurrentHand].primaryHitMode;
+        *hitMode = gInterfaceItemStates[gInterfaceCurrentHand].primaryHitMode;
         break;
     case INTERFACE_ITEM_ACTION_SECONDARY_AIMING:
     case INTERFACE_ITEM_ACTION_SECONDARY:
-        *hit_mode = gInterfaceItemStates[gInterfaceCurrentHand].secondaryHitMode;
+        *hitMode = gInterfaceItemStates[gInterfaceCurrentHand].secondaryHitMode;
         break;
     case INTERFACE_ITEM_ACTION_RELOAD:
-        *hit_mode = gInterfaceCurrentHand == HAND_LEFT
+        *hitMode = gInterfaceCurrentHand == HAND_LEFT
             ? HIT_MODE_LEFT_WEAPON_RELOAD
             : HIT_MODE_RIGHT_WEAPON_RELOAD;
         break;
     default:
-        *hit_mode = HIT_MODE_PUNCH;
+        *hitMode = HIT_MODE_PUNCH;
         break;
     }
 

--- a/src/interface.h
+++ b/src/interface.h
@@ -1,6 +1,7 @@
 #ifndef INTERFACE_H
 #define INTERFACE_H
 
+#include "combat_defs.h"
 #include "db.h"
 #include "obj_types.h"
 
@@ -49,7 +50,7 @@ void interfaceBarRefresh();
 void interfaceRenderHitPoints(bool animate);
 void interfaceRenderArmorClass(bool animate);
 void interfaceRenderActionPoints(int actionPointsLeft, int bonusActionPoints);
-int interfaceGetCurrentHitMode(int* hitMode, bool* aiming);
+int interfaceGetCurrentHitMode(HitMode* hitMode, bool* aiming);
 int interfaceUpdateItems(bool animated, int leftItemAction, int rightItemAction);
 int interfaceBarSwapHands(bool animated);
 int interfaceGetItemActions(int* leftItemAction, int* rightItemAction);
@@ -65,7 +66,7 @@ void interfaceBarEndButtonsRenderRedLights();
 int indicatorBarRefresh();
 bool indicatorBarShow();
 bool indicatorBarHide();
-bool interface_get_current_attack_mode(int* hit_mode);
+bool interface_get_current_attack_mode(HitMode* hitMode);
 int interfaceTagAdd();
 int interfaceTagGetMax();
 bool interfaceTagShow(int tag);

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -253,6 +253,57 @@ int programStackPopInteger(Program* program);
 char* programStackPopString(Program* program);
 void* programStackPopPointer(Program* program);
 
+template <typename T>
+T programStackPopEnum(Program* program);
+
+template <>
+inline HitMode programStackPopEnum(Program* program)
+{
+    int hitMode = programStackPopInteger(program);
+    if (!hitModeIsValid(hitMode))
+    {
+        programPrintError("invalid hit mode %d", hitMode);
+    }
+
+    return static_cast<HitMode>(hitMode);
+}
+
+template <>
+inline HitLocation programStackPopEnum(Program* program)
+{
+    int hitLocation = programStackPopInteger(program);
+    if (!hitLocationIsValid(hitLocation))
+    {
+        programPrintError("invalid hit location %d", hitLocation);
+    }
+
+    return static_cast<HitLocation>(hitLocation);
+}
+
+template <>
+inline CriticalHitDataMember programStackPopEnum(Program* program)
+{
+    int criticalHitDataMember = programStackPopInteger(program);
+    if (!criticalHitDataMemberIsValid(criticalHitDataMember))
+    {
+        programPrintError("invalid critical hit data member %d", criticalHitDataMember);
+    }
+
+    return static_cast<CriticalHitDataMember>(criticalHitDataMember);
+}
+
+template <>
+inline CombatBadShot programStackPopEnum(Program* program)
+{
+    int combatBadShot = programStackPopInteger(program);
+    if (!combatBadShotIsValid(combatBadShot))
+    {
+        programPrintError("invalid combat bad shot %d", combatBadShot);
+    }
+
+    return static_cast<CombatBadShot>(combatBadShot);
+}
+
 void programReturnStackPushValue(Program* program, ProgramValue& programValue);
 void programReturnStackPushInteger(Program* program, int value);
 void programReturnStackPushPointer(Program* program, void* value);

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -260,8 +260,7 @@ template <>
 inline HitMode programStackPopEnum(Program* program)
 {
     int hitMode = programStackPopInteger(program);
-    if (!hitModeIsValid(hitMode))
-    {
+    if (!hitModeIsValid(hitMode)) {
         programPrintError("invalid hit mode %d", hitMode);
     }
 
@@ -272,8 +271,7 @@ template <>
 inline HitLocation programStackPopEnum(Program* program)
 {
     int hitLocation = programStackPopInteger(program);
-    if (!hitLocationIsValid(hitLocation))
-    {
+    if (!hitLocationIsValid(hitLocation)) {
         programPrintError("invalid hit location %d", hitLocation);
     }
 
@@ -284,8 +282,7 @@ template <>
 inline CriticalHitDataMember programStackPopEnum(Program* program)
 {
     int criticalHitDataMember = programStackPopInteger(program);
-    if (!criticalHitDataMemberIsValid(criticalHitDataMember))
-    {
+    if (!criticalHitDataMemberIsValid(criticalHitDataMember)) {
         programPrintError("invalid critical hit data member %d", criticalHitDataMember);
     }
 
@@ -296,8 +293,7 @@ template <>
 inline CombatBadShot programStackPopEnum(Program* program)
 {
     int combatBadShot = programStackPopInteger(program);
-    if (!combatBadShotIsValid(combatBadShot))
-    {
+    if (!combatBadShotIsValid(combatBadShot)) {
         programPrintError("invalid combat bad shot %d", combatBadShot);
     }
 

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -289,17 +289,6 @@ inline CriticalHitDataMember programStackPopEnum(Program* program)
     return static_cast<CriticalHitDataMember>(criticalHitDataMember);
 }
 
-template <>
-inline CombatBadShot programStackPopEnum(Program* program)
-{
-    int combatBadShot = programStackPopInteger(program);
-    if (!combatBadShotIsValid(combatBadShot)) {
-        programPrintError("invalid combat bad shot %d", combatBadShot);
-    }
-
-    return static_cast<CombatBadShot>(combatBadShot);
-}
-
 void programReturnStackPushValue(Program* program, ProgramValue& programValue);
 void programReturnStackPushInteger(Program* program, int value);
 void programReturnStackPushPointer(Program* program, void* value);

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -4385,7 +4385,7 @@ static void opSfxBuildItemName(Program* program)
 static void opSfxBuildWeaponName(Program* program)
 {
     Object* target = static_cast<Object*>(programStackPopPointer(program));
-    HitMode hitMode = static_cast<HitMode>(programStackPopInteger(program));
+    HitMode hitMode = programStackPopEnum<HitMode>(program);
     Object* weapon = static_cast<Object*>(programStackPopPointer(program));
     int weaponSfxType = programStackPopInteger(program);
 

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -4385,7 +4385,7 @@ static void opSfxBuildItemName(Program* program)
 static void opSfxBuildWeaponName(Program* program)
 {
     Object* target = static_cast<Object*>(programStackPopPointer(program));
-    int hitMode = programStackPopInteger(program);
+    HitMode hitMode = static_cast<HitMode>(programStackPopInteger(program));
     Object* weapon = static_cast<Object*>(programStackPopPointer(program));
     int weaponSfxType = programStackPopInteger(program);
 

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -3445,17 +3445,17 @@ static void inventoryRenderSummary()
         gInventoryRightHandItem,
     };
 
-    const int hitModes[2] = {
+    const HitMode hitModes[2] = {
         HIT_MODE_LEFT_WEAPON_PRIMARY,
         HIT_MODE_RIGHT_WEAPON_PRIMARY,
     };
 
-    const int secondaryHitModes[2] = {
+    const HitMode secondaryHitModes[2] = {
         HIT_MODE_LEFT_WEAPON_SECONDARY,
         HIT_MODE_RIGHT_WEAPON_SECONDARY,
     };
 
-    const int unarmedHitModes[2] = {
+    const HitMode unarmedHitModes[2] = {
         HIT_MODE_PUNCH,
         HIT_MODE_KICK,
     };
@@ -3480,7 +3480,7 @@ static void inventoryRenderSummary()
             if (messageListGetItem(&gInventoryMessageList, &messageListItem)) {
                 // SFALL: Display the actual damage values of unarmed attacks.
                 // CE: Implementation is different.
-                int hitMode = unarmedHitModes[index];
+                HitMode hitMode = unarmedHitModes[index];
                 if (_stack[0] == gDude) {
                     int actions[2];
                     interfaceGetItemActions(&(actions[0]), &(actions[1]));
@@ -3533,7 +3533,7 @@ static void inventoryRenderSummary()
         }
 
         // SFALL: Fix displaying secondary mode weapon range.
-        int hitMode = hitModes[index];
+        HitMode hitMode = hitModes[index];
         if (_stack[0] == gDude) {
             int actions[2];
             interfaceGetItemActions(&(actions[0]), &(actions[1]));

--- a/src/item.cc
+++ b/src/item.cc
@@ -1029,7 +1029,7 @@ bool dudeIsWeaponDisabled(Object* weapon)
         }
     }
 
-    return !scriptHooks_CanUseWeapon(canUse, gDude, weapon, -1);
+    return !scriptHooks_CanUseWeapon(canUse, gDude, weapon, HIT_MODE_INVALID);
 }
 
 // 0x477FB0
@@ -1046,7 +1046,7 @@ int itemGetInventoryFid(Object* item)
 }
 
 // 0x477FF8
-Object* critterGetWeaponForHitMode(Object* critter, int hitMode)
+Object* critterGetWeaponForHitMode(Object* critter, HitMode hitMode)
 {
     switch (hitMode) {
     case HIT_MODE_LEFT_WEAPON_PRIMARY:
@@ -1063,7 +1063,7 @@ Object* critterGetWeaponForHitMode(Object* critter, int hitMode)
 }
 
 // 0x478040
-int itemGetActionPointCost(Object* obj, int hitMode, bool aiming)
+int itemGetActionPointCost(Object* obj, HitMode hitMode, bool aiming)
 {
     if (obj == nullptr) {
         return 0;
@@ -1194,7 +1194,7 @@ bool itemIsHidden(Object* item)
 }
 
 // 0x478280
-int weaponGetAttackTypeForHitMode(Object* weapon, int hitMode)
+int weaponGetAttackTypeForHitMode(Object* weapon, HitMode hitMode)
 {
     if (weapon == nullptr) {
         return ATTACK_TYPE_UNARMED;
@@ -1214,7 +1214,7 @@ int weaponGetAttackTypeForHitMode(Object* weapon, int hitMode)
 }
 
 // 0x4782CC
-int weaponGetSkillForHitMode(Object* weapon, int hitMode)
+int weaponGetSkillForHitMode(Object* weapon, HitMode hitMode)
 {
     if (weapon == nullptr) {
         return SKILL_UNARMED;
@@ -1249,7 +1249,7 @@ int weaponGetSkillForHitMode(Object* weapon, int hitMode)
 // Returns skill value when critter is about to perform hitMode.
 //
 // 0x478370
-int weaponGetSkillValue(Object* critter, int hitMode)
+int weaponGetSkillValue(Object* critter, HitMode hitMode)
 {
     if (critter == nullptr) {
         return 0;
@@ -1290,7 +1290,7 @@ int weaponGetDamageMinMax(Object* weapon, int* minDamagePtr, int* maxDamagePtr)
 }
 
 // 0x478448
-int weaponGetDamage(Object* critter, int hitMode)
+int weaponGetDamage(Object* critter, HitMode hitMode)
 {
     if (critter == nullptr) {
         return 0;
@@ -1378,7 +1378,7 @@ int weaponIsTwoHanded(Object* weapon)
 }
 
 // 0x4785DC
-int critterGetAnimationForHitMode(Object* critter, int hitMode)
+int critterGetAnimationForHitMode(Object* critter, HitMode hitMode)
 {
     // NOTE: Uninline.
     Object* weapon = critterGetWeaponForHitMode(critter, hitMode);
@@ -1386,7 +1386,7 @@ int critterGetAnimationForHitMode(Object* critter, int hitMode)
 }
 
 // 0x47860C
-int weaponGetAnimationForHitMode(Object* weapon, int hitMode)
+int weaponGetAnimationForHitMode(Object* weapon, HitMode hitMode)
 {
     if (hitMode == HIT_MODE_KICK || (hitMode >= FIRST_ADVANCED_KICK_HIT_MODE && hitMode <= LAST_ADVANCED_KICK_HIT_MODE)) {
         return ANIM_KICK_LEG;
@@ -1653,7 +1653,7 @@ int weaponReload(Object* weapon, Object* ammo)
 }
 
 // 0x478A1C
-int weaponGetRange(Object* critter, int hitMode)
+int weaponGetRange(Object* critter, HitMode hitMode)
 {
     int range;
     int effectiveStrength;
@@ -1702,7 +1702,7 @@ int weaponGetRange(Object* critter, int hitMode)
 // Returns action points required for hit mode.
 //
 // 0x478B24
-int weaponGetActionPointCost(Object* critter, int hitMode, bool aiming)
+int weaponGetActionPointCost(Object* critter, HitMode hitMode, bool aiming)
 {
     int actionPoints;
 
@@ -1884,7 +1884,7 @@ char weaponGetSoundId(Object* weapon)
 }
 
 // 0x478E5C
-bool critterCanAim(Object* critter, int hitMode)
+bool critterCanAim(Object* critter, HitMode hitMode)
 {
     if (critter == gDude && traitIsSelected(TRAIT_FAST_SHOT)) {
         return false;
@@ -2027,7 +2027,7 @@ int weaponComputeAmmoCost(const Object* obj, int* ammoQty)
 
 // Returns whether the weapon has enough loaded ammo to perform at least one
 // shot/bullet for the selected hit mode.
-bool weaponHasAmmoForAttack(const Object* weapon, int hitMode)
+bool weaponHasAmmoForAttack(const Object* weapon, HitMode hitMode)
 {
     if (weapon == nullptr) {
         return false;
@@ -2083,7 +2083,7 @@ bool weaponIsGrenade(Object* weapon)
 }
 
 // 0x47910C
-int weaponGetDamageRadius(Object* weapon, int hitMode)
+int weaponGetDamageRadius(Object* weapon, HitMode hitMode)
 {
     int attackType = weaponGetAttackTypeForHitMode(weapon, hitMode);
     int anim = weaponGetAnimationForHitMode(weapon, hitMode);

--- a/src/item.h
+++ b/src/item.h
@@ -1,6 +1,7 @@
 #ifndef ITEM_H
 #define ITEM_H
 
+#include "combat_defs.h"
 #include "db.h"
 #include "obj_types.h"
 #include "proto_instance.h"
@@ -52,21 +53,21 @@ int objectGetCost(Object* obj);
 int objectGetInventoryWeight(Object* obj);
 bool dudeIsWeaponDisabled(Object* weapon);
 int itemGetInventoryFid(Object* obj);
-Object* critterGetWeaponForHitMode(Object* critter, int hitMode);
-int itemGetActionPointCost(Object* obj, int hitMode, bool aiming);
+Object* critterGetWeaponForHitMode(Object* critter, HitMode hitMode);
+int itemGetActionPointCost(Object* obj, HitMode hitMode, bool aiming);
 int itemGetQuantity(Object* obj, Object* item);
 int itemIsQueued(Object* obj);
 Object* itemReplace(Object* owner, Object* itemToReplace, int flags);
 bool itemIsHidden(Object* obj);
-int weaponGetAttackTypeForHitMode(Object* weapon, int hitMode);
-int weaponGetSkillForHitMode(Object* weapon, int hitMode);
-int weaponGetSkillValue(Object* critter, int hitMode);
+int weaponGetAttackTypeForHitMode(Object* weapon, HitMode hitMode);
+int weaponGetSkillForHitMode(Object* weapon, HitMode hitMode);
+int weaponGetSkillValue(Object* critter, HitMode hitMode);
 int weaponGetDamageMinMax(Object* weapon, int* minDamagePtr, int* maxDamagePtr);
-int weaponGetDamage(Object* critter, int hitMode);
+int weaponGetDamage(Object* critter, HitMode hitMode);
 int weaponGetDamageType(Object* critter, Object* weapon);
 int weaponIsTwoHanded(Object* weapon);
-int critterGetAnimationForHitMode(Object* critter, int hitMode);
-int weaponGetAnimationForHitMode(Object* weapon, int hitMode);
+int critterGetAnimationForHitMode(Object* critter, HitMode hitMode);
+int weaponGetAnimationForHitMode(Object* weapon, HitMode hitMode);
 int ammoGetCapacity(Object* ammoOrWeapon);
 int ammoGetQuantity(Object* ammoOrWeapon);
 int ammoGetCaliber(Object* ammoOrWeapon);
@@ -74,8 +75,8 @@ void ammoSetQuantity(Object* ammoOrWeapon, int quantity);
 int weaponAttemptReload(Object* critter, Object* weapon);
 bool weaponCanBeReloadedWith(Object* weapon, Object* ammo);
 int weaponReload(Object* weapon, Object* ammo);
-int weaponGetRange(Object* critter, int hitMode);
-int weaponGetActionPointCost(Object* critter, int hitMode, bool aiming);
+int weaponGetRange(Object* critter, HitMode hitMode);
+int weaponGetActionPointCost(Object* critter, HitMode hitMode, bool aiming);
 int weaponGetMinStrengthRequired(Object* weapon);
 int weaponGetCriticalFailureType(Object* weapon);
 int weaponGetPerk(Object* weapon);
@@ -84,15 +85,15 @@ int weaponGetAnimationCode(Object* weapon);
 int weaponGetProjectilePid(Object* weapon);
 int weaponGetAmmoTypePid(Object* weapon);
 char weaponGetSoundId(Object* weapon);
-bool critterCanAim(Object* critter, int hitMode);
+bool critterCanAim(Object* critter, HitMode hitMode);
 int weaponCanBeUnloaded(Object* weapon);
 Object* weaponUnload(Object* weapon);
 int weaponGetPrimaryActionPointCost(Object* weapon);
 int weaponGetSecondaryActionPointCost(Object* weapon);
 int weaponComputeAmmoCost(const Object* obj, int* ammoQty);
-bool weaponHasAmmoForAttack(const Object* weapon, int hitMode);
+bool weaponHasAmmoForAttack(const Object* weapon, HitMode hitMode);
 bool weaponIsGrenade(Object* weapon);
-int weaponGetDamageRadius(Object* weapon, int hitMode);
+int weaponGetDamageRadius(Object* weapon, HitMode hitMode);
 int weaponGetGrenadeExplosionRadius(Object* weapon);
 int weaponGetRocketExplosionRadius(Object* weapon);
 int weaponGetAmmoArmorClassModifier(Object* weapon);

--- a/src/sfall_metarules.cc
+++ b/src/sfall_metarules.cc
@@ -273,7 +273,7 @@ namespace {
             attack->attacker = objectValue;
             return true;
         case AttackDataField::HitMode:
-            if (!intDataValue(data, intValue) || !hitModeIsValid(intValue)) { 
+            if (!intDataValue(data, intValue) || !hitModeIsValid(intValue)) {
                 return false;
             }
             attack->hitMode = static_cast<HitMode>(intValue);
@@ -283,8 +283,8 @@ namespace {
             attack->weapon = objectValue;
             return true;
         case AttackDataField::Unused:
-            if (!intDataValue(data, intValue) || !hitLocationIsValid(intValue)) { 
-                return false; 
+            if (!intDataValue(data, intValue) || !hitLocationIsValid(intValue)) {
+                return false;
             }
             attack->attackHitLocation = static_cast<HitLocation>(intValue);
             return true;
@@ -309,8 +309,8 @@ namespace {
             attack->defender = objectValue;
             return true;
         case AttackDataField::BodyPart:
-            if (!intDataValue(data, intValue) || !hitLocationIsValid(intValue)) { 
-                return false; 
+            if (!intDataValue(data, intValue) || !hitLocationIsValid(intValue)) {
+                return false;
             }
             attack->defenderHitLocation = static_cast<HitLocation>(intValue);
             return true;

--- a/src/sfall_metarules.cc
+++ b/src/sfall_metarules.cc
@@ -274,7 +274,7 @@ namespace {
             return true;
         case AttackDataField::HitMode:
             if (!intDataValue(data, intValue)) return false;
-            attack->hitMode = intValue;
+            attack->hitMode = static_cast<HitMode>(intValue);
             return true;
         case AttackDataField::Weapon:
             if (!objectDataValue(data, objectValue)) return false;
@@ -282,7 +282,7 @@ namespace {
             return true;
         case AttackDataField::Unused:
             if (!intDataValue(data, intValue)) return false;
-            attack->attackHitLocation = intValue;
+            attack->attackHitLocation = static_cast<HitLocation>(intValue);
             return true;
         case AttackDataField::DamageSource:
             if (!intDataValue(data, intValue)) return false;
@@ -306,7 +306,7 @@ namespace {
             return true;
         case AttackDataField::BodyPart:
             if (!intDataValue(data, intValue)) return false;
-            attack->defenderHitLocation = intValue;
+            attack->defenderHitLocation = static_cast<HitLocation>(intValue);
             return true;
         case AttackDataField::DamageTarget:
             if (!intDataValue(data, intValue)) return false;
@@ -1101,7 +1101,7 @@ void mf_add_iface_tag(OpcodeContext& ctx)
 
 void mf_attack_is_aimed(OpcodeContext& ctx)
 {
-    int hitMode;
+    HitMode hitMode;
     bool aiming;
 
     if (interfaceGetCurrentHitMode(&hitMode, &aiming) == -1) {

--- a/src/sfall_metarules.cc
+++ b/src/sfall_metarules.cc
@@ -273,7 +273,9 @@ namespace {
             attack->attacker = objectValue;
             return true;
         case AttackDataField::HitMode:
-            if (!intDataValue(data, intValue)) return false;
+            if (!intDataValue(data, intValue) || !hitModeIsValid(intValue)) { 
+                return false;
+            }
             attack->hitMode = static_cast<HitMode>(intValue);
             return true;
         case AttackDataField::Weapon:
@@ -281,7 +283,9 @@ namespace {
             attack->weapon = objectValue;
             return true;
         case AttackDataField::Unused:
-            if (!intDataValue(data, intValue)) return false;
+            if (!intDataValue(data, intValue) || !hitLocationIsValid(intValue)) { 
+                return false; 
+            }
             attack->attackHitLocation = static_cast<HitLocation>(intValue);
             return true;
         case AttackDataField::DamageSource:
@@ -305,7 +309,9 @@ namespace {
             attack->defender = objectValue;
             return true;
         case AttackDataField::BodyPart:
-            if (!intDataValue(data, intValue)) return false;
+            if (!intDataValue(data, intValue) || !hitLocationIsValid(intValue)) { 
+                return false; 
+            }
             attack->defenderHitLocation = static_cast<HitLocation>(intValue);
             return true;
         case AttackDataField::DamageTarget:

--- a/src/sfall_opcodes.cc
+++ b/src/sfall_opcodes.cc
@@ -431,19 +431,19 @@ static void op_set_car_current_town(Program* program)
 // get_bodypart_hit_modifier
 static void op_get_bodypart_hit_modifier(Program* program)
 {
-    int hit_location = programStackPopInteger(program);
-    programStackPushInteger(program, combat_get_hit_location_penalty(hit_location));
+    HitLocation hitLocation = static_cast<HitLocation>(programStackPopInteger(program));
+    programStackPushInteger(program, combat_get_hit_location_penalty(hitLocation));
 }
 
 // set_bodypart_hit_modifier
 static void op_set_bodypart_hit_modifier(Program* program)
 {
     int penalty = programStackPopInteger(program);
-    int hit_location = programStackPopInteger(program);
-    combat_set_hit_location_penalty(hit_location, penalty);
+    HitLocation hitLocation = static_cast<HitLocation>(programStackPopInteger(program));
+    combat_set_hit_location_penalty(hitLocation, penalty);
 }
 
-static bool criticalTableArgsAreValid(Program* program, const char* opcodeName, int killType, int hitLocation, int effect, int dataMember)
+static bool criticalTableArgsAreValid(Program* program, const char* opcodeName, int killType, HitLocation hitLocation, int effect, CriticalHitDescriptionDataMember dataMember)
 {
     if (killType < 0 || killType > SFALL_KILL_TYPE_COUNT
         || hitLocation < 0 || hitLocation >= HIT_LOCATION_COUNT
@@ -459,9 +459,9 @@ static bool criticalTableArgsAreValid(Program* program, const char* opcodeName, 
 static void op_set_critical_table(Program* program)
 {
     int value = programStackPopInteger(program);
-    int dataMember = programStackPopInteger(program);
+    CriticalHitDescriptionDataMember dataMember = static_cast<CriticalHitDescriptionDataMember>(programStackPopInteger(program));
     int effect = programStackPopInteger(program);
-    int hitLocation = programStackPopInteger(program);
+    HitLocation hitLocation = static_cast<HitLocation>(programStackPopInteger(program));
     int killType = programStackPopInteger(program);
 
     if (!criticalTableArgsAreValid(program, "set_critical_table", killType, hitLocation, effect, dataMember)) {
@@ -473,9 +473,9 @@ static void op_set_critical_table(Program* program)
 
 static void op_get_critical_table(Program* program)
 {
-    int dataMember = programStackPopInteger(program);
+    CriticalHitDescriptionDataMember dataMember = static_cast<CriticalHitDescriptionDataMember>(programStackPopInteger(program));
     int effect = programStackPopInteger(program);
-    int hitLocation = programStackPopInteger(program);
+    HitLocation hitLocation = static_cast<HitLocation>(programStackPopInteger(program));
     int killType = programStackPopInteger(program);
 
     if (!criticalTableArgsAreValid(program, "get_critical_table", killType, hitLocation, effect, dataMember)) {
@@ -488,9 +488,9 @@ static void op_get_critical_table(Program* program)
 
 static void op_reset_critical_table(Program* program)
 {
-    int dataMember = programStackPopInteger(program);
+    CriticalHitDescriptionDataMember dataMember = static_cast<CriticalHitDescriptionDataMember>(programStackPopInteger(program));
     int effect = programStackPopInteger(program);
-    int hitLocation = programStackPopInteger(program);
+    HitLocation hitLocation = static_cast<HitLocation>(programStackPopInteger(program));
     int killType = programStackPopInteger(program);
 
     if (!criticalTableArgsAreValid(program, "reset_critical_table", killType, hitLocation, effect, dataMember)) {
@@ -1000,7 +1000,7 @@ static void op_create_message_window(Program* program)
 // get_attack_type
 static void op_get_attack_type(Program* program)
 {
-    int hit_mode;
+    HitMode hit_mode;
     if (interface_get_current_attack_mode(&hit_mode)) {
         programStackPushInteger(program, hit_mode);
     } else {

--- a/src/sfall_opcodes.cc
+++ b/src/sfall_opcodes.cc
@@ -431,7 +431,7 @@ static void op_set_car_current_town(Program* program)
 // get_bodypart_hit_modifier
 static void op_get_bodypart_hit_modifier(Program* program)
 {
-    HitLocation hitLocation = static_cast<HitLocation>(programStackPopInteger(program));
+    HitLocation hitLocation = programStackPopEnum<HitLocation>(program);
     programStackPushInteger(program, combat_get_hit_location_penalty(hitLocation));
 }
 
@@ -439,16 +439,16 @@ static void op_get_bodypart_hit_modifier(Program* program)
 static void op_set_bodypart_hit_modifier(Program* program)
 {
     int penalty = programStackPopInteger(program);
-    HitLocation hitLocation = static_cast<HitLocation>(programStackPopInteger(program));
+    HitLocation hitLocation = programStackPopEnum<HitLocation>(program);
     combat_set_hit_location_penalty(hitLocation, penalty);
 }
 
-static bool criticalTableArgsAreValid(Program* program, const char* opcodeName, int killType, HitLocation hitLocation, int effect, CriticalHitDescriptionDataMember dataMember)
+static bool criticalTableArgsAreValid(Program* program, const char* opcodeName, int killType, HitLocation hitLocation, int effect, CriticalHitDataMember dataMember)
 {
     if (killType < 0 || killType > SFALL_KILL_TYPE_COUNT
-        || hitLocation < 0 || hitLocation >= HIT_LOCATION_COUNT
+        || !hitLocationIsValid(hitLocation)
         || effect < 0 || effect >= CRTICIAL_EFFECT_COUNT
-        || dataMember < 0 || dataMember >= CRIT_DATA_MEMBER_COUNT) {
+        || !criticalHitDataMemberIsValid(dataMember)) {
         programPrintError("%s: argument values out of range", opcodeName);
         return false;
     }
@@ -459,9 +459,9 @@ static bool criticalTableArgsAreValid(Program* program, const char* opcodeName, 
 static void op_set_critical_table(Program* program)
 {
     int value = programStackPopInteger(program);
-    CriticalHitDescriptionDataMember dataMember = static_cast<CriticalHitDescriptionDataMember>(programStackPopInteger(program));
+    CriticalHitDataMember dataMember = programStackPopEnum<CriticalHitDataMember>(program);
     int effect = programStackPopInteger(program);
-    HitLocation hitLocation = static_cast<HitLocation>(programStackPopInteger(program));
+    HitLocation hitLocation = programStackPopEnum<HitLocation>(program);
     int killType = programStackPopInteger(program);
 
     if (!criticalTableArgsAreValid(program, "set_critical_table", killType, hitLocation, effect, dataMember)) {
@@ -473,9 +473,9 @@ static void op_set_critical_table(Program* program)
 
 static void op_get_critical_table(Program* program)
 {
-    CriticalHitDescriptionDataMember dataMember = static_cast<CriticalHitDescriptionDataMember>(programStackPopInteger(program));
+    CriticalHitDataMember dataMember = programStackPopEnum<CriticalHitDataMember>(program);
     int effect = programStackPopInteger(program);
-    HitLocation hitLocation = static_cast<HitLocation>(programStackPopInteger(program));
+    HitLocation hitLocation = programStackPopEnum<HitLocation>(program);
     int killType = programStackPopInteger(program);
 
     if (!criticalTableArgsAreValid(program, "get_critical_table", killType, hitLocation, effect, dataMember)) {
@@ -488,9 +488,9 @@ static void op_get_critical_table(Program* program)
 
 static void op_reset_critical_table(Program* program)
 {
-    CriticalHitDescriptionDataMember dataMember = static_cast<CriticalHitDescriptionDataMember>(programStackPopInteger(program));
+    CriticalHitDataMember dataMember = programStackPopEnum<CriticalHitDataMember>(program);
     int effect = programStackPopInteger(program);
-    HitLocation hitLocation = static_cast<HitLocation>(programStackPopInteger(program));
+    HitLocation hitLocation = programStackPopEnum<HitLocation>(program);
     int killType = programStackPopInteger(program);
 
     if (!criticalTableArgsAreValid(program, "reset_critical_table", killType, hitLocation, effect, dataMember)) {

--- a/src/sfall_script_hooks.cc
+++ b/src/sfall_script_hooks.cc
@@ -312,7 +312,7 @@ int     arg5 - 1 if this is an attack using a melee weapon, 0 otherwise
 int     ret0 - Either the damage to be used, if ret1 isn't given, or the new minimum damage if it is
 int     ret1 - The new maximum damage
 */
-void scriptHooks_ItemDamage(Object* weapon, Object* critter, int hitMode, bool isMeleeWeaponAttack, int* minDamagePtr, int* maxDamagePtr)
+void scriptHooks_ItemDamage(Object* weapon, Object* critter, HitMode hitMode, bool isMeleeWeaponAttack, int* minDamagePtr, int* maxDamagePtr)
 {
     assert(critter != nullptr);
     assert(minDamagePtr != nullptr);
@@ -559,7 +559,7 @@ Item    arg4 - The weapon for which the cost is calculated. If it is 0, the
 
 int     ret0 - The new AP cost
 */
-int scriptHooks_CalcApCost(Object* critter, int hitMode, bool aiming, int actionPoints, Object* weapon)
+int scriptHooks_CalcApCost(Object* critter, HitMode hitMode, bool aiming, int actionPoints, Object* weapon)
 {
     ScriptHookCall hook(HOOK_CALCAPCOST, 1, { critter, hitMode, aiming ? 1 : 0, actionPoints, weapon });
     hook.call();
@@ -645,7 +645,7 @@ int     arg7 - The raw hit chance before applying the cap
 
 int     ret0 - The new hit chance. The value is limited to the range of -99 to 999
 */
-int scriptHooks_ToHit(Object* attacker, Object* defender, int tile, int hitMode, int hitLocation, int hitChance, int hitChanceUncapped, bool useDistance)
+int scriptHooks_ToHit(Object* attacker, Object* defender, int tile, HitMode hitMode, HitLocation hitLocation, int hitChance, int hitChanceUncapped, bool useDistance)
 {
     ScriptHookCall hook(HOOK_TOHIT, 1,
         { hitChance,
@@ -678,7 +678,7 @@ int     ret0 - Override the hit/miss
 int     ret1 - Override the targeted bodypart
 Critter ret2 - Override the target of the attack
 */
-int scriptHooks_AfterHitRoll(Object* attacker, Object** defenderPtr, int* hitLocationPtr, int hitChance, int roll)
+int scriptHooks_AfterHitRoll(Object* attacker, Object** defenderPtr, HitLocation* hitLocationPtr, int hitChance, int roll)
 {
     assert(defenderPtr != nullptr && hitLocationPtr != nullptr);
 
@@ -697,8 +697,8 @@ int scriptHooks_AfterHitRoll(Object* attacker, Object** defenderPtr, int* hitLoc
     }
 
     if (hook.numReturnValues() > 1) {
-        int hitLocationOverride = hook.getReturnValueAt(1).asInt();
-        if (hitLocationOverride >= 0 && hitLocationOverride < HIT_LOCATION_COUNT) {
+        HitLocation hitLocationOverride = static_cast<HitLocation>(hook.getReturnValueAt(1).asInt());
+        if (hitLocationOverride >= HIT_LOCATION_HEAD && hitLocationOverride < HIT_LOCATION_COUNT) {
             *hitLocationPtr = hitLocationOverride;
         } else {
             debugPrint("HOOK_AFTERHITROLL: ignoring invalid hit location override %d", hitLocationOverride);
@@ -1077,7 +1077,7 @@ bool scriptHooks_InvenWield(Object* critter, Object* item, InvenSlot slot, int i
 
     int     ret0 - overrides the result of engine function
 */
-bool scriptHooks_CanUseWeapon(bool result, Object* critter, Object* weapon, int hitMode)
+bool scriptHooks_CanUseWeapon(bool result, Object* critter, Object* weapon, HitMode hitMode)
 {
     ScriptHookCall hook(HOOK_CANUSEWEAPON, 1, { critter, weapon, hitMode, result ? 1 : 0 });
     hook.call();

--- a/src/sfall_script_hooks.cc
+++ b/src/sfall_script_hooks.cc
@@ -698,7 +698,7 @@ int scriptHooks_AfterHitRoll(Object* attacker, Object** defenderPtr, HitLocation
 
     if (hook.numReturnValues() > 1) {
         HitLocation hitLocationOverride = static_cast<HitLocation>(hook.getReturnValueAt(1).asInt());
-        if (hitLocationOverride >= HIT_LOCATION_HEAD && hitLocationOverride < HIT_LOCATION_COUNT) {
+        if (hitLocationIsValid(hitLocationOverride)) {
             *hitLocationPtr = hitLocationOverride;
         } else {
             debugPrint("HOOK_AFTERHITROLL: ignoring invalid hit location override %d", hitLocationOverride);

--- a/src/sfall_script_hooks.h
+++ b/src/sfall_script_hooks.h
@@ -312,7 +312,7 @@ enum class EncounterHookResult {
 
 bool scriptHooksRegister(Program* program, HookType hookType, int procedureIndex);
 bool scriptHooks_StdProcedure(int procedureNumber, Object* self, Object* source, Object* target, int fixedParam, bool after);
-void scriptHooks_ItemDamage(Object* weapon, Object* critter, int hitMode, bool isMeleeWeaponAttack, int* minDamagePtr, int* maxDamagePtr);
+void scriptHooks_ItemDamage(Object* weapon, Object* critter, HitMode hitMode, bool isMeleeWeaponAttack, int* minDamagePtr, int* maxDamagePtr);
 int scriptHooks_AmmoCost(Object* weapon, int rounds, int ammoCost, AmmoCostHookType hookType);
 int scriptHooks_Steal(Object* thief, Object* target, Object* item, bool isPlanting, int quantity, int* xpOverride);
 
@@ -330,10 +330,10 @@ bool scriptHooks_CombatTurnStart(Object* critter, bool reloadedDuringCombat);
 bool scriptHooks_CombatTurnEnd(Object* critter, int turnResult, bool reloadedDuringCombat);
 void scriptHooks_CombatTurnCombatEnd(Object* critter);
 PerceptionResult scriptHooks_WithinPerception(Object* watcher, Object* target, PerceptionType type, PerceptionResult result);
-int scriptHooks_CalcApCost(Object* critter, int hitMode, bool aiming, int actionPoints, Object* weapon);
+int scriptHooks_CalcApCost(Object* critter, HitMode hitMode, bool aiming, int actionPoints, Object* weapon);
 int scriptHooks_MoveCost(Object* critter, int distance, int actionPoints);
-int scriptHooks_ToHit(Object* attacker, Object* defender, int tile, int hitMode, int hitLocation, int hitChance, int hitChanceUncapped, bool useDistance);
-int scriptHooks_AfterHitRoll(Object* attacker, Object** defenderPtr, int* hitLocationPtr, int hitChance, int roll);
+int scriptHooks_ToHit(Object* attacker, Object* defender, int tile, HitMode hitMode, HitLocation hitLocation, int hitChance, int hitChanceUncapped, bool useDistance);
+int scriptHooks_AfterHitRoll(Object* attacker, Object** defenderPtr, HitLocation* hitLocationPtr, int hitChance, int roll);
 void scriptHooks_DeathAnim(Object* attacker, Object* defender, Object* weapon, int damage, int* anim);
 UseSkillOnHookResult scriptHooks_UseSkillOn(Object** userPtr, Object* target, int skill);
 int scriptHooks_UseSkill(Object* user, Object* target, int skill, int skillBonus);
@@ -345,7 +345,7 @@ void scriptHooks_BarterPrice(BarterPriceContext* ctx);
 
 int scriptHooks_AdjustFid(int vanillaFid, int modifiedFid);
 bool scriptHooks_InvenWield(Object* critter, Object* item, InvenSlot slot, int isWield, int isRemove, bool filterInactiveHand = true);
-bool scriptHooks_CanUseWeapon(bool result, Object* critter, Object* weapon, int hitMode);
+bool scriptHooks_CanUseWeapon(bool result, Object* critter, Object* weapon, HitMode hitMode);
 
 } // namespace fallout
 


### PR DESCRIPTION
### Description

Enums defined in `combat_defs.h` were used as integers instead of having proper compile time type check.
This PR is enforcing the proper usage and prevents any mishmashes between usages of those enums.
There are still some places where I had to leave the `static_cast` from `int` like in interpreter code as i would have to introduce a template function for getting int based enum from the stack.

Enums were changed from C to C++ style so I could enforce proper enum underlying type which is not guaranteed if you do the `typedef enum`

Please note that there was inconsistency in `combat_ai.cc`  `_ai_called_shot` method.
It was having swaped `hitMode`  `hitLocation` parameters when calling `_determine_to_hit`.
That seems to be a vanilla bug as it's like so in reference edition.
https://github.com/alexbatalov/fallout2-re/blob/b135fc46ef40c4aecd156f3cebcf88ec531bb8ac/src/game/combatai.c#L2434 