### PR TITLE
[Et tu] Add lower bound check to `op_tile_num_in_direction`

### DIFF
--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -1536,7 +1536,7 @@ static void opGetTileInDirection(Program* program)
     int tile = -1;
 
     if (origin != -1) {
-        if (rotation < ROTATION_COUNT) {
+        if (rotation >= ROTATION_FIRST && rotation < ROTATION_COUNT) {
             if (distance != 0) {
                 tile = tileGetTileInDirection(origin, rotation, distance);
                 if (tile < -1) {

--- a/src/obj_types.h
+++ b/src/obj_types.h
@@ -12,6 +12,7 @@ typedef enum Rotation {
     ROTATION_W, // 4
     ROTATION_NW, // 5
     ROTATION_COUNT,
+    ROTATION_FIRST = ROTATION_NE,
 } Rotation;
 
 enum ObjectType {


### PR DESCRIPTION
This prevents an ASAN crash for some versions of gl_autopush in Et tu
