### PR TITLE
Add proto reset on map exit for non-savable maps (random encounters)

### DIFF
--- a/src/map.cc
+++ b/src/map.cc
@@ -922,10 +922,6 @@ static int mapLoad(File* stream)
     }
 
     _obj_remove_all();
-    // Sfall: reset protos on map load
-    if (!settings.system.executableIsMapper()) {
-        _proto_remove_all();
-    }
 
     if (gMapHeader.globalVariablesCount < 0) {
         gMapHeader.globalVariablesCount = 0;
@@ -1570,14 +1566,14 @@ int _map_save_in_game(bool isLeavingMap)
         strcpy(gMapHeader.name, name);
 
         automapSaveCurrent();
+    }
 
-        if (isLeavingMap) {
-            gMapHeader.name[0] = '\0';
-            _obj_remove_all();
-            _proto_remove_all();
-            _square_reset();
-            gameTimeScheduleUpdateEvent();
-        }
+    if (isLeavingMap) {
+        gMapHeader.name[0] = '\0';
+        _obj_remove_all();
+        _proto_remove_all();
+        _square_reset();
+        gameTimeScheduleUpdateEvent();
     }
 
     return 0;

--- a/src/map.cc
+++ b/src/map.cc
@@ -923,7 +923,9 @@ static int mapLoad(File* stream)
 
     _obj_remove_all();
     // Sfall: reset protos on map load
-    _proto_remove_all();
+    if (!settings.system.executableIsMapper()) {
+        _proto_remove_all();
+    }
 
     if (gMapHeader.globalVariablesCount < 0) {
         gMapHeader.globalVariablesCount = 0;

--- a/src/map.cc
+++ b/src/map.cc
@@ -922,6 +922,8 @@ static int mapLoad(File* stream)
     }
 
     _obj_remove_all();
+    // Sfall: reset protos on map load
+    _proto_remove_all();
 
     if (gMapHeader.globalVariablesCount < 0) {
         gMapHeader.globalVariablesCount = 0;


### PR DESCRIPTION
Prevent PA weights are doubled in Et tu

This was a decompilation bug
