### PR TITLE
[Et tu] Add Fast Shot behavior modes

### DIFF
--- a/SFALL_COMPATIBILITY.md
+++ b/SFALL_COMPATIBILITY.md
@@ -48,6 +48,7 @@ The following settings were moved into [`<DAT>/config/game.cfg`](files/ce.dat/co
 | `Misc` | `ViewXPos` | `start` | `worldmap_view_x` |
 | `Misc` | `ViewYPos` | `start` | `worldmap_view_y` |
 | `Misc` | `StartGDialogFix` | `dialog` | `start_gdialog_fix` |
+| `Misc` | `FastShotFix` | `combat` | `fast_shot_fix` |
 
 ## Opcodes / Metarules
 

--- a/files/ce.dat/config/game.cfg
+++ b/files/ce.dat/config/game.cfg
@@ -86,6 +86,10 @@ science_on_critters=0
 ; Set to 1 to make pre-attack ammo checks respect weapon ammo cost and HOOK_AMMOCOST type 1 overrides.
 ; Set to 0 to preserve vanilla behavior where one loaded round is enough to attempt the attack.
 check_weapon_ammo_cost=1
+; Fast Shot behavior:
+; 0 - Fallout 2, 1 - allow aimed melee/short-range attacks, 2 - reduce all attacks by 1 AP,
+; 3 - Fallout 1 (reduce all weapon attacks by 1 AP).
+fast_shot_fix=0
 ; Set to 1 to enable modified burst bullet distribution (spray mod).
 burst_enabled=0
 ; Ratio of bullets going to the center group vs. left/right in burst attacks. Multiplier is capped at divisor.

--- a/src/game_config_migration.cc
+++ b/src/game_config_migration.cc
@@ -210,6 +210,7 @@ namespace {
         { kSfallMisc, "RemoveCriticalTimelimits", CONTENT_CONFIG_COMBAT_SECTION, "remove_critical_time_limits", "0" },
         { kSfallMisc, "ScienceOnCritters", CONTENT_CONFIG_COMBAT_SECTION, "science_on_critters", "0" },
         { kSfallMisc, "CheckWeaponAmmoCost", CONTENT_CONFIG_COMBAT_SECTION, "check_weapon_ammo_cost", nullptr },
+        { kSfallMisc, "FastShotFix", CONTENT_CONFIG_COMBAT_SECTION, "fast_shot_fix", "0" },
         { kSfallMisc, "ComputeSprayMod", CONTENT_CONFIG_COMBAT_SECTION, "burst_enabled", "0" },
         { kSfallMisc, "ComputeSpray_CenterMult", CONTENT_CONFIG_COMBAT_SECTION, "burst_center_mult", "1" },
         { kSfallMisc, "ComputeSpray_CenterDiv", CONTENT_CONFIG_COMBAT_SECTION, "burst_center_div", "3" },

--- a/src/item.cc
+++ b/src/item.cc
@@ -173,6 +173,7 @@ static Object* _wd_obj;
 static int _wd_gvar;
 
 static std::vector<BookDescription> gBooks;
+static int fastShotFixMode;
 static bool gExplosionEmitsLight;
 static int gGrenadeExplosionRadius;
 static int gRocketExplosionRadius;
@@ -209,6 +210,7 @@ int itemsInit()
     booksInit();
     explosionsInit();
     healingItemsInit();
+    configGetInt(&gContentConfig, CONTENT_CONFIG_COMBAT_SECTION, "fast_shot_fix", &fastShotFixMode, 0);
 
     return 0;
 }
@@ -1738,14 +1740,6 @@ int weaponGetActionPointCost(Object* critter, HitMode hitMode, bool aiming)
                 // NOTE: Uninline.
                 actionPoints = weaponGetSecondaryActionPointCost(weapon);
             }
-
-            if (critter == gDude) {
-                if (traitIsSelected(TRAIT_FAST_SHOT)) {
-                    if (weaponGetRange(critter, hitMode) > 2) {
-                        actionPoints--;
-                    }
-                }
-            }
         } else {
             actionPoints = 3;
         }
@@ -1753,6 +1747,23 @@ int weaponGetActionPointCost(Object* critter, HitMode hitMode, bool aiming)
 
     if (critter == gDude) {
         int attackType = weaponGetAttackTypeForHitMode(weapon, hitMode);
+
+        if (traitIsSelected(TRAIT_FAST_SHOT)) {
+            bool reduceActionPointCost;
+            if (fastShotFixMode > 2) {
+                // Fallout 1 behavior: all weapon attacks, but not unarmed.
+                reduceActionPointCost = weapon != nullptr;
+            } else if (fastShotFixMode == 2) {
+                reduceActionPointCost = true;
+            } else {
+                reduceActionPointCost = (attackType == ATTACK_TYPE_THROW || attackType == ATTACK_TYPE_RANGED)
+                    && weaponGetRange(critter, hitMode) >= 2;
+            }
+
+            if (reduceActionPointCost) {
+                actionPoints -= 1;
+            }
+        }
 
         if (perkHasRank(gDude, PERK_BONUS_HTH_ATTACKS)) {
             if (attackType == ATTACK_TYPE_MELEE || attackType == ATTACK_TYPE_UNARMED) {
@@ -1887,7 +1898,16 @@ char weaponGetSoundId(Object* weapon)
 bool critterCanAim(Object* critter, HitMode hitMode)
 {
     if (critter == gDude && traitIsSelected(TRAIT_FAST_SHOT)) {
-        return false;
+        if (fastShotFixMode != 1) {
+            return false;
+        }
+
+        Object* weapon = critterGetWeaponForHitMode(critter, hitMode);
+        int attackType = weaponGetAttackTypeForHitMode(weapon, hitMode);
+        if ((attackType == ATTACK_TYPE_THROW || attackType == ATTACK_TYPE_RANGED)
+            && weaponGetRange(critter, hitMode) >= 2) {
+            return false;
+        }
     }
 
     // NOTE: Uninline.


### PR DESCRIPTION
## Summary
- add `[combat] fast_shot_fix` with sfall modes 0 through 3
- apply mode-specific AP reductions for ranged, melee, weapon-unarmed, and true unarmed attacks
- implement mode 1 aimed-attack behavior
- migrate sfall `FastShotFix` and document the mapping

## Et Tu
Et Tu uses mode 3, matching Fallout 1: Fast Shot reduces every non-null weapon attack by 1 AP, including melee and brass-knuckle-style attacks, while true unarmed attacks receive no reduction. Aimed attacks remain disabled.

## Validation
- `make JOBS=8 BUILD_DIR=out/build/local-debug-arm64`
- Et Tu clean migration generated `fast_shot_fix=3`
- `git diff --check`
- independent subagent review against sfall AP/called-shot paths: no findings

Residual gap: there is no automated combat/AP matrix harness.