### PR TITLE
Typesafe usage of AutomapFlags, AnimationSequenceFlags, CaliberType, ProtoFlags and ProtoExtFlags

### DIFF
--- a/src/actions.cc
+++ b/src/actions.cc
@@ -1135,7 +1135,7 @@ int _action_use_an_item_on_object(Object* user, Object* targetObj, Object* item)
         ObjectType objectType = objectTypeFromFid(targetObj->fid);
         if (objectType == OBJ_TYPE_CRITTER && critterIsProne(targetObj)) {
             anim = ANIM_MAGIC_HANDS_GROUND;
-        } else if (objectType == OBJ_TYPE_SCENERY && (proto->scenery.extendedFlags & PROTO_EXT_FLAG_MAGIC_HANDS_GROUND) != 0) {
+        } else if (objectType == OBJ_TYPE_SCENERY && (proto->scenery.extendedFlags & PROTO_EXT_FLAG_MAGIC_HANDS_GROUND) != PROTO_EXT_FLAG_NONE) {
             anim = ANIM_MAGIC_HANDS_GROUND;
         } else {
             anim = ANIM_MAGIC_HANDS_MIDDLE;

--- a/src/animation.cc
+++ b/src/animation.cc
@@ -88,7 +88,7 @@ static bool animationKindIsCallback(AnimationKind kind)
     return kind == ANIM_KIND_CALLBACK || kind == ANIM_KIND_CALLBACK3;
 }
 
