### PR TITLE
[Et tu] Support worldmap encounter rate config

### DIFF
--- a/SFALL_COMPATIBILITY.md
+++ b/SFALL_COMPATIBILITY.md
@@ -59,9 +59,14 @@ The following settings were moved into [`<DAT>/config/game.cfg`](files/ce.dat/co
 | `Sound` | `MapLoadingSound` | `sound` | `map_loading_sound` |
 | `Interface` | `WorldMapTerrainInfo` | `worldmap` | `terrain_info` |
 | `Misc` | `WorldMapFPSPatch` + `WorldMapDelay2` | `worldmap` | `travel_delay` |
+| `Misc` | `WorldMapEncounterFix` + `WorldMapEncounterRate` | `worldmap` | `encounter_rate` |
 
 Unlike sfall, `travel_delay` throttles only world-map travel simulation. Input,
 rendering, and world-map scripts continue at the normal frame rate.
+
+CE also migrates a positive non-default `WorldMapEncounterRate` as an explicit
+`encounter_rate` override even when `WorldMapEncounterFix` is disabled. This
+preserves Fallout Et Tu's shipped `WorldMapEncounterRate=30` setting in CE.
 
 ## Opcodes / Metarules
 

--- a/files/ce.dat/config/game.cfg
+++ b/files/ce.dat/config/game.cfg
@@ -182,6 +182,9 @@ repair=293
 town_map_hotkeys_fix=1
 ; Milliseconds between world map travel updates (1-150). Set to 0 to update every rendered frame.
 travel_delay=0
+; Fixed world map encounter check cadence in travel updates. Set to 0 to use vanilla time-based checks.
+; Matches sfall WorldMapEncounterRate when enabled; higher values cause fewer encounter checks.
+encounter_rate=0
 ; Set to 1 to show travel markers on the world map, or 2 to show only when sneaking.
 trail_markers=0
 ; Set to 1 to show the current terrain name when hovering over the stopped party marker.

--- a/src/game_config_migration.cc
+++ b/src/game_config_migration.cc
@@ -175,6 +175,27 @@ namespace {
         const char* defaultValue;
     };
 
+    static bool contentConfigMigrateSfallWorldMapEncounterRate(Config* sfallConfig, Config* migratedConfig)
+    {
+        assert(sfallConfig != nullptr && migratedConfig != nullptr);
+
+        bool worldMapEncounterFix = false;
+        bool hasWorldMapEncounterFix = configGetBool(sfallConfig, kSfallMisc, "WorldMapEncounterFix", &worldMapEncounterFix);
+        int encounterRate = 5;
+        bool hasWorldMapEncounterRate = configGetInt(sfallConfig, kSfallMisc, "WorldMapEncounterRate", &encounterRate);
+        if (hasWorldMapEncounterFix && worldMapEncounterFix) {
+            configSetInt(migratedConfig, CONTENT_CONFIG_WORLDMAP_SECTION, "encounter_rate", std::max(encounterRate, 1));
+            return true;
+        }
+
+        if (hasWorldMapEncounterRate && encounterRate > 0 && encounterRate != 5) {
+            configSetInt(migratedConfig, CONTENT_CONFIG_WORLDMAP_SECTION, "encounter_rate", encounterRate);
+            return true;
+        }
+
+        return false;
+    }
+
     constexpr SfallMigrationEntry kSfallMigrationEntries[] = {
         // [start]
         { kSfallMisc, "StartingMap", CONTENT_CONFIG_START_SECTION, "map", "" },
@@ -296,7 +317,8 @@ namespace {
 // Migrate sfall settings from ddraw.ini to game.cfg.
 //
 // Runs once when no local game.cfg exists at contentConfigFilePath.
-// Writes only the settings found in sfallConfig to a new local file.
+// Writes only settings derived from sfallConfig, using sfall defaults where
+// needed to preserve enabled behavior.
 static bool contentConfigMigrateFromSfall(Config* sfallConfig, const char* contentConfigFilePath)
 {
     assert(sfallConfig != nullptr && contentConfigFilePath != nullptr);
@@ -320,6 +342,10 @@ static bool contentConfigMigrateFromSfall(Config* sfallConfig, const char* conte
         configGetInt(sfallConfig, kSfallMisc, "WorldMapDelay2", &travelDelay);
         travelDelay = std::clamp(travelDelay, 1, 150);
         configSetInt(&migratedConfig, CONTENT_CONFIG_WORLDMAP_SECTION, "travel_delay", travelDelay);
+        migrated = true;
+    }
+
+    if (contentConfigMigrateSfallWorldMapEncounterRate(sfallConfig, &migratedConfig)) {
         migrated = true;
     }
 

--- a/src/worldmap.cc
+++ b/src/worldmap.cc
@@ -994,6 +994,7 @@ static bool wmFaded = false;
 static int wmForceEncounterMapId = -1;
 static unsigned int wmForceEncounterFlags = 0;
 static int worldmapTravelDelay;
+static int worldmapEncounterRate;
 static unsigned int wmLastTravelTick;
 static int worldmapTrailMarkers;
 static bool worldmapTerrainInfo;
@@ -1105,6 +1106,8 @@ int wmWorldMap_init()
     configGetBool(&gContentConfig, CONTENT_CONFIG_WORLDMAP_SECTION, "town_map_hotkeys_fix", &gTownMapHotkeysFix, true);
     configGetInt(&gContentConfig, CONTENT_CONFIG_WORLDMAP_SECTION, "travel_delay", &worldmapTravelDelay, 0);
     worldmapTravelDelay = std::clamp(worldmapTravelDelay, 0, 150);
+    configGetInt(&gContentConfig, CONTENT_CONFIG_WORLDMAP_SECTION, "encounter_rate", &worldmapEncounterRate, 0);
+    worldmapEncounterRate = std::max(worldmapEncounterRate, 0);
     configGetInt(&gContentConfig, CONTENT_CONFIG_WORLDMAP_SECTION, "trail_markers", &worldmapTrailMarkers, 0);
     configGetBool(&gContentConfig, CONTENT_CONFIG_WORLDMAP_SECTION, "terrain_info", &worldmapTerrainInfo, false);
 
@@ -3377,6 +3380,11 @@ static int wmWorldMapFunc(int a1)
         int mouseEvent = mouseGetEvent();
 
         if (wmGenData.isWalking && wmTravelTickDue(now)) {
+            if (worldmapEncounterRate > 0) {
+                // sfall reuses wmLastRndTime as a travel-update counter in fixed-rate mode.
+                wmLastRndTime++;
+            }
+
             wmPartyWalkingStep();
 
             if (wmGenData.isInCar) {
@@ -3696,12 +3704,20 @@ static int wmRndEncounterOccurred(int* mapToLoadPtr)
     assert(mapToLoadPtr != nullptr);
     *mapToLoadPtr = -1;
 
-    unsigned int now = getTicks();
-    if (getTicksBetween(now, wmLastRndTime) < 1500) {
-        return 0;
-    }
+    if (worldmapEncounterRate > 0) {
+        if (wmLastRndTime < static_cast<unsigned int>(worldmapEncounterRate)) {
+            return 0;
+        }
 
-    wmLastRndTime = now;
+        wmLastRndTime = 0;
+    } else {
+        unsigned int now = getTicks();
+        if (getTicksBetween(now, wmLastRndTime) < 1500) {
+            return 0;
+        }
+
+        wmLastRndTime = now;
+    }
 
     if (abs(wmGenData.oldWorldPosX - wmGenData.worldPosX) < 3) {
         return 0;
@@ -4893,7 +4909,7 @@ static int wmInterfaceInit()
 {
     int fid;
 
-    wmLastRndTime = getTicks();
+    wmLastRndTime = worldmapEncounterRate > 0 ? 0 : getTicks();
 
     // SFALL: Fix default worldmap font.
     // CE: This setting affects only city names. In Sfall it's configurable via


### PR DESCRIPTION
## Summary
- add worldmap.encounter_rate as a game.cfg override for fixed world-map encounter check cadence
- migrate sfall WorldMapEncounterRate during full ddraw.ini -> game#patch.cfg migration
- document the migrated setting and Et Tu's positive non-default rate handling

(Actually, Et Tu might have this off, so not touching it)