### PR TITLE
Revert weight indicator to green, and add old option

### DIFF
--- a/files/fallout2.cfg
+++ b/files/fallout2.cfg
@@ -169,6 +169,7 @@ in_game_menu_help=1
 ; Set to 0 for vanilla behavior (no weight indicator)
 ; Set to 1 to show a simple weight indicator; works with all inventory_columns values
 ; Set to 2 to show a detailed weight indicator; works with inventory_columns > 1 only
+; Set to 3 to show container size as XX/YY without the Wt. label
 loot_weight_indicator=1
 
 ; Set to 0 to show container indicator at all times

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -930,7 +930,8 @@ static void inventoryLootRenderPaneWeight(unsigned char* windowBuffer, int pitch
 
     bool showLabel = inventoryLootLayout.columns > 1;
     bool showDetailed = loot_weight_indicator == 2 && showLabel;
-    bool showSimple = loot_weight_indicator == 1 || (loot_weight_indicator == 2 && !showLabel);
+    bool showSize = loot_weight_indicator == 3;
+    bool showSimple = loot_weight_indicator == 1 || (loot_weight_indicator == 2 && !showLabel) || showSize;
 
     if (!showDetailed && !showSimple) {
         return;
@@ -967,7 +968,7 @@ static void inventoryLootRenderPaneWeight(unsigned char* windowBuffer, int pitch
             pitch);
     }
 
-    int color = COLOR_WHITE;
+    int color = COLOR_GREEN;
     int inventoryWeight = objectGetInventoryWeight(object);
     if (PID_TYPE(object->pid) == OBJ_TYPE_CRITTER) {
         int currentWeight = inventoryWeight + extraWeight;
@@ -975,7 +976,7 @@ static void inventoryLootRenderPaneWeight(unsigned char* windowBuffer, int pitch
         int weightPercentage = maxWeight < 1 ? 0 : (int)std::ceil(currentWeight * 100 / (float)maxWeight);
 
         if (showSimple) {
-            if (showLabel) {
+            if (showLabel && !showSize) {
                 snprintf(formattedText, sizeof(formattedText), "%s %d/%d", messageListItem.text, currentWeight, maxWeight);
             } else {
                 snprintf(formattedText, sizeof(formattedText), "%d/%d", currentWeight, maxWeight);
@@ -997,13 +998,15 @@ static void inventoryLootRenderPaneWeight(unsigned char* windowBuffer, int pitch
             return;
         }
 
-        if (showSimple) {
+        if (showSize) {
+            snprintf(formattedText, sizeof(formattedText), "%d/%d", currentSize, maxSize);
+        } else if (showSimple) {
             snprintf(formattedText, sizeof(formattedText), "%d%%", sizePercentage);
         } else if (showDetailed) {
             snprintf(formattedText, sizeof(formattedText), "%s %d (%d%%)", messageListItem.text, inventoryWeight, sizePercentage);
         }
     } else {
-        if (showLabel) {
+        if (showLabel && !showSize) {
             snprintf(formattedText, sizeof(formattedText), "%s %d", messageListItem.text, inventoryWeight);
         } else {
             snprintf(formattedText, sizeof(formattedText), "%d", inventoryWeight);
@@ -4152,7 +4155,7 @@ static void displayLootPanePartyName(unsigned char* windowBuffer, int windowPitc
     int nameY = rect.bottom - fontGetLineHeight();
     fontSetCurrent(oldFont);
 
-    inventoryDrawCenteredText(windowBuffer, windowPitch, INVENTORY_BODY_VIEW_WIDTH, rect.left, nameY, name, COLOR_WHITE);
+    inventoryDrawCenteredText(windowBuffer, windowPitch, INVENTORY_BODY_VIEW_WIDTH, rect.left, nameY, name, COLOR_GREEN);
 }
 
 // Displays item description.

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -172,7 +172,7 @@ void initSettingsRegistry(bool isMapper)
     SETTING(extend_ap_bar);
     SETTING(expand_barter_window);
     SETTING_P(inventory_columns, clamp(1, 2));
-    SETTING_P(loot_weight_indicator, clamp(0, 2));
+    SETTING_P(loot_weight_indicator, clamp(0, 3));
     SETTING_P(loot_container_size_indicator_threshold, clamp(0, 100));
 #undef SECT
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -99,6 +99,7 @@ struct UISettings {
     // 0 - No indicator, vanilla
     // 1 - Simple indicator
     // 2 - Detailed indicator, works with inventory_columns > 1 only
+    // 3 - Size indicator for containers
     int loot_weight_indicator = 1;
 
     // 0   - Container indicator is always visible


### PR DESCRIPTION
Got feedback that people preferred the green since white text is rarely used on terminals, which is reasonable.  I also added back the old mode for people who prefer it, while maintaining the default to be 1

We can make the colour configurable in the future if people have different wants