### PR TITLE
Remove extra refreshes from character stat animation

### DIFF
--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -1019,7 +1019,6 @@ int characterEditorShow(bool isCreationMode)
                 if (characterEditorSelectedItem >= EDITOR_FIRST_PRIMARY_STAT && characterEditorSelectedItem <= EDITOR_LAST_PRIMARY_STAT) {
                     if (gCharacterEditorIsCreationMode) {
                         _win_button_press_and_release(gCharacterEditorPrimaryStatMinusBtns[characterEditorSelectedItem]);
-                        characterEditorDrawPrimaryStat(PRIMARY_STAT_COUNT, 0, 0);
                         windowRefresh(gCharacterEditorWindow);
                     }
                 } else if (characterEditorSelectedItem >= EDITOR_FIRST_SKILL && characterEditorSelectedItem <= EDITOR_LAST_SKILL) {
@@ -1043,7 +1042,6 @@ int characterEditorShow(bool isCreationMode)
                 if (characterEditorSelectedItem >= EDITOR_FIRST_PRIMARY_STAT && characterEditorSelectedItem <= EDITOR_LAST_PRIMARY_STAT) {
                     if (gCharacterEditorIsCreationMode) {
                         _win_button_press_and_release(gCharacterEditorPrimaryStatPlusBtns[characterEditorSelectedItem]);
-                        characterEditorDrawPrimaryStat(PRIMARY_STAT_COUNT, 0, 0);
                         windowRefresh(gCharacterEditorWindow);
                     }
                 } else if (characterEditorSelectedItem >= EDITOR_FIRST_SKILL && characterEditorSelectedItem <= EDITOR_LAST_SKILL) {


### PR DESCRIPTION
Small follow up to https://github.com/fallout2-ce/fallout2-ce/pull/633/changes

Right now the refreshing is happening twice per click.  Tested and it seems to always work when only drawing/refreshing after characterEditorAdjustPrimaryStat.  Lmk if I missed something!

h/t @NovaRain 