### PR TITLE
adds selective artCacheFlush() to mapLoad()

### DIFF
--- a/src/game.cc
+++ b/src/game.cc
@@ -420,7 +420,13 @@ void gameReset()
     aiReset();
     inventoryResetDude();
     gameSoundReset();
-    artCacheFlush();
+
+    // Flush the art cache during game loads if the target map differs from the current one.
+    // This prevents memory fragmentation and avoids heavy eviction loops on the art heap.
+    if (_isLoadingGame() && gMapHeader.index != mapIdBeingLoaded()) {
+        artCacheFlush();
+    }
+
     _movieStop();
     movieEffectsReset();
     gameMoviesReset();

--- a/src/game.cc
+++ b/src/game.cc
@@ -420,6 +420,7 @@ void gameReset()
     aiReset();
     inventoryResetDude();
     gameSoundReset();
+    artCacheFlush();
     _movieStop();
     movieEffectsReset();
     gameMoviesReset();

--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -289,6 +289,8 @@ static LoadGameHandler* _master_load_list[LOAD_SAVE_HANDLER_COUNT] = {
 // 0x5194C4 loadingGame
 static bool _loadingGame = false;
 
+static int _loadingMapId = -1;
+
 // lsgame.msg
 //
 // 0x613D28 lsgame_msgfl
@@ -1967,6 +1969,11 @@ bool _isLoadingGame()
     return _loadingGame;
 }
 
+int mapIdBeingLoaded()
+{
+    return _loadingMapId;
+}
+
 // 0x47DC68
 static int lsgLoadGameInSlot(int slot)
 {
@@ -2006,6 +2013,7 @@ static int lsgLoadGameInSlot(int slot)
     }
 
     LoadSaveSlotData* ptr = &(_LSData[slot]);
+    _loadingMapId = _LSData[slot].map;
     debugPrint("\nLOADSAVE: Load name: %s\n", ptr->description);
 
     debugPrint("LOADSAVE: Load file header size read: %d bytes.\n", fileTell(_flptr) - pos);
@@ -2020,11 +2028,14 @@ static int lsgLoadGameInSlot(int slot)
             fileClose(_flptr);
             gameReset();
             _loadingGame = false;
+            _loadingMapId = -1;
             return -1;
         }
 
         debugPrint("LOADSAVE: Load function #%d data size read: %d bytes.\n", index, fileTell(_flptr) - pos);
     }
+
+    _loadingMapId = -1;
 
     debugPrint("LOADSAVE: Total load data read: %ld bytes.\n", fileTell(_flptr));
     fileClose(_flptr);

--- a/src/loadsave.h
+++ b/src/loadsave.h
@@ -21,6 +21,7 @@ int lsgLoadGame(int mode);
 void lsgDevSetLoadGameSlot(int slot);
 int lsgGetTotalSlotCount();
 bool _isLoadingGame();
+int mapIdBeingLoaded();
 void lsgInit();
 int MapDirErase(const char* path, const char* extension);
 int _MapDirEraseFile_(const char* relativePath, const char* fileName);

--- a/src/map.cc
+++ b/src/map.cc
@@ -899,7 +899,6 @@ static int mapLoad(File* stream)
 
     gMapSid = -1;
 
-    int previousMapIndex = gMapHeader.index;
     const char* error = nullptr;
 
     error = "Invalid file handle";
@@ -993,11 +992,6 @@ static int mapLoad(File* stream)
     objectSetLocation(gDude, gEnteringTile, gElevation, nullptr);
     objectSetRotation(gDude, gEnteringRotation, nullptr);
     gMapHeader.index = wmMapMatchNameToIdx(gMapHeader.name);
-
-    if (previousMapIndex != gMapHeader.index) {
-        debugPrint("[map.cc]: flushing art cache before loading new map\n");
-        artCacheFlush();
-    }
 
     if ((gMapHeader.flags & 1) == 0) {
         char path[COMPAT_MAX_PATH];

--- a/src/map.cc
+++ b/src/map.cc
@@ -899,6 +899,7 @@ static int mapLoad(File* stream)
 
     gMapSid = -1;
 
+    int previousMapIndex = gMapHeader.index;
     const char* error = nullptr;
 
     error = "Invalid file handle";
@@ -992,6 +993,11 @@ static int mapLoad(File* stream)
     objectSetLocation(gDude, gEnteringTile, gElevation, nullptr);
     objectSetRotation(gDude, gEnteringRotation, nullptr);
     gMapHeader.index = wmMapMatchNameToIdx(gMapHeader.name);
+
+    if (previousMapIndex != gMapHeader.index) {
+        debugPrint("[map.cc]: flushing art cache before loading new map\n");
+        artCacheFlush();
+    }
 
     if ((gMapHeader.flags & 1) == 0) {
         char path[COMPAT_MAX_PATH];

--- a/src/settings.h
+++ b/src/settings.h
@@ -17,7 +17,7 @@ struct SystemSettings {
     std::string language = ENGLISH;
     int scroll_lock = 0;
     bool interrupt_walk = true;
-    int art_cache_size = 8;
+    int art_cache_size = 32;
     bool color_cycling = true;
     int cycle_speed_factor = 1;
     bool hashing = true;


### PR DESCRIPTION
### Summary
This PR minimizes memory fragmentation and eliminates `Heap Warning: Could not allocate block` warnings during map transitions by selectively flushing the art cache when a new map is loaded.

### The Problem
When transitioning between different maps, the legacy engine retains asset data from the previous map in the custom heap allocator (`gArtCache`).  In case of Larger textures, the allocator quickly becomes heavily fragmented. 

When `mapLoad()` attempts to load new assets for the destination map, it hits a hardcoded 10-attempt eviction loop because it cannot find contiguous space, generating massive log spam and leading to noticeable micro-stutters during map loading or requesting larger art pieces such as talking heads after map load


```
[Heap]
Total free blocks: 63
Total free size: 288900
Total moveable blocks: 829
Total moveable size: 7979604
Total locked blocks: 27
Total locked size: 109916
Total system blocks: 0
Total system size: 0
Total handles: 960
Total heaps: 2
INFO: Heap Warning: Could not allocate block of 168668 bytes.
```