### PR TITLE
Validate art rotation offsets against the payload size

### DIFF
--- a/src/art.cc
+++ b/src/art.cc
@@ -1442,8 +1442,30 @@ int artRead(const char* path, unsigned char* data)
     int currentPadding = paddingForSize(sizeof(Art));
     int previousPadding = 0;
 
+    // CE: `dataOffsets` comes straight from the file header and is never
+    // validated. Some third-party art (notably Fallout 1.5: Resurrection)
+    // carries rotation offsets pointing past the end of the payload, which
+    // makes both the write below and the addressing in `artGetFrame` land
+    // outside the buffer allocated from `artGetDataSize`.
+    // There is no earlier rotation to fall back on for the first one, so a
+    // broken offset there means the file cannot be read at all. Art carrying
+    // no frames writes nothing and stays harmless, so leave it alone.
+    if (art->frameCount > 0 && (art->dataOffsets[0] < 0 || art->dataOffsets[0] >= art->dataSize)) {
+        fileClose(stream);
+        return -5;
+    }
+
     for (int index = 0; index < ROTATION_COUNT; index++) {
         art->padding[index] = currentPadding;
+
+        // CE: Alias an out-of-range rotation to the previous one instead of
+        // leaving a dangling offset behind, so that every later lookup stays
+        // within the buffer.
+        if (index != 0 && (art->dataOffsets[index] < 0 || art->dataOffsets[index] >= art->dataSize)) {
+            art->dataOffsets[index] = art->dataOffsets[index - 1];
+            art->padding[index] = art->padding[index - 1];
+            continue;
+        }
 
         if (index == 0 || art->dataOffsets[index - 1] != art->dataOffsets[index]) {
             art->padding[index] += previousPadding;


### PR DESCRIPTION
### Description

Fixes the crash on loading art shipped with Fallout 1.5: Resurrection, and closes the
underlying out-of-bounds access more generally.

`artReadHeader` performs no validation at all — it is a plain sequence of
`fileReadInt32` calls — so `dataOffsets` arrives in `artRead` exactly as written in the
file. Frame data is then written at

```
data + sizeof(Art) + art->dataOffsets[index] + art->padding[index]
```

while the buffer is sized by `artGetDataSize` as `sizeof(Art) + art->dataSize` plus a
small alignment allowance. Any offset beyond `dataSize` therefore writes outside the
allocation, at a displacement taken verbatim from the file. Resurrection's art trips
this and crashes on load; a deliberately crafted `.frm` inside a `.dat` would give a
controlled out-of-bounds write, so this seems worth treating as a hardening issue and
not only as mod compatibility.

Bounding the write is not sufficient on its own. The bad offset stays in the header,
and `artGetFrame` addresses frames the same way:

```c
ArtFrame* frm = (ArtFrame*)((unsigned char*)art + sizeof(*art)
                            + art->dataOffsets[rotation] + art->padding[rotation]);
```

with no validation either. Requesting that rotation would still read past the
allocation and interpret whatever is there as an `ArtFrame` — including `size`, which
drives the pointer arithmetic that walks to subsequent frames.

This PR therefore:

- aliases an out-of-range rotation to the previous one, so every later lookup stays
  inside the buffer;
- rejects the file when the *first* rotation is out of range, since there is no earlier
  rotation to fall back on;
- rejects negative offsets as well — the fields are signed `int`, so a crafted file
  could otherwise index backwards;
- leaves frameless art alone, which writes nothing and is already refused by
  `artGetFrame`.

Well-formed art is unaffected: valid offsets never enter either new branch, and the
existing duplicate-offset path is untouched.

### Credit

The crash was found and reported by @sonilyan in
https://github.com/alexbatalov/fallout2-ce/pull/348, which is still open against the
original upstream repo and was never carried over here.

That patch added a `dataOffsets[index] < dataSize` term to the existing condition. It
stops the out-of-bounds write, but leaves two gaps: the bad offset remains in the
header, so `artGetFrame` still addresses out of bounds whenever that rotation is
requested, and negative offsets pass the check unharmed. This PR takes a different
approach to cover both.

### Reproduction Steps and Savefile (if available)

As reported in the original issue: launch Fallout 1.5: Resurrection — the crash happens
while loading art, before the main menu.

### Screenshots

N/A — no visual change.

---

Verification status: builds cleanly and satisfies `clang-format`; the analysis above is
from reading the code. I do not have the Resurrection data files, so a check against the
actual mod would be worth doing before merging — in particular that no legitimate art
trips the new "first rotation out of range" rejection.

Happy to restructure — for instance, rejecting broken files outright instead of
aliasing, if you would rather surface bad art loudly than paper over it.