-typedef enum AnimationSequenceFlags {
+enum AnimationSequenceFlags : unsigned int {
     ANIM_SEQ_NONE = 0x00,
 
     // Specifies that the animation sequence has high priority, it cannot be
@@ -121,7 +121,29 @@ typedef enum AnimationSequenceFlags {
     // Specifies that the animation sequence should not return to ANIM_STAND
     // when it's completed.
     ANIM_SEQ_NO_STAND = 0x80,
-} AnimationSequenceFlags;
+};
+
+constexpr inline AnimationSequenceFlags operator|(AnimationSequenceFlags lhs, AnimationSequenceFlags rhs)
+{
+    return static_cast<AnimationSequenceFlags>(static_cast<unsigned int>(lhs) | static_cast<unsigned int>(rhs));
+}
+
+constexpr inline AnimationSequenceFlags operator~(AnimationSequenceFlags rhs)
+{
+    return static_cast<AnimationSequenceFlags>(~static_cast<unsigned int>(rhs));
+}
+
+inline AnimationSequenceFlags& operator&=(AnimationSequenceFlags& lhs, AnimationSequenceFlags rhs)
+{
+    lhs = static_cast<AnimationSequenceFlags>(static_cast<unsigned int>(lhs) & static_cast<unsigned int>(rhs));
+    return lhs;
+}
+
+inline AnimationSequenceFlags& operator|=(AnimationSequenceFlags& lhs, AnimationSequenceFlags rhs)
+{
+    lhs = lhs | rhs;
+    return lhs;
+}
 
 typedef enum AnimationSadFlags {
     // Specifies that the animation should play from end to start.
@@ -237,7 +259,7 @@ typedef struct AnimationSequence {
     int animationIndex;
     // Number of scheduled animations in [animations] array.
     int length;
-    unsigned int flags;
+    AnimationSequenceFlags flags;
     AnimationDescription animations[ANIMATION_DESCRIPTION_LIST_CAPACITY];
 } AnimationSequence;
 
@@ -381,7 +403,7 @@ void animationReset()
 
     for (int index = 0; index < ANIMATION_SEQUENCE_LIST_CAPACITY; index++) {
         gAnimationSequences[index].step = ANIM_COMPLETE;
-        gAnimationSequences[index].flags = 0;
+        gAnimationSequences[index].flags = ANIM_SEQ_NONE;
     }
 }
 
@@ -1716,7 +1738,7 @@ static int _anim_set_end(int animationSequenceIndex)
     if (_anim_in_bk) {
         animationSequence->flags = ANIM_SEQ_0x20;
     } else {
-        animationSequence->flags = 0;
+        animationSequence->flags = ANIM_SEQ_NONE;
     }
 
     return 0;
@@ -2979,7 +3001,7 @@ static void _object_anim_compact()
     for (int index = 0; index < ANIMATION_SEQUENCE_LIST_CAPACITY; index++) {
         AnimationSequence* animationSequence = &(gAnimationSequences[index]);
         if ((animationSequence->flags & ANIM_SEQ_0x20) != 0) {
-            animationSequence->flags = 0;
+            animationSequence->flags = ANIM_SEQ_NONE;
         }
     }
 

--- a/src/automap.cc
+++ b/src/automap.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 
 #include "art.h"
+#include "automap.h"
 #include "color.h"
 #include "config.h"
 #include "dbox.h"
@@ -37,7 +38,7 @@ namespace fallout {
 #define AUTOMAP_PIPBOY_VIEW_X (238)
 #define AUTOMAP_PIPBOY_VIEW_Y (105)
 
-static void automapRenderInMapWindow(int window, int elevation, unsigned char* backgroundData, int flags);
+static void automapRenderInMapWindow(int window, int elevation, unsigned char* backgroundData, AutomapFlags flags);
 static int automapSaveEntry(File* stream);
 static int automapLoadEntry(int map, int elevation);
 static int automapSaveHeader(File* stream);
@@ -53,14 +54,14 @@ static bool automapEntryIsValid(int map, int elevation)
     return map >= 0 && map < AUTOMAP_MAP_COUNT && elevationIsValid(elevation);
 }
 
-typedef enum AutomapFrm {
+enum AutomapFrm : int {
     AUTOMAP_FRM_BACKGROUND,
     AUTOMAP_FRM_BUTTON_UP,
     AUTOMAP_FRM_BUTTON_DOWN,
     AUTOMAP_FRM_SWITCH_UP,
     AUTOMAP_FRM_SWITCH_DOWN,
     AUTOMAP_FRM_COUNT,
-} AutomapFrm;
+};
 
 typedef struct AutomapEntry {
     int dataSize;
@@ -250,7 +251,7 @@ static const int gAutomapFrmIds[AUTOMAP_FRM_COUNT] = {
 };
 
 // 0x5108C4 autoflags
-static int gAutomapFlags = 0;
+static AutomapFlags gAutomapFlags = AUTOMAP_NONE;
 
 // 0x56CB18 amdbhead
 static AutomapHeader gAutomapHeader;
@@ -262,7 +263,7 @@ static AutomapEntry gAutomapEntry;
 // 0x41B7F4 automap_init
 int automapInit()
 {
-    gAutomapFlags = 0;
+    gAutomapFlags = AUTOMAP_NONE;
     automapCreate();
     return 0;
 }
@@ -270,7 +271,7 @@ int automapInit()
 // 0x41B808 automap_reset
 int automapReset()
 {
-    gAutomapFlags = 0;
+    gAutomapFlags = AUTOMAP_NONE;
     automapCreate();
     return 0;
 }
@@ -286,13 +287,13 @@ void automapExit()
 // 0x41B87C automap_load
 int automapLoad(File* stream)
 {
-    return fileReadInt32(stream, &gAutomapFlags);
+    return fileReadInt32Enum<AutomapFlags>(stream, &gAutomapFlags);
 }
 
 // 0x41B898 automap_save
 int automapSave(File* stream)
 {
-    return fileWriteInt32(stream, gAutomapFlags);
+    return fileWriteInt32Enum<AutomapFlags>(stream, gAutomapFlags);
 }
 
 // 0x41B8B4 automapDisplayMap
@@ -518,10 +519,10 @@ int automapGetWindow()
 // Renders automap in Map window.
 //
 // 0x41BD1C draw_top_down_map
-static void automapRenderInMapWindow(int window, int elevation, unsigned char* backgroundData, int flags)
+static void automapRenderInMapWindow(int window, int elevation, unsigned char* backgroundData, AutomapFlags flags)
 {
     int color;
-    if ((flags & AUTOMAP_IN_GAME) != 0) {
+    if ((flags & AUTOMAP_IN_GAME) != AUTOMAP_NONE) {
         color = COLOR_DARK_GREY;
     } else {
         color = COLOR_SAND;
@@ -541,10 +542,10 @@ static void automapRenderInMapWindow(int window, int elevation, unsigned char* b
         ObjectType objectType = objectTypeFromFid(object->fid);
         unsigned char objectColor;
 
-        if ((flags & AUTOMAP_IN_GAME) != 0) {
+        if ((flags & AUTOMAP_IN_GAME) != AUTOMAP_NONE) {
             if (objectType == OBJ_TYPE_CRITTER
                 && (object->flags & OBJECT_HIDDEN) == OBJECT_NONE
-                && (flags & AUTOMAP_WITH_SCANNER) != 0
+                && (flags & AUTOMAP_WITH_SCANNER) != AUTOMAP_NONE
                 && (object->data.critter.combat.results & DAM_DEAD) == DAM_NONE) {
                 objectColor = COLOR_RED;
             } else {
@@ -557,7 +558,7 @@ static void automapRenderInMapWindow(int window, int elevation, unsigned char* b
                 } else if (objectType == OBJ_TYPE_WALL) {
                     objectColor = COLOR_GREEN;
                 } else if (objectType == OBJ_TYPE_SCENERY
-                    && (flags & AUTOMAP_WTH_HIGH_DETAILS) != 0
+                    && (flags & AUTOMAP_WTH_HIGH_DETAILS) != AUTOMAP_NONE
                     && object->pid != PROTO_ID_BLOCK_HEX_AUTO_INVISO) {
                     objectColor = COLOR_DARK_GREEN;
                 } else if (object == gDude) {
@@ -569,7 +570,7 @@ static void automapRenderInMapWindow(int window, int elevation, unsigned char* b
         }
 
         int pixelOffset = -2 * (object->tile % 200) - 10 + AUTOMAP_WINDOW_WIDTH * (2 * (object->tile / 200) + 9) - 60;
-        if ((flags & AUTOMAP_IN_GAME) == 0) {
+        if ((flags & AUTOMAP_IN_GAME) == AUTOMAP_NONE) {
             switch (objectType) {
             case OBJ_TYPE_ITEM:
                 objectColor = COLOR_LIGHT_BLUE;
@@ -593,7 +594,7 @@ static void automapRenderInMapWindow(int window, int elevation, unsigned char* b
 
         if (objectColor != COLOR_BLACK) {
             unsigned char* pixel = windowBuffer + pixelOffset;
-            if ((flags & AUTOMAP_IN_GAME) != 0) {
+            if ((flags & AUTOMAP_IN_GAME) != AUTOMAP_NONE) {
                 if (*pixel != COLOR_GREEN || objectColor != COLOR_DARK_GREEN) {
                     pixel[0] = objectColor;
                     pixel[1] = objectColor;
@@ -619,7 +620,7 @@ static void automapRenderInMapWindow(int window, int elevation, unsigned char* b
     }
 
     int textColor;
-    if ((flags & AUTOMAP_IN_GAME) != 0) {
+    if ((flags & AUTOMAP_IN_GAME) != AUTOMAP_NONE) {
         textColor = COLOR_GREEN;
     } else {
         textColor = COLOR_DARK_BROWN;

--- a/src/automap.h
+++ b/src/automap.h
@@ -16,7 +16,9 @@ namespace fallout {
 
 // View options for rendering automap for map window. These are stored in
 // [gAutomapFlags] and is saved in save game file.
-typedef enum AutomapFlags {
+enum AutomapFlags : int {
+    AUTOMAP_NONE = 0x00,
+
     // NOTE: This is a special flag to denote the map is activated in the game (as
     // opposed to the mapper). It's always on. Turning it off produces nice color
     // coded map with all objects and their types visible, however there is no way
@@ -28,7 +30,24 @@ typedef enum AutomapFlags {
 
     // Scanner is active.
     AUTOMAP_WITH_SCANNER = 0x04,
-} AutomapFlags;
+};
+
+constexpr inline AutomapFlags operator~(AutomapFlags rhs)
+{
+    return static_cast<AutomapFlags>(~static_cast<int>(rhs));
+}
+
+inline AutomapFlags& operator&=(AutomapFlags& lhs, AutomapFlags rhs)
+{
+    lhs = static_cast<AutomapFlags>(static_cast<int>(lhs) & static_cast<int>(rhs));
+    return lhs;
+}
+
+inline AutomapFlags& operator|=(AutomapFlags& lhs, AutomapFlags rhs)
+{
+    lhs = static_cast<AutomapFlags>(static_cast<int>(lhs) | static_cast<int>(rhs));
+    return lhs;
+}
 
 typedef struct AutomapHeader {
     unsigned char version;

--- a/src/item.cc
+++ b/src/item.cc
@@ -1194,7 +1194,7 @@ bool itemIsHidden(Object* item)
         return false;
     }
 
-    return (proto->item.extendedFlags & PROTO_EXT_FLAG_HIDDEN) != 0;
+    return (proto->item.extendedFlags & PROTO_EXT_FLAG_HIDDEN) != PROTO_EXT_FLAG_NONE;
 }
 
 // 0x478280
@@ -1241,7 +1241,7 @@ Skill weaponGetSkillForHitMode(Object* weapon, HitMode hitMode)
         if (damageType == DAMAGE_TYPE_LASER || damageType == DAMAGE_TYPE_PLASMA || damageType == DAMAGE_TYPE_ELECTRICAL) {
             skill = SKILL_ENERGY_WEAPONS;
         } else {
-            if ((proto->item.extendedFlags & PROTO_EXT_FLAG_BIG_GUN) != 0) {
+            if ((proto->item.extendedFlags & PROTO_EXT_FLAG_BIG_GUN) != PROTO_EXT_FLAG_NONE) {
                 skill = SKILL_BIG_GUNS;
             }
         }
@@ -1378,7 +1378,7 @@ int weaponIsTwoHanded(Object* weapon)
 
     protoGetProto(weapon->pid, &proto);
 
-    return (proto->item.extendedFlags & PROTO_EXT_FLAG_IS_TWO_HANDED) != 0;
+    return (proto->item.extendedFlags & PROTO_EXT_FLAG_IS_TWO_HANDED) != PROTO_EXT_FLAG_NONE;
 }
 
 // 0x4785DC

--- a/src/item.cc
+++ b/src/item.cc
@@ -1451,19 +1451,19 @@ int ammoGetQuantity(Object* ammoOrWeapon)
 }
 
 // 0x4786C8
-int ammoGetCaliber(Object* ammoOrWeapon)
+CaliberType ammoGetCaliber(Object* ammoOrWeapon)
 {
     Proto* proto;
 
     if (ammoOrWeapon == nullptr) {
-        return 0;
+        return CALIBER_TYPE_NONE;
     }
 
     protoGetProto(ammoOrWeapon->pid, &proto);
 
     if (proto->item.type != ITEM_TYPE_AMMO) {
         if (protoGetProto(ammoOrWeapon->data.item.weapon.ammoTypePid, &proto) == -1) {
-            return 0;
+            return CALIBER_TYPE_NONE;
         }
     }
 

--- a/src/item.h
+++ b/src/item.h
@@ -85,7 +85,7 @@ AnimationType critterGetAnimationForHitMode(Object* critter, HitMode hitMode);
 AnimationType weaponGetAnimationForHitMode(Object* weapon, HitMode hitMode);
 int ammoGetCapacity(Object* ammoOrWeapon);
 int ammoGetQuantity(Object* ammoOrWeapon);
-int ammoGetCaliber(Object* ammoOrWeapon);
+CaliberType ammoGetCaliber(Object* ammoOrWeapon);
 void ammoSetQuantity(Object* ammoOrWeapon, int quantity);
 int weaponAttemptReload(Object* critter, Object* weapon);
 bool weaponCanBeReloadedWith(Object* weapon, Object* ammo);

--- a/src/object.cc
+++ b/src/object.cc
@@ -946,47 +946,47 @@ int objectCreateWithFidPid(Object** objectPtr, int fid, int pid)
 
     objectSetLight(objectListNode->obj, proto->lightDistance, proto->lightIntensity, nullptr);
 
-    if ((proto->flags & PROTO_FLAG_FLAT) != 0) {
+    if ((proto->flags & PROTO_FLAG_FLAT) != PROTO_FLAG_NONE) {
         _obj_toggle_flat(objectListNode->obj, nullptr);
     }
 
-    if ((proto->flags & PROTO_FLAG_NO_BLOCK) != 0) {
+    if ((proto->flags & PROTO_FLAG_NO_BLOCK) != PROTO_FLAG_NONE) {
         objectListNode->obj->flags |= OBJECT_NO_BLOCK;
     }
 
-    if ((proto->flags & PROTO_FLAG_MULTIHEX) != 0) {
+    if ((proto->flags & PROTO_FLAG_MULTIHEX) != PROTO_FLAG_NONE) {
         objectListNode->obj->flags |= OBJECT_MULTIHEX;
     }
 
-    if ((proto->flags & PROTO_FLAG_TRANS_NONE) != 0) {
+    if ((proto->flags & PROTO_FLAG_TRANS_NONE) != PROTO_FLAG_NONE) {
         objectListNode->obj->flags |= OBJECT_TRANS_NONE;
     } else {
-        if ((proto->flags & PROTO_FLAG_TRANS_WALL) != 0) {
+        if ((proto->flags & PROTO_FLAG_TRANS_WALL) != PROTO_FLAG_NONE) {
             objectListNode->obj->flags |= OBJECT_TRANS_WALL;
-        } else if ((proto->flags & PROTO_FLAG_TRANS_GLASS) != 0) {
+        } else if ((proto->flags & PROTO_FLAG_TRANS_GLASS) != PROTO_FLAG_NONE) {
             objectListNode->obj->flags |= OBJECT_TRANS_GLASS;
-        } else if ((proto->flags & PROTO_FLAG_TRANS_STEAM) != 0) {
+        } else if ((proto->flags & PROTO_FLAG_TRANS_STEAM) != PROTO_FLAG_NONE) {
             objectListNode->obj->flags |= OBJECT_TRANS_STEAM;
-        } else if ((proto->flags & PROTO_FLAG_TRANS_ENERGY) != 0) {
+        } else if ((proto->flags & PROTO_FLAG_TRANS_ENERGY) != PROTO_FLAG_NONE) {
             objectListNode->obj->flags |= OBJECT_TRANS_ENERGY;
-        } else if ((proto->flags & PROTO_FLAG_TRANS_RED) != 0) {
+        } else if ((proto->flags & PROTO_FLAG_TRANS_RED) != PROTO_FLAG_NONE) {
             objectListNode->obj->flags |= OBJECT_TRANS_RED;
         }
     }
 
-    if ((proto->flags & PROTO_FLAG_LIGHT_THRU) != 0) {
+    if ((proto->flags & PROTO_FLAG_LIGHT_THRU) != PROTO_FLAG_NONE) {
         objectListNode->obj->flags |= OBJECT_LIGHT_THRU;
     }
 
-    if ((proto->flags & PROTO_FLAG_SHOOT_THRU) != 0) {
+    if ((proto->flags & PROTO_FLAG_SHOOT_THRU) != PROTO_FLAG_NONE) {
         objectListNode->obj->flags |= OBJECT_SHOOT_THRU;
     }
 
-    if ((proto->flags & PROTO_FLAG_WALL_TRANS_END) != 0) {
+    if ((proto->flags & PROTO_FLAG_WALL_TRANS_END) != PROTO_FLAG_NONE) {
         objectListNode->obj->flags |= OBJECT_WALL_TRANS_END;
     }
 
-    if ((proto->flags & PROTO_FLAG_NO_HIGHLIGHT) != 0) {
+    if ((proto->flags & PROTO_FLAG_NO_HIGHLIGHT) != PROTO_FLAG_NONE) {
         objectListNode->obj->flags |= OBJECT_NO_HIGHLIGHT;
     }
 

--- a/src/object.cc
+++ b/src/object.cc
@@ -2995,7 +2995,7 @@ ObjectFlags _obj_intersects_with(Object* object, int x, int y)
                                 protoGetProto(object->pid, &proto);
 
                                 bool v20;
-                                int extendedFlags = proto->scenery.extendedFlags;
+                                ProtoExtendedFlags extendedFlags = proto->scenery.extendedFlags;
                                 if ((extendedFlags & PROTO_EXT_FLAG_HIDDEN) != PROTO_EXT_FLAG_NONE || (extendedFlags & PROTO_EXT_FLAG_WEST_CORNER) != PROTO_EXT_FLAG_NONE) {
                                     v20 = tileIsInFrontOf(object->tile, gDude->tile);
                                 } else if ((extendedFlags & PROTO_EXT_FLAG_NORTH_CORNER) != PROTO_EXT_FLAG_NONE) {
@@ -4995,7 +4995,7 @@ static void _obj_render_object(Object* object, Rect* rect, int light)
             protoGetProto(object->pid, &proto);
 
             bool v17;
-            int extendedFlags = proto->critter.extendedFlags;
+            ProtoExtendedFlags extendedFlags = proto->critter.extendedFlags;
             if ((extendedFlags & PROTO_EXT_FLAG_HIDDEN) != PROTO_EXT_FLAG_NONE || (extendedFlags & PROTO_EXT_FLAG_WEST_CORNER) != PROTO_EXT_FLAG_NONE) {
                 // TODO: Verify this visibility branch against the original logic.
                 v17 = tileIsInFrontOf(object->tile, gDude->tile);

--- a/src/object.cc
+++ b/src/object.cc
@@ -2996,13 +2996,13 @@ ObjectFlags _obj_intersects_with(Object* object, int x, int y)
 
                                 bool v20;
                                 int extendedFlags = proto->scenery.extendedFlags;
-                                if ((extendedFlags & PROTO_EXT_FLAG_HIDDEN) != 0 || (extendedFlags & PROTO_EXT_FLAG_WEST_CORNER) != 0) {
+                                if ((extendedFlags & PROTO_EXT_FLAG_HIDDEN) != PROTO_EXT_FLAG_NONE || (extendedFlags & PROTO_EXT_FLAG_WEST_CORNER) != PROTO_EXT_FLAG_NONE) {
                                     v20 = tileIsInFrontOf(object->tile, gDude->tile);
-                                } else if ((extendedFlags & PROTO_EXT_FLAG_NORTH_CORNER) != 0) {
+                                } else if ((extendedFlags & PROTO_EXT_FLAG_NORTH_CORNER) != PROTO_EXT_FLAG_NONE) {
                                     // NOTE: Original code uses bitwise or, but given the fact that these functions return
                                     // bools, logical or is more suitable.
                                     v20 = tileIsInFrontOf(object->tile, gDude->tile) || tileIsToRightOf(gDude->tile, object->tile);
-                                } else if ((extendedFlags & PROTO_EXT_FLAG_SOUTH_CORNER) != 0) {
+                                } else if ((extendedFlags & PROTO_EXT_FLAG_SOUTH_CORNER) != PROTO_EXT_FLAG_NONE) {
                                     v20 = tileIsInFrontOf(object->tile, gDude->tile) && tileIsToRightOf(gDude->tile, object->tile);
                                 } else {
                                     v20 = tileIsToRightOf(gDude->tile, object->tile);
@@ -4596,18 +4596,18 @@ static int _obj_adjust_light(Object* obj, int a2, Rect* rect)
                                         if ((objectListNode->obj->flags & OBJECT_FLAT) == OBJECT_NONE) {
                                             Proto* proto;
                                             protoGetProto(objectListNode->obj->pid, &proto);
-                                            if ((proto->wall.extendedFlags & PROTO_EXT_FLAG_HIDDEN) != 0 || (proto->wall.extendedFlags & PROTO_EXT_FLAG_EAST_CORNER) != 0) {
+                                            if ((proto->wall.extendedFlags & PROTO_EXT_FLAG_HIDDEN) != PROTO_EXT_FLAG_NONE || (proto->wall.extendedFlags & PROTO_EXT_FLAG_EAST_CORNER) != PROTO_EXT_FLAG_NONE) {
                                                 if (rotation != ROTATION_W
                                                     && rotation != ROTATION_NW
                                                     && (rotation != ROTATION_NE || index >= 8)
                                                     && (rotation != ROTATION_SW || index <= 15)) {
                                                     v12 = false;
                                                 }
-                                            } else if ((proto->wall.extendedFlags & PROTO_EXT_FLAG_NORTH_CORNER) != 0) {
+                                            } else if ((proto->wall.extendedFlags & PROTO_EXT_FLAG_NORTH_CORNER) != PROTO_EXT_FLAG_NONE) {
                                                 if (rotation != ROTATION_NE && rotation != ROTATION_NW) {
                                                     v12 = false;
                                                 }
-                                            } else if ((proto->wall.extendedFlags & PROTO_EXT_FLAG_SOUTH_CORNER) != 0) {
+                                            } else if ((proto->wall.extendedFlags & PROTO_EXT_FLAG_SOUTH_CORNER) != PROTO_EXT_FLAG_NONE) {
                                                 if (rotation != ROTATION_NE
                                                     && rotation != ROTATION_E
                                                     && rotation != ROTATION_W
@@ -4996,7 +4996,7 @@ static void _obj_render_object(Object* object, Rect* rect, int light)
 
             bool v17;
             int extendedFlags = proto->critter.extendedFlags;
-            if ((extendedFlags & PROTO_EXT_FLAG_HIDDEN) != 0 || (extendedFlags & PROTO_EXT_FLAG_WEST_CORNER) != 0) {
+            if ((extendedFlags & PROTO_EXT_FLAG_HIDDEN) != PROTO_EXT_FLAG_NONE || (extendedFlags & PROTO_EXT_FLAG_WEST_CORNER) != PROTO_EXT_FLAG_NONE) {
                 // TODO: Verify this visibility branch against the original logic.
                 v17 = tileIsInFrontOf(object->tile, gDude->tile);
                 if (!v17
@@ -5006,11 +5006,11 @@ static void _obj_render_object(Object* object, Rect* rect, int light)
                 } else {
                     v17 = false;
                 }
-            } else if ((extendedFlags & PROTO_EXT_FLAG_NORTH_CORNER) != 0) {
+            } else if ((extendedFlags & PROTO_EXT_FLAG_NORTH_CORNER) != PROTO_EXT_FLAG_NONE) {
                 // NOTE: Original code used bitwise OR here; logical OR is clearer.
                 v17 = tileIsInFrontOf(object->tile, gDude->tile)
                     || tileIsToRightOf(gDude->tile, object->tile);
-            } else if ((extendedFlags & PROTO_EXT_FLAG_SOUTH_CORNER) != 0) {
+            } else if ((extendedFlags & PROTO_EXT_FLAG_SOUTH_CORNER) != PROTO_EXT_FLAG_NONE) {
                 v17 = tileIsInFrontOf(object->tile, gDude->tile)
                     && tileIsToRightOf(gDude->tile, object->tile);
             } else {

--- a/src/proto.cc
+++ b/src/proto.cc
@@ -94,7 +94,7 @@ static CritterProto gDudeProto = {
     0,
     0,
     PROTO_FLAG_LIGHT_THRU,
-    0,
+    PROTO_EXT_FLAG_NONE,
     -1,
     CRITTER_NONE,
     { 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 18, 0, 0, 0, 0, 0, 0, 0, 0, 100, 0, 0, 0, 23, 0 },
@@ -261,7 +261,7 @@ bool _proto_action_can_use(int pid)
         return false;
     }
 
-    if ((proto->item.extendedFlags & PROTO_EXT_FLAG_CAN_USE) != 0) {
+    if ((proto->item.extendedFlags & PROTO_EXT_FLAG_CAN_USE) != PROTO_EXT_FLAG_NONE) {
         return true;
     }
 
@@ -280,7 +280,7 @@ bool _proto_action_can_use_on(int pid)
         return false;
     }
 
-    if ((proto->item.extendedFlags & PROTO_EXT_FLAG_CAN_USE_ON) != 0) {
+    if ((proto->item.extendedFlags & PROTO_EXT_FLAG_CAN_USE_ON) != PROTO_EXT_FLAG_NONE) {
         return true;
     }
 
@@ -303,7 +303,7 @@ bool _proto_action_can_talk_to(int pid)
         return true;
     }
 
-    if (proto->critter.extendedFlags & PROTO_EXT_FLAG_CAN_TALK_TO) {
+    if ((proto->critter.extendedFlags & PROTO_EXT_FLAG_CAN_TALK_TO) != PROTO_EXT_FLAG_NONE) {
         return true;
     }
 
@@ -325,7 +325,7 @@ int _proto_action_can_pickup(int pid)
     }
 
     if (proto->item.type == ITEM_TYPE_CONTAINER) {
-        return (proto->item.extendedFlags & PROTO_EXT_FLAG_CAN_PICK_UP) != 0;
+        return (proto->item.extendedFlags & PROTO_EXT_FLAG_CAN_PICK_UP) != PROTO_EXT_FLAG_NONE;
     }
 
     return true;
@@ -1056,7 +1056,7 @@ int proto_misc_init(Proto* proto, int pid)
     proto->misc.lightDistance = 0;
     proto->misc.lightIntensity = 0;
     proto->misc.flags = PROTO_FLAG_NONE;
-    proto->misc.extendedFlags = 0;
+    proto->misc.extendedFlags = PROTO_EXT_FLAG_NONE;
 
     return 0;
 }
@@ -1678,7 +1678,7 @@ static int protoRead(Proto* proto, File* stream)
         if (fileReadInt32(stream, &(proto->item.lightDistance)) == -1) return -1;
         if (_db_freadInt(stream, &(proto->item.lightIntensity)) == -1) return -1;
         if (fileReadUInt32Enum<ProtoFlags>(stream, &(proto->item.flags)) == -1) return -1;
-        if (fileReadInt32(stream, &(proto->item.extendedFlags)) == -1) return -1;
+        if (fileReadUInt32Enum<ProtoExtendedFlags>(stream, &(proto->item.extendedFlags)) == -1) return -1;
         if (fileReadInt32(stream, &(proto->item.sid)) == -1) return -1;
         if (fileReadInt32Enum<ItemType>(stream, &(proto->item.type)) == -1) return -1;
         if (fileReadInt32Enum<MaterialType>(stream, &(proto->item.material)) == -1) return -1;
@@ -1694,7 +1694,7 @@ static int protoRead(Proto* proto, File* stream)
         if (fileReadInt32(stream, &(proto->critter.lightDistance)) == -1) return -1;
         if (_db_freadInt(stream, &(proto->critter.lightIntensity)) == -1) return -1;
         if (fileReadUInt32Enum<ProtoFlags>(stream, &(proto->critter.flags)) == -1) return -1;
-        if (fileReadInt32(stream, &(proto->critter.extendedFlags)) == -1) return -1;
+        if (fileReadUInt32Enum<ProtoExtendedFlags>(stream, &(proto->critter.extendedFlags)) == -1) return -1;
         if (fileReadInt32(stream, &(proto->critter.sid)) == -1) return -1;
         if (fileReadInt32(stream, &(proto->critter.headFid)) == -1) return -1;
         if (fileReadInt32(stream, &(proto->critter.aiPacket)) == -1) return -1;
@@ -1707,7 +1707,7 @@ static int protoRead(Proto* proto, File* stream)
         if (fileReadInt32(stream, &(proto->scenery.lightDistance)) == -1) return -1;
         if (_db_freadInt(stream, &(proto->scenery.lightIntensity)) == -1) return -1;
         if (fileReadUInt32Enum<ProtoFlags>(stream, &(proto->scenery.flags)) == -1) return -1;
-        if (fileReadInt32(stream, &(proto->scenery.extendedFlags)) == -1) return -1;
+        if (fileReadUInt32Enum<ProtoExtendedFlags>(stream, &(proto->scenery.extendedFlags)) == -1) return -1;
         if (fileReadInt32(stream, &(proto->scenery.sid)) == -1) return -1;
         if (fileReadInt32Enum<SceneryType>(stream, &(proto->scenery.type)) == -1) return -1;
         if (fileReadInt32Enum<MaterialType>(stream, &(proto->scenery.material)) == -1) return -1;
@@ -1718,14 +1718,14 @@ static int protoRead(Proto* proto, File* stream)
         if (fileReadInt32(stream, &(proto->wall.lightDistance)) == -1) return -1;
         if (_db_freadInt(stream, &(proto->wall.lightIntensity)) == -1) return -1;
         if (fileReadUInt32Enum<ProtoFlags>(stream, &(proto->wall.flags)) == -1) return -1;
-        if (fileReadInt32(stream, &(proto->wall.extendedFlags)) == -1) return -1;
+        if (fileReadUInt32Enum<ProtoExtendedFlags>(stream, &(proto->wall.extendedFlags)) == -1) return -1;
         if (fileReadInt32(stream, &(proto->wall.sid)) == -1) return -1;
         if (fileReadInt32Enum<MaterialType>(stream, &(proto->wall.material)) == -1) return -1;
 
         return 0;
     case OBJ_TYPE_TILE:
         if (fileReadUInt32Enum<ProtoFlags>(stream, &(proto->tile.flags)) == -1) return -1;
-        if (fileReadInt32(stream, &(proto->tile.extendedFlags)) == -1) return -1;
+        if (fileReadUInt32Enum<ProtoExtendedFlags>(stream, &(proto->tile.extendedFlags)) == -1) return -1;
         if (fileReadInt32(stream, &(proto->tile.sid)) == -1) return -1;
         if (fileReadInt32Enum<MaterialType>(stream, &(proto->tile.material)) == -1) return -1;
 
@@ -1734,7 +1734,7 @@ static int protoRead(Proto* proto, File* stream)
         if (fileReadInt32(stream, &(proto->misc.lightDistance)) == -1) return -1;
         if (_db_freadInt(stream, &(proto->misc.lightIntensity)) == -1) return -1;
         if (fileReadUInt32Enum<ProtoFlags>(stream, &(proto->misc.flags)) == -1) return -1;
-        if (fileReadInt32(stream, &(proto->misc.extendedFlags)) == -1) return -1;
+        if (fileReadUInt32Enum<ProtoExtendedFlags>(stream, &(proto->misc.extendedFlags)) == -1) return -1;
 
         return 0;
     default:
@@ -1862,8 +1862,8 @@ static int protoWrite(Proto* proto, File* stream)
     case OBJ_TYPE_ITEM:
         if (fileWriteInt32(stream, proto->item.lightDistance) == -1) return -1;
         if (_db_fwriteLong(stream, proto->item.lightIntensity) == -1) return -1;
-        if (fileWriteInt32(stream, proto->item.flags) == -1) return -1;
-        if (fileWriteInt32(stream, proto->item.extendedFlags) == -1) return -1;
+        if (fileWriteUInt32Enum<ProtoFlags>(stream, proto->item.flags) == -1) return -1;
+        if (fileWriteUInt32Enum<ProtoExtendedFlags>(stream, proto->item.extendedFlags) == -1) return -1;
         if (fileWriteInt32(stream, proto->item.sid) == -1) return -1;
         if (fileWriteInt32(stream, proto->item.type) == -1) return -1;
         if (fileWriteInt32(stream, proto->item.material) == -1) return -1;
@@ -1878,8 +1878,8 @@ static int protoWrite(Proto* proto, File* stream)
     case OBJ_TYPE_CRITTER:
         if (fileWriteInt32(stream, proto->critter.lightDistance) == -1) return -1;
         if (_db_fwriteLong(stream, proto->critter.lightIntensity) == -1) return -1;
-        if (fileWriteInt32(stream, proto->critter.flags) == -1) return -1;
-        if (fileWriteInt32(stream, proto->critter.extendedFlags) == -1) return -1;
+        if (fileWriteUInt32Enum<ProtoFlags>(stream, proto->critter.flags) == -1) return -1;
+        if (fileWriteUInt32Enum<ProtoExtendedFlags>(stream, proto->critter.extendedFlags) == -1) return -1;
         if (fileWriteInt32(stream, proto->critter.sid) == -1) return -1;
         if (fileWriteInt32(stream, proto->critter.headFid) == -1) return -1;
         if (fileWriteInt32(stream, proto->critter.aiPacket) == -1) return -1;
@@ -1890,8 +1890,8 @@ static int protoWrite(Proto* proto, File* stream)
     case OBJ_TYPE_SCENERY:
         if (fileWriteInt32(stream, proto->scenery.lightDistance) == -1) return -1;
         if (_db_fwriteLong(stream, proto->scenery.lightIntensity) == -1) return -1;
-        if (fileWriteInt32(stream, proto->scenery.flags) == -1) return -1;
-        if (fileWriteInt32(stream, proto->scenery.extendedFlags) == -1) return -1;
+        if (fileWriteUInt32Enum<ProtoFlags>(stream, proto->scenery.flags) == -1) return -1;
+        if (fileWriteUInt32Enum<ProtoExtendedFlags>(stream, proto->scenery.extendedFlags) == -1) return -1;
         if (fileWriteInt32(stream, proto->scenery.sid) == -1) return -1;
         if (fileWriteInt32(stream, proto->scenery.type) == -1) return -1;
         if (fileWriteInt32(stream, proto->scenery.material) == -1) return -1;
@@ -1900,15 +1900,15 @@ static int protoWrite(Proto* proto, File* stream)
     case OBJ_TYPE_WALL:
         if (fileWriteInt32(stream, proto->wall.lightDistance) == -1) return -1;
         if (_db_fwriteLong(stream, proto->wall.lightIntensity) == -1) return -1;
-        if (fileWriteInt32(stream, proto->wall.flags) == -1) return -1;
-        if (fileWriteInt32(stream, proto->wall.extendedFlags) == -1) return -1;
+        if (fileWriteUInt32Enum<ProtoFlags>(stream, proto->wall.flags) == -1) return -1;
+        if (fileWriteUInt32Enum<ProtoExtendedFlags>(stream, proto->wall.extendedFlags) == -1) return -1;
         if (fileWriteInt32(stream, proto->wall.sid) == -1) return -1;
         if (fileWriteInt32(stream, proto->wall.material) == -1) return -1;
 
         return 0;
     case OBJ_TYPE_TILE:
-        if (fileWriteInt32(stream, proto->tile.flags) == -1) return -1;
-        if (fileWriteInt32(stream, proto->tile.extendedFlags) == -1) return -1;
+        if (fileWriteUInt32Enum<ProtoFlags>(stream, proto->tile.flags) == -1) return -1;
+        if (fileWriteUInt32Enum<ProtoExtendedFlags>(stream, proto->tile.extendedFlags) == -1) return -1;
         if (fileWriteInt32(stream, proto->tile.sid) == -1) return -1;
         if (fileWriteInt32(stream, proto->tile.material) == -1) return -1;
 
@@ -1916,8 +1916,8 @@ static int protoWrite(Proto* proto, File* stream)
     case OBJ_TYPE_MISC:
         if (fileWriteInt32(stream, proto->misc.lightDistance) == -1) return -1;
         if (_db_fwriteLong(stream, proto->misc.lightIntensity) == -1) return -1;
-        if (fileWriteInt32(stream, proto->misc.flags) == -1) return -1;
-        if (fileWriteInt32(stream, proto->misc.extendedFlags) == -1) return -1;
+        if (fileWriteUInt32Enum<ProtoFlags>(stream, proto->misc.flags) == -1) return -1;
+        if (fileWriteUInt32Enum<ProtoExtendedFlags>(stream, proto->misc.extendedFlags) == -1) return -1;
 
         return 0;
     default:

--- a/src/proto.cc
+++ b/src/proto.cc
@@ -93,7 +93,7 @@ static CritterProto gDudeProto = {
     0x1000001,
     0,
     0,
-    0x20000000,
+    PROTO_FLAG_LIGHT_THRU,
     0,
     -1,
     CRITTER_NONE,
@@ -958,7 +958,7 @@ int proto_scenery_init(Proto* proto, int pid)
     }
     proto->scenery.lightDistance = 0;
     proto->scenery.lightIntensity = 0;
-    proto->scenery.flags = 0;
+    proto->scenery.flags = PROTO_FLAG_NONE;
     proto->scenery.extendedFlags = PROTO_EXT_FLAG_LOOK;
     proto->scenery.sid = -1;
     proto->scenery.type = SCENERY_TYPE_GENERIC;
@@ -1015,7 +1015,7 @@ int proto_wall_init(Proto* proto, int pid)
     }
     proto->wall.lightDistance = 0;
     proto->wall.lightIntensity = 0;
-    proto->wall.flags = 0;
+    proto->wall.flags = PROTO_FLAG_NONE;
     proto->wall.extendedFlags = PROTO_EXT_FLAG_LOOK;
     proto->wall.sid = -1;
     proto->wall.material = MATERIAL_TYPE_METAL;
@@ -1034,7 +1034,7 @@ int proto_tile_init(Proto* proto, int pid)
     if (!artExists(proto->tile.fid)) {
         proto->tile.fid = buildFid(OBJ_TYPE_TILE, 0);
     }
-    proto->tile.flags = 0;
+    proto->tile.flags = PROTO_FLAG_NONE;
     proto->tile.extendedFlags = PROTO_EXT_FLAG_LOOK;
     proto->tile.sid = -1;
     proto->tile.material = MATERIAL_TYPE_METAL;
@@ -1055,7 +1055,7 @@ int proto_misc_init(Proto* proto, int pid)
     }
     proto->misc.lightDistance = 0;
     proto->misc.lightIntensity = 0;
-    proto->misc.flags = 0;
+    proto->misc.flags = PROTO_FLAG_NONE;
     proto->misc.extendedFlags = 0;
 
     return 0;
@@ -1677,7 +1677,7 @@ static int protoRead(Proto* proto, File* stream)
     case OBJ_TYPE_ITEM:
         if (fileReadInt32(stream, &(proto->item.lightDistance)) == -1) return -1;
         if (_db_freadInt(stream, &(proto->item.lightIntensity)) == -1) return -1;
-        if (fileReadInt32(stream, &(proto->item.flags)) == -1) return -1;
+        if (fileReadUInt32Enum<ProtoFlags>(stream, &(proto->item.flags)) == -1) return -1;
         if (fileReadInt32(stream, &(proto->item.extendedFlags)) == -1) return -1;
         if (fileReadInt32(stream, &(proto->item.sid)) == -1) return -1;
         if (fileReadInt32Enum<ItemType>(stream, &(proto->item.type)) == -1) return -1;
@@ -1693,7 +1693,7 @@ static int protoRead(Proto* proto, File* stream)
     case OBJ_TYPE_CRITTER:
         if (fileReadInt32(stream, &(proto->critter.lightDistance)) == -1) return -1;
         if (_db_freadInt(stream, &(proto->critter.lightIntensity)) == -1) return -1;
-        if (fileReadInt32(stream, &(proto->critter.flags)) == -1) return -1;
+        if (fileReadUInt32Enum<ProtoFlags>(stream, &(proto->critter.flags)) == -1) return -1;
         if (fileReadInt32(stream, &(proto->critter.extendedFlags)) == -1) return -1;
         if (fileReadInt32(stream, &(proto->critter.sid)) == -1) return -1;
         if (fileReadInt32(stream, &(proto->critter.headFid)) == -1) return -1;
@@ -1706,7 +1706,7 @@ static int protoRead(Proto* proto, File* stream)
     case OBJ_TYPE_SCENERY:
         if (fileReadInt32(stream, &(proto->scenery.lightDistance)) == -1) return -1;
         if (_db_freadInt(stream, &(proto->scenery.lightIntensity)) == -1) return -1;
-        if (fileReadInt32(stream, &(proto->scenery.flags)) == -1) return -1;
+        if (fileReadUInt32Enum<ProtoFlags>(stream, &(proto->scenery.flags)) == -1) return -1;
         if (fileReadInt32(stream, &(proto->scenery.extendedFlags)) == -1) return -1;
         if (fileReadInt32(stream, &(proto->scenery.sid)) == -1) return -1;
         if (fileReadInt32Enum<SceneryType>(stream, &(proto->scenery.type)) == -1) return -1;
@@ -1717,14 +1717,14 @@ static int protoRead(Proto* proto, File* stream)
     case OBJ_TYPE_WALL:
         if (fileReadInt32(stream, &(proto->wall.lightDistance)) == -1) return -1;
         if (_db_freadInt(stream, &(proto->wall.lightIntensity)) == -1) return -1;
-        if (fileReadInt32(stream, &(proto->wall.flags)) == -1) return -1;
+        if (fileReadUInt32Enum<ProtoFlags>(stream, &(proto->wall.flags)) == -1) return -1;
         if (fileReadInt32(stream, &(proto->wall.extendedFlags)) == -1) return -1;
         if (fileReadInt32(stream, &(proto->wall.sid)) == -1) return -1;
         if (fileReadInt32Enum<MaterialType>(stream, &(proto->wall.material)) == -1) return -1;
 
         return 0;
     case OBJ_TYPE_TILE:
-        if (fileReadInt32(stream, &(proto->tile.flags)) == -1) return -1;
+        if (fileReadUInt32Enum<ProtoFlags>(stream, &(proto->tile.flags)) == -1) return -1;
         if (fileReadInt32(stream, &(proto->tile.extendedFlags)) == -1) return -1;
         if (fileReadInt32(stream, &(proto->tile.sid)) == -1) return -1;
         if (fileReadInt32Enum<MaterialType>(stream, &(proto->tile.material)) == -1) return -1;
@@ -1733,7 +1733,7 @@ static int protoRead(Proto* proto, File* stream)
     case OBJ_TYPE_MISC:
         if (fileReadInt32(stream, &(proto->misc.lightDistance)) == -1) return -1;
         if (_db_freadInt(stream, &(proto->misc.lightIntensity)) == -1) return -1;
-        if (fileReadInt32(stream, &(proto->misc.flags)) == -1) return -1;
+        if (fileReadUInt32Enum<ProtoFlags>(stream, &(proto->misc.flags)) == -1) return -1;
         if (fileReadInt32(stream, &(proto->misc.extendedFlags)) == -1) return -1;
 
         return 0;

--- a/src/proto.cc
+++ b/src/proto.cc
@@ -451,13 +451,13 @@ int proto_item_subdata_init(Proto* proto, ItemType type)
         proto->item.data.weapon.criticalFailureType = 0;
         proto->item.data.weapon.perk = PERK_INVALID;
         proto->item.data.weapon.rounds = 0;
-        proto->item.data.weapon.caliber = 0;
+        proto->item.data.weapon.caliber = CALIBER_TYPE_NONE;
         proto->item.data.weapon.ammoTypePid = -1;
         proto->item.data.weapon.ammoCapacity = 0;
         proto->item.data.weapon.soundCode = 0;
         break;
     case ITEM_TYPE_AMMO:
-        proto->item.data.ammo.caliber = 0;
+        proto->item.data.ammo.caliber = CALIBER_TYPE_NONE;
         proto->item.data.ammo.quantity = 20;
         proto->item.data.ammo.armorClassModifier = 0;
         proto->item.data.ammo.damageResistanceModifier = 0;
@@ -1454,8 +1454,8 @@ int protoInit()
     }
 
     // caliber types
-    for (int i = 0; i < CALIBER_TYPE_COUNT; i++) {
-        gCaliberTypeNames[i] = getmsg(&gProtoMessageList, &messageListItem, 300 + i);
+    for (CaliberType caliberType = CALIBER_TYPE_FIRST; caliberType < CALIBER_TYPE_COUNT; caliberType++) {
+        gCaliberTypeNames[caliberType] = getmsg(&gProtoMessageList, &messageListItem, 300 + caliberType);
     }
 
     // race types
@@ -1602,14 +1602,14 @@ static int protoItemDataRead(ItemProtoData* item_data, ItemType type, File* stre
         if (fileReadInt32(stream, &(item_data->weapon.criticalFailureType)) == -1) return -1;
         if (fileReadInt32Enum<Perk>(stream, &(item_data->weapon.perk)) == -1) return -1;
         if (fileReadInt32(stream, &(item_data->weapon.rounds)) == -1) return -1;
-        if (fileReadInt32(stream, &(item_data->weapon.caliber)) == -1) return -1;
+        if (fileReadInt32Enum<CaliberType>(stream, &(item_data->weapon.caliber)) == -1) return -1;
         if (fileReadInt32(stream, &(item_data->weapon.ammoTypePid)) == -1) return -1;
         if (fileReadInt32(stream, &(item_data->weapon.ammoCapacity)) == -1) return -1;
         if (fileReadUInt8(stream, &(item_data->weapon.soundCode)) == -1) return -1;
 
         return 0;
     case ITEM_TYPE_AMMO:
-        if (fileReadInt32(stream, &(item_data->ammo.caliber)) == -1) return -1;
+        if (fileReadInt32Enum<CaliberType>(stream, &(item_data->ammo.caliber)) == -1) return -1;
         if (fileReadInt32(stream, &(item_data->ammo.quantity)) == -1) return -1;
         if (fileReadInt32(stream, &(item_data->ammo.armorClassModifier)) == -1) return -1;
         if (fileReadInt32(stream, &(item_data->ammo.damageResistanceModifier)) == -1) return -1;
@@ -1750,7 +1750,7 @@ static int protoItemDataWrite(ItemProtoData* item_data, ItemType type, File* str
         if (fileWriteInt32(stream, item_data->armor.armorClass) == -1) return -1;
         if (fileWriteInt32List(stream, item_data->armor.damageResistance, 7) == -1) return -1;
         if (fileWriteInt32List(stream, item_data->armor.damageThreshold, 7) == -1) return -1;
-        if (fileWriteInt32(stream, item_data->armor.perk) == -1) return -1;
+        if (fileWriteInt32Enum<Perk>(stream, item_data->armor.perk) == -1) return -1;
         if (fileWriteInt32(stream, item_data->armor.maleFid) == -1) return -1;
         if (fileWriteInt32(stream, item_data->armor.femaleFid) == -1) return -1;
 
@@ -1761,9 +1761,9 @@ static int protoItemDataWrite(ItemProtoData* item_data, ItemType type, File* str
 
         return 0;
     case ITEM_TYPE_DRUG:
-        if (fileWriteInt32(stream, item_data->drug.stat[0]) == -1) return -1;
-        if (fileWriteInt32(stream, item_data->drug.stat[1]) == -1) return -1;
-        if (fileWriteInt32(stream, item_data->drug.stat[2]) == -1) return -1;
+        if (fileWriteInt32Enum<Stat>(stream, item_data->drug.stat[0]) == -1) return -1;
+        if (fileWriteInt32Enum<Stat>(stream, item_data->drug.stat[1]) == -1) return -1;
+        if (fileWriteInt32Enum<Stat>(stream, item_data->drug.stat[2]) == -1) return -1;
         if (fileWriteInt32List(stream, item_data->drug.amount, 3) == -1) return -1;
         if (fileWriteInt32(stream, item_data->drug.duration1) == -1) return -1;
         if (fileWriteInt32List(stream, item_data->drug.amount1, 3) == -1) return -1;
@@ -1775,7 +1775,7 @@ static int protoItemDataWrite(ItemProtoData* item_data, ItemType type, File* str
 
         return 0;
     case ITEM_TYPE_WEAPON:
-        if (fileWriteInt32(stream, item_data->weapon.animationCode) == -1) return -1;
+        if (fileWriteInt32Enum<WeaponAnimation>(stream, item_data->weapon.animationCode) == -1) return -1;
         if (fileWriteInt32(stream, item_data->weapon.maxDamage) == -1) return -1;
         if (fileWriteInt32(stream, item_data->weapon.minDamage) == -1) return -1;
         if (fileWriteInt32(stream, item_data->weapon.damageType) == -1) return -1;
@@ -1788,14 +1788,14 @@ static int protoItemDataWrite(ItemProtoData* item_data, ItemType type, File* str
         if (fileWriteInt32(stream, item_data->weapon.criticalFailureType) == -1) return -1;
         if (fileWriteInt32(stream, item_data->weapon.perk) == -1) return -1;
         if (fileWriteInt32(stream, item_data->weapon.rounds) == -1) return -1;
-        if (fileWriteInt32(stream, item_data->weapon.caliber) == -1) return -1;
+        if (fileWriteInt32Enum<CaliberType>(stream, item_data->weapon.caliber) == -1) return -1;
         if (fileWriteInt32(stream, item_data->weapon.ammoTypePid) == -1) return -1;
         if (fileWriteInt32(stream, item_data->weapon.ammoCapacity) == -1) return -1;
         if (fileWriteUInt8(stream, item_data->weapon.soundCode) == -1) return -1;
 
         return 0;
     case ITEM_TYPE_AMMO:
-        if (fileWriteInt32(stream, item_data->ammo.caliber) == -1) return -1;
+        if (fileWriteInt32Enum<CaliberType>(stream, item_data->ammo.caliber) == -1) return -1;
         if (fileWriteInt32(stream, item_data->ammo.quantity) == -1) return -1;
         if (fileWriteInt32(stream, item_data->ammo.armorClassModifier) == -1) return -1;
         if (fileWriteInt32(stream, item_data->ammo.damageResistanceModifier) == -1) return -1;

--- a/src/proto_instance.cc
+++ b/src/proto_instance.cc
@@ -328,7 +328,7 @@ int objectExamineFunc(Object* critter, Object* target, void (*fn)(const char* st
             if (item2 != nullptr) {
                 MessageListItem weaponMessageListItem;
 
-                if (ammoGetCaliber(item2) != 0) {
+                if (ammoGetCaliber(item2) != CALIBER_TYPE_NONE) {
                     weaponMessageListItem.num = 547; // and is wielding a %s with %d/%d shots of %s.
                 } else {
                     weaponMessageListItem.num = 546; // and is wielding a %s.
@@ -342,7 +342,7 @@ int objectExamineFunc(Object* critter, Object* target, void (*fn)(const char* st
                 char format[80];
                 snprintf(format, sizeof(format), "%s%s", hpMessageListItem.text, weaponMessageListItem.text);
 
-                if (ammoGetCaliber(item2) != 0) {
+                if (ammoGetCaliber(item2) != CALIBER_TYPE_NONE) {
                     const int ammoTypePid = weaponGetAmmoTypePid(item2);
                     const char* ammoName = protoGetName(ammoTypePid);
                     const int ammoCapacity = ammoGetCapacity(item2);
@@ -496,7 +496,7 @@ int objectExamineFunc(Object* critter, Object* target, void (*fn)(const char* st
     } else if (type == OBJ_TYPE_ITEM) {
         ItemType itemType = itemGetType(target);
         if (itemType == ITEM_TYPE_WEAPON) {
-            if (ammoGetCaliber(target) != 0) {
+            if (ammoGetCaliber(target) != CALIBER_TYPE_NONE) {
                 MessageListItem weaponMessageListItem;
                 weaponMessageListItem.num = 526;
 

--- a/src/proto_types.h
+++ b/src/proto_types.h
@@ -115,7 +115,7 @@ inline bool damageTypeIsValid(int damageType)
     return damageType >= DAMAGE_TYPE_FIRST && damageType < DAMAGE_TYPE_COUNT;
 }
 
-enum {
+enum CaliberType : int {
     CALIBER_TYPE_NONE,
     CALIBER_TYPE_ROCKET,
     CALIBER_TYPE_FLAMETHROWER_FUEL,
@@ -136,7 +136,15 @@ enum {
     CALIBER_TYPE_NH_NEEDLER,
     CALIBER_TYPE_7_62,
     CALIBER_TYPE_COUNT,
+    CALIBER_TYPE_FIRST = CALIBER_TYPE_NONE
 };
+
+inline CaliberType operator++(CaliberType& e, int)
+{
+    CaliberType result = e;
+    e = static_cast<CaliberType>(static_cast<int>(e) + 1);
+    return result;
+}
 
 enum RaceType : int {
     RACE_TYPE_CAUCASIAN,
@@ -378,14 +386,14 @@ typedef struct {
     int criticalFailureType; // d.crit_fail_table
     Perk perk; // d.perk
     int rounds; // d.rounds
-    int caliber; // d.caliber
+    CaliberType caliber; // d.caliber
     int ammoTypePid; // d.ammo_type_pid
     int ammoCapacity; // d.max_ammo
     unsigned char soundCode; // d.sound_id
 } ProtoItemWeaponData;
 
 typedef struct {
-    int caliber; // d.caliber
+    CaliberType caliber; // d.caliber
     int quantity; // d.quantity
     int armorClassModifier; // d.ac_adjust
     int damageResistanceModifier; // d.dr_adjust

--- a/src/proto_types.h
+++ b/src/proto_types.h
@@ -370,6 +370,12 @@ inline ProtoExtendedFlags& operator|=(ProtoExtendedFlags& lhs, ProtoExtendedFlag
     return lhs;
 }
 
+inline ProtoExtendedFlags& operator^=(ProtoExtendedFlags& lhs, ProtoExtendedFlags rhs)
+{
+    lhs = static_cast<ProtoExtendedFlags>(static_cast<unsigned int>(lhs) ^ static_cast<unsigned int>(rhs));
+    return lhs;
+}
+
 typedef struct {
     int armorClass; // d.ac
     int damageResistance[7]; // d.dam_resist

--- a/src/proto_types.h
+++ b/src/proto_types.h
@@ -301,7 +301,8 @@ enum {
 // FID of one of the Force Field sceneries. Used as a marker for special hidden "attacker" object created by `critter_dmg` opcode handler.
 #define FRAME_ID_FORCE_FIELD_NS 0x20001F5
 
-typedef enum ProtoFlags {
+enum ProtoFlags : unsigned int {
+    PROTO_FLAG_NONE = 0x00,
     PROTO_FLAG_FLAT = 0x08,
     PROTO_FLAG_NO_BLOCK = 0x10,
     PROTO_FLAG_MULTIHEX = 0x800,
@@ -315,7 +316,17 @@ typedef enum ProtoFlags {
     PROTO_FLAG_WALL_TRANS_END = 0x10000000,
     PROTO_FLAG_LIGHT_THRU = 0x20000000,
     PROTO_FLAG_SHOOT_THRU = 0x80000000,
-} ProtoFlags;
+};
+
+constexpr inline ProtoFlags operator&(ProtoFlags lhs, ProtoFlags rhs)
+{
+    return static_cast<ProtoFlags>(static_cast<unsigned int>(lhs) & static_cast<unsigned int>(rhs));
+}
+
+constexpr inline ProtoFlags operator|(ProtoFlags lhs, ProtoFlags rhs)
+{
+    return static_cast<ProtoFlags>(static_cast<unsigned int>(lhs) | static_cast<unsigned int>(rhs));
+}
 
 typedef enum ItemProtoExtendedFlags {
     // NOTE: `extendedFlags` packs non-boolean weapon data into the low
@@ -438,7 +449,7 @@ typedef struct ItemProto {
     int fid; // fid
     int lightDistance; // light_distance
     int lightIntensity; // light_intensity
-    int flags; // flags
+    ProtoFlags flags; // flags
     int extendedFlags; // flags_ext
     int sid; // sid
     ItemType type; // type
@@ -469,7 +480,7 @@ typedef struct CritterProto {
     int fid; // fid
     int lightDistance; // light_distance
     int lightIntensity; // light_intensity
-    int flags; // flags
+    ProtoFlags flags; // flags
     int extendedFlags; // flags_ext
     int sid; // sid
     CritterProtoData data; // d
@@ -517,7 +528,7 @@ typedef struct SceneryProto {
     int fid; // fid
     int lightDistance; // light_distance
     int lightIntensity; // light_intensity
-    int flags; // flags
+    ProtoFlags flags; // flags
     int extendedFlags; // flags_ext
     int sid; // sid
     SceneryType type; // type
@@ -533,7 +544,7 @@ typedef struct WallProto {
     int fid; // fid
     int lightDistance; // light_distance
     int lightIntensity; // light_intensity
-    int flags; // flags
+    ProtoFlags flags; // flags
     int extendedFlags; // flags_ext
     int sid; // sid
     MaterialType material; // material
@@ -543,7 +554,7 @@ typedef struct TileProto {
     int pid; // id
     int messageId; // message_num
     int fid; // fid
-    int flags; // flags
+    ProtoFlags flags; // flags
     int extendedFlags; // flags_ext
     int sid; // sid
     MaterialType material; // material
@@ -555,7 +566,7 @@ typedef struct MiscProto {
     int fid; // fid
     int lightDistance; // light_distance
     int lightIntensity; // light_intensity
-    int flags; // flags
+    ProtoFlags flags; // flags
     int extendedFlags; // flags_ext
 } MiscProto;
 
@@ -568,7 +579,7 @@ typedef union Proto {
         // TODO: Move to NonTile props?
         int lightDistance;
         int lightIntensity;
-        int flags;
+        ProtoFlags flags;
         int extendedFlags;
         int sid;
     };

--- a/src/proto_types.h
+++ b/src/proto_types.h
@@ -328,7 +328,9 @@ constexpr inline ProtoFlags operator|(ProtoFlags lhs, ProtoFlags rhs)
     return static_cast<ProtoFlags>(static_cast<unsigned int>(lhs) | static_cast<unsigned int>(rhs));
 }
 
-typedef enum ItemProtoExtendedFlags {
+enum ProtoExtendedFlags : unsigned int {
+    PROTO_EXT_FLAG_NONE = 0x0000,
+
     // NOTE: `extendedFlags` packs non-boolean weapon data into the low
     // nibbles (`0x0F` and `0xF0`) for attack mode metadata.
 
@@ -355,7 +357,18 @@ typedef enum ItemProtoExtendedFlags {
     PROTO_EXT_FLAG_SOUTH_CORNER = 0x20000000,
     PROTO_EXT_FLAG_EAST_CORNER = 0x40000000,
     PROTO_EXT_FLAG_WEST_CORNER = 0x80000000,
-} ItemProtoExtendedFlags;
+};
+
+constexpr inline ProtoExtendedFlags operator|(ProtoExtendedFlags lhs, ProtoExtendedFlags rhs)
+{
+    return static_cast<ProtoExtendedFlags>(static_cast<unsigned int>(lhs) | static_cast<unsigned int>(rhs));
+}
+
+inline ProtoExtendedFlags& operator|=(ProtoExtendedFlags& lhs, ProtoExtendedFlags rhs)
+{
+    lhs = lhs | rhs;
+    return lhs;
+}
 
 typedef struct {
     int armorClass; // d.ac
@@ -450,7 +463,7 @@ typedef struct ItemProto {
     int lightDistance; // light_distance
     int lightIntensity; // light_intensity
     ProtoFlags flags; // flags
-    int extendedFlags; // flags_ext
+    ProtoExtendedFlags extendedFlags; // flags_ext
     int sid; // sid
     ItemType type; // type
     ItemProtoData data; // d
@@ -481,7 +494,7 @@ typedef struct CritterProto {
     int lightDistance; // light_distance
     int lightIntensity; // light_intensity
     ProtoFlags flags; // flags
-    int extendedFlags; // flags_ext
+    ProtoExtendedFlags extendedFlags; // flags_ext
     int sid; // sid
     CritterProtoData data; // d
     int headFid; // head_fid
@@ -529,7 +542,7 @@ typedef struct SceneryProto {
     int lightDistance; // light_distance
     int lightIntensity; // light_intensity
     ProtoFlags flags; // flags
-    int extendedFlags; // flags_ext
+    ProtoExtendedFlags extendedFlags; // flags_ext
     int sid; // sid
     SceneryType type; // type
     SceneryProtoData data;
@@ -545,7 +558,7 @@ typedef struct WallProto {
     int lightDistance; // light_distance
     int lightIntensity; // light_intensity
     ProtoFlags flags; // flags
-    int extendedFlags; // flags_ext
+    ProtoExtendedFlags extendedFlags; // flags_ext
     int sid; // sid
     MaterialType material; // material
 } WallProto;
@@ -555,7 +568,7 @@ typedef struct TileProto {
     int messageId; // message_num
     int fid; // fid
     ProtoFlags flags; // flags
-    int extendedFlags; // flags_ext
+    ProtoExtendedFlags extendedFlags; // flags_ext
     int sid; // sid
     MaterialType material; // material
 } TileProto;
@@ -567,7 +580,7 @@ typedef struct MiscProto {
     int lightDistance; // light_distance
     int lightIntensity; // light_intensity
     ProtoFlags flags; // flags
-    int extendedFlags; // flags_ext
+    ProtoExtendedFlags extendedFlags; // flags_ext
 } MiscProto;
 
 typedef union Proto {
@@ -580,7 +593,7 @@ typedef union Proto {
         int lightDistance;
         int lightIntensity;
         ProtoFlags flags;
-        int extendedFlags;
+        ProtoExtendedFlags extendedFlags;
         int sid;
     };
     ItemProto item;


### PR DESCRIPTION
### Description

Another bunch of typesafe enum usages for `AutomapFlags`, `AnimationSequenceFlags`, `CaliberType`, `ProtoFlags` and `ProtoExtFlags`.

`ProtoFlags` and `ProtoExtendedFlags` were originally stored in `proto` structures as `int` but both of them are having defined high bits which fit only to `unsigned int` so had to change them.. Binary wise this is not an issue and no one anyway doesn't use `<>` comparison for those.

This is related to #668 