### PR TITLE
[Et tu] Fix several issues with TMA

### DIFF
--- a/src/game.cc
+++ b/src/game.cc
@@ -1670,6 +1670,12 @@ void GameMode::exitGameMode(int gameMode)
     }
 }
 
+// remove game mode without triggering hooks
+void GameMode::exitGameModeQuietly(int gameMode)
+{
+    currentGameMode &= ~gameMode;
+}
+
 bool GameMode::isInGameMode(int gameMode)
 {
     return (currentGameMode & gameMode) != 0;

--- a/src/game.h
+++ b/src/game.h
@@ -82,6 +82,7 @@ public:
 
     static void enterGameMode(int gameMode);
     static void exitGameMode(int gameMode);
+    static void exitGameModeQuietly(int gameMode);
     static bool isInGameMode(int gameMode);
     static int getCurrentGameMode() { return currentGameMode; }
 

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -2026,7 +2026,7 @@ int gameDialogProcessUI()
             if (dialogSwitchMode == GAME_DIALOG_MODE_BARTER_ACTIVE) {
                 dialogMode = GAME_DIALOG_MODE_BARTER;
 
-                GameMode::exitGameMode(GameMode::kSpecial);
+                GameMode::exitGameModeQuietly(GameMode::kSpecial);
 
                 barterProcessUI(gGameDialogWindow, gGameDialogSpeaker, gGameDialogPlayerTableObj, gGameDialogBartererTableObj, gGameDialogBarterModifier);
                 gameDialogBarterCleanupTables();

--- a/src/input.cc
+++ b/src/input.cc
@@ -1023,7 +1023,10 @@ void _GNW95_process_message()
             if (!keyboardIsDisabled()) {
                 if (!e.key.repeat && !syntheticSfallKey) {
                     int keyOverride = sfall_kb_handle_key_pressed(keyboardData.key, keyboardData.down);
-                    if (keyOverride != SDL_SCANCODE_UNKNOWN) {
+                    if (keyOverride == SDL_SCANCODE_UNKNOWN) {
+                        break;
+                    }
+                    if (keyOverride != -1) {
                         keyboardData.key = keyOverride;
                     }
                 }

--- a/src/sfall_global_scripts.cc
+++ b/src/sfall_global_scripts.cc
@@ -18,6 +18,11 @@ static constexpr int kGlobalScriptBusyFlags = PROGRAM_FLAG_FATAL_ERROR
     | PROGRAM_FLAG_CHILD_CALL
     | PROGRAM_FLAG_CHILD_SPAWN;
 
+// sfall runs global script procs directly. CE keeps globals outside the normal
+// program list, so pending callbacks are resumed here; use a large bounded burst
+// to avoid stretching UI callbacks over multiple frames.
+static constexpr int kGlobalScriptContinuationBurstSize = 100;
+
 struct GlobalScript {
     Program* program = nullptr;
     int procs[SCRIPT_PROC_COUNT] = { 0 };
@@ -236,8 +241,9 @@ bool sfall_gl_scr_is_loaded(Program* program)
 
 void sfall_gl_scr_update(int burstSize)
 {
+    int globalScriptBurstSize = std::max(burstSize, kGlobalScriptContinuationBurstSize);
     for (auto& scr : state->globalScripts) {
-        programInterpret(scr.program, burstSize);
+        programInterpret(scr.program, globalScriptBurstSize);
     }
 }
 

--- a/src/sfall_kb_helpers.cc
+++ b/src/sfall_kb_helpers.cc
@@ -366,7 +366,7 @@ void sfall_kb_clear_synthetic_key_events()
 
 int sfall_kb_handle_key_pressed(int sdlScanCode, bool pressed)
 {
-    if (!gGameLoaded) return SDL_SCANCODE_UNKNOWN;
+    if (!gGameLoaded) return -1;
 
     ScriptHookCall hook(HOOK_KEYPRESS, 1, {
                                               pressed ? 1 : 0, get_key_from_scancode(static_cast<SDL_Scancode>(sdlScanCode)),
@@ -375,7 +375,7 @@ int sfall_kb_handle_key_pressed(int sdlScanCode, bool pressed)
     hook.call();
 
     if (hook.numReturnValues() <= 0) {
-        return SDL_SCANCODE_UNKNOWN;
+        return -1;
     }
 
     int overrideDxCode = hook.getReturnValueAt(0).asInt();

--- a/src/sfall_kb_helpers.h
+++ b/src/sfall_kb_helpers.h
@@ -15,6 +15,8 @@ bool sfall_kb_consume_synthetic_key_event(int sdlScanCode, bool pressed);
 // Clears queued synthetic `tap_key` markers after SDL key events are discarded.
 void sfall_kb_clear_synthetic_key_events();
 
+// Returns -1 when scripts did not override the key. Otherwise returns the
+// replacement SDL scancode, or SDL_SCANCODE_UNKNOWN to swallow the event.
 int sfall_kb_handle_key_pressed(int sdlScanCode, bool pressed);
 
 } // namespace fallout


### PR DESCRIPTION
* `b` and other keys no longer triggers non-TMA actions
* performance is restored.

Both are much closer to Sfall semantics now.  Performance was due to only executing 10 instructions per frame, now bumped to 100
