### PR TITLE
Fixes memory leak of party member script local vars in _partyMemberItemRecover

### DIFF
--- a/src/party_member.cc
+++ b/src/party_member.cc
@@ -1110,6 +1110,9 @@ static int _partyMemberItemRecover(PartyMemberListItem* a1)
     if (a1->vars != nullptr) {
         script->localVarsOffset = mapAllocLocalVars(script->localVarsCount);
         memcpy(gMapLocalVars + script->localVarsOffset, a1->vars, sizeof(int) * script->localVarsCount);
+
+        internal_free(a1->vars);
+        a1->vars = nullptr;
     }
 
     return 0;


### PR DESCRIPTION
### Description
This PR fixes a minor memory leak in `_partyMemberItemRecover`. 

The `a1->vars` buffer dynamically allocates memory (e.g., when saving party member states) which is later copied into the global map local variables array via `memcpy` during map transitions or loads. However, while `a1->script` is properly freed using `internal_free`, the memory allocated for `a1->vars` was left hanging in the heap, causing a leak right before the parent `PartyMemberListItem` node itself is destroyed in `_partyMemberRecoverLoad`.

### Changes
* Added `internal_free(a1->vars)` and nullified the pointer after copying the data in `_partyMemberItemRecover`.

### Code Reference
```cpp
    if (a1->vars != nullptr) {
        script->localVarsOffset = mapAllocLocalVars(script->localVarsCount);
        memcpy(gMapLocalVars + script->localVarsOffset, a1->vars, sizeof(int) * script->localVarsCount);
        
        internal_free(a1->vars);
        a1->vars = nullptr;
    }
```