### PR TITLE
Make blood non-examinable again

### DIFF
--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -710,24 +710,27 @@ void gameMouseRefresh()
                         // if the pointedObject is OBJ_TYPE_SCENERY/OBJ_TYPE_WALL/OBJ_TYPE_MISC object then try to find possible itemObject behind it
                         // this must be in sync with the switch/case in _gmouse_handle_event
                         Object* itemObject = gameMouseGetObjectUnderCursor(OBJ_TYPE_ITEM, true, gElevation);
+
+                        if (itemObject == nullptr && objectType == OBJ_TYPE_MISC) {
+                            break;
+                        }
+
                         bool itemIsOutlined = objectHasVisibleOutline(itemObject);
 
-                        // filter out potential itemObject behind usable scenery which is not outlined already
-                        if (!itemIsOutlined && objectType == OBJ_TYPE_SCENERY && _obj_action_can_use(pointedObject)) {
-                            primaryAction = GAME_MOUSE_ACTION_MENU_ITEM_USE;
-                            break;
-                        }
+                        if (!itemIsOutlined) {
+                            // filter out potential itemObject behind usable scenery which is not outlined already
+                            if (objectType == OBJ_TYPE_SCENERY && _obj_action_can_use(pointedObject)) {
+                                primaryAction = GAME_MOUSE_ACTION_MENU_ITEM_USE;
+                                break;
+                            }
 
-                        bool canBeShootOrSeenThroughObject = (pointedObject->flags & OBJECT_SHOOT_THRU) != 0 || (pointedObject->flags & OBJECT_LIGHT_THRU) != 0;
+                            bool canBeShootOrSeenThroughObject = (pointedObject->flags & (OBJECT_SHOOT_THRU | OBJECT_LIGHT_THRU)) != 0;
 
-                        // filter out not found itemObject and itemObject behind the blocking walls which is not outlined already
-                        if (objectType == OBJ_TYPE_MISC && itemObject == nullptr) {
-                            break;
-                        }
-
-                        if (itemObject == nullptr || (!itemIsOutlined && objectType == OBJ_TYPE_WALL && !canBeShootOrSeenThroughObject)) {
-                            primaryAction = GAME_MOUSE_ACTION_MENU_ITEM_LOOK;
-                            break;
+                            // filter out not found itemObject and itemObject behind the blocking walls which is not outlined already
+                            if (itemObject == nullptr || (objectType == OBJ_TYPE_WALL && !canBeShootOrSeenThroughObject)) {
+                                primaryAction = GAME_MOUSE_ACTION_MENU_ITEM_LOOK;
+                                break;
+                            }
                         }
 
                         // intentionally fall trough the OBJ_TYPE_ITEM to enforce auto outlining of the itemObject and changing the mouse action menu

--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -713,7 +713,7 @@ void gameMouseRefresh()
                         bool itemIsOutlined = objectHasVisibleOutline(itemObject);
 
                         // filter out potential itemObject behind usable scenery which is not outlined already
-                        if (!itemIsOutlined && _obj_action_can_use(pointedObject)) {
+                        if (!itemIsOutlined && objectType == OBJ_TYPE_SCENERY && _obj_action_can_use(pointedObject)) {
                             primaryAction = GAME_MOUSE_ACTION_MENU_ITEM_USE;
                             break;
                         }
@@ -721,6 +721,10 @@ void gameMouseRefresh()
                         bool canBeShootOrSeenThroughObject = (pointedObject->flags & OBJECT_SHOOT_THRU) != 0 || (pointedObject->flags & OBJECT_LIGHT_THRU) != 0;
 
                         // filter out not found itemObject and itemObject behind the blocking walls which is not outlined already
+                        if (objectType == OBJ_TYPE_MISC && itemObject == nullptr) {
+                            break;
+                        }
+
                         if (itemObject == nullptr || (!itemIsOutlined && objectType == OBJ_TYPE_WALL && !canBeShootOrSeenThroughObject)) {
                             primaryAction = GAME_MOUSE_ACTION_MENU_ITEM_LOOK;
                             break;
@@ -1016,12 +1020,13 @@ void _gmouse_handle_event(int mouseX, int mouseY, int mouseState)
                     // this must be in sync with the switch/case in gameMouseRefresh
                     Object* itemObj = gameMouseGetObjectUnderCursor(OBJ_TYPE_ITEM, true, gElevation);
                     if (!objectHasVisibleOutline(itemObj)) {
-                        if (_obj_action_can_use(targetObj)) {
+                        int objectType = FID_TYPE(targetObj->fid);
+                        if (objectType == OBJ_TYPE_SCENERY && _obj_action_can_use(targetObj)) {
                             _action_use_an_object(gDude, targetObj);
                             break;
                         }
 
-                        if (objectExamine(gDude, targetObj) == -1) {
+                        if (objectType != OBJ_TYPE_MISC && objectExamine(gDude, targetObj) == -1) {
                             objectLookAt(gDude, targetObj);
                         }
                         break;

--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -1012,7 +1012,8 @@ void _gmouse_handle_event(int mouseX, int mouseY, int mouseState)
         if (gGameMouseMode == GAME_MOUSE_MODE_ARROW) {
             Object* targetObj = gameMouseGetObjectUnderCursor(-1, true, gElevation);
             if (targetObj != nullptr) {
-                switch (FID_TYPE(targetObj->fid)) {
+                int objectType = FID_TYPE(targetObj->fid);
+                switch (objectType) {
                 case OBJ_TYPE_WALL:
                 case OBJ_TYPE_SCENERY:
                 case OBJ_TYPE_MISC: {
@@ -1020,7 +1021,6 @@ void _gmouse_handle_event(int mouseX, int mouseY, int mouseState)
                     // this must be in sync with the switch/case in gameMouseRefresh
                     Object* itemObj = gameMouseGetObjectUnderCursor(OBJ_TYPE_ITEM, true, gElevation);
                     if (!objectHasVisibleOutline(itemObj)) {
-                        int objectType = FID_TYPE(targetObj->fid);
                         if (objectType == OBJ_TYPE_SCENERY && _obj_action_can_use(targetObj)) {
                             _action_use_an_object(gDude, targetObj);
                             break;


### PR DESCRIPTION
Fix for #603 to returns to the state of MISC objects not having an Examine function

Before 603:
<img width="744" height="522" alt="image" src="https://github.com/user-attachments/assets/5ee97220-8d93-4190-a335-f9be531bb5a7" />

After 603:
<img width="584" height="505" alt="image" src="https://github.com/user-attachments/assets/713316fe-c73a-4683-8e8f-97702dd8d43e" />
