### PR TITLE
[Et tu] Add special map ID toggle

### DIFF
--- a/SFALL_COMPATIBILITY.md
+++ b/SFALL_COMPATIBILITY.md
@@ -48,6 +48,7 @@ The following settings were moved into [`<DAT>/config/game.cfg`](files/ce.dat/co
 | `Misc` | `ViewXPos` | `start` | `worldmap_view_x` |
 | `Misc` | `ViewYPos` | `start` | `worldmap_view_y` |
 | `Misc` | `StartGDialogFix` | `dialog` | `start_gdialog_fix` |
+| `Misc` | `DisableSpecialMapIDs` | `maps` | `disable_special_map_ids` |
 
 ## Opcodes / Metarules
 

--- a/files/ce.dat/config/game.cfg
+++ b/files/ce.dat/config/game.cfg
@@ -26,6 +26,11 @@ model_female_default=hfjmps
 ; Set to 2 to make the pipboy available by only skipping the vault suit movie check.
 pipboy=0
 
+[maps]
+; Set to 1 to apply transition tile, elevation, and rotation overrides on all maps,
+; including Fallout 2 map IDs 19 and 37.
+disable_special_map_ids=0
+
 [karma]
 ; FRM numbers for karma icons on the character screen. Number of points entries should be 1 less than number of frms entries.
 ; Example: frms=47,48,49  points=-100,100

--- a/src/content_config.h
+++ b/src/content_config.h
@@ -8,6 +8,7 @@ namespace fallout {
 #define CONTENT_CONFIG_START_SECTION "start"
 #define CONTENT_CONFIG_KARMA_SECTION "karma"
 #define CONTENT_CONFIG_ITEMS_SECTION "items"
+#define CONTENT_CONFIG_MAPS_SECTION "maps"
 #define CONTENT_CONFIG_DIALOG_SECTION "dialog"
 #define CONTENT_CONFIG_MAIN_MENU_SECTION "main_menu"
 #define CONTENT_CONFIG_MOVIES_SECTION "movies"

--- a/src/game_config_migration.cc
+++ b/src/game_config_migration.cc
@@ -184,6 +184,8 @@ namespace {
         { kSfallMisc, "FemaleStartModel", CONTENT_CONFIG_START_SECTION, "model_female", "hfprim" },
         { kSfallMisc, "FemaleDefaultModel", CONTENT_CONFIG_START_SECTION, "model_female_default", "hfjmps" },
         { kSfallMisc, "PipBoyAvailableAtGameStart", CONTENT_CONFIG_START_SECTION, "pipboy", "0" },
+        // [maps]
+        { kSfallMisc, "DisableSpecialMapIDs", CONTENT_CONFIG_MAPS_SECTION, "disable_special_map_ids", "0" },
         // [karma]
         { kSfallMisc, "KarmaFRMs", CONTENT_CONFIG_KARMA_SECTION, "frms" },
         { kSfallMisc, "KarmaPoints", CONTENT_CONFIG_KARMA_SECTION, "points" },

--- a/src/map.cc
+++ b/src/map.cc
@@ -12,6 +12,7 @@
 #include "character_editor.h"
 #include "color.h"
 #include "combat.h"
+#include "content_config.h"
 #include "critter.h"
 #include "cycle.h"
 #include "debug.h"
@@ -137,6 +138,7 @@ static TileData _square_data[ELEVATION_COUNT];
 
 // 0x631D28 map_state
 static MapTransition gMapTransition;
+static bool disableSpecialMapIds;
 
 // 0x631D38 map_display_rect
 static Rect gIsoWindowRect;
@@ -287,6 +289,8 @@ void isoExit()
 // 0x481FB4
 void mapInit()
 {
+    configGetBool(&gContentConfig, CONTENT_CONFIG_MAPS_SECTION, "disable_special_map_ids", &disableSpecialMapIds, false);
+
     if (settings.system.executableIsMapper()) {
         _map_scroll_refresh = isoWindowRefreshRectMapper;
     }
@@ -1332,7 +1336,8 @@ int mapHandleTransition()
             }
 
             if (gMapTransition.tile != -1 && gMapTransition.tile != 0
-                && gMapHeader.index != MAP_MODOC_BEDNBREAKFAST && gMapHeader.index != MAP_THE_SQUAT_A
+                && (disableSpecialMapIds
+                    || (gMapHeader.index != MAP_MODOC_BEDNBREAKFAST && gMapHeader.index != MAP_THE_SQUAT_A))
                 && elevationIsValid(gMapTransition.elevation)) {
                 objectSetLocation(gDude, gMapTransition.tile, gMapTransition.elevation, nullptr);
                 mapSetElevation(gMapTransition.elevation);


### PR DESCRIPTION
## Summary
- add `[maps] disable_special_map_ids` content configuration
- allow transition tile, elevation, and rotation overrides on Fallout 2 map IDs 19 and 37 when enabled
- migrate sfall `DisableSpecialMapIDs` and document the mapping

## Semantics
sfall replaces the two hardcoded comparison IDs with `-1`. CE expresses the same behavior directly by gating those exclusions, leaving transition validity checks and location/elevation/rotation ordering unchanged. Default-off behavior is preserved.

## Validation
- `make JOBS=8 BUILD_DIR=out/build/local-debug-arm64`
- Et Tu clean migration generated `disable_special_map_ids=1`
- `git diff --check`
- independent subagent review: no findings

Residual gap: no direct runtime transition into Fallout 2 map IDs 19/37 was exercised.