### PR TITLE
Remove world map transition fades

### DIFF
--- a/src/worldmap.cc
+++ b/src/worldmap.cc
@@ -3364,15 +3364,11 @@ static int wmWorldMapFunc(int a1)
 
     wmResetTrailMarkers();
 
-    wmFadeOut();
-
     if (wmInterfaceInit() == -1) {
         wmInterfaceExit();
-        wmFadeReset();
         return -1;
     }
 
-    wmFadeIn();
     touch_set_touchscreen_mode(false);
 
     wmMatchWorldPosToArea(wmGenData.worldPosX, wmGenData.worldPosY, &(wmGenData.currentAreaId));
@@ -3520,7 +3516,6 @@ static int wmWorldMapFunc(int a1)
                             }
                         }
 
-                        wmFadeOut();
                         mapLoadById(mapToLoad);
                     }
                     break;
@@ -3583,7 +3578,6 @@ static int wmWorldMapFunc(int a1)
                             }
                         }
 
-                        wmFadeOut();
                         mapLoadById(map);
                         break;
                     }
@@ -3623,7 +3617,6 @@ static int wmWorldMapFunc(int a1)
                             wmGenData.currentCarAreaId = wmGenData.currentAreaId;
                         }
 
-                        wmFadeOut();
                         mapLoadById(map);
                     }
                 }
@@ -3778,7 +3771,6 @@ static int wmRndEncounterOccurred(int* mapToLoadPtr)
                 wmMatchAreaContainingMapIdx(MAP_IN_GAME_MOVIE1, &(wmGenData.currentCarAreaId));
             }
 
-            wmFadeOut();
             mapLoadById(MAP_IN_GAME_MOVIE1);
             return 1;
         }


### PR DESCRIPTION
## Summary
- remove the non-original palette fades when entering and leaving the world map
- retain the explicit `ENCOUNTER_FLAG_FADEOUT` behavior for scripted forced encounters
- retain the full-window clearing and interface hiding that fixed the stale local-map background reported in alexbatalov/fallout2-ce#193

Closes #495
