### PR TITLE
[Et tu] Add world map travel timing

### DIFF
--- a/SFALL_COMPATIBILITY.md
+++ b/SFALL_COMPATIBILITY.md
@@ -57,6 +57,10 @@ The following settings were moved into [`<DAT>/config/game.cfg`](files/ce.dat/co
 | `Sound` | `EndGameMovieMusic1` | `sound` | `endgame_movie_music1` |
 | `Sound` | `MapLoadingSound` | `sound` | `map_loading_sound` |
 | `Interface` | `WorldMapTerrainInfo` | `worldmap` | `terrain_info` |
+| `Misc` | `WorldMapFPSPatch` + `WorldMapDelay2` | `worldmap` | `travel_delay` |
+
+Unlike sfall, `travel_delay` throttles only world-map travel simulation. Input,
+rendering, and world-map scripts continue at the normal frame rate.
 
 ## Opcodes / Metarules
 

--- a/files/ce.dat/config/game.cfg
+++ b/files/ce.dat/config/game.cfg
@@ -170,6 +170,8 @@ repair=293
 [worldmap]
 ; Set to 1 to prevent using number keys to enter unvisited areas on a town map.
 town_map_hotkeys_fix=1
+; Milliseconds between world map travel updates (1-150). Set to 0 to update every rendered frame.
+travel_delay=0
 ; Set to 1 to show travel markers on the world map, or 2 to show only when sneaking.
 trail_markers=0
 ; Set to 1 to show the current terrain name when hovering over the stopped party marker.

--- a/src/game_config_migration.cc
+++ b/src/game_config_migration.cc
@@ -1,5 +1,6 @@
 #include "game_config_migration.h"
 
+#include <algorithm>
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
@@ -307,6 +308,17 @@ static bool contentConfigMigrateFromSfall(Config* sfallConfig, const char* conte
     }
 
     bool migrated = false;
+
+    bool worldMapFpsPatch;
+    if (configGetBool(sfallConfig, kSfallMisc, "WorldMapFPSPatch", &worldMapFpsPatch)
+        && worldMapFpsPatch) {
+        int travelDelay = 66;
+        configGetInt(sfallConfig, kSfallMisc, "WorldMapDelay2", &travelDelay);
+        travelDelay = std::clamp(travelDelay, 1, 150);
+        configSetInt(&migratedConfig, CONTENT_CONFIG_WORLDMAP_SECTION, "travel_delay", travelDelay);
+        migrated = true;
+    }
+
     // Migrate start year/month/day only when explicitly set (not the sfall -1 sentinel).
     auto migrateStartInt = [&](const char* sfallKey, const char* targetKey, int defaultValue) {
         int value;

--- a/src/worldmap.cc
+++ b/src/worldmap.cc
@@ -544,6 +544,7 @@ static bool wmGameTimeIncrement(int ticksToAdd);
 static int wmGrabTileWalkMask(int tileIdx);
 static bool wmWorldPosInvalid(int x, int y);
 static void wmPartyInitWalking(int x, int y);
+static bool wmTravelTickDue(unsigned int now);
 static void wmPartyWalkingStep();
 static void wmInterfaceScrollTabsStart(int delta);
 static void wmInterfaceScrollTabsStop();
@@ -986,6 +987,8 @@ static FrmImage _townFrmImage;
 static bool wmFaded = false;
 static int wmForceEncounterMapId = -1;
 static unsigned int wmForceEncounterFlags = 0;
+static int worldmapTravelDelay;
+static unsigned int wmLastTravelTick;
 static int worldmapTrailMarkers;
 static bool worldmapTerrainInfo;
 static bool wmTerrainInfoIsVisible;
@@ -1094,6 +1097,8 @@ int wmWorldMap_init()
 
     // SFALL
     configGetBool(&gContentConfig, CONTENT_CONFIG_WORLDMAP_SECTION, "town_map_hotkeys_fix", &gTownMapHotkeysFix, true);
+    configGetInt(&gContentConfig, CONTENT_CONFIG_WORLDMAP_SECTION, "travel_delay", &worldmapTravelDelay, 0);
+    worldmapTravelDelay = std::clamp(worldmapTravelDelay, 0, 150);
     configGetInt(&gContentConfig, CONTENT_CONFIG_WORLDMAP_SECTION, "trail_markers", &worldmapTrailMarkers, 0);
     configGetBool(&gContentConfig, CONTENT_CONFIG_WORLDMAP_SECTION, "terrain_info", &worldmapTerrainInfo, false);
 
@@ -3319,6 +3324,7 @@ static int wmWorldMapFunc(int a1)
     int map = -1;
     int rc = 0;
     wmResetTerrainInfo();
+    wmLastTravelTick = getTicks();
 
     while (true) {
         sharedFpsLimiter.mark();
@@ -3362,7 +3368,7 @@ static int wmWorldMapFunc(int a1)
 
         int mouseEvent = mouseGetEvent();
 
-        if (wmGenData.isWalking) {
+        if (wmGenData.isWalking && wmTravelTickDue(now)) {
             wmPartyWalkingStep();
 
             if (wmGenData.isInCar) {
@@ -4671,6 +4677,7 @@ static void wmPartyInitWalking(int x, int y)
     wmGenData.walkDestinationY = y;
     wmGenData.currentAreaId = -1;
     wmGenData.isWalking = true;
+    wmLastTravelTick = getTicks();
 
     int dx = abs(x - wmGenData.worldPosX);
     int dy = abs(y - wmGenData.worldPosY);
@@ -4708,6 +4715,25 @@ static void wmPartyInitWalking(int x, int y)
     if (!wmCursorIsVisible()) {
         wmInterfaceCenterOnParty();
     }
+}
+
+static bool wmTravelTickDue(unsigned int now)
+{
+    if (worldmapTravelDelay == 0) {
+        return true;
+    }
+
+    if (getTicksBetween(now, wmLastTravelTick) < worldmapTravelDelay) {
+        return false;
+    }
+
+    wmLastTravelTick += worldmapTravelDelay;
+    if (getTicksBetween(now, wmLastTravelTick) >= worldmapTravelDelay) {
+        // Drop accumulated ticks after a stall instead of advancing in bursts.
+        wmLastTravelTick = now;
+    }
+
+    return true;
 }
 
 // 0x4C1F90 wmPartyWalkingStep


### PR DESCRIPTION
## Summary
- add semantic `[worldmap] travel_delay` content configuration
- gate travel, game-time, fuel, healing, and encounter simulation without throttling input or rendering
- migrate enabled sfall `WorldMapFPSPatch` + `WorldMapDelay2` settings

## Semantics
`0` preserves CE's current once-per-rendered-frame behavior. Values from 1 through 150 specify the travel update delay in milliseconds and use sfall's default of 66 during legacy migration. Accumulated ticks after a stall are dropped instead of advancing the simulation in bursts.

Unlike sfall's patched loop, CE keeps input, rendering, and world-map global scripts running at the normal frame rate.

## Validation
- `make JOBS=8 BUILD_DIR=out/build/local-debug-arm64`
- Et Tu clean migration: `WorldMapFPSPatch=1` + `WorldMapDelay2=33` generated `travel_delay=33`
- `git diff --check`
- independent subagent review: no findings