### PR TITLE
[Et tu] rest_option metarules

### DIFF
--- a/SFALL_COMPATIBILITY.md
+++ b/SFALL_COMPATIBILITY.md
@@ -122,7 +122,9 @@ CE defines several metarules that are not supported in Sfall.  Include [ce.h](fi
 
 | Name | Definition |
 | --- | --- |
+| `rest_option_msgs(base_msg_id)` | Change the base message id used for Pip-Boy rest option labels. CE reads the rest labels from `base_msg_id` through `base_msg_id + 13`; the default Fallout 2 range is 302-315. |
 | `set_party_member_cc_msg_ids(pid, start_msg_id, end_msg_id)` | Override party-member combat-control update messages for a pid. Picks randomly from the inclusive contiguous range. Default fallback ranges are 670-674 for humans and 677-678 for the hardcoded dog pid list. |
+| `set_rest_option(rest_option, value)` | Change the wake hour for Pip-Boy rest options 8-11: morning, noon, evening, and midnight. `value` is an hour from 0-23. Defaults are 8, 12, 18, and 0. |
 
 ## Hooks
 

--- a/files/ce.h
+++ b/files/ce.h
@@ -3,5 +3,12 @@
 
 // CE-only metarules
 #define set_party_member_cc_msg_ids(pid, start_msg_id, end_msg_id) sfall_func3("set_party_member_cc_msg_ids", pid, start_msg_id, end_msg_id)
+#define rest_option_msgs(base_msg_id) sfall_func1("rest_option_msgs", base_msg_id)
+#define set_rest_option(rest_option, value) sfall_func2("set_rest_option", rest_option, value)
+
+#define REST_OPTION_MORNING 8
+#define REST_OPTION_NOON 9
+#define REST_OPTION_EVENING 10
+#define REST_OPTION_MIDNIGHT 11
 
 #endif

--- a/src/pipboy.cc
+++ b/src/pipboy.cc
@@ -2083,24 +2083,17 @@ static void pipboyHandleAlarmClock(int eventCode)
             pipboyRest(duration - 1, 0, 0);
             break;
         case PIPBOY_REST_DURATION_UNTIL_MORNING:
-            _ClacTime(&hours, &minutes, pipboyRestOptionWakeHour(duration));
-            pipboyRest(hours, minutes, 0);
-            break;
         case PIPBOY_REST_DURATION_UNTIL_NOON:
-            _ClacTime(&hours, &minutes, pipboyRestOptionWakeHour(duration));
-            pipboyRest(hours, minutes, 0);
-            break;
         case PIPBOY_REST_DURATION_UNTIL_EVENING:
-            _ClacTime(&hours, &minutes, pipboyRestOptionWakeHour(duration));
-            pipboyRest(hours, minutes, 0);
-            break;
-        case PIPBOY_REST_DURATION_UNTIL_MIDNIGHT:
-            _ClacTime(&hours, &minutes, pipboyRestOptionWakeHour(duration));
-            if (pipboyRest(hours, minutes, 0) == 0) {
+        case PIPBOY_REST_DURATION_UNTIL_MIDNIGHT: {
+            int wakeUpHour = pipboyRestOptionWakeHour(duration);
+            _ClacTime(&hours, &minutes, wakeUpHour);
+            if (pipboyRest(hours, minutes, 0) == 0 && wakeUpHour == 0) {
                 pipboyDrawNumber(0, 4, PIPBOY_WINDOW_TIME_X, PIPBOY_WINDOW_TIME_Y);
+                windowRefresh(gPipboyWindow);
             }
-            windowRefresh(gPipboyWindow);
             break;
+        }
         case PIPBOY_REST_DURATION_UNTIL_HEALED:
         case PIPBOY_REST_DURATION_UNTIL_PARTY_HEALED:
             pipboyRest(0, 0, duration);

--- a/src/pipboy.cc
+++ b/src/pipboy.cc
@@ -1,6 +1,7 @@
 #include "pipboy.h"
 
 #include <algorithm>
+#include <assert.h>
 #include <ctype.h>
 #include <stdio.h>
 #include <string.h>
@@ -147,6 +148,15 @@ typedef enum PipboyRestDuration {
     PIPBOY_REST_DURATION_COUNT_WITHOUT_PARTY = PIPBOY_REST_DURATION_COUNT - 1,
 } PipboyRestDuration;
 
+static constexpr int PIPBOY_REST_DURATION_WAKE_HOUR_COUNT = PIPBOY_REST_DURATION_UNTIL_MIDNIGHT - PIPBOY_REST_DURATION_UNTIL_MORNING + 1;
+static constexpr int kDefaultPipboyRestDurationWakeHours[PIPBOY_REST_DURATION_WAKE_HOUR_COUNT] = {
+    8,
+    12,
+    18,
+    0,
+};
+static constexpr int kDefaultPipboyRestDurationBaseMessageId = 302;
+
 typedef enum PipboyFrm {
     PIPBOY_FRM_LITTLE_RED_BUTTON_UP,
     PIPBOY_FRM_LITTLE_RED_BUTTON_DOWN,
@@ -231,6 +241,8 @@ static bool pipboyRest(int hours, int minutes, int kind);
 static bool _Check4Health(int minutes);
 static bool _AddHealth();
 static void _ClacTime(int* hours, int* minutes, int wakeUpHour);
+static int pipboyRestOptionWakeHour(int restOption);
+static void pipboyRestOptionsReset();
 static int pipboyRenderScreensaver();
 static int questInit();
 static void questFree();
@@ -277,6 +289,9 @@ int gHolodisksCount = 0;
 //
 // 0x51C138 currentAlarmTypeCount
 int gPipboyRestOptionsCount = PIPBOY_REST_DURATION_COUNT;
+
+static int pipboyRestDurationBaseMessageId = kDefaultPipboyRestDurationBaseMessageId;
+static int pipboyRestDurationWakeHours[PIPBOY_REST_DURATION_WAKE_HOUR_COUNT];
 
 // 0x51C13C bk_enable_5
 bool gPipboyWindowIsoWasEnabled = false;
@@ -879,12 +894,14 @@ static void _pip_init_()
 // pip_init
 void pipboyInit()
 {
+    pipboyRestOptionsReset();
     _pip_init_();
 }
 
 // NOTE: Uncollapsed 0x497918.
 void pipboyReset()
 {
+    pipboyRestOptionsReset();
     _pip_init_();
 }
 
@@ -2066,19 +2083,19 @@ static void pipboyHandleAlarmClock(int eventCode)
             pipboyRest(duration - 1, 0, 0);
             break;
         case PIPBOY_REST_DURATION_UNTIL_MORNING:
-            _ClacTime(&hours, &minutes, 8);
+            _ClacTime(&hours, &minutes, pipboyRestOptionWakeHour(duration));
             pipboyRest(hours, minutes, 0);
             break;
         case PIPBOY_REST_DURATION_UNTIL_NOON:
-            _ClacTime(&hours, &minutes, 12);
+            _ClacTime(&hours, &minutes, pipboyRestOptionWakeHour(duration));
             pipboyRest(hours, minutes, 0);
             break;
         case PIPBOY_REST_DURATION_UNTIL_EVENING:
-            _ClacTime(&hours, &minutes, 18);
+            _ClacTime(&hours, &minutes, pipboyRestOptionWakeHour(duration));
             pipboyRest(hours, minutes, 0);
             break;
         case PIPBOY_REST_DURATION_UNTIL_MIDNIGHT:
-            _ClacTime(&hours, &minutes, 0);
+            _ClacTime(&hours, &minutes, pipboyRestOptionWakeHour(duration));
             if (pipboyRest(hours, minutes, 0) == 0) {
                 pipboyDrawNumber(0, 4, PIPBOY_WINDOW_TIME_X, PIPBOY_WINDOW_TIME_Y);
             }
@@ -2128,7 +2145,7 @@ static void pipboyWindowRenderRestOptions(int a1)
         // 302 - Rest for ten minutes
         // ...
         // 315 - Rest until party is healed
-        text = getmsg(&gPipboyMessageList, &gPipboyMessageListItem, 302 + option - 1);
+        text = getmsg(&gPipboyMessageList, &gPipboyMessageListItem, pipboyRestDurationBaseMessageId + option - 1);
         int color = option == a1 ? COLOR_LIGHT_YELLOW : COLOR_GREEN;
 
         pipboyDrawText(text, 0, color);
@@ -2514,6 +2531,44 @@ static void _ClacTime(int* hours, int* minutes, int wakeUpHour)
     } else {
         *hours = 24;
     }
+}
+
+bool pipboyRestOptionMsgsSetBase(int baseMessageId)
+{
+    if (baseMessageId <= 0) {
+        return false;
+    }
+
+    pipboyRestDurationBaseMessageId = baseMessageId;
+    return true;
+}
+
+bool pipboyRestOptionSet(int restOption, int value)
+{
+    if (restOption < PIPBOY_REST_DURATION_UNTIL_MORNING || restOption > PIPBOY_REST_DURATION_UNTIL_MIDNIGHT) {
+        return false;
+    }
+
+    if (value < 0 || value > 23) {
+        return false;
+    }
+
+    pipboyRestDurationWakeHours[restOption - PIPBOY_REST_DURATION_UNTIL_MORNING] = value;
+    return true;
+}
+
+static int pipboyRestOptionWakeHour(int restOption)
+{
+    assert(restOption >= PIPBOY_REST_DURATION_UNTIL_MORNING);
+    assert(restOption <= PIPBOY_REST_DURATION_UNTIL_MIDNIGHT);
+
+    return pipboyRestDurationWakeHours[restOption - PIPBOY_REST_DURATION_UNTIL_MORNING];
+}
+
+static void pipboyRestOptionsReset()
+{
+    pipboyRestDurationBaseMessageId = kDefaultPipboyRestDurationBaseMessageId;
+    std::copy(kDefaultPipboyRestDurationWakeHours, kDefaultPipboyRestDurationWakeHours + PIPBOY_REST_DURATION_WAKE_HOUR_COUNT, pipboyRestDurationWakeHours);
 }
 
 // 0x49A0C8

--- a/src/pipboy.h
+++ b/src/pipboy.h
@@ -17,6 +17,8 @@ void pipboyReset();
 int pipboySave(File* stream);
 int pipboyLoad(File* stream);
 int pipboyGetWindow();
+bool pipboyRestOptionMsgsSetBase(int baseMessageId);
+bool pipboyRestOptionSet(int restOption, int value);
 
 extern MessageList gPipboyMessageList;
 int pipboyMessageListInit();

--- a/src/sfall_metarules.cc
+++ b/src/sfall_metarules.cc
@@ -807,6 +807,7 @@ static void mf_opcode_exists(OpcodeContext& ctx);
 static void mf_outlined_object(OpcodeContext& ctx);
 static void mf_real_dude_obj(OpcodeContext& ctx);
 static void mf_remove_wm_town_names(OpcodeContext& ctx);
+static void mf_rest_option_msgs(OpcodeContext& ctx);
 static void mf_set_car_intface_art(OpcodeContext& ctx);
 static void mf_set_combat_free_move(OpcodeContext& ctx);
 static void mf_set_cursor_mode(OpcodeContext& ctx);
@@ -817,6 +818,7 @@ static void mf_set_object_data(OpcodeContext& ctx);
 static void mf_set_outline(OpcodeContext& ctx);
 static void mf_set_party_member_cc_msg_ids(OpcodeContext& ctx);
 static void mf_set_rest_mode(OpcodeContext& ctx);
+static void mf_set_rest_option(OpcodeContext& ctx);
 static void mf_set_scr_name(OpcodeContext& ctx);
 static void mf_set_terrain_name(OpcodeContext& ctx);
 static void mf_set_town_title(OpcodeContext& ctx);
@@ -902,6 +904,7 @@ const MetaruleInfo kMetarules[] = {
     { "outlined_object", mf_outlined_object, 0, 0 },
     { "real_dude_obj", mf_real_dude_obj, 0, 0 },
     { "remove_wm_town_names", mf_remove_wm_town_names, 1, 1, -1, { ARG_INT } },
+    { "rest_option_msgs", mf_rest_option_msgs, 1, 1, -1, { ARG_INT } },
     { "reg_anim_animate_and_move", mf_reg_anim_animate_and_move, 4, 4, -1, { ARG_OBJECT, ARG_INT, ARG_INT, ARG_INT } },
     // {"remove_timer_event",        mf_remove_timer_event,        0, 1, -1, {ARG_INT}},
     // {"set_spray_settings",        mf_set_spray_settings,        4, 4, -1, {ARG_INT, ARG_INT, ARG_INT, ARG_INT}},
@@ -925,6 +928,7 @@ const MetaruleInfo kMetarules[] = {
     // {"set_rest_heal_time",        mf_set_rest_heal_time,        1, 1, -1, {ARG_INT}},
     // {"set_worldmap_heal_time",    mf_set_worldmap_heal_time,    1, 1, -1, {ARG_INT}},
     { "set_rest_mode", mf_set_rest_mode, 1, 1, -1, { ARG_INT } },
+    { "set_rest_option", mf_set_rest_option, 2, 2, -1, { ARG_INT, ARG_INT } },
     { "set_scr_name", mf_set_scr_name, 0, 1, -1, { ARG_STRING } },
     // {"set_selectable_perk_npc",   mf_set_selectable_perk_npc,   5, 5, -1, {ARG_OBJECT, ARG_STRING, ARG_INT, ARG_INT, ARG_STRING}},
     { "set_terrain_name", mf_set_terrain_name, 3, 3, -1, { ARG_INT, ARG_INT, ARG_STRING } },
@@ -2066,6 +2070,15 @@ static void mf_remove_wm_town_names(OpcodeContext& ctx)
     wmRemoveTownNames(ctx.arg(0).asInt() != 0);
 }
 
+static void mf_rest_option_msgs(OpcodeContext& ctx)
+{
+    int baseMessageId = ctx.arg(0).asInt();
+
+    if (!pipboyRestOptionMsgsSetBase(baseMessageId)) {
+        ctx.printError("%s() - invalid base message id (%d).", ctx.name(), baseMessageId);
+    }
+}
+
 static void mf_encounter_detection(OpcodeContext& ctx)
 {
     wmSetEncounterDetection(ctx.arg(0).asInt() != 0);
@@ -2074,6 +2087,16 @@ static void mf_encounter_detection(OpcodeContext& ctx)
 static void mf_set_rest_mode(OpcodeContext& ctx)
 {
     wmSetRestMode(ctx.arg(0).asInt());
+}
+
+static void mf_set_rest_option(OpcodeContext& ctx)
+{
+    int restOption = ctx.arg(0).asInt();
+    int value = ctx.arg(1).asInt();
+
+    if (!pipboyRestOptionSet(restOption, value)) {
+        ctx.printError("%s() - invalid rest option (%d) or wake hour (%d).", ctx.name(), restOption, value);
+    }
 }
 
 static void mf_set_scr_name(OpcodeContext& ctx)


### PR DESCRIPTION
`set_rest_option()` overrides the hour to rest to
`rest_option_msgs()` overrides the base message id of the rest options

In the future, set_rest_option could be extended to the "X hours" options as well