### PR TITLE
Change hires stencil popup to log

### DIFF
--- a/src/tile_hires_stencil.cc
+++ b/src/tile_hires_stencil.cc
@@ -405,7 +405,7 @@ void tile_hires_stencil_init()
     if (settings.ui.ignore_map_edges) {
         static bool isMessageShown = false;
         if (!isMessageShown) {
-            showMessageBox("Tile hires stencil is disabled because map edges are ignored.");
+            debugPrint("Tile hires stencil is disabled because map edges are ignored.");
             isMessageShown = true;
         }
         gIsTileHiresStencilEnabled = false;


### PR DESCRIPTION
People who change configs know what they are doing.  We do not need to do a pop up every time