### PR TITLE
Typesafe usage of WeaponAnimation, AnimationRequestOptions, DudeNativeLook and ScienceRepairTargetType enums

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ set(FALLOUT_ENGINE_SOURCES
     "src/actions.h"
     "src/animation.cc"
     "src/animation.h"
+    "src/art_defs.h"
     "src/art.cc"
     "src/art.h"
     "src/audio.cc"

--- a/src/actions.cc
+++ b/src/actions.cc
@@ -139,7 +139,7 @@ int actionKnockdown(Object* obj, AnimationType* anim, int maxDistance, int rotat
         }
     }
 
-    const char* soundEffectName = sfxBuildCharName(obj, *anim, WEAPON_ANIMATION_KNIFE);
+    const char* soundEffectName = sfxBuildCharName(obj, *anim, CHARACTER_SOUND_EFFECT_KNOCKDOWN);
     animationRegisterPlaySoundEffect(obj, soundEffectName, delay);
 
     // TODO: Check, probably step back because we've started with 1?
@@ -328,7 +328,7 @@ void showDamageToObject(Object* defender, int damage, int flags, Object* weapon,
                     actionKnockdown(defender, &anim, knockbackDistance, knockbackRotation, delay);
                     anim = actionBlood(defender, anim, -1);
                 } else {
-                    sfx_name = sfxBuildCharName(defender, anim, WEAPON_ANIMATION_HAMMER);
+                    sfx_name = sfxBuildCharName(defender, anim, CHARACTER_SOUND_EFFECT_DIE);
                     animationRegisterPlaySoundEffect(defender, sfx_name, delay);
 
                     anim = pickFallAnim(defender, anim);
@@ -341,7 +341,7 @@ void showDamageToObject(Object* defender, int damage, int flags, Object* weapon,
             } else {
                 fid = buildFid(OBJ_TYPE_CRITTER, defender->fid & 0xFFF, ANIM_FIRE_DANCE, weaponAnimationFromFid(defender->fid), defender->rotation + 1);
                 if (artExists(fid)) {
-                    sfx_name = sfxBuildCharName(defender, anim, WEAPON_ANIMATION_NONE);
+                    sfx_name = sfxBuildCharName(defender, anim, CHARACTER_SOUND_EFFECT_UNUSED);
                     animationRegisterPlaySoundEffect(defender, sfx_name, delay);
 
                     // SFALL
@@ -402,14 +402,14 @@ void showDamageToObject(Object* defender, int damage, int flags, Object* weapon,
                 }
 
                 anim = ANIM_BURNED_TO_NOTHING;
-                sfx_name = sfxBuildCharName(defender, anim, WEAPON_ANIMATION_NONE);
+                sfx_name = sfxBuildCharName(defender, anim, CHARACTER_SOUND_EFFECT_UNUSED);
                 animationRegisterPlaySoundEffect(defender, sfx_name, -1);
                 animationRegisterAnimate(defender, anim, 0);
             }
         } else {
             if ((flags & (DAM_KNOCKED_OUT | DAM_KNOCKED_DOWN)) != 0) {
                 anim = hitFromFront ? ANIM_FALL_BACK : ANIM_FALL_FRONT;
-                sfx_name = sfxBuildCharName(defender, anim, WEAPON_ANIMATION_NONE);
+                sfx_name = sfxBuildCharName(defender, anim, CHARACTER_SOUND_EFFECT_UNUSED);
                 animationRegisterPlaySoundEffect(defender, sfx_name, delay);
                 if (knockbackDistance != 0) {
                     actionKnockdown(defender, &anim, knockbackDistance, knockbackRotation, 0);
@@ -438,7 +438,7 @@ void showDamageToObject(Object* defender, int damage, int flags, Object* weapon,
                         anim = ANIM_HIT_FROM_BACK;
                     }
 
-                    sfx_name = sfxBuildCharName(defender, anim, WEAPON_ANIMATION_NONE);
+                    sfx_name = sfxBuildCharName(defender, anim, CHARACTER_SOUND_EFFECT_UNUSED);
                     animationRegisterPlaySoundEffect(defender, sfx_name, delay);
 
                     animationRegisterAnimate(defender, anim, 0);
@@ -635,7 +635,7 @@ int _action_melee(Attack* attack, AnimationType anim)
     if (anim != ANIM_THROW_PUNCH && anim != ANIM_KICK_LEG) {
         sfx_name = sfxBuildWeaponName(WEAPON_SOUND_EFFECT_ATTACK, attack->weapon, attack->hitMode, attack->defender);
     } else {
-        sfx_name = sfxBuildCharName(attack->attacker, anim, WEAPON_ANIMATION_NONE);
+        sfx_name = sfxBuildCharName(attack->attacker, anim, CHARACTER_SOUND_EFFECT_UNUSED);
     }
 
     strcpy(sfx_name_temp, sfx_name);
@@ -647,7 +647,7 @@ int _action_melee(Attack* attack, AnimationType anim)
         if (anim != ANIM_THROW_PUNCH && anim != ANIM_KICK_LEG) {
             sfx_name = sfxBuildWeaponName(WEAPON_SOUND_EFFECT_HIT, attack->weapon, attack->hitMode, attack->defender);
         } else {
-            sfx_name = sfxBuildCharName(attack->attacker, anim, WEAPON_ANIMATION_SPEAR);
+            sfx_name = sfxBuildCharName(attack->attacker, anim, CHARACTER_SOUND_EFFECT_CONTACT);
         }
 
         strcpy(sfx_name_temp, sfx_name);
@@ -670,11 +670,11 @@ int _action_melee(Attack* attack, AnimationType anim)
                     animationRegisterPlaySoundEffect(attack->attacker, sfx_name_temp, -1);
                     animationRegisterAnimate(attack->attacker, anim, 0);
 
-                    sfx_name = sfxBuildCharName(attack->defender, ANIM_DODGE_ANIM, WEAPON_ANIMATION_NONE);
+                    sfx_name = sfxBuildCharName(attack->defender, ANIM_DODGE_ANIM, CHARACTER_SOUND_EFFECT_UNUSED);
                     animationRegisterPlaySoundEffect(attack->defender, sfx_name, delay - dodgeDelay);
                     animationRegisterAnimate(attack->defender, ANIM_DODGE_ANIM, 0);
                 } else {
-                    sfx_name = sfxBuildCharName(attack->defender, ANIM_DODGE_ANIM, WEAPON_ANIMATION_NONE);
+                    sfx_name = sfxBuildCharName(attack->defender, ANIM_DODGE_ANIM, CHARACTER_SOUND_EFFECT_UNUSED);
                     animationRegisterPlaySoundEffect(attack->defender, sfx_name, -1);
                     animationRegisterAnimate(attack->defender, ANIM_DODGE_ANIM, 0);
                     animationRegisterPlaySoundEffect(attack->attacker, sfx_name_temp, dodgeDelay - delay);
@@ -750,7 +750,7 @@ int _action_ranged(Attack* attack, AnimationType anim)
     if ((weaponAnimationFromFid(attack->attacker->fid)) != WEAPON_ANIMATION_NONE) {
         sfx = sfxBuildWeaponName(WEAPON_SOUND_EFFECT_ATTACK, weapon, attack->hitMode, attack->defender);
     } else {
-        sfx = sfxBuildCharName(attack->attacker, anim, WEAPON_ANIMATION_NONE);
+        sfx = sfxBuildCharName(attack->attacker, anim, CHARACTER_SOUND_EFFECT_UNUSED);
     }
     animationRegisterPlaySoundEffect(attack->attacker, sfx, -1);
 
@@ -1057,12 +1057,12 @@ int _action_climb_ladder(Object* critter, Object* ladder)
 
     WeaponAnimation weaponAnimationCode = weaponAnimationFromFid(critter->fid);
     if (weaponAnimationCode != 0) {
-        const char* puttingAwaySfx = sfxBuildCharName(critter, ANIM_PUT_AWAY, WEAPON_ANIMATION_NONE);
+        const char* puttingAwaySfx = sfxBuildCharName(critter, ANIM_PUT_AWAY, CHARACTER_SOUND_EFFECT_UNUSED);
         animationRegisterPlaySoundEffect(critter, puttingAwaySfx, -1);
         animationRegisterAnimate(critter, ANIM_PUT_AWAY, 0);
     }
 
-    const char* climbingSfx = sfxBuildCharName(critter, ANIM_CLIMB_LADDER, WEAPON_ANIMATION_NONE);
+    const char* climbingSfx = sfxBuildCharName(critter, ANIM_CLIMB_LADDER, CHARACTER_SOUND_EFFECT_UNUSED);
     animationRegisterPlaySoundEffect(critter, climbingSfx, -1);
     animationRegisterAnimate(critter, ANIM_CLIMB_LADDER, 0);
     animationRegisterCallback(critter, ladder, (AnimationCallback*)objectUse, -1);
@@ -1126,7 +1126,7 @@ int _action_use_an_item_on_object(Object* user, Object* targetObj, Object* item)
 
         WeaponAnimation weaponAnimCode = weaponAnimationFromFid(user->fid);
         if (weaponAnimCode != WEAPON_ANIMATION_NONE) {
-            const char* sfx = sfxBuildCharName(user, ANIM_PUT_AWAY, WEAPON_ANIMATION_NONE);
+            const char* sfx = sfxBuildCharName(user, ANIM_PUT_AWAY, CHARACTER_SOUND_EFFECT_UNUSED);
             animationRegisterPlaySoundEffect(user, sfx, -1);
             animationRegisterAnimate(user, ANIM_PUT_AWAY, 0);
         }
@@ -1224,7 +1224,7 @@ int actionPickUp(Object* critter, Object* item)
     } else {
         WeaponAnimation weaponAnimationCode = weaponAnimationFromFid(critter->fid);
         if (weaponAnimationCode != 0) {
-            const char* sfx = sfxBuildCharName(critter, ANIM_PUT_AWAY, WEAPON_ANIMATION_NONE);
+            const char* sfx = sfxBuildCharName(critter, ANIM_PUT_AWAY, CHARACTER_SOUND_EFFECT_UNUSED);
             animationRegisterPlaySoundEffect(critter, sfx, -1);
             animationRegisterAnimate(critter, ANIM_PUT_AWAY, -1);
         }

--- a/src/actions.cc
+++ b/src/actions.cc
@@ -40,11 +40,11 @@ namespace fallout {
 
 #define MAX_KNOCKDOWN_DISTANCE 20
 
-typedef enum ScienceRepairTargetType {
+enum ScienceRepairTargetType : int {
     SCIENCE_REPAIR_TARGET_TYPE_DEFAULT,
     SCIENCE_REPAIR_TARGET_TYPE_DUDE,
     SCIENCE_REPAIR_TARGET_TYPE_ANYONE,
-} ScienceRepairTargetType;
+};
 
 // 0x5106D0 action_in_explode
 static bool _action_in_explode = false;
@@ -1413,8 +1413,8 @@ int actionUseSkill(Object* user, Object* target, Skill skill)
 
         // SFALL: Science on critters patch.
         if (1) {
-            int targetType = SCIENCE_REPAIR_TARGET_TYPE_DEFAULT;
-            configGetInt(&gContentConfig, CONTENT_CONFIG_COMBAT_SECTION, "science_on_critters", &targetType, SCIENCE_REPAIR_TARGET_TYPE_DEFAULT);
+            ScienceRepairTargetType targetType = SCIENCE_REPAIR_TARGET_TYPE_DEFAULT;
+            configGetEnum<ScienceRepairTargetType>(&gContentConfig, CONTENT_CONFIG_COMBAT_SECTION, "science_on_critters", &targetType, SCIENCE_REPAIR_TARGET_TYPE_DEFAULT);
             if (targetType == SCIENCE_REPAIR_TARGET_TYPE_DUDE) {
                 if (target == gDude) {
                     break;

--- a/src/actions.cc
+++ b/src/actions.cc
@@ -109,7 +109,7 @@ int actionKnockdown(Object* obj, AnimationType* anim, int maxDistance, int rotat
     }
 
     if (*anim == ANIM_FALL_FRONT) {
-        int fid = buildFid(OBJ_TYPE_CRITTER, obj->fid & 0xFFF, *anim, (obj->fid & 0xF000) >> 12, obj->rotation + 1);
+        int fid = buildFid(OBJ_TYPE_CRITTER, obj->fid & 0xFFF, *anim, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
         if (!artExists(fid)) {
             *anim = ANIM_FALL_BACK;
         }
@@ -174,7 +174,7 @@ AnimationType actionBlood(Object* obj, AnimationType anim, int delay)
         return anim;
     }
 
-    int fid = buildFid(OBJ_TYPE_CRITTER, obj->fid & 0xFFF, bloodyAnim, (obj->fid & 0xF000) >> 12, obj->rotation + 1);
+    int fid = buildFid(OBJ_TYPE_CRITTER, obj->fid & 0xFFF, bloodyAnim, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
     if (artExists(fid)) {
         animationRegisterAnimate(obj, bloodyAnim, delay);
     } else {
@@ -280,7 +280,7 @@ AnimationType checkDeathAnim(Object* obj, AnimationType anim, int minViolenceLev
     int fid;
 
     if (settings.preferences.violence_level >= minViolenceLevel) {
-        fid = buildFid(OBJ_TYPE_CRITTER, obj->fid & 0xFFF, anim, (obj->fid & 0xF000) >> 12, obj->rotation + 1);
+        fid = buildFid(OBJ_TYPE_CRITTER, obj->fid & 0xFFF, anim, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
         if (artExists(fid)) {
             return anim;
         }
@@ -290,7 +290,7 @@ AnimationType checkDeathAnim(Object* obj, AnimationType anim, int minViolenceLev
         return ANIM_FALL_BACK;
     }
 
-    fid = buildFid(OBJ_TYPE_CRITTER, obj->fid & 0xFFF, ANIM_FALL_FRONT, (obj->fid & 0xF000) >> 12, obj->rotation + 1);
+    fid = buildFid(OBJ_TYPE_CRITTER, obj->fid & 0xFFF, ANIM_FALL_FRONT, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
     // CE: fixed vanilla logic that returned ANIM_FALL_BACK if artExists for ANIM_FALL_FRONT returned true.
     if (!artExists(fid)) {
         return ANIM_FALL_BACK;
@@ -339,7 +339,7 @@ void showDamageToObject(Object* defender, int damage, int flags, Object* weapon,
                     }
                 }
             } else {
-                fid = buildFid(OBJ_TYPE_CRITTER, defender->fid & 0xFFF, ANIM_FIRE_DANCE, (defender->fid & 0xF000) >> 12, defender->rotation + 1);
+                fid = buildFid(OBJ_TYPE_CRITTER, defender->fid & 0xFFF, ANIM_FIRE_DANCE, weaponAnimationFromFid(defender->fid), defender->rotation + 1);
                 if (artExists(fid)) {
                     sfx_name = sfxBuildCharName(defender, anim, WEAPON_ANIMATION_NONE);
                     animationRegisterPlaySoundEffect(defender, sfx_name, delay);
@@ -417,10 +417,10 @@ void showDamageToObject(Object* defender, int damage, int flags, Object* weapon,
                     anim = pickFallAnim(defender, anim);
                     animationRegisterAnimate(defender, anim, 0);
                 }
-            } else if ((flags & DAM_ON_FIRE) != 0 && artExists(buildFid(OBJ_TYPE_CRITTER, defender->fid & 0xFFF, ANIM_FIRE_DANCE, (defender->fid & 0xF000) >> 12, defender->rotation + 1))) {
+            } else if ((flags & DAM_ON_FIRE) != 0 && artExists(buildFid(OBJ_TYPE_CRITTER, defender->fid & 0xFFF, ANIM_FIRE_DANCE, weaponAnimationFromFid(defender->fid), defender->rotation + 1))) {
                 animationRegisterAnimate(defender, ANIM_FIRE_DANCE, delay);
 
-                fid = buildFid(OBJ_TYPE_CRITTER, defender->fid & 0xFFF, ANIM_STAND, (defender->fid & 0xF000) >> 12, defender->rotation + 1);
+                fid = buildFid(OBJ_TYPE_CRITTER, defender->fid & 0xFFF, ANIM_STAND, weaponAnimationFromFid(defender->fid), defender->rotation + 1);
                 animationRegisterSetFid(defender, fid, -1);
             } else {
                 if (knockbackDistance != 0) {
@@ -432,7 +432,7 @@ void showDamageToObject(Object* defender, int damage, int flags, Object* weapon,
                         animationRegisterAnimate(defender, ANIM_PRONE_TO_STANDING, -1);
                     }
                 } else {
-                    if (hitFromFront || !artExists(buildFid(OBJ_TYPE_CRITTER, defender->fid & 0xFFF, ANIM_HIT_FROM_BACK, (defender->fid & 0xF000) >> 12, defender->rotation + 1))) {
+                    if (hitFromFront || !artExists(buildFid(OBJ_TYPE_CRITTER, defender->fid & 0xFFF, ANIM_HIT_FROM_BACK, weaponAnimationFromFid(defender->fid), defender->rotation + 1))) {
                         anim = ANIM_HIT_FROM_FRONT;
                     } else {
                         anim = ANIM_HIT_FROM_BACK;
@@ -486,7 +486,7 @@ int _show_death(Object* obj, AnimationType anim)
 
     objectGetRect(obj, &dirtyRect);
     if (anim < ANIM_FALL_BACK_SF && anim > ANIM_FALL_FRONT_BLOOD_SF) {
-        fid = buildFid(OBJ_TYPE_CRITTER, obj->fid & 0xFFF, anim + 28, (obj->fid & 0xF000) >> 12, obj->rotation + 1);
+        fid = buildFid(OBJ_TYPE_CRITTER, obj->fid & 0xFFF, anim + 28, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
         if (objectSetFid(obj, fid, &tempRect) == 0) {
             rectUnion(&dirtyRect, &tempRect, &dirtyRect);
         }
@@ -620,7 +620,7 @@ int _action_melee(Attack* attack, AnimationType anim)
     reg_anim_begin(ANIMATION_REQUEST_RESERVED);
     _register_priority(1);
 
-    fid = buildFid(OBJ_TYPE_CRITTER, attack->attacker->fid & 0xFFF, anim, (attack->attacker->fid & 0xF000) >> 12, attack->attacker->rotation + 1);
+    fid = buildFid(OBJ_TYPE_CRITTER, attack->attacker->fid & 0xFFF, anim, weaponAnimationFromFid(attack->attacker->fid), attack->attacker->rotation + 1);
     art = artLock(fid, &cache_entry);
     if (art != nullptr) {
         delay = artGetActionFrame(art);
@@ -660,7 +660,7 @@ int _action_melee(Attack* attack, AnimationType anim)
             animationRegisterPlaySoundEffect(attack->attacker, sfx_name_temp, -1);
             animationRegisterAnimate(attack->attacker, anim, 0);
         } else {
-            fid = buildFid(OBJ_TYPE_CRITTER, attack->defender->fid & 0xFFF, ANIM_DODGE_ANIM, (attack->defender->fid & 0xF000) >> 12, attack->defender->rotation + 1);
+            fid = buildFid(OBJ_TYPE_CRITTER, attack->defender->fid & 0xFFF, ANIM_DODGE_ANIM, weaponAnimationFromFid(attack->defender->fid), attack->defender->rotation + 1);
             art = artLock(fid, &cache_entry);
             if (art != nullptr) {
                 int dodgeDelay = artGetActionFrame(art);
@@ -720,7 +720,7 @@ int _action_ranged(Attack* attack, AnimationType anim)
     Object* weapon = attack->weapon;
     protoGetProto(weapon->pid, &weaponProto);
 
-    int fid = buildFid(OBJ_TYPE_CRITTER, attack->attacker->fid & 0xFFF, anim, (attack->attacker->fid & 0xF000) >> 12, attack->attacker->rotation + 1);
+    int fid = buildFid(OBJ_TYPE_CRITTER, attack->attacker->fid & 0xFFF, anim, weaponAnimationFromFid(attack->attacker->fid), attack->attacker->rotation + 1);
     CacheEntry* artHandle;
     Art* art = artLock(fid, &artHandle);
     int delay = (art != nullptr) ? artGetActionFrame(art) : 0;
@@ -747,7 +747,7 @@ int _action_ranged(Attack* attack, AnimationType anim)
     _combatai_msg(attack->attacker, attack, AI_MESSAGE_TYPE_ATTACK, 0);
 
     const char* sfx;
-    if (((attack->attacker->fid & 0xF000) >> 12) != 0) {
+    if ((weaponAnimationFromFid(attack->attacker->fid)) != WEAPON_ANIMATION_NONE) {
         sfx = sfxBuildWeaponName(WEAPON_SOUND_EFFECT_ATTACK, weapon, attack->hitMode, attack->defender);
     } else {
         sfx = sfxBuildCharName(attack->attacker, anim, WEAPON_ANIMATION_NONE);
@@ -1203,7 +1203,7 @@ int actionPickUp(Object* critter, Object* item)
     if (itemProto->item.type != ITEM_TYPE_CONTAINER || _proto_action_can_pickup(item->pid)) {
         animationRegisterAnimate(critter, ANIM_MAGIC_HANDS_GROUND, 0);
 
-        int fid = buildFid(OBJ_TYPE_CRITTER, critter->fid & 0xFFF, ANIM_MAGIC_HANDS_GROUND, (critter->fid & 0xF000) >> 12, critter->rotation + 1);
+        int fid = buildFid(OBJ_TYPE_CRITTER, critter->fid & 0xFFF, ANIM_MAGIC_HANDS_GROUND, weaponAnimationFromFid(critter->fid), critter->rotation + 1);
 
         int actionFrame;
         CacheEntry* cacheEntry;
@@ -1581,7 +1581,7 @@ AnimationType pickFallAnim(Object* obj, AnimationType anim)
     }
 
     if (anim == ANIM_FALL_FRONT) {
-        fid = buildFid(OBJ_TYPE_CRITTER, obj->fid & 0xFFF, ANIM_FALL_FRONT, (obj->fid & 0xF000) >> 12, obj->rotation + 1);
+        fid = buildFid(OBJ_TYPE_CRITTER, obj->fid & 0xFFF, ANIM_FALL_FRONT, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
         if (!artExists(fid)) {
             anim = ANIM_FALL_BACK;
         }

--- a/src/actions.cc
+++ b/src/actions.cc
@@ -139,7 +139,7 @@ int actionKnockdown(Object* obj, AnimationType* anim, int maxDistance, int rotat
         }
     }
 
-    const char* soundEffectName = sfxBuildCharName(obj, *anim, CHARACTER_SOUND_EFFECT_KNOCKDOWN);
+    const char* soundEffectName = sfxBuildCharName(obj, *anim, WEAPON_ANIMATION_KNIFE);
     animationRegisterPlaySoundEffect(obj, soundEffectName, delay);
 
     // TODO: Check, probably step back because we've started with 1?
@@ -328,7 +328,7 @@ void showDamageToObject(Object* defender, int damage, int flags, Object* weapon,
                     actionKnockdown(defender, &anim, knockbackDistance, knockbackRotation, delay);
                     anim = actionBlood(defender, anim, -1);
                 } else {
-                    sfx_name = sfxBuildCharName(defender, anim, CHARACTER_SOUND_EFFECT_DIE);
+                    sfx_name = sfxBuildCharName(defender, anim, WEAPON_ANIMATION_HAMMER);
                     animationRegisterPlaySoundEffect(defender, sfx_name, delay);
 
                     anim = pickFallAnim(defender, anim);
@@ -341,7 +341,7 @@ void showDamageToObject(Object* defender, int damage, int flags, Object* weapon,
             } else {
                 fid = buildFid(OBJ_TYPE_CRITTER, defender->fid & 0xFFF, ANIM_FIRE_DANCE, (defender->fid & 0xF000) >> 12, defender->rotation + 1);
                 if (artExists(fid)) {
-                    sfx_name = sfxBuildCharName(defender, anim, CHARACTER_SOUND_EFFECT_UNUSED);
+                    sfx_name = sfxBuildCharName(defender, anim, WEAPON_ANIMATION_NONE);
                     animationRegisterPlaySoundEffect(defender, sfx_name, delay);
 
                     // SFALL
@@ -402,14 +402,14 @@ void showDamageToObject(Object* defender, int damage, int flags, Object* weapon,
                 }
 
                 anim = ANIM_BURNED_TO_NOTHING;
-                sfx_name = sfxBuildCharName(defender, anim, CHARACTER_SOUND_EFFECT_UNUSED);
+                sfx_name = sfxBuildCharName(defender, anim, WEAPON_ANIMATION_NONE);
                 animationRegisterPlaySoundEffect(defender, sfx_name, -1);
                 animationRegisterAnimate(defender, anim, 0);
             }
         } else {
             if ((flags & (DAM_KNOCKED_OUT | DAM_KNOCKED_DOWN)) != 0) {
                 anim = hitFromFront ? ANIM_FALL_BACK : ANIM_FALL_FRONT;
-                sfx_name = sfxBuildCharName(defender, anim, CHARACTER_SOUND_EFFECT_UNUSED);
+                sfx_name = sfxBuildCharName(defender, anim, WEAPON_ANIMATION_NONE);
                 animationRegisterPlaySoundEffect(defender, sfx_name, delay);
                 if (knockbackDistance != 0) {
                     actionKnockdown(defender, &anim, knockbackDistance, knockbackRotation, 0);
@@ -438,7 +438,7 @@ void showDamageToObject(Object* defender, int damage, int flags, Object* weapon,
                         anim = ANIM_HIT_FROM_BACK;
                     }
 
-                    sfx_name = sfxBuildCharName(defender, anim, CHARACTER_SOUND_EFFECT_UNUSED);
+                    sfx_name = sfxBuildCharName(defender, anim, WEAPON_ANIMATION_NONE);
                     animationRegisterPlaySoundEffect(defender, sfx_name, delay);
 
                     animationRegisterAnimate(defender, anim, 0);
@@ -635,7 +635,7 @@ int _action_melee(Attack* attack, AnimationType anim)
     if (anim != ANIM_THROW_PUNCH && anim != ANIM_KICK_LEG) {
         sfx_name = sfxBuildWeaponName(WEAPON_SOUND_EFFECT_ATTACK, attack->weapon, attack->hitMode, attack->defender);
     } else {
-        sfx_name = sfxBuildCharName(attack->attacker, anim, CHARACTER_SOUND_EFFECT_UNUSED);
+        sfx_name = sfxBuildCharName(attack->attacker, anim, WEAPON_ANIMATION_NONE);
     }
 
     strcpy(sfx_name_temp, sfx_name);
@@ -647,7 +647,7 @@ int _action_melee(Attack* attack, AnimationType anim)
         if (anim != ANIM_THROW_PUNCH && anim != ANIM_KICK_LEG) {
             sfx_name = sfxBuildWeaponName(WEAPON_SOUND_EFFECT_HIT, attack->weapon, attack->hitMode, attack->defender);
         } else {
-            sfx_name = sfxBuildCharName(attack->attacker, anim, CHARACTER_SOUND_EFFECT_CONTACT);
+            sfx_name = sfxBuildCharName(attack->attacker, anim, WEAPON_ANIMATION_SPEAR);
         }
 
         strcpy(sfx_name_temp, sfx_name);
@@ -670,11 +670,11 @@ int _action_melee(Attack* attack, AnimationType anim)
                     animationRegisterPlaySoundEffect(attack->attacker, sfx_name_temp, -1);
                     animationRegisterAnimate(attack->attacker, anim, 0);
 
-                    sfx_name = sfxBuildCharName(attack->defender, ANIM_DODGE_ANIM, CHARACTER_SOUND_EFFECT_UNUSED);
+                    sfx_name = sfxBuildCharName(attack->defender, ANIM_DODGE_ANIM, WEAPON_ANIMATION_NONE);
                     animationRegisterPlaySoundEffect(attack->defender, sfx_name, delay - dodgeDelay);
                     animationRegisterAnimate(attack->defender, ANIM_DODGE_ANIM, 0);
                 } else {
-                    sfx_name = sfxBuildCharName(attack->defender, ANIM_DODGE_ANIM, CHARACTER_SOUND_EFFECT_UNUSED);
+                    sfx_name = sfxBuildCharName(attack->defender, ANIM_DODGE_ANIM, WEAPON_ANIMATION_NONE);
                     animationRegisterPlaySoundEffect(attack->defender, sfx_name, -1);
                     animationRegisterAnimate(attack->defender, ANIM_DODGE_ANIM, 0);
                     animationRegisterPlaySoundEffect(attack->attacker, sfx_name_temp, dodgeDelay - delay);
@@ -750,7 +750,7 @@ int _action_ranged(Attack* attack, AnimationType anim)
     if (((attack->attacker->fid & 0xF000) >> 12) != 0) {
         sfx = sfxBuildWeaponName(WEAPON_SOUND_EFFECT_ATTACK, weapon, attack->hitMode, attack->defender);
     } else {
-        sfx = sfxBuildCharName(attack->attacker, anim, CHARACTER_SOUND_EFFECT_UNUSED);
+        sfx = sfxBuildCharName(attack->attacker, anim, WEAPON_ANIMATION_NONE);
     }
     animationRegisterPlaySoundEffect(attack->attacker, sfx, -1);
 
@@ -961,7 +961,7 @@ int _action_ranged(Attack* attack, AnimationType anim)
         if (anim == ANIM_THROW_ANIM) {
             bool takeOutAnimationRegistered = false;
             if (replacedWeapon != nullptr) {
-                int weaponAnimationCode = weaponGetAnimationCode(replacedWeapon);
+                WeaponAnimation weaponAnimationCode = weaponGetAnimationCode(replacedWeapon);
                 if (weaponAnimationCode != 0) {
                     animationRegisterTakeOutWeapon(attack->attacker, weaponAnimationCode, -1);
                     takeOutAnimationRegistered = true;
@@ -1055,14 +1055,14 @@ int _action_climb_ladder(Object* critter, Object* ladder)
     animationRegisterRotateToTile(critter, ladder->tile);
     animationRegisterCallbackForced(critter, ladder, (AnimationCallback*)checkSceneryUseActionPointCost, -1);
 
-    int weaponAnimationCode = (critter->fid & 0xF000) >> 12;
+    WeaponAnimation weaponAnimationCode = weaponAnimationFromFid(critter->fid);
     if (weaponAnimationCode != 0) {
-        const char* puttingAwaySfx = sfxBuildCharName(critter, ANIM_PUT_AWAY, CHARACTER_SOUND_EFFECT_UNUSED);
+        const char* puttingAwaySfx = sfxBuildCharName(critter, ANIM_PUT_AWAY, WEAPON_ANIMATION_NONE);
         animationRegisterPlaySoundEffect(critter, puttingAwaySfx, -1);
         animationRegisterAnimate(critter, ANIM_PUT_AWAY, 0);
     }
 
-    const char* climbingSfx = sfxBuildCharName(critter, ANIM_CLIMB_LADDER, CHARACTER_SOUND_EFFECT_UNUSED);
+    const char* climbingSfx = sfxBuildCharName(critter, ANIM_CLIMB_LADDER, WEAPON_ANIMATION_NONE);
     animationRegisterPlaySoundEffect(critter, climbingSfx, -1);
     animationRegisterAnimate(critter, ANIM_CLIMB_LADDER, 0);
     animationRegisterCallback(critter, ladder, (AnimationCallback*)objectUse, -1);
@@ -1124,9 +1124,9 @@ int _action_use_an_item_on_object(Object* user, Object* targetObj, Object* item)
             animationRegisterCallback(user, targetObj, (AnimationCallback*)checkSceneryUseActionPointCost, -1);
         }
 
-        int weaponAnimCode = (user->fid & 0xF000) >> 12;
-        if (weaponAnimCode != 0) {
-            const char* sfx = sfxBuildCharName(user, ANIM_PUT_AWAY, CHARACTER_SOUND_EFFECT_UNUSED);
+        WeaponAnimation weaponAnimCode = weaponAnimationFromFid(user->fid);
+        if (weaponAnimCode != WEAPON_ANIMATION_NONE) {
+            const char* sfx = sfxBuildCharName(user, ANIM_PUT_AWAY, WEAPON_ANIMATION_NONE);
             animationRegisterPlaySoundEffect(user, sfx, -1);
             animationRegisterAnimate(user, ANIM_PUT_AWAY, 0);
         }
@@ -1152,7 +1152,7 @@ int _action_use_an_item_on_object(Object* user, Object* targetObj, Object* item)
             animationRegisterCallback(user, targetObj, (AnimationCallback*)objectUse, -1);
         }
 
-        if (weaponAnimCode != 0) {
+        if (weaponAnimCode != WEAPON_ANIMATION_NONE) {
             animationRegisterTakeOutWeapon(user, weaponAnimCode, -1);
         }
 
@@ -1222,9 +1222,9 @@ int actionPickUp(Object* critter, Object* item)
 
         animationRegisterCallback(critter, item, (AnimationCallback*)objectPickup, actionFrame);
     } else {
-        int weaponAnimationCode = (critter->fid & 0xF000) >> 12;
+        WeaponAnimation weaponAnimationCode = weaponAnimationFromFid(critter->fid);
         if (weaponAnimationCode != 0) {
-            const char* sfx = sfxBuildCharName(critter, ANIM_PUT_AWAY, CHARACTER_SOUND_EFFECT_UNUSED);
+            const char* sfx = sfxBuildCharName(critter, ANIM_PUT_AWAY, WEAPON_ANIMATION_NONE);
             animationRegisterPlaySoundEffect(critter, sfx, -1);
             animationRegisterAnimate(critter, ANIM_PUT_AWAY, -1);
         }

--- a/src/actions.cc
+++ b/src/actions.cc
@@ -1025,7 +1025,7 @@ int _action_climb_ladder(Object* critter, Object* ladder)
         }
     }
 
-    int animationRequestOptions;
+    AnimationRequestOptions animationRequestOptions;
     int actionPoints;
     if (isInCombat()) {
         animationRequestOptions = ANIMATION_REQUEST_RESERVED;
@@ -1096,7 +1096,7 @@ int _action_use_an_item_on_object(Object* user, Object* targetObj, Object* item)
             }
         }
 
-        int animationRequestOptions;
+        AnimationRequestOptions animationRequestOptions;
         int actionPoints;
         if (isInCombat()) {
             animationRequestOptions = ANIMATION_REQUEST_RESERVED;

--- a/src/animation.cc
+++ b/src/animation.cc
@@ -1221,7 +1221,7 @@ int animationRegisterSetFid(Object* owner, int fid, int delay)
 }
 
 // 0x415238
-int animationRegisterTakeOutWeapon(Object* owner, int weaponAnimationCode, int delay)
+int animationRegisterTakeOutWeapon(Object* owner, WeaponAnimation weaponAnimationCode, int delay)
 {
     const char* sfx = sfxBuildCharName(owner, ANIM_TAKE_OUT, weaponAnimationCode);
     if (animationRegisterPlaySoundEffect(owner, sfx, delay) == -1) {
@@ -3158,7 +3158,7 @@ void _dude_fidget()
         }
 
         if (shoudPlaySound) {
-            const char* sfx = sfxBuildCharName(object, ANIM_STAND, CHARACTER_SOUND_EFFECT_UNUSED);
+            const char* sfx = sfxBuildCharName(object, ANIM_STAND, WEAPON_ANIMATION_NONE);
             animationRegisterPlaySoundEffect(object, sfx, 0);
         }
 

--- a/src/animation.cc
+++ b/src/animation.cc
@@ -3160,7 +3160,7 @@ void _dude_fidget()
         }
 
         if (shoudPlaySound) {
-            const char* sfx = sfxBuildCharName(object, ANIM_STAND, WEAPON_ANIMATION_NONE);
+            const char* sfx = sfxBuildCharName(object, ANIM_STAND, CHARACTER_SOUND_EFFECT_UNUSED);
             animationRegisterPlaySoundEffect(object, sfx, 0);
         }
 

--- a/src/animation.cc
+++ b/src/animation.cc
@@ -293,7 +293,7 @@ typedef struct AnimationSad {
 #define SAD_INIT -2000
 #define ANIM_COMPLETE -1000
 
-static int _anim_free_slot(int a1);
+static int _anim_free_slot(AnimationRequestOptions requestOptions);
 static int _anim_preload(Object* object, int fid, CacheEntry** cacheEntryPtr);
 static void _anim_cleanup();
 static int _check_registry(Object* obj);
@@ -390,7 +390,7 @@ void animationExit()
 }
 
 // 0x413AF4
-int reg_anim_begin(int requestOptions)
+int reg_anim_begin(AnimationRequestOptions requestOptions)
 {
     if (gAnimationSequenceCurrentIndex != -1) {
         return -1;
@@ -408,15 +408,15 @@ int reg_anim_begin(int requestOptions)
     AnimationSequence* animationSequence = &(gAnimationSequences[v1]);
     animationSequence->flags |= ANIM_SEQ_ACCUMULATING;
 
-    if ((requestOptions & ANIMATION_REQUEST_RESERVED) != 0) {
+    if ((requestOptions & ANIMATION_REQUEST_RESERVED) != ANIMATION_REQUEST_NONE) {
         animationSequence->flags |= ANIM_SEQ_RESERVED;
     }
 
-    if ((requestOptions & ANIMATION_REQUEST_INSIGNIFICANT) != 0) {
+    if ((requestOptions & ANIMATION_REQUEST_INSIGNIFICANT) != ANIMATION_REQUEST_NONE) {
         animationSequence->flags |= ANIM_SEQ_INSIGNIFICANT;
     }
 
-    if ((requestOptions & ANIMATION_REQUEST_NO_STAND) != 0) {
+    if ((requestOptions & ANIMATION_REQUEST_NO_STAND) != ANIMATION_REQUEST_NONE) {
         animationSequence->flags |= ANIM_SEQ_NO_STAND;
     }
 
@@ -428,28 +428,28 @@ int reg_anim_begin(int requestOptions)
 }
 
 // 0x413B80
-static int _anim_free_slot(int requestOptions)
+static int _anim_free_slot(AnimationRequestOptions requestOptions)
 {
     int v1 = -1;
     int v2 = 0;
     for (int index = 0; index < ANIMATION_SEQUENCE_LIST_CAPACITY; index++) {
         AnimationSequence* animationSequence = &(gAnimationSequences[index]);
-        if (animationSequence->step != ANIM_COMPLETE || (animationSequence->flags & ANIM_SEQ_ACCUMULATING) != 0 || (animationSequence->flags & ANIM_SEQ_0x20) != 0) {
+        if (animationSequence->step != ANIM_COMPLETE || (animationSequence->flags & ANIM_SEQ_ACCUMULATING) != ANIMATION_REQUEST_NONE || (animationSequence->flags & ANIM_SEQ_0x20) != 0) {
             if (!(animationSequence->flags & ANIM_SEQ_RESERVED)) {
                 v2++;
             }
-        } else if (v1 == -1 && ((requestOptions & ANIMATION_REQUEST_PING) == 0 || (animationSequence->flags & ANIM_SEQ_0x10) == 0)) {
+        } else if (v1 == -1 && ((requestOptions & ANIMATION_REQUEST_PING) == ANIMATION_REQUEST_NONE || (animationSequence->flags & ANIM_SEQ_0x10) == 0)) {
             v1 = index;
         }
     }
 
     if (v1 == -1) {
-        if ((requestOptions & ANIMATION_REQUEST_RESERVED) != 0) {
+        if ((requestOptions & ANIMATION_REQUEST_RESERVED) != ANIMATION_REQUEST_NONE) {
             debugPrint("Unable to begin reserved animation!\n");
         }
 
         return -1;
-    } else if ((requestOptions & ANIMATION_REQUEST_RESERVED) != 0 || v2 < ANIMATION_NON_RESERVED_LIST_CAPACITY) {
+    } else if ((requestOptions & ANIMATION_REQUEST_RESERVED) != ANIMATION_REQUEST_NONE || v2 < ANIMATION_NON_RESERVED_LIST_CAPACITY) {
         return v1;
     }
 
@@ -1359,14 +1359,14 @@ int animationRegisterAnimateForever(Object* owner, AnimationType anim, int delay
 }
 
 // 0x415598
-int animationRegisterPing(int flags, int delay)
+int animationRegisterPing(AnimationRequestOptions requestOptions, int delay)
 {
     if (_check_registry(nullptr) == -1) {
         _anim_cleanup();
         return -1;
     }
 
-    int animationSequenceIndex = _anim_free_slot(flags | ANIMATION_REQUEST_PING);
+    int animationSequenceIndex = _anim_free_slot(requestOptions | ANIMATION_REQUEST_PING);
     if (animationSequenceIndex == -1) {
         return -1;
     }

--- a/src/animation.cc
+++ b/src/animation.cc
@@ -88,6 +88,8 @@ static bool animationKindIsCallback(AnimationKind kind)
 }
 
 typedef enum AnimationSequenceFlags {
+    ANIM_SEQ_NONE = 0x00,
+
     // Specifies that the animation sequence has high priority, it cannot be
     // cleared.
     ANIM_SEQ_PRIORITIZED = 0x01,
@@ -434,11 +436,11 @@ static int _anim_free_slot(AnimationRequestOptions requestOptions)
     int v2 = 0;
     for (int index = 0; index < ANIMATION_SEQUENCE_LIST_CAPACITY; index++) {
         AnimationSequence* animationSequence = &(gAnimationSequences[index]);
-        if (animationSequence->step != ANIM_COMPLETE || (animationSequence->flags & ANIM_SEQ_ACCUMULATING) != ANIMATION_REQUEST_NONE || (animationSequence->flags & ANIM_SEQ_0x20) != 0) {
+        if (animationSequence->step != ANIM_COMPLETE || (animationSequence->flags & ANIM_SEQ_ACCUMULATING) != ANIM_SEQ_NONE || (animationSequence->flags & ANIM_SEQ_0x20) != ANIM_SEQ_NONE) {
             if (!(animationSequence->flags & ANIM_SEQ_RESERVED)) {
                 v2++;
             }
-        } else if (v1 == -1 && ((requestOptions & ANIMATION_REQUEST_PING) == ANIMATION_REQUEST_NONE || (animationSequence->flags & ANIM_SEQ_0x10) == 0)) {
+        } else if (v1 == -1 && ((requestOptions & ANIMATION_REQUEST_PING) == ANIMATION_REQUEST_NONE || (animationSequence->flags & ANIM_SEQ_0x10) == ANIM_SEQ_NONE)) {
             v1 = index;
         }
     }

--- a/src/animation.cc
+++ b/src/animation.cc
@@ -666,7 +666,7 @@ int animationRegisterMoveToObject(Object* owner, Object* destination, int action
     animationDescription->actionPoints = actionPoints;
     animationDescription->delay = delay;
 
-    int fid = buildFid(FID_TYPE(owner->fid), owner->fid & 0xFFF, animationDescription->anim, (owner->fid & 0xF000) >> 12, owner->rotation + 1);
+    int fid = buildFid(FID_TYPE(owner->fid), owner->fid & 0xFFF, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
 
     // NOTE: Uninline.
     if (_anim_preload(owner, fid, &(animationDescription->artCacheKey)) == -1) {
@@ -715,7 +715,7 @@ int animationRegisterRunToObject(Object* owner, Object* destination, int actionP
     animationDescription->actionPoints = actionPoints;
     animationDescription->delay = delay;
 
-    int fid = buildFid(FID_TYPE(owner->fid), owner->fid & 0xFFF, animationDescription->anim, (owner->fid & 0xF000) >> 12, owner->rotation + 1);
+    int fid = buildFid(FID_TYPE(owner->fid), owner->fid & 0xFFF, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
 
     // NOTE: Uninline.
     if (_anim_preload(owner, fid, &(animationDescription->artCacheKey)) == -1) {
@@ -748,7 +748,7 @@ int animationRegisterMoveToTile(Object* owner, int tile, int elevation, int acti
     animationDescription->actionPoints = actionPoints;
     animationDescription->delay = delay;
 
-    int fid = buildFid(FID_TYPE(owner->fid), owner->fid & 0xFFF, animationDescription->anim, (owner->fid & 0xF000) >> 12, owner->rotation + 1);
+    int fid = buildFid(FID_TYPE(owner->fid), owner->fid & 0xFFF, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
 
     // NOTE: Uninline.
     if (_anim_preload(owner, fid, &(animationDescription->artCacheKey)) == -1) {
@@ -798,7 +798,7 @@ int animationRegisterRunToTile(Object* owner, int tile, int elevation, int actio
     animationDescription->actionPoints = actionPoints;
     animationDescription->delay = delay;
 
-    int fid = buildFid(FID_TYPE(owner->fid), owner->fid & 0xFFF, animationDescription->anim, (owner->fid & 0xF000) >> 12, owner->rotation + 1);
+    int fid = buildFid(FID_TYPE(owner->fid), owner->fid & 0xFFF, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
 
     // NOTE: Uninline.
     if (_anim_preload(owner, fid, &(animationDescription->artCacheKey)) == -1) {
@@ -833,7 +833,7 @@ int animationRegisterMoveToTileStraight(Object* object, int tile, int elevation,
     animationDescription->anim = anim;
     animationDescription->delay = delay;
 
-    int fid = buildFid(FID_TYPE(object->fid), object->fid & 0xFFF, animationDescription->anim, (object->fid & 0xF000) >> 12, object->rotation + 1);
+    int fid = buildFid(FID_TYPE(object->fid), object->fid & 0xFFF, animationDescription->anim, weaponAnimationFromFid(object->fid), object->rotation + 1);
 
     // NOTE: Uninline.
     if (_anim_preload(object, fid, &(animationDescription->artCacheKey)) == -1) {
@@ -867,7 +867,7 @@ int animationRegisterMoveToTileStraightAndWaitForComplete(Object* owner, int til
     animationDescription->anim = anim;
     animationDescription->delay = delay;
 
-    int fid = buildFid(FID_TYPE(owner->fid), owner->fid & 0xFFF, animationDescription->anim, (owner->fid & 0xF000) >> 12, owner->rotation + 1);
+    int fid = buildFid(FID_TYPE(owner->fid), owner->fid & 0xFFF, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
 
     // NOTE: Uninline.
     if (_anim_preload(owner, fid, &(animationDescription->artCacheKey)) == -1) {
@@ -895,7 +895,7 @@ int animationRegisterAnimate(Object* owner, AnimationType anim, int delay)
     animationDescription->anim = anim;
     animationDescription->delay = delay;
 
-    int fid = buildFid(FID_TYPE(owner->fid), owner->fid & 0xFFF, animationDescription->anim, (owner->fid & 0xF000) >> 12, owner->rotation + 1);
+    int fid = buildFid(FID_TYPE(owner->fid), owner->fid & 0xFFF, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
 
     // NOTE: Uninline.
     if (_anim_preload(owner, fid, &(animationDescription->artCacheKey)) == -1) {
@@ -924,7 +924,7 @@ int animationRegisterAnimateReversed(Object* owner, AnimationType anim, int dela
     animationDescription->delay = delay;
     animationDescription->artCacheKey = nullptr;
 
-    int fid = buildFid(FID_TYPE(owner->fid), owner->fid & 0xFFF, animationDescription->anim, (owner->fid & 0xF000) >> 12, owner->rotation + 1);
+    int fid = buildFid(FID_TYPE(owner->fid), owner->fid & 0xFFF, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
 
     // NOTE: Uninline.
     if (_anim_preload(owner, fid, &(animationDescription->artCacheKey)) == -1) {
@@ -953,7 +953,7 @@ int animationRegisterAnimateAndHide(Object* owner, AnimationType anim, int delay
     animationDescription->delay = delay;
     animationDescription->artCacheKey = nullptr;
 
-    int fid = buildFid(FID_TYPE(owner->fid), owner->fid & 0xFFF, anim, (owner->fid & 0xF000) >> 12, owner->rotation + 1);
+    int fid = buildFid(FID_TYPE(owner->fid), owner->fid & 0xFFF, anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
 
     // NOTE: Uninline.
     if (_anim_preload(owner, fid, &(animationDescription->artCacheKey)) == -1) {
@@ -1345,7 +1345,7 @@ int animationRegisterAnimateForever(Object* owner, AnimationType anim, int delay
     animationDescription->anim = anim;
     animationDescription->delay = delay;
 
-    int fid = buildFid(FID_TYPE(owner->fid), owner->fid & 0xFFF, anim, (owner->fid & 0xF000) >> 12, owner->rotation + 1);
+    int fid = buildFid(FID_TYPE(owner->fid), owner->fid & 0xFFF, anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
 
     // NOTE: Uninline.
     if (_anim_preload(owner, fid, &(animationDescription->artCacheKey)) == -1) {
@@ -2461,7 +2461,7 @@ static int _anim_move(Object* obj, int tile, int elev, int a3, AnimationType ani
     }
 
     sad->step = SAD_INIT;
-    sad->fid = buildFid(FID_TYPE(obj->fid), obj->fid & 0xFFF, anim, (obj->fid & 0xF000) >> 12, obj->rotation + 1);
+    sad->fid = buildFid(FID_TYPE(obj->fid), obj->fid & 0xFFF, anim, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
     sad->animationTimestamp = 0;
     sad->ticksPerFrame = animationComputeTicksPerFrame(obj, sad->fid);
     sad->targetTile = tile;
@@ -2497,7 +2497,7 @@ static int animateMoveObjectToTileStraight(Object* obj, int tile, int elevation,
         sad->fid = obj->fid;
         sad->flags |= ANIM_SAD_NO_ANIM;
     } else {
-        sad->fid = buildFid(FID_TYPE(obj->fid), obj->fid & 0xFFF, anim, (obj->fid & 0xF000) >> 12, obj->rotation + 1);
+        sad->fid = buildFid(FID_TYPE(obj->fid), obj->fid & 0xFFF, anim, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
     }
     sad->step = SAD_INIT;
     sad->animationTimestamp = 0;
@@ -2539,7 +2539,7 @@ static int _anim_move_on_stairs(Object* obj, int tile, int elevation, AnimationT
         sad->fid = obj->fid;
         sad->flags |= ANIM_SAD_NO_ANIM;
     } else {
-        sad->fid = buildFid(FID_TYPE(obj->fid), obj->fid & 0xFFF, anim, (obj->fid & 0xF000) >> 12, obj->rotation + 1);
+        sad->fid = buildFid(FID_TYPE(obj->fid), obj->fid & 0xFFF, anim, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
     }
     sad->step = SAD_INIT;
     sad->animationTimestamp = 0;
@@ -2574,7 +2574,7 @@ static int _check_for_falling(Object* obj, AnimationType anim, int a3)
         sad->fid = obj->fid;
         sad->flags |= ANIM_SAD_NO_ANIM;
     } else {
-        sad->fid = buildFid(FID_TYPE(obj->fid), obj->fid & 0xFFF, anim, (obj->fid & 0xF000) >> 12, obj->rotation + 1);
+        sad->fid = buildFid(FID_TYPE(obj->fid), obj->fid & 0xFFF, anim, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
     }
     sad->step = SAD_INIT;
     sad->animationTimestamp = 0;
@@ -2609,7 +2609,7 @@ static void _object_move(int index)
         objectSetRotation(object, sad->rotations[0], &tempRect);
         rectUnion(&dirtyRect, &tempRect, &dirtyRect);
 
-        int fid = buildFid(FID_TYPE(object->fid), object->fid & 0xFFF, sad->anim, (object->fid & 0xF000) >> 12, object->rotation + 1);
+        int fid = buildFid(FID_TYPE(object->fid), object->fid & 0xFFF, sad->anim, weaponAnimationFromFid(object->fid), object->rotation + 1);
         objectSetFid(object, fid, &tempRect);
         rectUnion(&dirtyRect, &tempRect, &dirtyRect);
 
@@ -2782,7 +2782,7 @@ static int _anim_animate(Object* obj, AnimationType anim, int animationSequenceI
         fid = buildFid(FID_TYPE(obj->fid), obj->fid & 0xFFF, ANIM_TAKE_OUT, flags, obj->rotation + 1);
     } else {
         sad->flags = flags;
-        fid = buildFid(FID_TYPE(obj->fid), obj->fid & 0xFFF, anim, (obj->fid & 0xF000) >> 12, obj->rotation + 1);
+        fid = buildFid(FID_TYPE(obj->fid), obj->fid & 0xFFF, anim, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
     }
 
     if (!artExists(fid)) {
@@ -3189,8 +3189,8 @@ void _dude_stand(Object* obj, int rotation, int fid)
     int x = 0;
     int y = 0;
 
-    int weaponAnimationCode = (obj->fid & 0xF000) >> 12;
-    if (weaponAnimationCode != 0) {
+    WeaponAnimation weaponAnimationCode = weaponAnimationFromFid(obj->fid);
+    if (weaponAnimationCode != WEAPON_ANIMATION_NONE) {
         if (fid == -1) {
             int takeOutFid = buildFid(FID_TYPE(obj->fid), obj->fid & 0xFFF, ANIM_TAKE_OUT, weaponAnimationCode, obj->rotation + 1);
             CacheEntry* takeOutFrmHandle;

--- a/src/animation.h
+++ b/src/animation.h
@@ -6,13 +6,24 @@
 
 namespace fallout {
 
-typedef enum AnimationRequestOptions {
+enum AnimationRequestOptions : int {
+    ANIMATION_REQUEST_NONE = 0x00,
     ANIMATION_REQUEST_UNRESERVED = 0x01,
     ANIMATION_REQUEST_RESERVED = 0x02,
     ANIMATION_REQUEST_NO_STAND = 0x04,
     ANIMATION_REQUEST_PING = 0x100,
     ANIMATION_REQUEST_INSIGNIFICANT = 0x200,
-} AnimationRequestOptions;
+};
+
+constexpr inline AnimationRequestOptions operator|(AnimationRequestOptions lhs, AnimationRequestOptions rhs)
+{
+    return static_cast<AnimationRequestOptions>(static_cast<int>(lhs) | static_cast<int>(rhs));
+}
+
+inline AnimationRequestOptions& operator|=(AnimationRequestOptions& lhs, AnimationRequestOptions rhs)
+{
+    return lhs = lhs | rhs;
+}
 
 // Basic animations: 0-19
 // Knockdown and death: 20-35
@@ -130,7 +141,7 @@ void animationExit();
 bool animationCheckCombatMode();
 void animationSetCombatCheck(bool enable);
 void animationResetCombatCheck();
-int reg_anim_begin(int a1);
+int reg_anim_begin(AnimationRequestOptions requestOptions);
 int _register_priority(int a1);
 int reg_anim_clear(Object* a1);
 int reg_anim_end();
@@ -160,7 +171,7 @@ int animationRegisterSetLightDistance(Object* owner, int lightDistance, int dela
 int animationRegisterToggleOutline(Object* object, bool outline, int delay);
 int animationRegisterPlaySoundEffect(Object* owner, const char* soundEffectName, int delay);
 int animationRegisterAnimateForever(Object* owner, AnimationType anim, int delay);
-int animationRegisterPing(int flags, int delay);
+int animationRegisterPing(AnimationRequestOptions requestOptions, int delay);
 int _make_path(Object* object, int from, int to, unsigned char* rotations, int requireEmptyDest);
 int pathfinderFindPath(Object* object, int from, int to, unsigned char* rotations, int requireEmptyDest, PathBuilderCallback* callback);
 int _make_straight_path(Object* object, int from, int to, StraightPathNode* straightPathNodeList, Object** obstaclePtr, int a6);

--- a/src/animation.h
+++ b/src/animation.h
@@ -1,6 +1,7 @@
 #ifndef ANIMATION_H
 #define ANIMATION_H
 
+#include "art_defs.h"
 #include "combat_defs.h"
 #include "obj_types.h"
 
@@ -166,7 +167,7 @@ int animationRegisterCallbackForced(void* a1, void* a2, AnimationCallback* proc,
 int animationRegisterSetFlag(Object* object, int flag, int delay);
 int animationRegisterUnsetFlag(Object* object, int flag, int delay);
 int animationRegisterSetFid(Object* owner, int fid, int delay);
-int animationRegisterTakeOutWeapon(Object* owner, int weaponAnimationCode, int delay);
+int animationRegisterTakeOutWeapon(Object* owner, WeaponAnimation weaponAnimationCode, int delay);
 int animationRegisterSetLightDistance(Object* owner, int lightDistance, int delay);
 int animationRegisterToggleOutline(Object* object, bool outline, int delay);
 int animationRegisterPlaySoundEffect(Object* owner, const char* soundEffectName, int delay);

--- a/src/art.cc
+++ b/src/art.cc
@@ -9,6 +9,7 @@
 #include <string.h>
 
 #include "animation.h"
+#include "art_defs.h"
 #include "content_config.h"
 #include "datafile.h"
 #include "debug.h"
@@ -47,7 +48,7 @@ static int artReadFrameData(unsigned char* data, File* stream, int count, int* p
 static int artReadHeader(Art* art, File* stream);
 static int artGetDataSize(const Art* art);
 static int paddingForSize(int size);
-static char artGetCritterWeaponCode(int weaponType);
+static char artGetCritterWeaponCode(WeaponAnimation weaponType);
 
 // A frame is laid out like [ArtFrame header][pixel bytes][padding].
 // These functions return a pointer to the pixel bytes, but must be given a pointer to a frame header,
@@ -572,9 +573,9 @@ int artCopyFileName(int objectType, int id, char* dest)
 }
 
 // 0x419314
-int _art_get_code(AnimationType animation, int weaponType, char* weaponCodePtr, char* animationCodePtr)
+int _art_get_code(AnimationType animation, WeaponAnimation weaponType, char* weaponCodePtr, char* animationCodePtr)
 {
-    if (weaponType < 0 || weaponType >= WEAPON_ANIMATION_COUNT) {
+    if (!weaponAnimationIsValid(weaponType)) {
         return -1;
     }
 
@@ -642,7 +643,7 @@ int _art_get_code(AnimationType animation, int weaponType, char* weaponCodePtr, 
     return 0;
 }
 
-static char artGetCritterWeaponCode(int weaponType)
+static char artGetCritterWeaponCode(WeaponAnimation weaponType)
 {
     switch (weaponType) {
     case WEAPON_ANIMATION_SFALL_S:
@@ -675,7 +676,7 @@ char* artBuildFilePath(int fid)
 
     int frmId = baseFid & 0xFFF;
     AnimationType animType = animationTypeFromFid(baseFid);
-    int weaponCode = (baseFid & 0xF000) >> 12;
+    WeaponAnimation weaponCode = weaponAnimationFromFid(baseFid);
     int objectType = FID_TYPE(baseFid);
 
     if (objectType < OBJ_TYPE_ITEM || objectType >= OBJ_TYPE_COUNT) {

--- a/src/art.h
+++ b/src/art.h
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "animation.h"
+#include "art_defs.h"
 #include "cache.h"
 #include "draw.h"
 #include "memory.h"
@@ -11,63 +12,6 @@
 #include "proto_types.h"
 
 namespace fallout {
-
-typedef enum Head {
-    HEAD_INVALID,
-    HEAD_MARCUS,
-    HEAD_MYRON,
-    HEAD_ELDER,
-    HEAD_LYNETTE,
-    HEAD_HAROLD,
-    HEAD_TANDI,
-    HEAD_COM_OFFICER,
-    HEAD_SULIK,
-    HEAD_PRESIDENT,
-    HEAD_HAKUNIN,
-    HEAD_BOSS,
-    HEAD_DYING_HAKUNIN,
-    HEAD_COUNT,
-} Head;
-
-typedef enum HeadAnimation {
-    HEAD_ANIMATION_VERY_GOOD_REACTION = 0,
-    FIDGET_GOOD = 1,
-    HEAD_ANIMATION_GOOD_TO_NEUTRAL = 2,
-    HEAD_ANIMATION_NEUTRAL_TO_GOOD = 3,
-    FIDGET_NEUTRAL = 4,
-    HEAD_ANIMATION_NEUTRAL_TO_BAD = 5,
-    HEAD_ANIMATION_BAD_TO_NEUTRAL = 6,
-    FIDGET_BAD = 7,
-    HEAD_ANIMATION_VERY_BAD_REACTION = 8,
-    HEAD_ANIMATION_GOOD_PHONEMES = 9,
-    HEAD_ANIMATION_NEUTRAL_PHONEMES = 10,
-    HEAD_ANIMATION_BAD_PHONEMES = 11,
-} HeadAnimation;
-
-typedef enum Background {
-    BACKGROUND_0,
-    BACKGROUND_1,
-    BACKGROUND_2,
-    BACKGROUND_HUB,
-    BACKGROUND_NECROPOLIS,
-    BACKGROUND_BROTHERHOOD,
-    BACKGROUND_MILITARY_BASE,
-    BACKGROUND_JUNK_TOWN,
-    BACKGROUND_CATHEDRAL,
-    BACKGROUND_SHADY_SANDS,
-    BACKGROUND_VAULT,
-    BACKGROUND_MASTER,
-    BACKGROUND_FOLLOWER,
-    BACKGROUND_RAIDERS,
-    BACKGROUND_CAVE,
-    BACKGROUND_ENCLAVE,
-    BACKGROUND_WASTELAND,
-    BACKGROUND_BOSS,
-    BACKGROUND_PRESIDENT,
-    BACKGROUND_TENT,
-    BACKGROUND_ADOBE,
-    BACKGROUND_COUNT,
-} Background;
 
 typedef struct Art {
     int version;
@@ -89,35 +33,6 @@ typedef struct ArtFrame {
     short y;
 } ArtFrame;
 
-typedef enum WeaponAnimation {
-    WEAPON_ANIMATION_NONE,
-    WEAPON_ANIMATION_KNIFE, // d
-    WEAPON_ANIMATION_CLUB, // e
-    WEAPON_ANIMATION_HAMMER, // f
-    WEAPON_ANIMATION_SPEAR, // g
-    WEAPON_ANIMATION_PISTOL, // h
-    WEAPON_ANIMATION_SMG, // i
-    WEAPON_ANIMATION_SHOTGUN, // j
-    WEAPON_ANIMATION_LASER_RIFLE, // k
-    WEAPON_ANIMATION_MINIGUN, // l
-    WEAPON_ANIMATION_LAUNCHER, // m
-    WEAPON_ANIMATION_SFALL_S, // s
-    WEAPON_ANIMATION_SFALL_O, // o
-    WEAPON_ANIMATION_SFALL_P, // p
-    WEAPON_ANIMATION_SFALL_Q, // q
-    WEAPON_ANIMATION_SFALL_T, // t
-    WEAPON_ANIMATION_COUNT,
-} WeaponAnimation;
-
-typedef enum DudeNativeLook {
-    // Hero looks as one the tribals (before finishing Temple of Trails).
-    DUDE_NATIVE_LOOK_TRIBAL,
-
-    // Hero have finished Temple of Trails and received Vault Jumpsuit.
-    DUDE_NATIVE_LOOK_JUMPSUIT,
-    DUDE_NATIVE_LOOK_COUNT,
-} DudeNativeLook;
-
 extern int _art_vault_guy_num;
 extern int _art_vault_person_nums[DUDE_NATIVE_LOOK_COUNT][GENDER_COUNT];
 
@@ -137,7 +52,7 @@ unsigned char* artLockFrameData(int fid, int frame, int direction, CacheEntry** 
 int artUnlock(CacheEntry* cache_entry);
 int artCacheFlush();
 int artCopyFileName(int objectType, int id, char* dest);
-int _art_get_code(AnimationType animation, int weaponType, char* weaponCodePtr, char* animationCodePtr);
+int _art_get_code(AnimationType animation, WeaponAnimation weaponType, char* weaponCodePtr, char* animationCodePtr);
 char* artBuildFilePath(int fid);
 int artGetFramesPerSecond(Art* art);
 int artGetActionFrame(Art* art);

--- a/src/art_defs.h
+++ b/src/art_defs.h
@@ -59,14 +59,14 @@ typedef enum Background {
     BACKGROUND_COUNT,
 } Background;
 
-typedef enum DudeNativeLook {
+enum DudeNativeLook : int {
     // Hero looks as one the tribals (before finishing Temple of Trails).
     DUDE_NATIVE_LOOK_TRIBAL,
 
     // Hero have finished Temple of Trails and received Vault Jumpsuit.
     DUDE_NATIVE_LOOK_JUMPSUIT,
     DUDE_NATIVE_LOOK_COUNT,
-} DudeNativeLook;
+};
 
 enum WeaponAnimation : int {
     WEAPON_ANIMATION_INVALID = -1,

--- a/src/art_defs.h
+++ b/src/art_defs.h
@@ -1,0 +1,108 @@
+#ifndef ART_DEFS_H
+#define ART_DEFS_H
+namespace fallout {
+
+typedef enum Head {
+    HEAD_INVALID,
+    HEAD_MARCUS,
+    HEAD_MYRON,
+    HEAD_ELDER,
+    HEAD_LYNETTE,
+    HEAD_HAROLD,
+    HEAD_TANDI,
+    HEAD_COM_OFFICER,
+    HEAD_SULIK,
+    HEAD_PRESIDENT,
+    HEAD_HAKUNIN,
+    HEAD_BOSS,
+    HEAD_DYING_HAKUNIN,
+    HEAD_COUNT,
+} Head;
+
+typedef enum HeadAnimation {
+    HEAD_ANIMATION_VERY_GOOD_REACTION = 0,
+    FIDGET_GOOD = 1,
+    HEAD_ANIMATION_GOOD_TO_NEUTRAL = 2,
+    HEAD_ANIMATION_NEUTRAL_TO_GOOD = 3,
+    FIDGET_NEUTRAL = 4,
+    HEAD_ANIMATION_NEUTRAL_TO_BAD = 5,
+    HEAD_ANIMATION_BAD_TO_NEUTRAL = 6,
+    FIDGET_BAD = 7,
+    HEAD_ANIMATION_VERY_BAD_REACTION = 8,
+    HEAD_ANIMATION_GOOD_PHONEMES = 9,
+    HEAD_ANIMATION_NEUTRAL_PHONEMES = 10,
+    HEAD_ANIMATION_BAD_PHONEMES = 11,
+} HeadAnimation;
+
+typedef enum Background {
+    BACKGROUND_0,
+    BACKGROUND_1,
+    BACKGROUND_2,
+    BACKGROUND_HUB,
+    BACKGROUND_NECROPOLIS,
+    BACKGROUND_BROTHERHOOD,
+    BACKGROUND_MILITARY_BASE,
+    BACKGROUND_JUNK_TOWN,
+    BACKGROUND_CATHEDRAL,
+    BACKGROUND_SHADY_SANDS,
+    BACKGROUND_VAULT,
+    BACKGROUND_MASTER,
+    BACKGROUND_FOLLOWER,
+    BACKGROUND_RAIDERS,
+    BACKGROUND_CAVE,
+    BACKGROUND_ENCLAVE,
+    BACKGROUND_WASTELAND,
+    BACKGROUND_BOSS,
+    BACKGROUND_PRESIDENT,
+    BACKGROUND_TENT,
+    BACKGROUND_ADOBE,
+    BACKGROUND_COUNT,
+} Background;
+
+typedef enum DudeNativeLook {
+    // Hero looks as one the tribals (before finishing Temple of Trails).
+    DUDE_NATIVE_LOOK_TRIBAL,
+
+    // Hero have finished Temple of Trails and received Vault Jumpsuit.
+    DUDE_NATIVE_LOOK_JUMPSUIT,
+    DUDE_NATIVE_LOOK_COUNT,
+} DudeNativeLook;
+
+enum WeaponAnimation : int {
+    WEAPON_ANIMATION_INVALID = -1,
+    WEAPON_ANIMATION_NONE,
+    WEAPON_ANIMATION_KNIFE, // d
+    WEAPON_ANIMATION_CLUB, // e
+    WEAPON_ANIMATION_HAMMER, // f
+    WEAPON_ANIMATION_SPEAR, // g
+    WEAPON_ANIMATION_PISTOL, // h
+    WEAPON_ANIMATION_SMG, // i
+    WEAPON_ANIMATION_SHOTGUN, // j
+    WEAPON_ANIMATION_LASER_RIFLE, // k
+    WEAPON_ANIMATION_MINIGUN, // l
+    WEAPON_ANIMATION_LAUNCHER, // m
+    WEAPON_ANIMATION_SFALL_S, // s
+    WEAPON_ANIMATION_SFALL_O, // o
+    WEAPON_ANIMATION_SFALL_P, // p
+    WEAPON_ANIMATION_SFALL_Q, // q
+    WEAPON_ANIMATION_SFALL_T, // t
+    WEAPON_ANIMATION_COUNT,
+};
+
+inline bool weaponAnimationIsValid(int weaponAnimation)
+{
+    return weaponAnimation >= WEAPON_ANIMATION_NONE && weaponAnimation < WEAPON_ANIMATION_COUNT;
+}
+
+inline WeaponAnimation weaponAnimationFromFid(int fid)
+{
+    int anim = (fid & 0xF000) >> 12;
+    if (!weaponAnimationIsValid(anim)) {
+        return WEAPON_ANIMATION_INVALID;
+    }
+
+    return static_cast<WeaponAnimation>(anim);
+}
+
+} // namespace fallout
+#endif /* ART_DEFS_H */

--- a/src/art_defs.h
+++ b/src/art_defs.h
@@ -87,6 +87,13 @@ enum WeaponAnimation : int {
     WEAPON_ANIMATION_SFALL_Q, // q
     WEAPON_ANIMATION_SFALL_T, // t
     WEAPON_ANIMATION_COUNT,
+
+    // There's mixed usage of WeaponAnimation and CharacterSoundEffect in the code, lets merge those as we any cannot distinguish between them.
+    CHARACTER_SOUND_EFFECT_UNUSED = WEAPON_ANIMATION_NONE,
+    CHARACTER_SOUND_EFFECT_KNOCKDOWN = WEAPON_ANIMATION_KNIFE,
+    CHARACTER_SOUND_EFFECT_PASS_OUT = WEAPON_ANIMATION_CLUB,
+    CHARACTER_SOUND_EFFECT_DIE = WEAPON_ANIMATION_HAMMER,
+    CHARACTER_SOUND_EFFECT_CONTACT = WEAPON_ANIMATION_SPEAR,
 };
 
 inline bool weaponAnimationIsValid(int weaponAnimation)

--- a/src/combat.cc
+++ b/src/combat.cc
@@ -3582,7 +3582,7 @@ void attackInit(Attack* attack, Object* attacker, Object* defender, HitMode hitM
 int _combat_attack(Object* attacker, Object* defender, HitMode hitMode, HitLocation hitLocation)
 {
     if (attacker != gDude && hitMode == HIT_MODE_PUNCH && randomBetween(1, 4) == 1) {
-        int fid = buildFid(OBJ_TYPE_CRITTER, attacker->fid & 0xFFF, ANIM_KICK_LEG, (attacker->fid & 0xF000) >> 12, FID_ROTATION(attacker->fid));
+        int fid = buildFid(OBJ_TYPE_CRITTER, attacker->fid & 0xFFF, ANIM_KICK_LEG, weaponAnimationFromFid(attacker->fid), FID_ROTATION(attacker->fid));
         if (artExists(fid)) {
             hitMode = HIT_MODE_KICK;
         }

--- a/src/combat_ai.cc
+++ b/src/combat_ai.cc
@@ -2717,8 +2717,8 @@ static int _ai_try_attack(Object* attacker, Object* defender)
     int actionPointsToUse = 0;
     if (weapon != nullptr
         || (critterGetBodyType(defender) == BODY_TYPE_BIPED
-            && ((defender->fid & 0xF000) >> 12 == 0)
-            && artExists(buildFid(OBJ_TYPE_CRITTER, attacker->fid & 0xFFF, ANIM_THROW_PUNCH, 0, attacker->rotation + 1)))) {
+            && (weaponAnimationFromFid(defender->fid) == WEAPON_ANIMATION_NONE)
+            && artExists(buildFid(OBJ_TYPE_CRITTER, attacker->fid & 0xFFF, ANIM_THROW_PUNCH, WEAPON_ANIMATION_NONE, attacker->rotation + 1)))) {
         // SFALL: Check the safety of weapons based on the selected attack mode
         // instead of always the primary weapon hit mode.
         if (_combat_safety_invalidate_weapon(attacker, weapon, hitMode, defender, &safeDistance)) {

--- a/src/critter.cc
+++ b/src/critter.cc
@@ -836,14 +836,14 @@ void critterKill(Object* critter, AnimationType anim, bool refreshRect)
             if (current == ANIM_FALL_BACK) {
                 back = true;
             } else {
-                fid = buildFid(OBJ_TYPE_CRITTER, critter->fid & 0xFFF, ANIM_FALL_FRONT_SF, (critter->fid & 0xF000) >> 12, critter->rotation + 1);
+                fid = buildFid(OBJ_TYPE_CRITTER, critter->fid & 0xFFF, ANIM_FALL_FRONT_SF, weaponAnimationFromFid(critter->fid), critter->rotation + 1);
                 if (!artExists(fid)) {
                     back = true;
                 }
             }
 
             if (back) {
-                fid = buildFid(OBJ_TYPE_CRITTER, critter->fid & 0xFFF, ANIM_FALL_BACK_SF, (critter->fid & 0xF000) >> 12, critter->rotation + 1);
+                fid = buildFid(OBJ_TYPE_CRITTER, critter->fid & 0xFFF, ANIM_FALL_BACK_SF, weaponAnimationFromFid(critter->fid), critter->rotation + 1);
             }
 
             shouldChangeFid = true;
@@ -858,12 +858,12 @@ void critterKill(Object* critter, AnimationType anim, bool refreshRect)
             anim = LAST_SF_DEATH_ANIM;
         }
 
-        fid = buildFid(OBJ_TYPE_CRITTER, critter->fid & 0xFFF, anim, (critter->fid & 0xF000) >> 12, critter->rotation + 1);
+        fid = buildFid(OBJ_TYPE_CRITTER, critter->fid & 0xFFF, anim, weaponAnimationFromFid(critter->fid), critter->rotation + 1);
         _obj_fix_violence_settings(&fid);
         if (!artExists(fid)) {
             debugPrint("\nError: Critter Kill: Can't match fid!");
 
-            fid = buildFid(OBJ_TYPE_CRITTER, critter->fid & 0xFFF, ANIM_FALL_BACK_BLOOD_SF, (critter->fid & 0xF000) >> 12, critter->rotation + 1);
+            fid = buildFid(OBJ_TYPE_CRITTER, critter->fid & 0xFFF, ANIM_FALL_BACK_BLOOD_SF, weaponAnimationFromFid(critter->fid), critter->rotation + 1);
             _obj_fix_violence_settings(&fid);
         }
 
@@ -1306,7 +1306,7 @@ int knockoutClear(Object* obj, void* data)
 
     obj->data.critter.combat.results &= ~(DAM_KNOCKED_OUT | DAM_KNOCKED_DOWN);
 
-    int fid = buildFid(FID_TYPE(obj->fid), obj->fid & 0xFFF, ANIM_STAND, (obj->fid & 0xF000) >> 12, obj->rotation + 1);
+    int fid = buildFid(FID_TYPE(obj->fid), obj->fid & 0xFFF, ANIM_STAND, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
     objectSetFid(obj, fid, nullptr);
 
     return 0;

--- a/src/game.cc
+++ b/src/game.cc
@@ -812,14 +812,14 @@ int gameHandleKey(int eventCode, bool isInCombatMode)
         break;
     case KEY_COMMA:
     case KEY_LESS:
-        if (reg_anim_begin(ANIMATION_REQUEST_RESERVED) == 0) {
+        if (reg_anim_begin(ANIMATION_REQUEST_RESERVED) == ANIMATION_REQUEST_NONE) {
             animationRegisterRotateCounterClockwise(gDude);
             reg_anim_end();
         }
         break;
     case KEY_DOT:
     case KEY_GREATER:
-        if (reg_anim_begin(ANIMATION_REQUEST_RESERVED) == 0) {
+        if (reg_anim_begin(ANIMATION_REQUEST_RESERVED) == ANIMATION_REQUEST_NONE) {
             animationRegisterRotateClockwise(gDude);
             reg_anim_end();
         }

--- a/src/game.cc
+++ b/src/game.cc
@@ -812,14 +812,14 @@ int gameHandleKey(int eventCode, bool isInCombatMode)
         break;
     case KEY_COMMA:
     case KEY_LESS:
-        if (reg_anim_begin(ANIMATION_REQUEST_RESERVED) == ANIMATION_REQUEST_NONE) {
+        if (reg_anim_begin(ANIMATION_REQUEST_RESERVED) == 0) {
             animationRegisterRotateCounterClockwise(gDude);
             reg_anim_end();
         }
         break;
     case KEY_DOT:
     case KEY_GREATER:
-        if (reg_anim_begin(ANIMATION_REQUEST_RESERVED) == ANIMATION_REQUEST_NONE) {
+        if (reg_anim_begin(ANIMATION_REQUEST_RESERVED) == 0) {
             animationRegisterRotateClockwise(gDude);
             reg_anim_end();
         }

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -3772,7 +3772,7 @@ void partyMemberControlWindowUpdate()
 
     // Render preview.
     CacheEntry* previewHandle;
-    int previewFid = buildFid(FID_TYPE(gGameDialogSpeaker->fid), gGameDialogSpeaker->fid & 0xFFF, ANIM_STAND, (gGameDialogSpeaker->fid & 0xF000) >> 12, ROTATION_SW);
+    int previewFid = buildFid(FID_TYPE(gGameDialogSpeaker->fid), gGameDialogSpeaker->fid & 0xFFF, ANIM_STAND, weaponAnimationFromFid(gGameDialogSpeaker->fid), ROTATION_SW);
     Art* preview = artLock(previewFid, &previewHandle);
     if (preview != nullptr) {
         int width = artGetWidth(preview, 0, ROTATION_SW);

--- a/src/game_sound.cc
+++ b/src/game_sound.cc
@@ -1324,45 +1324,40 @@ int _gsound_compute_relative_volume(Object* obj)
     return v3;
 }
 
-char* sfxBuildCharName(Object* a1, AnimationType anim, WeaponAnimation weaponType)
-{
-    return sfxBuildCharName(a1, anim, static_cast<CharacterSoundEffect>(weaponType));
-}
-
 // sfx_build_char_name
 // 0x451604
-char* sfxBuildCharName(Object* a1, AnimationType anim, CharacterSoundEffect extra)
+char* sfxBuildCharName(Object* a1, AnimationType anim, WeaponAnimation weaponType)
 {
-    char v7[13];
-    char v8;
-    char v9;
+    char artName[13];
+    char weaponCode;
+    char animationCode;
 
-    if (artCopyFileName(FID_TYPE(a1->fid), a1->fid & 0xFFF, v7) == -1) {
+    if (artCopyFileName(FID_TYPE(a1->fid), a1->fid & 0xFFF, artName) == -1) {
         return nullptr;
     }
 
     if (anim == ANIM_TAKE_OUT) {
-        if (_art_get_code(anim, static_cast<WeaponAnimation>(extra), &v8, &v9) == -1) {
+        if (_art_get_code(anim, weaponType, &weaponCode, &animationCode) == -1) {
             return nullptr;
         }
     } else {
-        if (_art_get_code(anim, weaponAnimationFromFid(a1->fid), &v8, &v9) == -1) {
+        if (_art_get_code(anim, weaponAnimationFromFid(a1->fid), &weaponCode, &animationCode) == -1) {
             return nullptr;
         }
     }
 
     // TODO: Check.
     if (anim == ANIM_FALL_FRONT || anim == ANIM_FALL_BACK) {
-        if (extra == CHARACTER_SOUND_EFFECT_PASS_OUT) {
-            v8 = 'Y';
-        } else if (extra == CHARACTER_SOUND_EFFECT_DIE) {
-            v8 = 'Z';
+        if (weaponType == CHARACTER_SOUND_EFFECT_PASS_OUT) {
+            weaponCode = 'Y';
+        } else if (weaponType == CHARACTER_SOUND_EFFECT_DIE) {
+            weaponCode = 'Z';
         }
-    } else if ((anim == ANIM_THROW_PUNCH || anim == ANIM_KICK_LEG) && extra == CHARACTER_SOUND_EFFECT_CONTACT) {
-        v8 = 'Z';
+    } else if ((anim == ANIM_THROW_PUNCH || anim == ANIM_KICK_LEG) && weaponType == CHARACTER_SOUND_EFFECT_CONTACT) {
+        weaponCode = 'Z';
     }
 
-    snprintf(_sfx_file_name, sizeof(_sfx_file_name), "%s%c%c", v7, v8, v9);
+    snprintf(_sfx_file_name, sizeof(_sfx_file_name), "%s%c%c", artName, weaponCode, animationCode);
     compat_strupr(_sfx_file_name);
     return _sfx_file_name;
 }

--- a/src/game_sound.cc
+++ b/src/game_sound.cc
@@ -1324,9 +1324,14 @@ int _gsound_compute_relative_volume(Object* obj)
     return v3;
 }
 
+char* sfxBuildCharName(Object* a1, AnimationType anim, WeaponAnimation weaponType)
+{
+    return sfxBuildCharName(a1, anim, static_cast<CharacterSoundEffect>(weaponType));
+}
+
 // sfx_build_char_name
 // 0x451604
-char* sfxBuildCharName(Object* a1, AnimationType anim, WeaponAnimation weaponType)
+char* sfxBuildCharName(Object* a1, AnimationType anim, CharacterSoundEffect extra)
 {
     char v7[13];
     char v8;
@@ -1337,7 +1342,7 @@ char* sfxBuildCharName(Object* a1, AnimationType anim, WeaponAnimation weaponTyp
     }
 
     if (anim == ANIM_TAKE_OUT) {
-        if (_art_get_code(anim, weaponType, &v8, &v9) == -1) {
+        if (_art_get_code(anim, static_cast<WeaponAnimation>(extra), &v8, &v9) == -1) {
             return nullptr;
         }
     } else {
@@ -1348,12 +1353,12 @@ char* sfxBuildCharName(Object* a1, AnimationType anim, WeaponAnimation weaponTyp
 
     // TODO: Check.
     if (anim == ANIM_FALL_FRONT || anim == ANIM_FALL_BACK) {
-        if (weaponType == WEAPON_ANIMATION_CLUB) {
+        if (extra == CHARACTER_SOUND_EFFECT_PASS_OUT) {
             v8 = 'Y';
-        } else if (weaponType == WEAPON_ANIMATION_HAMMER) {
+        } else if (extra == CHARACTER_SOUND_EFFECT_DIE) {
             v8 = 'Z';
         }
-    } else if ((anim == ANIM_THROW_PUNCH || anim == ANIM_KICK_LEG) && weaponType == WEAPON_ANIMATION_SPEAR) {
+    } else if ((anim == ANIM_THROW_PUNCH || anim == ANIM_KICK_LEG) && extra == CHARACTER_SOUND_EFFECT_CONTACT) {
         v8 = 'Z';
     }
 

--- a/src/game_sound.cc
+++ b/src/game_sound.cc
@@ -5,6 +5,7 @@
 
 #include "animation.h"
 #include "art.h"
+#include "art_defs.h"
 #include "audio.h"
 #include "combat.h"
 #include "content_config.h"
@@ -1325,7 +1326,7 @@ int _gsound_compute_relative_volume(Object* obj)
 
 // sfx_build_char_name
 // 0x451604
-char* sfxBuildCharName(Object* a1, AnimationType anim, int extra)
+char* sfxBuildCharName(Object* a1, AnimationType anim, WeaponAnimation weaponType)
 {
     char v7[13];
     char v8;
@@ -1336,23 +1337,23 @@ char* sfxBuildCharName(Object* a1, AnimationType anim, int extra)
     }
 
     if (anim == ANIM_TAKE_OUT) {
-        if (_art_get_code(anim, extra, &v8, &v9) == -1) {
+        if (_art_get_code(anim, weaponType, &v8, &v9) == -1) {
             return nullptr;
         }
     } else {
-        if (_art_get_code(anim, (a1->fid & 0xF000) >> 12, &v8, &v9) == -1) {
+        if (_art_get_code(anim, weaponAnimationFromFid(a1->fid), &v8, &v9) == -1) {
             return nullptr;
         }
     }
 
     // TODO: Check.
     if (anim == ANIM_FALL_FRONT || anim == ANIM_FALL_BACK) {
-        if (extra == CHARACTER_SOUND_EFFECT_PASS_OUT) {
+        if (weaponType == WEAPON_ANIMATION_CLUB) {
             v8 = 'Y';
-        } else if (extra == CHARACTER_SOUND_EFFECT_DIE) {
+        } else if (weaponType == WEAPON_ANIMATION_HAMMER) {
             v8 = 'Z';
         }
-    } else if ((anim == ANIM_THROW_PUNCH || anim == ANIM_KICK_LEG) && extra == CHARACTER_SOUND_EFFECT_CONTACT) {
+    } else if ((anim == ANIM_THROW_PUNCH || anim == ANIM_KICK_LEG) && weaponType == WEAPON_ANIMATION_SPEAR) {
         v8 = 'Z';
     }
 

--- a/src/game_sound.h
+++ b/src/game_sound.h
@@ -102,7 +102,7 @@ void soundEffectDelete(Sound* sound);
 int _gsnd_anim_sound(Sound* sound, void* objectPtr);
 int soundEffectPlay(Sound* sound);
 int _gsound_compute_relative_volume(Object* obj);
-char* sfxBuildCharName(Object* object, AnimationType anim, int weaponAnimationCode);
+char* sfxBuildCharName(Object* object, AnimationType anim, WeaponAnimation weaponType);
 char* gameSoundBuildAmbientSoundEffectName(const char* name);
 char* gameSoundBuildInterfaceName(const char* name);
 char* sfxBuildWeaponName(int effectType, Object* weapon, HitMode hitMode, Object* target);

--- a/src/game_sound.h
+++ b/src/game_sound.h
@@ -26,14 +26,6 @@ typedef enum ScenerySoundEffect {
     SCENERY_SOUND_EFFECT_COUNT,
 } ScenerySoundEffect;
 
-enum CharacterSoundEffect : int {
-    CHARACTER_SOUND_EFFECT_UNUSED,
-    CHARACTER_SOUND_EFFECT_KNOCKDOWN,
-    CHARACTER_SOUND_EFFECT_PASS_OUT,
-    CHARACTER_SOUND_EFFECT_DIE,
-    CHARACTER_SOUND_EFFECT_CONTACT,
-};
-
 typedef enum GameSoundReadLimitMode {
     GSOUND_LOAD_NO_PLAY = 10,
     GSOUND_LIMIT_BEFORE = 11,
@@ -102,7 +94,6 @@ void soundEffectDelete(Sound* sound);
 int _gsnd_anim_sound(Sound* sound, void* objectPtr);
 int soundEffectPlay(Sound* sound);
 int _gsound_compute_relative_volume(Object* obj);
-char* sfxBuildCharName(Object* object, AnimationType anim, CharacterSoundEffect extra);
 char* sfxBuildCharName(Object* object, AnimationType anim, WeaponAnimation weaponType);
 char* gameSoundBuildAmbientSoundEffectName(const char* name);
 char* gameSoundBuildInterfaceName(const char* name);

--- a/src/game_sound.h
+++ b/src/game_sound.h
@@ -26,13 +26,13 @@ typedef enum ScenerySoundEffect {
     SCENERY_SOUND_EFFECT_COUNT,
 } ScenerySoundEffect;
 
-typedef enum CharacterSoundEffect {
+enum CharacterSoundEffect : int {
     CHARACTER_SOUND_EFFECT_UNUSED,
     CHARACTER_SOUND_EFFECT_KNOCKDOWN,
     CHARACTER_SOUND_EFFECT_PASS_OUT,
     CHARACTER_SOUND_EFFECT_DIE,
     CHARACTER_SOUND_EFFECT_CONTACT,
-} CharacterSoundEffect;
+};
 
 typedef enum GameSoundReadLimitMode {
     GSOUND_LOAD_NO_PLAY = 10,
@@ -102,6 +102,7 @@ void soundEffectDelete(Sound* sound);
 int _gsnd_anim_sound(Sound* sound, void* objectPtr);
 int soundEffectPlay(Sound* sound);
 int _gsound_compute_relative_volume(Object* obj);
+char* sfxBuildCharName(Object* object, AnimationType anim, CharacterSoundEffect extra);
 char* sfxBuildCharName(Object* object, AnimationType anim, WeaponAnimation weaponType);
 char* gameSoundBuildAmbientSoundEffectName(const char* name);
 char* gameSoundBuildInterfaceName(const char* name);

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -124,7 +124,7 @@ struct CustomIndicatorDescription {
 
 static int _intface_redraw_items_callback(Object* _, Object* __);
 static int _intface_change_fid_callback(Object* _, Object* __);
-static void interfaceBarSwapHandsAnimatePutAwayTakeOutSequence(int previousWeaponAnimationCode, int weaponAnimationCode);
+static void interfaceBarSwapHandsAnimatePutAwayTakeOutSequence(WeaponAnimation previousWeaponAnimationCode, WeaponAnimation weaponAnimationCode);
 static int intface_init_items();
 static int interfaceBarRefreshMainAction();
 static int endTurnButtonInit();
@@ -1225,14 +1225,14 @@ int interfaceUpdateItems(bool animated, InterfaceItemAction leftItemAction, Inte
     if (animated) {
         Object* newCurrentItem = gInterfaceItemStates[gInterfaceCurrentHand].item;
         if (newCurrentItem != oldCurrentItem) {
-            int animationCode = 0;
+            WeaponAnimation animationCode = WEAPON_ANIMATION_NONE;
             if (newCurrentItem != nullptr) {
                 if (itemGetType(newCurrentItem) == ITEM_TYPE_WEAPON) {
                     animationCode = weaponGetAnimationCode(newCurrentItem);
                 }
             }
 
-            interfaceBarSwapHandsAnimatePutAwayTakeOutSequence((gDude->fid & 0xF000) >> 12, animationCode);
+            interfaceBarSwapHandsAnimatePutAwayTakeOutSequence(weaponAnimationFromFid(gDude->fid), animationCode);
 
             return 0;
         }
@@ -1254,14 +1254,14 @@ int interfaceBarSwapHands(bool animated)
 
     if (animated) {
         Object* item = gInterfaceItemStates[gInterfaceCurrentHand].item;
-        int animationCode = 0;
+        WeaponAnimation animationCode = WEAPON_ANIMATION_NONE;
         if (item != nullptr) {
             if (itemGetType(item) == ITEM_TYPE_WEAPON) {
                 animationCode = weaponGetAnimationCode(item);
             }
         }
 
-        interfaceBarSwapHandsAnimatePutAwayTakeOutSequence((gDude->fid & 0xF000) >> 12, animationCode);
+        interfaceBarSwapHandsAnimatePutAwayTakeOutSequence(weaponAnimationFromFid(gDude->fid), animationCode);
     } else {
         interfaceBarRefreshMainAction();
     }
@@ -1888,7 +1888,7 @@ static int _intface_change_fid_callback(Object* _, Object* __)
 }
 
 // 0x46066C intface_change_fid_animate
-static void interfaceBarSwapHandsAnimatePutAwayTakeOutSequence(int previousWeaponAnimationCode, int weaponAnimationCode)
+static void interfaceBarSwapHandsAnimatePutAwayTakeOutSequence(WeaponAnimation previousWeaponAnimationCode, WeaponAnimation weaponAnimationCode)
 {
     gInterfaceBarSwapHandsInProgress = true;
 
@@ -1896,8 +1896,8 @@ static void interfaceBarSwapHandsAnimatePutAwayTakeOutSequence(int previousWeapo
     reg_anim_begin(ANIMATION_REQUEST_RESERVED);
     animationRegisterSetLightDistance(gDude, 4, 0);
 
-    if (previousWeaponAnimationCode != 0) {
-        const char* sfx = sfxBuildCharName(gDude, ANIM_PUT_AWAY, CHARACTER_SOUND_EFFECT_UNUSED);
+    if (previousWeaponAnimationCode != WEAPON_ANIMATION_NONE) {
+        const char* sfx = sfxBuildCharName(gDude, ANIM_PUT_AWAY, WEAPON_ANIMATION_NONE);
         animationRegisterPlaySoundEffect(gDude, sfx, 0);
         animationRegisterAnimate(gDude, ANIM_PUT_AWAY, 0);
     }

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -1778,6 +1778,8 @@ static int interfaceBarRefreshMainAction()
                 case ANIM_FIRE_CONTINUOUS:
                     id = 40; // burst
                     break;
+                default:
+                    break;
                 }
 
                 primaryFid = buildFid(OBJ_TYPE_INTERFACE, id, 0, 0, 0);

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -1897,7 +1897,7 @@ static void interfaceBarSwapHandsAnimatePutAwayTakeOutSequence(WeaponAnimation p
     animationRegisterSetLightDistance(gDude, 4, 0);
 
     if (previousWeaponAnimationCode != WEAPON_ANIMATION_NONE) {
-        const char* sfx = sfxBuildCharName(gDude, ANIM_PUT_AWAY, WEAPON_ANIMATION_NONE);
+        const char* sfx = sfxBuildCharName(gDude, ANIM_PUT_AWAY, CHARACTER_SOUND_EFFECT_UNUSED);
         animationRegisterPlaySoundEffect(gDude, sfx, 0);
         animationRegisterAnimate(gDude, ANIM_PUT_AWAY, 0);
     }
@@ -1910,7 +1910,7 @@ static void interfaceBarSwapHandsAnimatePutAwayTakeOutSequence(WeaponAnimation p
         animationRegisterSetLightDistance(gDude, item->lightDistance, 0);
     }
 
-    if (weaponAnimationCode != 0) {
+    if (weaponAnimationCode != WEAPON_ANIMATION_NONE) {
         animationRegisterTakeOutWeapon(gDude, weaponAnimationCode, -1);
     } else {
         int fid = buildFid(OBJ_TYPE_CRITTER, gDude->fid & 0xFFF, ANIM_STAND, 0, gDude->rotation + 1);

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -371,6 +371,17 @@ inline AnimationType programStackPopEnum(Program* program)
     return static_cast<AnimationType>(anim);
 }
 
+template <>
+inline WeaponAnimation programStackPopEnum(Program* program)
+{
+    int anim = programStackPopInteger(program);
+    if (!weaponAnimationIsValid(anim)) {
+        programPrintError("invalid weapon animation %d", anim);
+    }
+
+    return static_cast<WeaponAnimation>(anim);
+}
+
 void programReturnStackPushValue(Program* program, ProgramValue& programValue);
 void programReturnStackPushInteger(Program* program, int value);
 void programReturnStackPushPointer(Program* program, void* value);

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -3481,7 +3481,7 @@ static void opRegAnimFunc(Program* program)
     if (!animationCheckCombatMode()) {
         switch (cmd) {
         case OP_REG_ANIM_FUNC_BEGIN:
-            reg_anim_begin(param.integerValue);
+            reg_anim_begin(static_cast<AnimationRequestOptions>(param.integerValue));
             break;
         case OP_REG_ANIM_FUNC_CLEAR:
             reg_anim_clear(static_cast<Object*>(param.pointerValue));

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -7,6 +7,7 @@
 #include "actions.h"
 #include "animation.h"
 #include "art.h"
+#include "art_defs.h"
 #include "color.h"
 #include "combat.h"
 #include "combat_ai.h"
@@ -423,28 +424,28 @@ int correctFidForRemovedItem(Object* critter, Object* item, int flags)
     }
 
     int fid = critter->fid;
-    int weaponCode = FID_WEAPON_CODE(fid);
+    WeaponAnimation weaponCode = weaponAnimationFromFid(fid);
     int newFid = -1;
 
     if ((flags & OBJECT_IN_ANY_HAND) != 0) {
         if (critter == gDude) {
             if (interfaceGetCurrentHand() == HAND_RIGHT) {
                 if ((flags & OBJECT_IN_RIGHT_HAND) != 0) {
-                    weaponCode = 0;
+                    weaponCode = WEAPON_ANIMATION_NONE;
                 }
             } else {
                 if ((flags & OBJECT_IN_LEFT_HAND) != 0) {
-                    weaponCode = 0;
+                    weaponCode = WEAPON_ANIMATION_NONE;
                 }
             }
         } else {
             if ((flags & OBJECT_IN_RIGHT_HAND) != 0) {
-                weaponCode = 0;
+                weaponCode = WEAPON_ANIMATION_NONE;
             }
         }
 
-        if (weaponCode == 0) {
-            newFid = buildFid(FID_TYPE(fid), fid & 0xFFF, animationTypeFromFid(fid), 0, FID_ROTATION(fid));
+        if (weaponCode == WEAPON_ANIMATION_NONE) {
+            newFid = buildFid(FID_TYPE(fid), fid & 0xFFF, animationTypeFromFid(fid), WEAPON_ANIMATION_NONE, FID_ROTATION(fid));
         }
     } else {
         if (critter == gDude) {
@@ -4349,13 +4350,13 @@ static void opCritterModifySkill(Program* program)
 // 0x45B9C4 op_sfx_build_char_name
 static void opSfxBuildCharName(Program* program)
 {
-    int extra = programStackPopInteger(program);
+    WeaponAnimation weaponType = programStackPopEnum<WeaponAnimation>(program);
     AnimationType anim = programStackPopEnum<AnimationType>(program);
     Object* obj = static_cast<Object*>(programStackPopPointer(program));
 
     if (obj != nullptr) {
         char soundEffectName[16];
-        strcpy(soundEffectName, sfxBuildCharName(obj, anim, extra));
+        strcpy(soundEffectName, sfxBuildCharName(obj, anim, weaponType));
         programStackPushString(program, soundEffectName);
     } else {
         scriptPredefinedError(program, "sfx_build_char_name", SCRIPT_ERROR_OBJECT_IS_NULL);

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -2045,7 +2045,7 @@ static void opMetarule3(Program* program)
             int fid = buildFid(FID_TYPE(obj->fid),
                 frmId,
                 animationTypeFromFid(obj->fid),
-                (obj->fid & 0xF000) >> 12,
+                weaponAnimationFromFid(obj->fid),
                 FID_ROTATION(obj->fid));
 
             Rect updatedRect;
@@ -2347,7 +2347,7 @@ static AnimationType _correctDeath(Object* critter, AnimationType anim, bool for
         if (settings.preferences.violence_level < VIOLENCE_LEVEL_MAXIMUM_BLOOD) {
             useStandardDeath = true;
         } else {
-            int fid = buildFid(OBJ_TYPE_CRITTER, critter->fid & 0xFFF, anim, (critter->fid & 0xF000) >> 12, critter->rotation + 1);
+            int fid = buildFid(OBJ_TYPE_CRITTER, critter->fid & 0xFFF, anim, weaponAnimationFromFid(critter->fid), critter->rotation + 1);
             if (!artExists(fid)) {
                 useStandardDeath = true;
             }
@@ -2357,7 +2357,7 @@ static AnimationType _correctDeath(Object* critter, AnimationType anim, bool for
             if (forceBack) {
                 anim = ANIM_FALL_BACK;
             } else {
-                int fid = buildFid(OBJ_TYPE_CRITTER, critter->fid & 0xFFF, ANIM_FALL_FRONT, (critter->fid & 0xF000) >> 12, critter->rotation + 1);
+                int fid = buildFid(OBJ_TYPE_CRITTER, critter->fid & 0xFFF, ANIM_FALL_FRONT, weaponAnimationFromFid(critter->fid), critter->rotation + 1);
                 if (artExists(fid)) {
                     anim = ANIM_FALL_FRONT;
                 } else {
@@ -3415,7 +3415,7 @@ static void opAnim(Program* program)
         if (frame == 0) { // ANIMATE_FORWARD
             animationRegisterAnimate(obj, anim, 0);
             if (anim >= ANIM_FALL_BACK && anim <= ANIM_FALL_FRONT_BLOOD) {
-                int fid = buildFid(OBJ_TYPE_CRITTER, obj->fid & 0xFFF, anim + 28, (obj->fid & 0xF000) >> 12, FID_ROTATION(obj->fid));
+                int fid = buildFid(OBJ_TYPE_CRITTER, obj->fid & 0xFFF, anim + 28, weaponAnimationFromFid(obj->fid), FID_ROTATION(obj->fid));
                 animationRegisterSetFid(obj, fid, -1);
             }
 
@@ -3423,13 +3423,13 @@ static void opAnim(Program* program)
                 combatData->results &= ~DAM_KNOCKED_DOWN;
             }
         } else { // ANIMATE_REVERSE == 1
-            int fid = buildFid(FID_TYPE(obj->fid), obj->fid & 0xFFF, anim, (obj->fid & 0xF000) >> 12, FID_ROTATION(obj->fid));
+            int fid = buildFid(FID_TYPE(obj->fid), obj->fid & 0xFFF, anim, weaponAnimationFromFid(obj->fid), FID_ROTATION(obj->fid));
             animationRegisterAnimateReversed(obj, anim, 0);
 
             if (anim == ANIM_PRONE_TO_STANDING) {
-                fid = buildFid(FID_TYPE(obj->fid), obj->fid & 0xFFF, ANIM_FALL_FRONT_SF, (obj->fid & 0xF000) >> 12, FID_ROTATION(obj->fid));
+                fid = buildFid(FID_TYPE(obj->fid), obj->fid & 0xFFF, ANIM_FALL_FRONT_SF, weaponAnimationFromFid(obj->fid), FID_ROTATION(obj->fid));
             } else if (anim == ANIM_BACK_TO_STANDING) {
-                fid = buildFid(FID_TYPE(obj->fid), obj->fid & 0xFFF, ANIM_FALL_BACK_SF, (obj->fid & 0xF000) >> 12, FID_ROTATION(obj->fid));
+                fid = buildFid(FID_TYPE(obj->fid), obj->fid & 0xFFF, ANIM_FALL_BACK_SF, weaponAnimationFromFid(obj->fid), FID_ROTATION(obj->fid));
             }
 
             if (combatData != nullptr) {

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -3864,8 +3864,8 @@ int inventoryEquipFunc(Object* critter, Object* item, Hand handIndex, bool anima
             hand = HAND_RIGHT;
         }
 
-        int weaponAnimationCode = weaponGetAnimationCode(item);
-        int hitModeAnimationCode = weaponGetAnimationForHitMode(item, HIT_MODE_RIGHT_WEAPON_PRIMARY);
+        WeaponAnimation weaponAnimationCode = weaponGetAnimationCode(item);
+        AnimationType hitModeAnimationCode = weaponGetAnimationForHitMode(item, HIT_MODE_RIGHT_WEAPON_PRIMARY);
         int fid = buildFid(OBJ_TYPE_CRITTER, critter->fid & 0xFFF, hitModeAnimationCode, weaponAnimationCode, critter->rotation + 1);
         if (!artExists(fid)) {
             debugPrint("\ninven_wield failed!  ERROR ERROR ERROR!");
@@ -3923,14 +3923,14 @@ int inventoryEquipFunc(Object* critter, Object* item, Hand handIndex, bool anima
         if (itemGetType(item) == ITEM_TYPE_WEAPON) {
             weaponAnimationCode = weaponGetAnimationCode(item);
         } else {
-            weaponAnimationCode = 0;
+            weaponAnimationCode = WEAPON_ANIMATION_NONE;
         }
 
         if (hand == handIndex) {
-            if ((critter->fid & 0xF000) >> 12 != 0) {
+            if (weaponAnimationFromFid(critter->fid) != WEAPON_ANIMATION_NONE) {
                 if (animate) {
                     if (!isoIsDisabled()) {
-                        const char* soundEffectName = sfxBuildCharName(critter, ANIM_PUT_AWAY, CHARACTER_SOUND_EFFECT_UNUSED);
+                        const char* soundEffectName = sfxBuildCharName(critter, ANIM_PUT_AWAY, WEAPON_ANIMATION_NONE);
                         animationRegisterPlaySoundEffect(critter, soundEffectName, 0);
                         animationRegisterAnimate(critter, ANIM_PUT_AWAY, 0);
                     }
@@ -3938,7 +3938,7 @@ int inventoryEquipFunc(Object* critter, Object* item, Hand handIndex, bool anima
             }
 
             if (animate && !isoIsDisabled()) {
-                if (weaponAnimationCode != 0) {
+                if (weaponAnimationCode != WEAPON_ANIMATION_NONE) {
                     animationRegisterTakeOutWeapon(critter, weaponAnimationCode, -1);
                 } else {
                     int fid = buildFid(OBJ_TYPE_CRITTER, critter->fid & 0xFFF, 0, 0, critter->rotation + 1);
@@ -3997,11 +3997,11 @@ int inventoryUnequipFunc(Object* critter, Hand hand, bool animate)
         item->flags &= ~OBJECT_IN_ANY_HAND;
     }
 
-    if (activeHand == hand && ((critter->fid & 0xF000) >> 12) != 0) {
+    if (activeHand == hand && (weaponAnimationFromFid(critter->fid) != WEAPON_ANIMATION_NONE)) {
         if (animate && !isoIsDisabled()) {
             reg_anim_begin(ANIMATION_REQUEST_RESERVED);
 
-            const char* sfx = sfxBuildCharName(critter, ANIM_PUT_AWAY, CHARACTER_SOUND_EFFECT_UNUSED);
+            const char* sfx = sfxBuildCharName(critter, ANIM_PUT_AWAY, WEAPON_ANIMATION_NONE);
             animationRegisterPlaySoundEffect(critter, sfx, 0);
 
             animationRegisterAnimate(critter, ANIM_PUT_AWAY, 0);

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -3930,7 +3930,7 @@ int inventoryEquipFunc(Object* critter, Object* item, Hand handIndex, bool anima
             if (weaponAnimationFromFid(critter->fid) != WEAPON_ANIMATION_NONE) {
                 if (animate) {
                     if (!isoIsDisabled()) {
-                        const char* soundEffectName = sfxBuildCharName(critter, ANIM_PUT_AWAY, WEAPON_ANIMATION_NONE);
+                        const char* soundEffectName = sfxBuildCharName(critter, ANIM_PUT_AWAY, CHARACTER_SOUND_EFFECT_UNUSED);
                         animationRegisterPlaySoundEffect(critter, soundEffectName, 0);
                         animationRegisterAnimate(critter, ANIM_PUT_AWAY, 0);
                     }
@@ -4001,7 +4001,7 @@ int inventoryUnequipFunc(Object* critter, Hand hand, bool animate)
         if (animate && !isoIsDisabled()) {
             reg_anim_begin(ANIMATION_REQUEST_RESERVED);
 
-            const char* sfx = sfxBuildCharName(critter, ANIM_PUT_AWAY, WEAPON_ANIMATION_NONE);
+            const char* sfx = sfxBuildCharName(critter, ANIM_PUT_AWAY, CHARACTER_SOUND_EFFECT_UNUSED);
             animationRegisterPlaySoundEffect(critter, sfx, 0);
 
             animationRegisterAnimate(critter, ANIM_PUT_AWAY, 0);

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -3850,7 +3850,7 @@ int inventoryEquipFunc(Object* critter, Object* item, Hand handIndex, bool anima
 
         if (critter == gDude) {
             if (!isoIsDisabled()) {
-                int fid = buildFid(OBJ_TYPE_CRITTER, baseFrmId, 0, (critter->fid & 0xF000) >> 12, critter->rotation + 1);
+                int fid = buildFid(OBJ_TYPE_CRITTER, baseFrmId, 0, weaponAnimationFromFid(critter->fid), critter->rotation + 1);
                 animationRegisterSetFid(critter, fid, 0);
             }
         } else {

--- a/src/item.cc
+++ b/src/item.cc
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "animation.h"
+#include "art_defs.h"
 #include "art.h"
 #include "automap.h"
 #include "combat.h"
@@ -1831,10 +1832,10 @@ int weaponGetBurstRounds(Object* weapon)
 }
 
 // 0x478DA8
-int weaponGetAnimationCode(Object* weapon)
+WeaponAnimation weaponGetAnimationCode(Object* weapon)
 {
     if (weapon == nullptr) {
-        return -1;
+        return WEAPON_ANIMATION_INVALID;
     }
 
     Proto* proto;

--- a/src/item.cc
+++ b/src/item.cc
@@ -6,8 +6,8 @@
 #include <vector>
 
 #include "animation.h"
-#include "art_defs.h"
 #include "art.h"
+#include "art_defs.h"
 #include "automap.h"
 #include "combat.h"
 #include "content_config.h"

--- a/src/item.h
+++ b/src/item.h
@@ -2,6 +2,7 @@
 #define ITEM_H
 
 #include "animation.h"
+#include "art_defs.h"
 #include "combat_defs.h"
 #include "db.h"
 #include "obj_types.h"
@@ -95,7 +96,7 @@ int weaponGetMinStrengthRequired(Object* weapon);
 int weaponGetCriticalFailureType(Object* weapon);
 int weaponGetPerk(Object* weapon);
 int weaponGetBurstRounds(Object* weapon);
-int weaponGetAnimationCode(Object* weapon);
+WeaponAnimation weaponGetAnimationCode(Object* weapon);
 int weaponGetProjectilePid(Object* weapon);
 int weaponGetAmmoTypePid(Object* weapon);
 char weaponGetSoundId(Object* weapon);

--- a/src/map.cc
+++ b/src/map.cc
@@ -1759,7 +1759,7 @@ static void _map_place_dude_and_mouse()
     if (gDude != nullptr) {
         if (animationTypeFromFid(gDude->fid) != ANIM_STAND) {
             objectSetFrame(gDude, 0, nullptr);
-            gDude->fid = buildFid(OBJ_TYPE_CRITTER, gDude->fid & 0xFFF, ANIM_STAND, (gDude->fid & 0xF000) >> 12, gDude->rotation + 1);
+            gDude->fid = buildFid(OBJ_TYPE_CRITTER, gDude->fid & 0xFFF, ANIM_STAND, weaponAnimationFromFid(gDude->fid), gDude->rotation + 1);
         }
 
         if (gDude->tile == -1) {
@@ -1799,11 +1799,11 @@ static void _square_reset()
                 // check subsequent calls.
                 int fid = *p;
                 fid &= ~0xFFFF;
-                *p = (((buildFid(OBJ_TYPE_TILE, 1, 0, 0, 0) & 0xFFF) | (((fid >> 16) & 0xF000) >> 12)) << 16) | (fid & 0xFFFF);
+                *p = (((buildFid(OBJ_TYPE_TILE, 1, 0, WEAPON_ANIMATION_NONE, 0) & 0xFFF) | (((fid >> 16) & 0xF000) >> 12)) << 16) | (fid & 0xFFFF);
 
                 fid = *p;
                 int tileFlags = (fid & 0xF000) >> 12;
-                int updatedLowerTile = (buildFid(OBJ_TYPE_TILE, 1, 0, 0, 0) & 0xFFF) | tileFlags;
+                int updatedLowerTile = (buildFid(OBJ_TYPE_TILE, 1, 0, WEAPON_ANIMATION_NONE, 0) & 0xFFF) | tileFlags;
 
                 fid &= ~0xFFFF;
 

--- a/src/obj_types.h
+++ b/src/obj_types.h
@@ -34,7 +34,6 @@ enum ObjectType {
 #define PID_TYPE(value) (value) >> 24
 #define SID_TYPE(value) (value) >> 24
 
-#define FID_WEAPON_CODE(fid) (((fid) & 0xF000) >> 12)
 #define FID_ROTATION(fid) (((fid) & 0x70000000) >> 28)
 
 typedef enum OutlineType {

--- a/src/object.cc
+++ b/src/object.cc
@@ -5175,7 +5175,7 @@ void _obj_fix_violence_settings(int* fid)
         anim = (anim == ANIM_FALL_BACK_BLOOD_SF)
             ? ANIM_FALL_BACK_SF
             : ANIM_FALL_FRONT_SF;
-        *fid = buildFid(OBJ_TYPE_CRITTER, *fid & 0xFFF, anim, (*fid & 0xF000) >> 12, FID_ROTATION(*fid));
+        *fid = buildFid(OBJ_TYPE_CRITTER, *fid & 0xFFF, anim, weaponAnimationFromFid(*fid), FID_ROTATION(*fid));
     }
 
     if (shouldResetViolenceLevel) {

--- a/src/proto.cc
+++ b/src/proto.cc
@@ -864,9 +864,9 @@ int _proto_dude_update_gender()
     _art_vault_guy_num = frmId;
 
     if (critterGetArmor(gDude) == nullptr) {
-        int weaponAnimationCode = 0;
+        WeaponAnimation weaponAnimationCode = WEAPON_ANIMATION_NONE;
         if (critterGetItem2(gDude) != nullptr || critterGetItem1(gDude) != nullptr) {
-            weaponAnimationCode = (gDude->fid & 0xF000) >> 12;
+            weaponAnimationCode = weaponAnimationFromFid(gDude->fid);
         }
 
         int fid = buildFid(OBJ_TYPE_CRITTER, _art_vault_guy_num, 0, weaponAnimationCode, 0);

--- a/src/proto.cc
+++ b/src/proto.cc
@@ -438,7 +438,7 @@ int proto_item_subdata_init(Proto* proto, int type)
         proto->item.extendedFlags |= PROTO_EXT_FLAG_CAN_USE_ON;
         break;
     case ITEM_TYPE_WEAPON:
-        proto->item.data.weapon.animationCode = 0;
+        proto->item.data.weapon.animationCode = WEAPON_ANIMATION_NONE;
         proto->item.data.weapon.minDamage = 0;
         proto->item.data.weapon.maxDamage = 0;
         proto->item.data.weapon.damageType = DAMAGE_TYPE_NORMAL;
@@ -1580,7 +1580,7 @@ static int protoItemDataRead(ItemProtoData* item_data, int type, File* stream)
 
         return 0;
     case ITEM_TYPE_WEAPON:
-        if (fileReadInt32(stream, &(item_data->weapon.animationCode)) == -1) return -1;
+        if (fileReadInt32Enum<WeaponAnimation>(stream, &(item_data->weapon.animationCode)) == -1) return -1;
         if (fileReadInt32(stream, &(item_data->weapon.minDamage)) == -1) return -1;
         if (fileReadInt32(stream, &(item_data->weapon.maxDamage)) == -1) return -1;
         if (fileReadInt32Enum<DamageType>(stream, &(item_data->weapon.damageType)) == -1) return -1;

--- a/src/proto.cc
+++ b/src/proto.cc
@@ -849,7 +849,7 @@ int _proto_dude_update_gender()
         return -1;
     }
 
-    int nativeLook = DUDE_NATIVE_LOOK_TRIBAL;
+    DudeNativeLook nativeLook = DUDE_NATIVE_LOOK_TRIBAL;
     if (gameMovieIsSeen(MOVIE_VSUIT)) {
         nativeLook = DUDE_NATIVE_LOOK_JUMPSUIT;
     }

--- a/src/proto_instance.cc
+++ b/src/proto_instance.cc
@@ -674,7 +674,7 @@ static int _obj_remove_from_inven(Object* critter, Object* item)
                     defaultFid = proto->fid;
                 }
 
-                fid = buildFid(OBJ_TYPE_CRITTER, defaultFid, animationTypeFromFid(critter->fid), (critter->fid & 0xF000) >> 12, critter->rotation);
+                fid = buildFid(OBJ_TYPE_CRITTER, defaultFid, animationTypeFromFid(critter->fid), weaponAnimationFromFid(critter->fid), critter->rotation);
                 objectSetFid(critter, fid, &updatedRect);
                 appearanceUpdateType = 3;
             }

--- a/src/proto_types.h
+++ b/src/proto_types.h
@@ -1,6 +1,7 @@
 #ifndef PROTO_TYPES_H
 #define PROTO_TYPES_H
 
+#include "art_defs.h"
 #include "perk_defs.h"
 #include "skill_defs.h"
 #include "stat_defs.h"
@@ -337,7 +338,7 @@ typedef struct {
 } ProtoItemDrugData;
 
 typedef struct {
-    int animationCode; // d.animation_code
+    WeaponAnimation animationCode; // d.animation_code
     int minDamage; // d.min_damage
     int maxDamage; // d.max_damage
     DamageType damageType; // d.dt

--- a/src/sfall_animation.cc
+++ b/src/sfall_animation.cc
@@ -74,7 +74,7 @@ void op_reg_anim_change_fid(Program* program)
 void op_reg_anim_take_out(Program* program)
 {
     int delay = programStackPopInteger(program);
-    int holdFrame = programStackPopInteger(program);
+    WeaponAnimation holdFrame = programStackPopEnum<WeaponAnimation>(program);
     Object* object = static_cast<Object*>(programStackPopPointer(program));
 
     if (object != nullptr && !animationCheckCombatMode()) {


### PR DESCRIPTION
### Description

Another bunch of type safe usages of `WeaponAnimation`, `AnimationRequestOptions`, `DudeNativeLook` and `ScienceRepairTargetType` enums.

Also replaced a ton of raw expressions for getting `WeaponAnimation` from fid by newly introduced inline method `weaponAnimationFromFid`.

Moved `WeaponType` into new header `art_defs.h` due to the circular dependency.

