### PR TITLE
adds gameFreeGlobalVars() to gameReset()

### DIFF
--- a/src/game.cc
+++ b/src/game.cc
@@ -427,6 +427,7 @@ void gameReset()
     gameMouseReset();
     protoReset();
     _scr_reset();
+    gameFreeGlobalVars();
     gameLoadGlobalVars();
     scriptsReset();
     wmWorldMap_reset();


### PR DESCRIPTION
Adds missing gameFreeGlobalVars() to gameReset():

```cpp
--- File: src/game.cc ---
430 |     gameFreeGlobalVars();
431 |     gameLoadGlobalVars();
```

Asan logs are below, globalVars kept leaking on every game load.

Looks like the most basic scenarios (map transitions/game load) are clean now