### PR TITLE
HRP EdgeClipping CheckRect

### DIFF
--- a/src/map.cc
+++ b/src/map.cc
@@ -404,13 +404,13 @@ int mapSetElevation(int elevation)
         gameMouseObjectsShow();
     }
 
-    // Makes sure buffer is updated
+    tile_hires_stencil_on_center_tile_or_elevation_change();
+
+    // Makes sure buffer is updated.
     tileWindowRefresh();
 
-    // force a redraw (in case new elevation isn't scrollable)
+    // Force a redraw in case new elevation isn't scrollable.
     windowRefresh(gIsoWindow);
-
-    tile_hires_stencil_on_center_tile_or_elevation_change();
 
     return 0;
 }

--- a/src/map.cc
+++ b/src/map.cc
@@ -406,9 +406,6 @@ int mapSetElevation(int elevation)
 
     tile_hires_stencil_on_center_tile_or_elevation_change();
 
-    // Makes sure buffer is updated.
-    tileWindowRefresh();
-
     // Force a redraw in case new elevation isn't scrollable.
     windowRefresh(gIsoWindow);
 

--- a/src/map.cc
+++ b/src/map.cc
@@ -404,6 +404,7 @@ int mapSetElevation(int elevation)
         gameMouseObjectsShow();
     }
 
+    windowRefresh(gIsoWindow);
     tile_hires_stencil_on_center_tile_or_elevation_change();
 
     return 0;

--- a/src/map.cc
+++ b/src/map.cc
@@ -406,9 +406,6 @@ int mapSetElevation(int elevation)
 
     tile_hires_stencil_on_center_tile_or_elevation_change();
 
-    // Force a redraw in case new elevation isn't scrollable.
-    windowRefresh(gIsoWindow);
-
     return 0;
 }
 

--- a/src/map.cc
+++ b/src/map.cc
@@ -404,7 +404,12 @@ int mapSetElevation(int elevation)
         gameMouseObjectsShow();
     }
 
+    // Makes sure buffer is updated
+    tileWindowRefresh();
+
+    // force a redraw (in case new elevation isn't scrollable)
     windowRefresh(gIsoWindow);
+
     tile_hires_stencil_on_center_tile_or_elevation_change();
 
     return 0;

--- a/src/tile.cc
+++ b/src/tile.cc
@@ -661,10 +661,7 @@ bool checkRectNeedsClear(const Rect* rect, bool hasVisArea, const Rect* visArea)
         return true;
     }
 
-    return (rect->left < visArea->left ||
-            rect->right > visArea->right ||
-            rect->top < visArea->top ||
-            rect->bottom > visArea->bottom);
+    return (rect->left < visArea->left || rect->right > visArea->right || rect->top < visArea->top || rect->bottom > visArea->bottom);
 }
 
 // TODO: these two functions are exact copies of isoWindowRefreshRect*. gTileWindowBuffer == gIsoWindowBuffer, these are the same window!

--- a/src/tile.cc
+++ b/src/tile.cc
@@ -677,8 +677,11 @@ static void tileRefreshMapper(Rect* rect, int elevation)
     Rect visArea;
     bool hasVisArea = mapEdgeComputeVisibleArea(elevation, &visArea);
 
+    Rect renderRect = rectToUpdate;
+    bool didClear = checkRectNeedsClear(&rectToUpdate, hasVisArea, &visArea);
+
     // HRP EdgeClipping: when clipped, clear only if CheckRect; otherwise always clear.
