### PR TITLE
Handle objects in rotation_to_tile

### DIFF
--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -4715,7 +4715,7 @@ static void opGetRotationToTile(Program* program)
     int tile2;
     if (value2.isInt()) {
         tile2 = value2.integerValue;
-    } else if (value2.isPointer()) {
+    } else if (value2.isPointer() && value2.pointerValue != nullptr) {
         tile2 = static_cast<Object*>(value2.pointerValue)->tile;
     } else {
         programFatalError("script error: %s: invalid arg 2 to rotation_to_tile", program->name);
@@ -4724,7 +4724,7 @@ static void opGetRotationToTile(Program* program)
     int tile1;
     if (value1.isInt()) {
         tile1 = value1.integerValue;
-    } else if (value1.isPointer()) {
+    } else if (value1.isPointer() && value1.pointerValue != nullptr) {
         tile1 = static_cast<Object*>(value1.pointerValue)->tile;
     } else {
         programFatalError("script error: %s: invalid arg 1 to rotation_to_tile", program->name);

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -4704,8 +4704,31 @@ static void opGetPartyMember(Program* program)
 // 0x45C6DC op_rotation_to_tile
 static void opGetRotationToTile(Program* program)
 {
-    int tile2 = programStackPopInteger(program);
-    int tile1 = programStackPopInteger(program);
+    // CE: There is a bug in Olympus (tgrdqest) - object is passed as one of the
+    // arguments instead of tile. Original game (x86) does not distinguish
+    // between integers and pointers, so one of the tiles is silently ignored
+    // while calculating rotation. As a workaround this opcode now accepts
+    // both integers and objects.
+    ProgramValue value2 = programStackPopValue(program);
+    ProgramValue value1 = programStackPopValue(program);
+
+    int tile2;
+    if (value2.isInt()) {
+        tile2 = value2.integerValue;
+    } else if (value2.isPointer()) {
+        tile2 = static_cast<Object*>(value2.pointerValue)->tile;
+    } else {
+        programFatalError("script error: %s: invalid arg 2 to rotation_to_tile", program->name);
+    }
+
+    int tile1;
+    if (value1.isInt()) {
+        tile1 = value1.integerValue;
+    } else if (value1.isPointer()) {
+        tile1 = static_cast<Object*>(value1.pointerValue)->tile;
+    } else {
+        programFatalError("script error: %s: invalid arg 1 to rotation_to_tile", program->name);
+    }
 
     int rotation = tileGetRotationTo(tile1, tile2);
     programStackPushInteger(program, rotation);


### PR DESCRIPTION
### Description

`rotation_to_tile` popped both arguments as integers. Olympus (`tgrdqest`) passes an
object where a tile is expected. On the original x86 build integers and pointers are
indistinguishable, so the stray argument was silently ignored while the rotation was
computed; here it produced a wrong result.

The opcode now pops `ProgramValue` and accepts either form, using `Object::tile` when a
pointer is passed, and raises a script error otherwise.

### Credit

The bug was found and fixed by @alexbatalov in
https://github.com/alexbatalov/fallout2-ce/pull/299 (issue
https://github.com/alexbatalov/fallout2-ce/issues/302), still open against the original
upstream repo and never carried over here. The first commit is his, unchanged.

The second commit addresses a gap in it: the pointer branch dereferenced the argument
without a null check, so a script passing a null object would crash rather than get a
script error. `opcode_context.cc` (`ARG_OBJECT`) and `sfall_metarules.cc` both guard
against exactly this when turning a `ProgramValue` into an `Object*`, so this follows
the existing convention.

### A pre-existing issue this widens

Worth flagging rather than fixing here, since it belongs to a different subsystem.

`tileGetRotationTo` ignores the return value of `tileToScreenXY`:

```c
int tileGetRotationTo(int tile1, int tile2)
{
    int x1, y1;
    tileToScreenXY(tile1, &x1, &y1);   // returns -1 without writing when the tile is invalid
    ...
    int dy = y2 - y1;                  // reads uninitialized locals
```

`tileToScreenXY` bails out early via `tileIsValid` and leaves the outputs untouched, so
an invalid tile means the arithmetic runs on indeterminate stack values.

This is reachable today — a script can already call `rotation_to_tile(-1, 100)` — but
accepting objects adds a new route to it, because an object that is not on the map
(carried in an inventory, for instance) has `tile == -1`.

The same shape appears elsewhere: `_tile_num_beyond` immediately below does it too, and
most of the ~46 `tileToScreenXY` call sites ignore the return value. It looks like an
artifact of the original decompilation rather than a recent regression, so I have left
it alone. Happy to open a separate PR or issue if you would like it addressed — and
equally happy to add a `tileIsValid` guard to this opcode instead, though that would
change behaviour for any mod currently relying on the lenient path.

### Reproduction Steps and Savefile (if available)

As described in the original issue: requires the Olympus mod, triggered by the
`tgrdqest` script.

### Screenshots

N/A — no visual change.

---

Verification status: builds cleanly and satisfies `clang-format`. I do not have Olympus
installed, so the behaviour change has not been exercised at runtime; the null-check
commit comes from the surrounding conventions rather than an observed crash.
