### PR TITLE
Fix three inaccuracies in reported sfall compatibility

### DIFF
--- a/SFALL_COMPATIBILITY.md
+++ b/SFALL_COMPATIBILITY.md
@@ -94,7 +94,7 @@ See [`https://sfall-team.github.io/sfall/`](https://sfall-team.github.io/sfall/)
 | NPCs | inc_npc_level<br>get_npc_level<br>npc_engine_level_up | not implemented | - |
 | Hero Appearance | set_dm/df_model<br>hero_select_win<br>set_hero_race<br>set_hero_style | not implemented | - |
 | Events | add_g_timer_event<br>remove_timer_event<br>create_spatial<br>spatial_radius | not implemented | - |
-| Other | get_year<br>active_hand<br>toggle_active_hand<br>get/set_viewport_x/y<br>get_light_level<br>message_str_game<br>sneak_success<br>unwield_slot<br>add_extra_msg_file<br>get_metarule_table<br>metarule_exist<br> | ✅ except get/set_viewport_x/y, sneak_success  | `input_funcs_available`, `nb_create_char` are deprecated in sfall and intentionally absent in CE. `add_extra_msg_file` does not support the explicit `fileNumber` form in CE. |
+| Other | get_year<br>active_hand<br>toggle_active_hand<br>get/set_viewport_x/y<br>get_light_level<br>message_str_game<br>sneak_success<br>unwield_slot<br>add_extra_msg_file<br>get_metarule_table<br>metarule_exist<br> | ✅ except get/set_viewport_x/y, sneak_success, get_metarule_table  | `input_funcs_available`, `nb_create_char` are deprecated in sfall and intentionally absent in CE. `add_extra_msg_file` does not support the explicit `fileNumber` form in CE. `metarule_exist` is available; `get_metarule_table` is not. |
 
 ## Hooks
 

--- a/SFALL_COMPATIBILITY.md
+++ b/SFALL_COMPATIBILITY.md
@@ -114,6 +114,10 @@ See [`https://sfall-team.github.io/sfall/`](https://sfall-team.github.io/sfall/)
 | BarterPrice | `HOOK_BARTERPRICE` | ✅ | - |
 | ItemDamage | `HOOK_ITEMDAMAGE` | ✅ | - |
 | MoveCost | `HOOK_MOVECOST` | ✅ | - |
+| HexMoveBlocking | `HOOK_HEXMOVEBLOCKING` | 🚫 | Deprecated in sfall; see below |
+| HexAIBlocking | `HOOK_HEXAIBLOCKING` | 🚫 | Deprecated in sfall; see below |
+| HexShootBlocking | `HOOK_HEXSHOOTBLOCKING` | 🚫 | Deprecated in sfall; see below |
+| HexSightBlocking | `HOOK_HEXSIGHTBLOCKING` | 🚫 | Deprecated in sfall; see below |
 | AmmoCost | `HOOK_AMMOCOST` | ✅ | Requires `check_weapon_ammo_cost=1` if you want pre-attack ammo validation to respect per-shot/per-round overrides. |
 | KeyPress | `HOOK_KEYPRESS` | ✅ | Third hook arg is currently `0`; CE doesn't use VK codes. |
 | MouseClick | `HOOK_MOUSECLICK` | ✅ | - |
@@ -146,3 +150,16 @@ See [`https://sfall-team.github.io/sfall/`](https://sfall-team.github.io/sfall/)
 | BestWeapon | `HOOK_BESTWEAPON` | 🚫 | - |
 | CanUseWeapon | `HOOK_CANUSEWEAPON` | ✅ | - |
 | BuildSfxWeapon | `HOOK_BUILDSFXWEAPON` | 🚫 | - |
+
+### The hex-blocking hooks
+
+`HOOK_HEXMOVEBLOCKING`, `HOOK_HEXAIBLOCKING`, `HOOK_HEXSHOOTBLOCKING` and
+`HOOK_HEXSIGHTBLOCKING` are deprecated by sfall itself, which warns that they "can become
+very CPU-intensive and you should avoid using them", that they are "not thoroughly
+supported in sfall", and that they "may be removed in future versions". CE marks them
+obsolete in `sfall_script_hooks.h` for the same reason, so they are unlikely to be
+implemented.
+
+Sfall points at `obj_blocking_tile`, `obj_blocking_line` and `path_find_to` instead — all
+three are supported in CE — and suggests `HOOK_MOVECOST` for reacting to NPC movement,
+which is supported as well.

--- a/src/scan_unimplemented_opcodes.h
+++ b/src/scan_unimplemented_opcodes.h
@@ -56,7 +56,6 @@ bool is_implemented_hook(int hookId)
     case 30: // HOOK_RESTTIMER
     case 31: // HOOK_GAMEMODECHANGE
     case 33: // HOOK_EXPLOSIVETIMER
-    case 34: // HOOK_DESCRIPTIONOBJ
     case 35: // HOOK_USESKILLON
     case 40: // HOOK_STDPROCEDURE
     case 41: // HOOK_STDPROCEDURE_END


### PR DESCRIPTION
### Description

Three inaccuracies in how CE reports its own sfall coverage. Found while diffing CE
against an sfall fork hook-by-hook and metarule-by-metarule; no behaviour changes, and
each commit stands alone.

**1. `--scan-unimplemented` reported an unimplemented hook as supported**

`is_implemented_hook` in `scan_unimplemented_opcodes.h` is what the scanner uses to tell
modders which of the hooks their mod registers are actually covered. It listed hook 34,
`HOOK_DESCRIPTIONOBJ`, but that hook exists only as an enum entry in
`sfall_script_hooks.h:115` — there is no `scriptHooks_` function for it and no call site
anywhere in the engine. A mod registering `hs_descriptionobj` was told it was covered
while the hook never fires. `SFALL_COMPATIBILITY.md` already had this one right (🚫), so
this brings the tool in line with the document.

**2. `get_metarule_table` was listed as supported**

The "Other" row marks the group supported apart from `get/set_viewport_x/y` and
`sneak_success`, which implies `get_metarule_table` works. It is commented out in the
metarule table (`sfall_metarules.cc:856`) and has no handler. `metarule_exist`, listed
right next to it, *is* available — the note now spells out the difference rather than
leaving the reader to work out which of the pair is missing.

I checked the rest of that row rather than just the one entry: `get_year`,
`active_hand`, `toggle_active_hand` and `get_light_level` are registered as opcodes in
`sfall_opcodes.cc`; `message_str_game` is registered at `0x826B` as `op_get_message`;
`unwield_slot` and `add_extra_msg_file` are in the metarule table. Those claims are all
correct and are left alone.

**3. Four standard hooks were missing from the table entirely**

`HOOK_HEXMOVEBLOCKING` (12), `HOOK_HEXAIBLOCKING` (13), `HOOK_HEXSHOOTBLOCKING` (14) and
`HOOK_HEXSIGHTBLOCKING` (15) were the only sfall hooks with no row at all. Every other
unsupported hook is marked 🚫, so a modder looking these up found nothing and could not
tell whether they were unsupported, undocumented, or just forgotten.

They are marked 🚫 with an explanation rather than left as an open gap, because sfall
deprecates them itself — it warns they "can become very CPU-intensive and you should
avoid using them", are "not thoroughly supported in sfall", and "may be removed in future
versions". That lines up with the `// obsolete:` marker already on them in
`sfall_script_hooks.h` and with the "bad for performance and/or stability" note at the top
of that enum, so CE's exclusion is deliberate. The added note carries over the
alternatives sfall recommends — `obj_blocking_tile`, `obj_blocking_line`, `path_find_to`,
and `HOOK_MOVECOST` for reacting to NPC movement — all of which CE supports.

I also cross-checked the whole hooks table in the other direction: all 30 hooks marked ✅
do have call sites. No other discrepancies found.

### Reproduction Steps and Savefile (if available)

For the first item: register `hs_descriptionobj` in a mod and run
`--scan-unimplemented`; the hook is reported as implemented, but no handler exists for
it in the engine.

The other two are documentation-only.

### Screenshots

N/A.

---

Verification: builds cleanly and satisfies `clang-format`. Unlike a behavioural change,
each claim here is checkable by reading the tree — the file and line references above are
the evidence, and the only code change is deleting one `case` label from a lookup used by
a diagnostic tool.

Happy to split this into separate PRs if you would rather review them independently.