-    if (checkRectNeedsClear(&rectToUpdate, hasVisArea, &visArea)) {
+    if (didClear) {
         bufferFill(gTileWindowBuffer + gTileWindowPitch * rectToUpdate.top + rectToUpdate.left,
             rectGetWidth(&rectToUpdate),
             rectGetHeight(&rectToUpdate),
@@ -686,23 +689,26 @@ static void tileRefreshMapper(Rect* rect, int elevation)
             0);
     }
 
-    if (hasVisArea && rectIntersection(&rectToUpdate, &visArea, &rectToUpdate) == -1) {
+    if (hasVisArea && rectIntersection(&renderRect, &visArea, &renderRect) == -1) {
+        if (didClear) {
+            gTileWindowRefreshProc(&rectToUpdate);
+        }
         return;
     }
 
-    tileRenderFloorsInRect(&rectToUpdate, elevation);
-    _grid_render(&rectToUpdate, elevation);
-    _obj_render_pre_roof(&rectToUpdate, elevation);
-    tileRenderRoofsInRect(&rectToUpdate, elevation);
-    _obj_render_post_roof(&rectToUpdate, elevation);
+    tileRenderFloorsInRect(&renderRect, elevation);
+    _grid_render(&renderRect, elevation);
+    _obj_render_pre_roof(&renderRect, elevation);
+    tileRenderRoofsInRect(&renderRect, elevation);
+    _obj_render_post_roof(&renderRect, elevation);
 
     if (!hasVisArea) {
-        tile_hires_stencil_draw(&rectToUpdate, gTileWindowBuffer, gTileWindowWidth, gTileWindowHeight);
+        tile_hires_stencil_draw(&renderRect, gTileWindowBuffer, gTileWindowWidth, gTileWindowHeight);
     }
 
-    tileMapperOverlayRender(gTileWindowBuffer, gTileWindowPitch, elevation, &rectToUpdate);
+    tileMapperOverlayRender(gTileWindowBuffer, gTileWindowPitch, elevation, &renderRect);
 
-    gTileWindowRefreshProc(&rectToUpdate);
+    gTileWindowRefreshProc(didClear ? &rectToUpdate : &renderRect);
 }
 
 // 0x4B15E8 refresh_game
@@ -717,8 +723,11 @@ static void tileRefreshGame(Rect* rect, int elevation)
     Rect visArea;
     bool hasVisArea = mapEdgeComputeVisibleArea(elevation, &visArea);
 
+    Rect renderRect = rectToUpdate;
+    bool didClear = checkRectNeedsClear(&rectToUpdate, hasVisArea, &visArea);
+
     // HRP EdgeClipping: when clipped, clear only if CheckRect; otherwise always clear.
-    if (checkRectNeedsClear(&rectToUpdate, hasVisArea, &visArea)) {
+    if (didClear) {
         bufferFill(gTileWindowBuffer + rectToUpdate.top * gTileWindowPitch + rectToUpdate.left,
             rectGetWidth(&rectToUpdate),
             rectGetHeight(&rectToUpdate),
@@ -726,20 +735,23 @@ static void tileRefreshGame(Rect* rect, int elevation)
             0);
     }
 
-    if (hasVisArea && rectIntersection(&rectToUpdate, &visArea, &rectToUpdate) == -1) {
+    if (hasVisArea && rectIntersection(&renderRect, &visArea, &renderRect) == -1) {
+        if (didClear) {
+            gTileWindowRefreshProc(&rectToUpdate);
+        }
         return;
     }
 
-    tileRenderFloorsInRect(&rectToUpdate, elevation);
-    _obj_render_pre_roof(&rectToUpdate, elevation);
-    tileRenderRoofsInRect(&rectToUpdate, elevation);
-    _obj_render_post_roof(&rectToUpdate, elevation);
+    tileRenderFloorsInRect(&renderRect, elevation);
+    _obj_render_pre_roof(&renderRect, elevation);
+    tileRenderRoofsInRect(&renderRect, elevation);
+    _obj_render_post_roof(&renderRect, elevation);
 
     if (!hasVisArea) {
-        tile_hires_stencil_draw(&rectToUpdate, gTileWindowBuffer, gTileWindowWidth, gTileWindowHeight);
+        tile_hires_stencil_draw(&renderRect, gTileWindowBuffer, gTileWindowWidth, gTileWindowHeight);
     }
 
-    gTileWindowRefreshProc(&rectToUpdate);
+    gTileWindowRefreshProc(didClear ? &rectToUpdate : &renderRect);
 }
 
 // 0x4B1634 tile_toggle_roof

--- a/src/tile.cc
+++ b/src/tile.cc
@@ -655,39 +655,16 @@ int tileSetCenter(int tile, int flags)
     return 0;
 }
 
-// Port of HRP EdgeClipping::CheckRect.
-// Returns true if any corner of the screen-space rect maps to a tile outside the 200x200 grid.
-bool checkRectNeedsClear(const Rect* rect, int elevation)
+bool checkRectNeedsClear(const Rect* rect, bool hasVisArea, const Rect* visArea)
 {
-    (void)elevation;
-
-    int cX, cY;
-    tileToPixelOffset(gCenterTile, cX, cY);
-
-    const int halfW = gTileWindowWidth / 2;
-    const int halfH = gTileWindowHeight / 2;
-
-    // Convert screen-space rect corners to pixel-offset space (HRP formula).
-    // xLeft = (cX + width) - rect->left,  yTop = (cY + rect->top) - height
-    // xRight = (cX + width) - rect->right, yBottom = (cY + rect->bottom) - height
-    struct {
-        int x, y;
-    } corners[4] = {
-        { (cX + halfW) - rect->left, (cY + rect->top) - halfH },
-        { (cX + halfW) - rect->right, (cY + rect->top) - halfH },
-        { (cX + halfW) - rect->left, (cY + rect->bottom) - halfH },
-        { (cX + halfW) - rect->right, (cY + rect->bottom) - halfH }
-    };
-
-    for (int i = 0; i < 4; i++) {
-        int x = corners[i].x;
-        int y = corners[i].y;
-        pixelToTileCoord(x, y);
-        if (x < 0 || x >= HEX_GRID_WIDTH || y < 0 || y >= HEX_GRID_HEIGHT) {
-            return true;
-        }
+    if (!hasVisArea) {
+        return true;
     }
-    return false;
+
+    return (rect->left < visArea->left ||
+            rect->right > visArea->right ||
+            rect->top < visArea->top ||
+            rect->bottom > visArea->bottom);
 }
 
 // TODO: these two functions are exact copies of isoWindowRefreshRect*. gTileWindowBuffer == gIsoWindowBuffer, these are the same window!
@@ -704,7 +681,7 @@ static void tileRefreshMapper(Rect* rect, int elevation)
     bool hasVisArea = mapEdgeComputeVisibleArea(elevation, &visArea);
 
     // HRP EdgeClipping: when clipped, clear only if CheckRect; otherwise always clear.
-    if (!hasVisArea || checkRectNeedsClear(&rectToUpdate, elevation)) {
+    if (!hasVisArea || checkRectNeedsClear(&rectToUpdate, hasVisArea, &visArea)) {
         bufferFill(gTileWindowBuffer + gTileWindowPitch * rectToUpdate.top + rectToUpdate.left,
             rectGetWidth(&rectToUpdate),
             rectGetHeight(&rectToUpdate),
@@ -744,7 +721,7 @@ static void tileRefreshGame(Rect* rect, int elevation)
     bool hasVisArea = mapEdgeComputeVisibleArea(elevation, &visArea);
 
     // HRP EdgeClipping: when clipped, clear only if CheckRect; otherwise always clear.
-    if (!hasVisArea || checkRectNeedsClear(&rectToUpdate, elevation)) {
+    if (!hasVisArea || checkRectNeedsClear(&rectToUpdate, hasVisArea, &visArea)) {
         bufferFill(gTileWindowBuffer + rectToUpdate.top * gTileWindowPitch + rectToUpdate.left,
             rectGetWidth(&rectToUpdate),
             rectGetHeight(&rectToUpdate),

--- a/src/tile.cc
+++ b/src/tile.cc
@@ -678,7 +678,7 @@ static void tileRefreshMapper(Rect* rect, int elevation)
     bool hasVisArea = mapEdgeComputeVisibleArea(elevation, &visArea);
 
     // HRP EdgeClipping: when clipped, clear only if CheckRect; otherwise always clear.
-    if (!hasVisArea || checkRectNeedsClear(&rectToUpdate, hasVisArea, &visArea)) {
+    if (checkRectNeedsClear(&rectToUpdate, hasVisArea, &visArea)) {
         bufferFill(gTileWindowBuffer + gTileWindowPitch * rectToUpdate.top + rectToUpdate.left,
             rectGetWidth(&rectToUpdate),
             rectGetHeight(&rectToUpdate),
@@ -718,7 +718,7 @@ static void tileRefreshGame(Rect* rect, int elevation)
     bool hasVisArea = mapEdgeComputeVisibleArea(elevation, &visArea);
 
     // HRP EdgeClipping: when clipped, clear only if CheckRect; otherwise always clear.
-    if (!hasVisArea || checkRectNeedsClear(&rectToUpdate, hasVisArea, &visArea)) {
+    if (checkRectNeedsClear(&rectToUpdate, hasVisArea, &visArea)) {
         bufferFill(gTileWindowBuffer + rectToUpdate.top * gTileWindowPitch + rectToUpdate.left,
             rectGetWidth(&rectToUpdate),
             rectGetHeight(&rectToUpdate),

--- a/src/tile.h
+++ b/src/tile.h
@@ -77,7 +77,7 @@ static bool tileIsValid(int tile)
 
 // Returns true if the rect's screen-space corners map to tiles outside the 200x200 grid.
 // Port of HRP EdgeClipping::CheckRect — used to decide whether to clear (blacken) a rect.
-bool checkRectNeedsClear(const Rect* rect, int elevation);
+bool checkRectNeedsClear(const Rect* rect, bool hasVisArea, const Rect* visArea);
 
 } // namespace fallout
 

--- a/src/tile.h
+++ b/src/tile.h
@@ -75,8 +75,7 @@ static bool tileIsValid(int tile)
     return tile >= 0 && tile < gHexGridSize;
 }
 
-// Returns true if the rect's screen-space corners map to tiles outside the 200x200 grid.
-// Port of HRP EdgeClipping::CheckRect — used to decide whether to clear (blacken) a rect.
+// used to decide whether to clear (blacken) a rect.
 bool checkRectNeedsClear(const Rect* rect, bool hasVisArea, const Rect* visArea);
 
 } // namespace fallout


### PR DESCRIPTION
Additionally mentioned in #670 

When transitioning from a lower elevation map with an unrestricted hex grid (e.g., caves, where hasVisArea == false) to an upper elevation map that is clamped/centered with black stencil borders (hasVisArea == true), residual artifacts of the previous map remain rendered on the black edges

Solution: Since  sfall/HRP Edge Clipping relies on configuration-driven pixel zones (EdgeZone) handled by mapEdgeComputeVisibleArea it shouldn't be necessary to evaluate boundaries using screen-to-tile coordinate formulas?

Changed checkRectNeedsClear to perform a straightforward comparison between the update Rect and the actual visibleArea