### PR TITLE
Fix removing next object after hidden object when critter dies

### DIFF
--- a/src/item.cc
+++ b/src/item.cc
@@ -576,10 +576,11 @@ int itemDestroyAllHidden(Object* owner)
     Inventory* inventory = &(owner->data.inventory);
     for (int index = 0; index < inventory->length;) {
         InventoryItem* inventoryItem = &(inventory->items[index]);
+        Object* item = inventoryItem->item;
         // NOTE: Uninline.
-        if (itemIsHidden(inventoryItem->item)) {
-            itemRemoveWithReason(owner, inventoryItem->item, 1, RemoveInventoryObjectHookReason::ItemDestroyed);
-            objectDestroy(inventoryItem->item);
+        if (itemIsHidden(item)) {
+            itemRemoveWithReason(owner, item, 1, RemoveInventoryObjectHookReason::ItemDestroyed);
+            objectDestroy(item);
         } else {
             index++;
         }


### PR DESCRIPTION
### Description

There's an issue with `itemDestroyAllHidden` in `item.cc`.
When it finds a hidden item like Gecko fire breath it removes it but since `itemRemoveWithReason` already modifies `intentoryItem->item` reference it actually destroys also second object after the the hidden object via `objectDestroy` which is also internally removing from inventory.

This is the case for Gecko pelt which is the second object after the fire breath item thus it's missing.

### Reproduction Steps and Savefile (if available)
[SLOT02_gecko_pelt_fix.zip](https://github.com/user-attachments/files/30855385/SLOT02_gecko_pelt_fix.zip)

### Screenshots
Before:

https://github.com/user-attachments/assets/c37e341c-38cb-4fea-8602-d15694892753

After:

https://github.com/user-attachments/assets/64522370-a3d7-407a-8dc3-832c2479992c
