### PR TITLE
[Et tu] Add safe cropping to town screen

### DIFF
--- a/src/worldmap.cc
+++ b/src/worldmap.cc
@@ -6626,10 +6626,12 @@ static int wmTownMapInit()
 // 0x4C4BD0 wmTownMapRefresh
 static int wmTownMapRefresh()
 {
-    blitBuffer2D(_townFrmImage.getBuffer(),
-        { wmBkWinBuf, WM_WINDOW_WIDTH, WM_WINDOW_HEIGHT },
-        WM_VIEW_X,
-        WM_VIEW_Y);
+    blitBufferToBuffer(_townFrmImage.getData(),
+        std::min(_townFrmImage.getWidth(), WM_VIEW_WIDTH),
+        std::min(_townFrmImage.getHeight(), WM_VIEW_HEIGHT),
+        _townFrmImage.getWidth(),
+        wmBkWinBuf + WM_WINDOW_WIDTH * WM_VIEW_Y + WM_VIEW_X,
+        WM_WINDOW_WIDTH);
 
     wmRefreshInterfaceOverlay(false);
 

--- a/src/worldmap.cc
+++ b/src/worldmap.cc
@@ -6626,12 +6626,10 @@ static int wmTownMapInit()
 // 0x4C4BD0 wmTownMapRefresh
 static int wmTownMapRefresh()
 {
-    blitBufferToBuffer(_townFrmImage.getData(),
-        _townFrmImage.getWidth(),
-        _townFrmImage.getHeight(),
-        _townFrmImage.getWidth(),
-        wmBkWinBuf + WM_WINDOW_WIDTH * WM_VIEW_Y + WM_VIEW_X,
-        WM_WINDOW_WIDTH);
+    blitBuffer2D(_townFrmImage.getBuffer(),
+        { wmBkWinBuf, WM_WINDOW_WIDTH, WM_WINDOW_HEIGHT },
+        WM_VIEW_X,
+        WM_VIEW_Y);
 
     wmRefreshInterfaceOverlay(false);
 


### PR DESCRIPTION
This prevents crashing when `InterfaceUpscaled` mod is enabled, which has larger frms that we can handle on the small worldmap.

It's still not a great idea to enable.
