### PR TITLE
fixes memory leak of script lists during map transitions

### DIFF
--- a/src/scripts.cc
+++ b/src/scripts.cc
@@ -2349,6 +2349,11 @@ static void scriptListsFreeAll()
         scriptList->tail = nullptr;
         scriptList->length = 0;
     }
+
+    gScriptsEnumerationScriptIndex = 0;
+    gScriptsEnumerationScriptListExtent = nullptr;
+    gScriptsEnumerationElevation = 0;
+    scriptSelfOverrides.clear();
 }
 
 // 0x4A5C50
@@ -2361,7 +2366,7 @@ int scriptLoadAll(File* stream)
 
         int scriptsCount = 0;
         if (fileReadInt32(stream, &scriptsCount) == -1) {
-            return -1;
+            goto cleanup;
         }
 
         if (scriptsCount != 0) {
@@ -2372,14 +2377,16 @@ int scriptLoadAll(File* stream)
             }
 
             ScriptListExtent* extent = (ScriptListExtent*)internal_malloc(sizeof(*extent));
-            scriptList->head = extent;
-            scriptList->tail = extent;
+
             if (extent == nullptr) {
-                return -1;
+                goto cleanup;
             }
 
+            scriptList->head = extent;
+            scriptList->tail = extent;
+
             if (scriptListExtentRead(extent, stream) != 0) {
-                return -1;
+                goto cleanup;
             }
 
             scriptListExtentClearRuntimeState(extent);
@@ -2390,11 +2397,11 @@ int scriptLoadAll(File* stream)
             for (int extentIndex = 1; extentIndex < scriptList->length; extentIndex++) {
                 ScriptListExtent* extent = (ScriptListExtent*)internal_malloc(sizeof(*extent));
                 if (extent == nullptr) {
-                    return -1;
+                    goto cleanup;
                 }
 
                 if (scriptListExtentRead(extent, stream) != 0) {
-                    return -1;
+                    goto cleanup;
                 }
 
                 scriptListExtentClearRuntimeState(extent);
@@ -2413,6 +2420,10 @@ int scriptLoadAll(File* stream)
     }
 
     return 0;
+
+cleanup:
+    scriptListsFreeAll();
+    return -1;
 }
 
 // scr_ptr

--- a/src/scripts.cc
+++ b/src/scripts.cc
@@ -2333,9 +2333,29 @@ static void scriptListExtentClearRuntimeState(ScriptListExtent* scriptExtent)
     }
 }
 
+static void scriptListsFreeAll()
+{
+    for (int index = 0; index < SCRIPT_TYPE_COUNT; index++) {
+        ScriptList* scriptList = &(gScriptLists[index]);
+        ScriptListExtent* current = scriptList->head;
+
+        while (current != nullptr) {
+            ScriptListExtent* next = current->next;
+            internal_free(current);
+            current = next;
+        }
+
+        scriptList->head = nullptr;
+        scriptList->tail = nullptr;
+        scriptList->length = 0;
+    }
+}
+
 // 0x4A5C50
 int scriptLoadAll(File* stream)
 {
+    scriptListsFreeAll();
+
     for (int index = 0; index < SCRIPT_TYPE_COUNT; index++) {
         ScriptList* scriptList = &(gScriptLists[index]);
 

--- a/src/scripts.cc
+++ b/src/scripts.cc
@@ -2348,6 +2348,7 @@ static void scriptListsFreeAll()
         scriptList->head = nullptr;
         scriptList->tail = nullptr;
         scriptList->length = 0;
+        scriptList->nextScriptId = 0;
     }
 
     gScriptsEnumerationScriptIndex = 0;
@@ -2382,6 +2383,8 @@ int scriptLoadAll(File* stream)
                 goto cleanup;
             }
 
+            extent->next = nullptr;
+
             scriptList->head = extent;
             scriptList->tail = extent;
 
@@ -2391,14 +2394,14 @@ int scriptLoadAll(File* stream)
 
             scriptListExtentClearRuntimeState(extent);
 
-            extent->next = nullptr;
-
             ScriptListExtent* prevExtent = extent;
             for (int extentIndex = 1; extentIndex < scriptList->length; extentIndex++) {
                 ScriptListExtent* extent = (ScriptListExtent*)internal_malloc(sizeof(*extent));
                 if (extent == nullptr) {
                     goto cleanup;
                 }
+
+                extent->next = nullptr;
 
                 if (scriptListExtentRead(extent, stream) != 0) {
                     goto cleanup;
@@ -2407,7 +2410,6 @@ int scriptLoadAll(File* stream)
                 scriptListExtentClearRuntimeState(extent);
 
                 prevExtent->next = extent;
-                extent->next = nullptr;
                 prevExtent = extent;
             }
 


### PR DESCRIPTION
### Description
This PR fixes a memory leak in `src/scripts.cc` where `gScriptLists` (the linked lists of `ScriptListExtent` nodes) were never freed when transitioning between maps or recovering from a failed map load. 

Previously, `scriptLoadAll` would simply overwrite the `head` and `tail` pointers of `gScriptLists` with newly allocated extents for the incoming map, leaving all previous `ScriptListExtent` blocks orphaned in the heap.

### Changes
* Introduced a static `scriptListsFreeAll()` helper function to properly traverse and free the linked lists within `gScriptLists`.
* Integrated `scriptListsFreeAll()` at the very beginning of `scriptLoadAll()` to guarantee a clean slate before reading the new layout, effectively handling both successful map transitions and cleanup after failed map loads.
