### PR TITLE
Cache case-insensitive file resolution on non-Windows platforms

### DIFF
--- a/src/map.cc
+++ b/src/map.cc
@@ -72,6 +72,8 @@ static void _square_reset();
 static int _square_load(File* stream, int flags);
 static int mapHeaderWrite(MapHeader* ptr, File* stream);
 static int mapHeaderRead(MapHeader* ptr, File* stream);
+static void mapLoadTimerStart();
+static void mapLoadTimerFinish(const char* fileName, int rc);
 
 // 0x50B058
 static char byte_50B058[] = "";
@@ -164,6 +166,9 @@ int gIsoWindow;
 
 // 0x631E50 scratchStr
 static char _scratchStr[40];
+
+static int mapLoadTimerDepth = 0;
+static unsigned int mapLoadStartTime = 0;
 
 // CE: Basically the same problem described in |gMapLocalPointers|, but this
 // time Olympus folks use global map variables to store objects (looks like
@@ -797,6 +802,8 @@ void mapNewMap()
 // 0x482A68 map_load
 int mapLoadByName(char* fileName)
 {
+    mapLoadTimerStart();
+
     int rc;
 
     compat_strupr(fileName);
@@ -836,7 +843,34 @@ int mapLoadByName(char* fileName)
         }
     }
 
+    mapLoadTimerFinish(fileName, rc);
+
     return rc;
+}
+
+static void mapLoadTimerStart()
+{
+    if (mapLoadTimerDepth == 0) {
+        mapLoadStartTime = compat_timeGetTime();
+    }
+
+    mapLoadTimerDepth++;
+}
+
+static void mapLoadTimerFinish(const char* fileName, int rc)
+{
+    assert(mapLoadTimerDepth > 0);
+
+    mapLoadTimerDepth--;
+    if (mapLoadTimerDepth != 0) {
+        return;
+    }
+
+    unsigned int elapsed = getTicksBetween(compat_timeGetTime(), mapLoadStartTime);
+    debugPrint("\nMAP LOAD: %s rc=%d total=%ums",
+        fileName != nullptr ? fileName : "<null>",
+        rc,
+        elapsed);
 }
 
 // 0x482B34

--- a/src/platform_compat.cc
+++ b/src/platform_compat.cc
@@ -2,6 +2,9 @@
 
 #include <string.h>
 
+#include <string>
+#include <unordered_map>
+
 #ifdef _WIN32
 #include <direct.h>
 #include <io.h>
@@ -33,6 +36,62 @@ static bool compatIsPathSeparator(char ch)
 {
     return ch == '/' || ch == '\\';
 }
