### PR TITLE
Clamp `art_cache_size` to (8, 512)

### DIFF
--- a/files/fallout2.cfg
+++ b/files/fallout2.cfg
@@ -81,6 +81,8 @@ speech=1
 speech_volume=22281
 
 [system]
+// Original installer set this to 50% of system ram, up to a max of 512 (mb).
+// Theres no reason to make this higher than 256.
 art_cache_size=32
 color_cycling=1
 critter_dat=critter.dat

--- a/files/fallout2.cfg
+++ b/files/fallout2.cfg
@@ -81,8 +81,9 @@ speech=1
 speech_volume=22281
 
 [system]
-// Original installer set this to 50% of system ram, up to a max of 512 (mb).
-// Theres no reason to make this higher than 256.
+; Original installer set this to 50% of system ram, up to a max of 512 (mb).
+; There's no reason to make this higher than 256.
+; Value is capped to 512 with a minimum of 8
 art_cache_size=32
 color_cycling=1
 critter_dat=critter.dat

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -149,7 +149,7 @@ void initSettingsRegistry(bool isMapper)
     SETTING(language);
     SETTING(scroll_lock);
     SETTING(interrupt_walk);
-    SETTING(art_cache_size);
+    SETTING_P(art_cache_size, clamp(8, 512));
     SETTING(color_cycling);
     SETTING(cycle_speed_factor);
     SETTING(hashing);


### PR DESCRIPTION
Prevents game from crashing if someone edits fallout2.cfg with 0 art_cache_size