### PR TITLE
[Et tu] Filter out GL* scripts as global if they are in scripts.lst

### DIFF
--- a/src/scripts.cc
+++ b/src/scripts.cc
@@ -1436,7 +1436,7 @@ static int scriptsLoadScriptsList()
         gScriptsListEntries = entries;
 
         ScriptsListEntry* entry = &(entries[gScriptsListEntriesLength - 1]);
-        entry->local_vars_num = 0;
+        memset(entry, 0, sizeof(*entry));
 
         char* substr = strstr(string, ".int");
         if (substr != nullptr) {
@@ -1493,6 +1493,13 @@ int _scr_find_str_run_info(int scriptIndex, int* /*unused*/, int sid)
 // 0x4A4F68
 int scriptsGetFileName(int scriptIndex, char* name, size_t size)
 {
+    if (!scriptsIsValidScriptIndex(scriptIndex) || gScriptsListEntries[scriptIndex].name[0] == '\0') {
+        if (size != 0) {
+            name[0] = '\0';
+        }
+        return -1;
+    }
+
     snprintf(name, size, "%s.int", gScriptsListEntries[scriptIndex].name);
     return 0;
 }

--- a/src/sfall_global_scripts.cc
+++ b/src/sfall_global_scripts.cc
@@ -34,6 +34,19 @@ struct GlobalScriptsState {
 
 static GlobalScriptsState* state = nullptr;
 
+static bool sfall_gl_scr_is_game_script(const char* fileName)
+{
+    for (int index = 0; index < scriptsGetListLength(); index++) {
+        char gameScriptFileName[20];
+        scriptsGetFileName(index, gameScriptFileName, sizeof(gameScriptFileName));
+        if (compat_stricmp(fileName, gameScriptFileName) == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 bool sfall_gl_scr_init()
 {
     state = new (std::nothrow) GlobalScriptsState();
@@ -48,6 +61,10 @@ bool sfall_gl_scr_init()
     int filesLength = fileNameListInit(scriptPath, &files);
     if (filesLength != 0) {
         for (int index = 0; index < filesLength; index++) {
+            if (sfall_gl_scr_is_game_script(files[index])) {
+                continue;
+            }
+
             char path[COMPAT_MAX_PATH];
             snprintf(path, sizeof(path), "%s\\%s", dir, files[index]);
             state->paths.push_back(std::string { path });

--- a/src/sfall_global_scripts.cc
+++ b/src/sfall_global_scripts.cc
@@ -37,7 +37,7 @@ static GlobalScriptsState* state = nullptr;
 static bool sfall_gl_scr_is_game_script(const char* fileName)
 {
     for (int index = 0; index < scriptsGetListLength(); index++) {
-        char gameScriptFileName[20];
+        char gameScriptFileName[100];
         if (scriptsGetFileName(index, gameScriptFileName, sizeof(gameScriptFileName)) == -1) {
             continue;
         }

--- a/src/sfall_global_scripts.cc
+++ b/src/sfall_global_scripts.cc
@@ -38,7 +38,10 @@ static bool sfall_gl_scr_is_game_script(const char* fileName)
 {
     for (int index = 0; index < scriptsGetListLength(); index++) {
         char gameScriptFileName[20];
-        scriptsGetFileName(index, gameScriptFileName, sizeof(gameScriptFileName));
+        if (scriptsGetFileName(index, gameScriptFileName, sizeof(gameScriptFileName)) == -1) {
+            continue;
+        }
+
         if (compat_stricmp(fileName, gameScriptFileName) == 0) {
             return true;
         }


### PR DESCRIPTION
Matches Sfall, prevents Et tu problems since a lot of Fo1 scripts start with GL*