+
+static bool compatFileModeMayWrite(const char* mode)
+{
+    return mode != nullptr && (strchr(mode, 'w') != nullptr || strchr(mode, 'a') != nullptr || strchr(mode, '+') != nullptr);
+}
+
+#ifndef _WIN32
+typedef struct CompatDirectoryCacheEntry {
+    std::unordered_map<std::string, std::string> entries;
+} CompatDirectoryCacheEntry;
+
+static std::unordered_map<std::string, CompatDirectoryCacheEntry> compatDirectoryEntryCache;
+
+static std::string compatLowercase(std::string value)
+{
+    for (char& ch : value) {
+        ch = static_cast<char>(SDL_tolower(ch));
+    }
+    return value;
+}
+
+static void compatDirectoryEntryCacheClear()
+{
+    compatDirectoryEntryCache.clear();
+}
+
+static const CompatDirectoryCacheEntry* compatDirectoryEntryCacheGet(const std::string& directoryPath)
+{
+    auto existing = compatDirectoryEntryCache.find(directoryPath);
+    if (existing != compatDirectoryEntryCache.end()) {
+        return &(existing->second);
+    }
+
+    DIR* dir = opendir(directoryPath.c_str());
+    if (dir == nullptr) {
+        return nullptr;
+    }
+
+    auto inserted = compatDirectoryEntryCache.emplace(directoryPath, CompatDirectoryCacheEntry());
+    CompatDirectoryCacheEntry& cacheEntry = inserted.first->second;
+
+    struct dirent* entry = readdir(dir);
+    while (entry != nullptr) {
+        cacheEntry.entries.emplace(compatLowercase(entry->d_name), entry->d_name);
+        entry = readdir(dir);
+    }
+
+    closedir(dir);
+
+    return &cacheEntry;
+}
+#else
+static void compatDirectoryEntryCacheClear()
+{
+}
+#endif
 
 static void compat_prepare_native_path(char* nativePath, const char* path)
 {
@@ -219,6 +278,8 @@ long compat_filelength(int fd)
 
 int compat_mkdir(const char* path)
 {
+    compatDirectoryEntryCacheClear();
+
     char nativePath[COMPAT_MAX_PATH];
     compat_prepare_native_path(nativePath, path);
 
@@ -306,6 +367,10 @@ unsigned int compat_timeGetTime()
 
 FILE* compat_fopen(const char* path, const char* mode)
 {
+    if (compatFileModeMayWrite(mode)) {
+        compatDirectoryEntryCacheClear();
+    }
+
     char nativePath[COMPAT_MAX_PATH];
     compat_prepare_native_path(nativePath, path);
     return fopen(nativePath, mode);
@@ -313,6 +378,10 @@ FILE* compat_fopen(const char* path, const char* mode)
 
 gzFile compat_gzopen(const char* path, const char* mode)
 {
+    if (compatFileModeMayWrite(mode)) {
+        compatDirectoryEntryCacheClear();
+    }
+
     char nativePath[COMPAT_MAX_PATH];
     compat_prepare_native_path(nativePath, path);
     return gzopen(nativePath, mode);
@@ -350,6 +419,8 @@ char* compat_gzgets(gzFile stream, char* buffer, int maxCount)
 
 int compat_remove(const char* path)
 {
+    compatDirectoryEntryCacheClear();
+
     char nativePath[COMPAT_MAX_PATH];
     compat_prepare_native_path(nativePath, path);
     return remove(nativePath);
@@ -357,6 +428,8 @@ int compat_remove(const char* path)
 
 int compat_rename(const char* oldFileName, const char* newFileName)
 {
+    compatDirectoryEntryCacheClear();
+
     char nativeOldFileName[COMPAT_MAX_PATH];
     compat_prepare_native_path(nativeOldFileName, oldFileName);
 
@@ -383,22 +456,20 @@ void compat_resolve_path(char* path)
 {
 #ifndef _WIN32
     char* pch = path;
-
-    DIR* dir;
+    std::string directoryPath;
     if (pch[0] == '/') {
-        dir = opendir("/");
+        directoryPath = "/";
         pch++;
     } else {
-        dir = opendir(".");
+        directoryPath = ".";
     }
 
-    while (dir != nullptr) {
+    while (true) {
         while (*pch == '/') {
             pch++;
         }
 
         if (*pch == '\0') {
-            closedir(dir);
             break;
         }
 
@@ -410,31 +481,25 @@ void compat_resolve_path(char* path)
             length = strlen(pch);
         }
 
-        bool found = false;
-
-        struct dirent* entry = readdir(dir);
-        while (entry != nullptr) {
-            if (strlen(entry->d_name) == length && compat_strnicmp(pch, entry->d_name, length) == 0) {
-                strncpy(pch, entry->d_name, length);
-                found = true;
-                break;
-            }
-            entry = readdir(dir);
-        }
-
-        closedir(dir);
-        dir = nullptr;
-
-        if (!found) {
+        const CompatDirectoryCacheEntry* directoryCacheEntry = compatDirectoryEntryCacheGet(directoryPath);
+        if (directoryCacheEntry == nullptr) {
             break;
         }
+
+        std::string component(pch, length);
+        auto cacheEntry = directoryCacheEntry->entries.find(compatLowercase(component));
+        if (cacheEntry == directoryCacheEntry->entries.end()) {
+            break;
+        }
+
+        strncpy(pch, cacheEntry->second.c_str(), length);
 
         if (sep == nullptr) {
             break;
         }
 
         *sep = '\0';
-        dir = opendir(path);
+        directoryPath = path;
         *sep = '/';
 
         pch = sep + 1;

--- a/src/platform_compat.cc
+++ b/src/platform_compat.cc
@@ -47,12 +47,13 @@ typedef struct CompatDirectoryCacheEntry {
     std::unordered_map<std::string, std::string> entries;
 } CompatDirectoryCacheEntry;
 
+static constexpr size_t kCompatDirectoryEntryCacheMaxSize = 1024;
 static std::unordered_map<std::string, CompatDirectoryCacheEntry> compatDirectoryEntryCache;
 
 static std::string compatLowercase(std::string value)
 {
     for (char& ch : value) {
-        ch = static_cast<char>(SDL_tolower(ch));
+        ch = static_cast<char>(SDL_tolower(static_cast<unsigned char>(ch)));
     }
     return value;
 }
@@ -72,6 +73,10 @@ static const CompatDirectoryCacheEntry* compatDirectoryEntryCacheGet(const std::
     DIR* dir = opendir(directoryPath.c_str());
     if (dir == nullptr) {
         return nullptr;
+    }
+
+    if (compatDirectoryEntryCache.size() >= kCompatDirectoryEntryCacheMaxSize) {
+        compatDirectoryEntryCache.clear();
     }
 
     auto inserted = compatDirectoryEntryCache.emplace(directoryPath, CompatDirectoryCacheEntry());
@@ -284,10 +289,14 @@ int compat_mkdir(const char* path)
     compat_prepare_native_path(nativePath, path);
 
 #ifdef _WIN32
-    return mkdir(nativePath);
+    int rc = mkdir(nativePath);
 #else
-    return mkdir(nativePath, 0755);
+    int rc = mkdir(nativePath, 0755);
 #endif
+    if (rc == 0) {
+        compatDirectoryEntryCacheClear();
+    }
+    return rc;
 }
 
 int compat_mkdir_recursive(const char* path)
@@ -367,24 +376,34 @@ unsigned int compat_timeGetTime()
 
 FILE* compat_fopen(const char* path, const char* mode)
 {
-    if (compatFileModeMayWrite(mode)) {
+    bool mayWrite = compatFileModeMayWrite(mode);
+    if (mayWrite) {
         compatDirectoryEntryCacheClear();
     }
 
     char nativePath[COMPAT_MAX_PATH];
     compat_prepare_native_path(nativePath, path);
-    return fopen(nativePath, mode);
+    FILE* stream = fopen(nativePath, mode);
+    if (mayWrite && stream != nullptr) {
+        compatDirectoryEntryCacheClear();
+    }
+    return stream;
 }
 
 gzFile compat_gzopen(const char* path, const char* mode)
 {
-    if (compatFileModeMayWrite(mode)) {
+    bool mayWrite = compatFileModeMayWrite(mode);
+    if (mayWrite) {
         compatDirectoryEntryCacheClear();
     }
 
     char nativePath[COMPAT_MAX_PATH];
     compat_prepare_native_path(nativePath, path);
-    return gzopen(nativePath, mode);
+    gzFile stream = gzopen(nativePath, mode);
+    if (mayWrite && stream != nullptr) {
+        compatDirectoryEntryCacheClear();
+    }
+    return stream;
 }
 
 char* compat_fgets(char* buffer, int maxCount, FILE* stream)
@@ -423,7 +442,11 @@ int compat_remove(const char* path)
 
     char nativePath[COMPAT_MAX_PATH];
     compat_prepare_native_path(nativePath, path);
-    return remove(nativePath);
+    int rc = remove(nativePath);
+    if (rc == 0) {
+        compatDirectoryEntryCacheClear();
+    }
+    return rc;
 }
 
 int compat_rename(const char* oldFileName, const char* newFileName)
@@ -436,7 +459,11 @@ int compat_rename(const char* oldFileName, const char* newFileName)
     char nativeNewFileName[COMPAT_MAX_PATH];
     compat_prepare_native_path(nativeNewFileName, newFileName);
 
-    return rename(nativeOldFileName, nativeNewFileName);
+    int rc = rename(nativeOldFileName, nativeNewFileName);
+    if (rc == 0) {
+        compatDirectoryEntryCacheClear();
+    }
+    return rc;
 }
 
 void compat_windows_path_to_native(char* path)


### PR DESCRIPTION
Right now, we Do a pretty expensive directory walk to find assets in a file system without matching case exactly. When loading a map, we do this tens of thousands of times. A cache that only exists during map load cuts this down significantly. On my Mac, this cuts down a map load from 1,700 ms to 400 ms.
