### PR TITLE
Fix the cursor getting stuck in view scrolling mode for encounters

### DIFF
--- a/src/map.cc
+++ b/src/map.cc
@@ -878,6 +878,9 @@ static int mapLoad(File* stream)
     _gmouse_disable_scrolling();
 
     int savedMouseCursorId = gameMouseGetCursor();
+    if (savedMouseCursorId >= MOUSE_CURSOR_SCROLL_NW && savedMouseCursorId <= MOUSE_CURSOR_SCROLL_W_INVALID) {
+        savedMouseCursorId = MOUSE_CURSOR_ARROW; // reset if it was in view scrolling mode
+    }
     gameMouseSetCursor(MOUSE_CURSOR_WAIT_PLANET);
     fileSetReadProgressHandler(gameMouseRefreshImmediately, 32768);
     tileDisable();


### PR DESCRIPTION
When you automatically enter a non-hostile encounter (i.e. fail to detect it) while scrolling WM viewport, the cursor will be stuck in scrolling mode. You can't switch the cursor with the right mouse button, can only get the cursor unstuck via some other actions that trigger a cursor change, e.g. opening other game UIs or starting combat.
<img width="800" height="600" alt="scr00006" src="https://github.com/user-attachments/assets/5759b355-2063-4191-af08-c4f3dcdba6b8" />

Here's a test save for RPU, but it is harder to reproduce in FO2 because the majority of encounters are hostile/combat-related. In Et Tu it's way more easier to have this issue.
[RPU_testsave_wm_enc.zip](https://github.com/user-attachments/files/30695111/RPU_testsave_wm_enc.zip)

If you want to reproduce in your own game easier, edit a save to make your Outdoorsman extremely low to fail the detection check and edit `worldmap.txt` to make non-hostile encounters (farmers, trappers, or caravan ones)) have much higher chance.