### PR TITLE
adds OBJECT_HIDDEN flag check for exit grids in objectSetLocation

### DIFF
--- a/src/object.cc
+++ b/src/object.cc
@@ -1436,6 +1436,11 @@ int objectSetLocation(Object* obj, int tile, int elevation, Rect* rect)
             if (elevation == elev) {
                 if (FID_TYPE(obj->fid) == OBJ_TYPE_MISC) {
                     if (isExitGridPid(obj->pid)) {
+                        if ((obj->flags & OBJECT_HIDDEN) != 0) {
+                            objectListNode = objectListNode->next;
+                            continue;
+                        }
+
                         ObjectData* data = &(obj->data);
 
                         MapTransition transition;


### PR DESCRIPTION
### Description

Currently, the `isExitGridAt` helper function correctly respects the OBJECT_HIDDEN flag and treats hidden exit grids as non-existent/invisible. However, the core movement logic inside `objectSetLocation` completely ignores this flag.When `gDude` steps onto a tile, `objectSetLocation` unconditionally triggers a map transition if any exit grid PID is found on that tile, completely ignoring whether the exit grid object has the OBJECT_HIDDEN flag set. This creates a logical inconsistency between what the game scripts/engine see as a valid exit grid and what physically triggers a map transition.

### Solution
This PR introduces a safe, explicit check for the OBJECT_HIDDEN flag directly inside the object iteration loop of objectSetLocation. If a hidden exit grid is encountered, the loop advances to the next node and continues scanning the tile safely, preventing any unexpected hangs or infinite loops.
