### PR TITLE
Correct PC placement when screen is large

### DIFF
--- a/src/map.cc
+++ b/src/map.cc
@@ -978,7 +978,7 @@ static int mapLoad(File* stream)
     }
 
     lightSetAmbientIntensity(LIGHT_INTENSITY_MAX, false);
-    objectSetLocation(gDude, gCenterTile, gElevation, nullptr);
+    objectSetLocation(gDude, gEnteringTile, gElevation, nullptr);
     objectSetRotation(gDude, gEnteringRotation, nullptr);
     gMapHeader.index = wmMapMatchNameToIdx(gMapHeader.name);
 


### PR DESCRIPTION
Fixes https://github.com/fallout2-ce/fallout2-ce/issues/578

This matches SFall/HRP change to map entering logic that ensures player is placed on the right tile