### PR TITLE
fixes party_member.cc memory leaks

### DIFF
--- a/src/party_member.cc
+++ b/src/party_member.cc
@@ -698,6 +698,9 @@ static int _partyMemberRecoverLoadInstance(PartyMemberListItem* a1)
     if (a1->vars != nullptr) {
         script->localVarsOffset = mapAllocLocalVars(script->localVarsCount);
         memcpy(gMapLocalVars + script->localVarsOffset, a1->vars, sizeof(int) * script->localVarsCount);
+
+        internal_free(a1->vars);
+        a1->vars = nullptr;
     }
 
     return 0;
@@ -706,21 +709,21 @@ static int _partyMemberRecoverLoadInstance(PartyMemberListItem* a1)
 // 0x494BBC partyMemberLoad
 int partyMembersLoad(File* stream)
 {
+    int result = -1;
+
     int* partyMemberObjectIds = (int*)internal_malloc(sizeof(*partyMemberObjectIds) * (gPartyMemberDescriptionsLength + 20));
     if (partyMemberObjectIds == nullptr) {
         return -1;
     }
 
-    // FIXME: partyMemberObjectIds is never free'd in this function, obviously memory leak.
-
-    if (fileReadInt32(stream, &gPartyMembersLength) == -1) return -1;
-    if (fileReadInt32(stream, &_partyMemberItemCount) == -1) return -1;
+    if (fileReadInt32(stream, &gPartyMembersLength) == -1) goto cleanup;
+    if (fileReadInt32(stream, &_partyMemberItemCount) == -1) goto cleanup;
 
     gPartyMembers->object = gDude;
 
     if (gPartyMembersLength != 0) {
         for (int index = 1; index < gPartyMembersLength; index++) {
-            if (fileReadInt32(stream, &(partyMemberObjectIds[index])) == -1) return -1;
+            if (fileReadInt32(stream, &(partyMemberObjectIds[index])) == -1) goto cleanup;
         }
 
         for (int index = 1; index < gPartyMembersLength; index++) {
@@ -750,7 +753,7 @@ int partyMembersLoad(File* stream)
         }
 
         if (_partyMemberUnPrepSave() == -1) {
-            return -1;
+            goto cleanup;
         }
     }
 
@@ -759,12 +762,16 @@ int partyMembersLoad(File* stream)
     for (int index = 1; index < gPartyMemberDescriptionsLength; index++) {
         PartyMemberLevelUpInfo* levelUpInfo = &(_partyMemberLevelUpInfoList[index]);
 
-        if (fileReadInt32(stream, &(levelUpInfo->level)) == -1) return -1;
-        if (fileReadInt32(stream, &(levelUpInfo->numLevelUps)) == -1) return -1;
-        if (fileReadInt32(stream, &(levelUpInfo->isEarly)) == -1) return -1;
+        if (fileReadInt32(stream, &(levelUpInfo->level)) == -1) goto cleanup;
+        if (fileReadInt32(stream, &(levelUpInfo->numLevelUps)) == -1) goto cleanup;
+        if (fileReadInt32(stream, &(levelUpInfo->isEarly)) == -1) goto cleanup;
     }
 
-    return 0;
+    result = 0;
+
+cleanup:
+    internal_free(partyMemberObjectIds);
+    return result;
 }
 
 // 0x494D7C partyMemberClear


### PR DESCRIPTION
clears out couple annoying leaks (gets in the way when debugging stuff) because they keep stacking up on every map transition/loadgame