### PR TITLE
Typesafe usage of AudioFlags, AudioOpenMode, CacheEntryFlags, HeadFidget, Background, HeadAnition and Head enums

### DIFF
--- a/src/animation.cc
+++ b/src/animation.cc
@@ -3152,7 +3152,7 @@ void _dude_fidget()
         } else {
             char fileName[16];
             fileName[0] = '\0';
-            artCopyFileName(1, object->fid & 0xFFF, fileName);
+            artCopyFileName(OBJ_TYPE_CRITTER, object->fid & 0xFFF, fileName);
             if (fileName[0] == 'm' || fileName[0] == 'M') {
                 if (objectGetDistanceBetween(object, gDude) < critterGetStat(gDude, STAT_PERCEPTION) * 2) {
                     shoudPlaySound = true;

--- a/src/art.cc
+++ b/src/art.cc
@@ -398,7 +398,7 @@ int artGetFidgetCount(int headFid)
 
     HeadDescription* headDescription = &(gHeadDescriptions[head]);
 
-    int fidget = (headFid & 0xFF0000) >> 16;
+    HeadFidget fidget = headFidgetFromFid(headFid);
     switch (fidget) {
     case FIDGET_GOOD:
         return headDescription->goodFidgetCount;

--- a/src/art.cc
+++ b/src/art.cc
@@ -553,7 +553,7 @@ int artCacheFlush()
 }
 
 // 0x4192B0
-int artCopyFileName(int objectType, int id, char* dest)
+int artCopyFileName(ObjectType objectType, int id, char* dest)
 {
     ArtListDescription* ptr;
 

--- a/src/art.cc
+++ b/src/art.cc
@@ -390,7 +390,7 @@ int artGetFidgetCount(int headFid)
         return 0;
     }
 
-    int head = headFid & 0xFFF;
+    Head head = headFromFid(headFid);
 
     if (head > gArtListDescriptions[OBJ_TYPE_HEAD].fileNamesLength) {
         return 0;
@@ -400,6 +400,8 @@ int artGetFidgetCount(int headFid)
 
     HeadFidget fidget = headFidgetFromFid(headFid);
     switch (fidget) {
+    case FIDGET_INVALID:
+        return -1;
     case FIDGET_GOOD:
         return headDescription->goodFidgetCount;
     case FIDGET_NEUTRAL:

--- a/src/art.cc
+++ b/src/art.cc
@@ -406,8 +406,9 @@ int artGetFidgetCount(int headFid)
         return headDescription->neutralFidgetCount;
     case FIDGET_BAD:
         return headDescription->badFidgetCount;
+    default:
+        return 0;
     }
-    return 0;
 }
 
 // 0x418FFC

--- a/src/art.h
+++ b/src/art.h
@@ -51,7 +51,7 @@ Art* artLock(int fid, CacheEntry** cache_entry);
 unsigned char* artLockFrameData(int fid, int frame, Rotation rotation, CacheEntry** out_cache_entry);
 int artUnlock(CacheEntry* cache_entry);
 int artCacheFlush();
-int artCopyFileName(int objectType, int id, char* dest);
+int artCopyFileName(ObjectType objectType, int id, char* dest);
 int _art_get_code(AnimationType animation, WeaponAnimation weaponType, char* weaponCodePtr, char* animationCodePtr);
 char* artBuildFilePath(int fid);
 int artGetFramesPerSecond(Art* art);

--- a/src/art_defs.h
+++ b/src/art_defs.h
@@ -2,8 +2,9 @@
 #define ART_DEFS_H
 namespace fallout {
 
-typedef enum Head {
-    HEAD_INVALID,
+enum Head : int {
+    HEAD_INVALID = -1,
+    HEAD_NONE,
     HEAD_MARCUS,
     HEAD_MYRON,
     HEAD_ELDER,
@@ -16,8 +17,18 @@ typedef enum Head {
     HEAD_HAKUNIN,
     HEAD_BOSS,
     HEAD_DYING_HAKUNIN,
-    HEAD_COUNT,
-} Head;
+};
+
+inline bool headIsValid(int head)
+{
+    return head >= HEAD_NONE;
+}
+
+inline Head headFromFid(int fid)
+{
+    int head = fid & 0xFFF;
+    return static_cast<Head>(head);
+}
 
 enum HeadAnimation : int {
     HEAD_ANIMATION_VERY_GOOD_REACTION = 0,
@@ -74,7 +85,7 @@ enum Background : int {
 
 inline bool backgroundIsValid(int background)
 {
-    return background > BACKGROUND_INVALID;
+    return background >= BACKGROUND_0;
 }
 
 enum DudeNativeLook : int {

--- a/src/art_defs.h
+++ b/src/art_defs.h
@@ -47,7 +47,8 @@ inline HeadFidget headFidgetFromFid(int fid)
     return static_cast<HeadFidget>(fidget);
 }
 
-typedef enum Background {
+enum Background : int {
+    BACKGROUND_INVALID = -1,
     BACKGROUND_0,
     BACKGROUND_1,
     BACKGROUND_2,
@@ -69,8 +70,12 @@ typedef enum Background {
     BACKGROUND_PRESIDENT,
     BACKGROUND_TENT,
     BACKGROUND_ADOBE,
-    BACKGROUND_COUNT,
-} Background;
+};
+
+inline bool backgroundIsValid(int background)
+{
+    return background > BACKGROUND_INVALID;
+}
 
 enum DudeNativeLook : int {
     // Hero looks as one the tribals (before finishing Temple of Trails).

--- a/src/art_defs.h
+++ b/src/art_defs.h
@@ -19,20 +19,33 @@ typedef enum Head {
     HEAD_COUNT,
 } Head;
 
-typedef enum HeadAnimation {
+enum HeadAnimation : int {
     HEAD_ANIMATION_VERY_GOOD_REACTION = 0,
-    FIDGET_GOOD = 1,
+    HEAD_ANIMATION_GOOD = 1,
     HEAD_ANIMATION_GOOD_TO_NEUTRAL = 2,
     HEAD_ANIMATION_NEUTRAL_TO_GOOD = 3,
-    FIDGET_NEUTRAL = 4,
+    HEAD_ANIMATION_NEUTRAL = 4,
     HEAD_ANIMATION_NEUTRAL_TO_BAD = 5,
     HEAD_ANIMATION_BAD_TO_NEUTRAL = 6,
-    FIDGET_BAD = 7,
+    HEAD_ANIMATION_BAD = 7,
     HEAD_ANIMATION_VERY_BAD_REACTION = 8,
     HEAD_ANIMATION_GOOD_PHONEMES = 9,
     HEAD_ANIMATION_NEUTRAL_PHONEMES = 10,
     HEAD_ANIMATION_BAD_PHONEMES = 11,
-} HeadAnimation;
+};
+
+enum HeadFidget : int {
+    FIDGET_INVALID = -1,
+    FIDGET_GOOD = 1,
+    FIDGET_NEUTRAL = 4,
+    FIDGET_BAD = 7,
+};
+
+inline HeadFidget headFidgetFromFid(int fid)
+{
+    int fidget = (fid & 0xFF0000) >> 16;
+    return static_cast<HeadFidget>(fidget);
+}
 
 typedef enum Background {
     BACKGROUND_0,

--- a/src/audio.cc
+++ b/src/audio.cc
@@ -16,15 +16,22 @@
 
 namespace fallout {
 
-typedef enum AudioFlags {
+enum AudioFlags : int {
+    AUDIO_NONE = 0x00,
     AUDIO_IN_USE = 0x01,
     AUDIO_COMPRESSED = 0x02,
     // CE: Decoded formats like WAV/OGG are fully loaded into memory up front.
     AUDIO_MEMORY = 0x04,
-} AudioFileFlags;
+};
+
+inline AudioFlags& operator|=(AudioFlags& lhs, AudioFlags rhs)
+{
+    lhs = static_cast<AudioFlags>(static_cast<int>(lhs) | static_cast<int>(rhs));
+    return lhs;
+}
 
 typedef struct Audio {
-    int flags;
+    AudioFlags flags;
     File* stream;
     SoundDecoder* soundDecoder;
     unsigned char* data;
@@ -205,7 +212,7 @@ int audioOpen(const char* fname, AudioFileInfo* info, bool* isMemoryBackedPtr)
 
     int index;
     for (index = 0; index < gAudioListLength; index++) {
-        if ((gAudioList[index].flags & AUDIO_IN_USE) == 0) {
+        if ((gAudioList[index].flags & AUDIO_IN_USE) == AUDIO_NONE) {
             break;
         }
     }
@@ -292,7 +299,7 @@ int audioOpen(const char* fname, AudioFileInfo* info, bool* isMemoryBackedPtr)
 int audioClose(int handle)
 {
     Audio* audioFile = &(gAudioList[handle - 1]);
-    if ((audioFile->flags & AUDIO_MEMORY) != 0) {
+    if ((audioFile->flags & AUDIO_MEMORY) != AUDIO_NONE) {
         if (audioFile->data != nullptr) {
             internal_free_safe(audioFile->data, __FILE__, __LINE__);
         }
@@ -300,7 +307,7 @@ int audioClose(int handle)
         fileClose(audioFile->stream);
     }
 
-    if ((audioFile->flags & AUDIO_COMPRESSED) != 0) {
+    if ((audioFile->flags & AUDIO_COMPRESSED) != AUDIO_NONE) {
         soundDecoderFree(audioFile->soundDecoder);
     }
 
@@ -315,7 +322,7 @@ int audioRead(int handle, void* buffer, unsigned int size)
     Audio* audioFile = &(gAudioList[handle - 1]);
 
     int bytesRead;
-    if ((audioFile->flags & AUDIO_MEMORY) != 0) {
+    if ((audioFile->flags & AUDIO_MEMORY) != AUDIO_NONE) {
         bytesRead = audioFile->fileSize - audioFile->position;
         if (bytesRead > static_cast<int>(size)) {
             bytesRead = size;
@@ -324,7 +331,7 @@ int audioRead(int handle, void* buffer, unsigned int size)
         if (bytesRead > 0) {
             memcpy(buffer, audioFile->data + audioFile->position, bytesRead);
         }
-    } else if ((audioFile->flags & AUDIO_COMPRESSED) != 0) {
+    } else if ((audioFile->flags & AUDIO_COMPRESSED) != AUDIO_NONE) {
         bytesRead = soundDecoderDecode(audioFile->soundDecoder, buffer, size);
     } else {
         bytesRead = fileRead(buffer, 1, size, audioFile->stream);
@@ -358,7 +365,7 @@ long audioSeek(int handle, long offset, int origin)
         assert(false && "Should be unreachable");
     }
 
-    if ((audioFile->flags & AUDIO_MEMORY) != 0) {
+    if ((audioFile->flags & AUDIO_MEMORY) != AUDIO_NONE) {
         if (pos < 0) {
             pos = 0;
         }
@@ -369,7 +376,7 @@ long audioSeek(int handle, long offset, int origin)
 
         audioFile->position = pos;
         return audioFile->position;
-    } else if ((audioFile->flags & AUDIO_COMPRESSED) != 0) {
+    } else if ((audioFile->flags & AUDIO_COMPRESSED) != AUDIO_NONE) {
         if (pos < audioFile->position) {
             soundDecoderFree(audioFile->soundDecoder);
             fileSeek(audioFile->stream, 0, SEEK_SET);

--- a/src/audio.cc
+++ b/src/audio.cc
@@ -42,12 +42,12 @@ typedef struct Audio {
     int position;
 } Audio;
 
-typedef enum AudioOpenMode {
+enum AudioOpenMode : int {
     AUDIO_OPEN_MODE_RAW = 0,
     AUDIO_OPEN_MODE_COMPRESSED = 1, // ACM
     AUDIO_OPEN_MODE_WAV = 2,
     AUDIO_OPEN_MODE_OGG = 3,
-} AudioOpenMode;
+};
 
 static bool defaultCompressionFunc(char* filePath);
 static int audioSoundDecoderReadHandler(void* data, void* buf, unsigned int size);

--- a/src/cache.cc
+++ b/src/cache.cc
@@ -379,7 +379,7 @@ static bool cacheEntryInit(CacheEntry* cacheEntry)
     cacheEntry->data = nullptr;
     cacheEntry->referenceCount = 0;
     cacheEntry->hits = 0;
-    cacheEntry->flags = 0;
+    cacheEntry->flags = CACHE_ENTRY_NONE;
     cacheEntry->mru = 0;
     return true;
 }
@@ -528,7 +528,7 @@ static bool cacheSweep(Cache* cache)
 {
     for (int index = 0; index < cache->entriesLength; index++) {
         CacheEntry* cacheEntry = cache->entries[index];
-        if ((cacheEntry->flags & CACHE_ENTRY_MARKED_FOR_EVICTION) != 0) {
+        if ((cacheEntry->flags & CACHE_ENTRY_MARKED_FOR_EVICTION) != CACHE_ENTRY_NONE) {
             if (cacheEntry->referenceCount != 0) {
                 // Entry was marked for eviction but still has references,
                 // unmark it.

--- a/src/cache.h
+++ b/src/cache.h
@@ -9,11 +9,30 @@ namespace fallout {
 
 #define INVALID_CACHE_ENTRY ((CacheEntry*)-1)
 
-typedef enum CacheEntryFlags {
+enum CacheEntryFlags : unsigned int {
+    CACHE_ENTRY_NONE = 0x00,
+
     // Specifies that cache entry has no references as should be evicted during
     // the next sweep operation.
     CACHE_ENTRY_MARKED_FOR_EVICTION = 0x01,
-} CacheEntryFlags;
+};
+
+constexpr inline CacheEntryFlags operator~(CacheEntryFlags rhs)
+{
+    return static_cast<CacheEntryFlags>(~static_cast<unsigned int>(rhs));
+}
+
+inline CacheEntryFlags& operator&=(CacheEntryFlags& lhs, CacheEntryFlags rhs)
+{
+    lhs = static_cast<CacheEntryFlags>(static_cast<unsigned int>(lhs) & static_cast<unsigned int>(rhs));
+    return lhs;
+}
+
+inline CacheEntryFlags& operator|=(CacheEntryFlags& lhs, CacheEntryFlags rhs)
+{
+    lhs = static_cast<CacheEntryFlags>(static_cast<unsigned int>(lhs) | static_cast<unsigned int>(rhs));
+    return lhs;
+}
 
 typedef int CacheSizeProc(int key, int* sizePtr);
 typedef int CacheReadProc(int key, int* sizePtr, unsigned char* buffer);
@@ -29,7 +48,7 @@ typedef struct CacheEntry {
     // lifetime.
     unsigned int hits;
 
-    unsigned int flags;
+    CacheEntryFlags flags;
 
     // The most recent hit in terms of cache hit counter. Used to track most
     // recently used entries in eviction strategy.

--- a/src/combat.cc
+++ b/src/combat.cc
@@ -114,8 +114,8 @@ static void waitForGorisAnimation(Object* critter);
 static int _combat_turn(Object* obj, bool reloadedDuringCombat);
 static bool _combat_should_end();
 static bool _check_ranged_miss(Attack* attack);
-static int _shoot_along_path(Attack* attack, int endTile, int rounds, int anim);
-static int _compute_spray(Attack* attack, int accuracy, int* roundsHitMainTargetPtr, int* roundsFiredPtr, int anim);
+static int _shoot_along_path(Attack* attack, int endTile, int rounds, AnimationType anim);
+static int _compute_spray(Attack* attack, int accuracy, int* roundsHitMainTargetPtr, int* roundsFiredPtr, AnimationType anim);
 static int attackComputeEnhancedKnockout(Attack* attack);
 static int attackCompute(Attack* attack);
 static int attackComputeCriticalHit(Attack* a1);
@@ -3712,7 +3712,7 @@ static bool _check_ranged_miss(Attack* attack)
 }
 
 // 0x423284
-static int _shoot_along_path(Attack* attack, int endTile, int rounds, int anim)
+static int _shoot_along_path(Attack* attack, int endTile, int rounds, AnimationType anim)
 {
     int remainingRounds = rounds;
     int roundsHitMainTarget = 0;
@@ -3786,7 +3786,7 @@ static int _shoot_along_path(Attack* attack, int endTile, int rounds, int anim)
 }
 
 // 0x423488 compute_spray
-static int _compute_spray(Attack* attack, int accuracy, int* roundsHitMainTargetPtr, int* roundsFiredPtr, int anim)
+static int _compute_spray(Attack* attack, int accuracy, int* roundsHitMainTargetPtr, int* roundsFiredPtr, AnimationType anim)
 {
     *roundsHitMainTargetPtr = 0;
 
@@ -3927,7 +3927,7 @@ static int attackCompute(Attack* attack)
         return -1;
     }
 
-    int anim = critterGetAnimationForHitMode(attack->attacker, attack->hitMode);
+    AnimationType anim = critterGetAnimationForHitMode(attack->attacker, attack->hitMode);
     int accuracy = attackDetermineToHit(attack->attacker, attack->attacker->tile, attack->defender, attack->defenderHitLocation, attack->hitMode, true);
 
     bool isGrenade = false;

--- a/src/endgame.cc
+++ b/src/endgame.cc
@@ -75,7 +75,7 @@ static void endgameEndingSlideshowWindowFree();
 static void endgameEndingVoiceOverInit(const char* fname);
 static void endgameEndingVoiceOverReset();
 static void endgameEndingVoiceOverFree();
-static void endgameEndingLoadPalette(int type, int id);
+static void endgameEndingLoadPalette(ObjectType type, int id);
 static void _endgame_voiceover_callback();
 static int endgameEndingSubtitlesLoad(const char* filePath);
 static void endgameEndingRefreshSubtitles();
@@ -354,7 +354,7 @@ static void endgameEndingRenderPanningScene(int direction, const char* narratorF
         int height = artGetHeight(background);
         unsigned char* backgroundData = artGetFrameData(background);
         bufferFill(gEndgameEndingSlideshowWindowBuffer, ENDGAME_ENDING_WINDOW_WIDTH, ENDGAME_ENDING_WINDOW_HEIGHT, ENDGAME_ENDING_WINDOW_WIDTH, COLOR_BLACK);
-        endgameEndingLoadPalette(6, 327);
+        endgameEndingLoadPalette(OBJ_TYPE_INTERFACE, 327);
 
         // CE: Update overlay.
         endgameEndingUpdateOverlay();
@@ -769,7 +769,7 @@ static void endgameEndingVoiceOverFree()
 }
 
 // 0x440378 endgame_load_palette
-static void endgameEndingLoadPalette(int type, int id)
+static void endgameEndingLoadPalette(ObjectType type, int id)
 {
     char fileName[13];
     if (artCopyFileName(type, id, fileName) != 0) {

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -593,7 +593,7 @@ static int _oldFont;
 static unsigned int gGameDialogFidgetLastUpdateTimestamp;
 
 // 0x58F4D0 fidgetAnim
-static int gGameDialogFidgetReaction;
+static HeadFidget gGameDialogFidgetReaction;
 
 // 0x58F4D4 dialogBlock
 static Program* gDialogReplyProgram;
@@ -669,7 +669,7 @@ static void gameDialogRenderReply();
 static void _gdProcessUpdate();
 static int _gdCreateHeadWindow();
 static void _gdDestroyHeadWindow();
-static void _gdSetupFidget(int headFid, int reaction);
+static void _gdSetupFidget(int headFid, HeadFidget reaction);
 static void gameDialogWaitForFidgetToComplete();
 static void _gdPlayTransition(int animation);
 static void _reply_arrow_up(int btn, int keyCode);
@@ -965,7 +965,7 @@ int gameDialogDisable()
 }
 
 // 0x44510C
-int _gdialogInitFromScript(int headFid, int reaction)
+int _gdialogInitFromScript(int headFid, HeadFidget reaction)
 {
     if (dialogMode == GAME_DIALOG_MODE_TALK) {
         return -1;
@@ -2597,7 +2597,7 @@ void _gdDestroyHeadWindow()
 }
 
 // 0x447300
-void _gdSetupFidget(int headFrmId, int reaction)
+void _gdSetupFidget(int headFrmId, HeadFidget reaction)
 {
     gGameDialogFidgetFrmCurrentFrame = 0;
 
@@ -2605,7 +2605,7 @@ void _gdSetupFidget(int headFrmId, int reaction)
         gGameDialogFidgetFid = -1;
         gGameDialogFidgetFrm = nullptr;
         gGameDialogFidgetFrmHandle = INVALID_CACHE_ENTRY;
-        gGameDialogFidgetReaction = -1;
+        gGameDialogFidgetReaction = FIDGET_INVALID;
         gGameDialogFidgetUpdateDelay = 0;
         gGameDialogFidgetLastUpdateTimestamp = 0;
         gameDialogRenderTalkingHead(nullptr, 0);
@@ -3023,7 +3023,7 @@ void gameDialogTicker()
             _can_start_new_fidget = false;
             _dialogue_seconds_since_last_input += _tocksWaiting / 1000;
             _tocksWaiting = 1000 * (randomBetween(0, 3) + 4);
-            _gdSetupFidget(gGameDialogFidgetFid & 0xFFF, (gGameDialogFidgetFid & 0xFF0000) >> 16);
+            _gdSetupFidget(gGameDialogFidgetFid & 0xFFF, headFidgetFromFid(gGameDialogFidgetFid));
         }
         return;
     }

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -669,7 +669,7 @@ static void gameDialogRenderReply();
 static void _gdProcessUpdate();
 static int _gdCreateHeadWindow();
 static void _gdDestroyHeadWindow();
-static void _gdSetupFidget(int headFid, HeadFidget reaction);
+static void _gdSetupFidget(Head head, HeadFidget reaction);
 static void gameDialogWaitForFidgetToComplete();
 static void _gdPlayTransition(HeadAnimation animation);
 static void _reply_arrow_up(int btn, int keyCode);
@@ -924,7 +924,7 @@ void gameDialogStartLips(const char* audioFileName)
     }
 
     char name[16];
-    if (artCopyFileName(OBJ_TYPE_HEAD, gGameDialogHeadFid & 0xFFF, name) == -1) {
+    if (artCopyFileName(OBJ_TYPE_HEAD, headFromFid(gGameDialogHeadFid), name) == -1) {
         return;
     }
 
@@ -965,7 +965,7 @@ int gameDialogDisable()
 }
 
 // 0x44510C
-int _gdialogInitFromScript(int headFid, HeadFidget reaction)
+int _gdialogInitFromScript(Head head, HeadFidget reaction)
 {
     if (dialogMode == GAME_DIALOG_MODE_TALK) {
         return -1;
@@ -1005,11 +1005,11 @@ int _gdialogInitFromScript(int headFid, HeadFidget reaction)
     // CE: Fix Barter button.
     _gdCreateHeadWindow();
     tickersAdd(gameDialogTicker);
-    _gdSetupFidget(headFid, reaction);
+    _gdSetupFidget(head, reaction);
     _gdialog_state = GAME_DIALOG_ACTIVE;
     _gmouse_disable_scrolling();
 
-    if (headFid == -1) {
+    if (!headIsValid(head)) {
         // SFALL: Fix the music volume when entering the dialog.
         gGameDialogOldMusicVolume = _gsound_background_volume_get_set(gMusicVolume / 2);
     } else {
@@ -2597,11 +2597,11 @@ void _gdDestroyHeadWindow()
 }
 
 // 0x447300
-void _gdSetupFidget(int headFrmId, HeadFidget reaction)
+void _gdSetupFidget(Head head, HeadFidget reaction)
 {
     gGameDialogFidgetFrmCurrentFrame = 0;
 
-    if (headFrmId == -1) {
+    if (!headIsValid(head)) {
         gGameDialogFidgetFid = -1;
         gGameDialogFidgetFrm = nullptr;
         gGameDialogFidgetFrmHandle = INVALID_CACHE_ENTRY;
@@ -2638,7 +2638,7 @@ void _gdSetupFidget(int headFrmId, HeadFidget reaction)
 
     if (_lipsFID == 0) {
         _phone_anim = anim;
-        _lipsFID = buildFid(OBJ_TYPE_HEAD, headFrmId, anim);
+        _lipsFID = buildFid(OBJ_TYPE_HEAD, head, anim);
         _lipsFp = artLock(_lipsFID, &_lipsKey);
         if (_lipsFp == nullptr) {
             debugPrint("failure!\n");
@@ -2649,7 +2649,7 @@ void _gdSetupFidget(int headFrmId, HeadFidget reaction)
         }
     }
 
-    int fid = buildFid(OBJ_TYPE_HEAD, headFrmId, reaction);
+    int fid = buildFid(OBJ_TYPE_HEAD, head, reaction);
     int fidgetCount = artGetFidgetCount(fid);
     if (fidgetCount == -1) {
         debugPrint("\tError - No available fidgets for given frame id\n");
@@ -2690,7 +2690,7 @@ void _gdSetupFidget(int headFrmId, HeadFidget reaction)
         }
     }
 
-    gGameDialogFidgetFid = buildFid(OBJ_TYPE_HEAD, headFrmId, reaction, fidget);
+    gGameDialogFidgetFid = buildFid(OBJ_TYPE_HEAD, head, reaction, fidget);
     gGameDialogFidgetFrmCurrentFrame = 0;
     gGameDialogFidgetFrm = artLock(gGameDialogFidgetFid, &gGameDialogFidgetFrmHandle);
     if (gGameDialogFidgetFrm == nullptr) {
@@ -2760,7 +2760,7 @@ void _gdPlayTransition(HeadAnimation anim)
     }
 
     CacheEntry* headFrmHandle;
-    int headFid = buildFid(OBJ_TYPE_HEAD, gGameDialogHeadFid, anim);
+    int headFid = buildFid(OBJ_TYPE_HEAD, headFromFid(gGameDialogHeadFid), anim);
     Art* headFrm = artLock(headFid, &headFrmHandle);
     if (headFrm == nullptr) {
         debugPrint("\tError locking transition...\n");
@@ -3023,7 +3023,7 @@ void gameDialogTicker()
             _can_start_new_fidget = false;
             _dialogue_seconds_since_last_input += _tocksWaiting / 1000;
             _tocksWaiting = 1000 * (randomBetween(0, 3) + 4);
-            _gdSetupFidget(gGameDialogFidgetFid & 0xFFF, headFidgetFromFid(gGameDialogFidgetFid));
+            _gdSetupFidget(headFromFid(gGameDialogFidgetFid), headFidgetFromFid(gGameDialogFidgetFid));
         }
         return;
     }
@@ -3062,15 +3062,15 @@ void _talk_to_critter_reacts(int reaction)
         switch (gGameDialogFidgetReaction) {
         case FIDGET_GOOD:
             _gdPlayTransition(HEAD_ANIMATION_VERY_GOOD_REACTION);
-            _gdSetupFidget(gGameDialogHeadFid, FIDGET_GOOD);
+            _gdSetupFidget(headFromFid(gGameDialogHeadFid), FIDGET_GOOD);
             break;
         case FIDGET_NEUTRAL:
             _gdPlayTransition(HEAD_ANIMATION_NEUTRAL_TO_GOOD);
-            _gdSetupFidget(gGameDialogHeadFid, FIDGET_GOOD);
+            _gdSetupFidget(headFromFid(gGameDialogHeadFid), FIDGET_GOOD);
             break;
         case FIDGET_BAD:
             _gdPlayTransition(HEAD_ANIMATION_BAD_TO_NEUTRAL);
-            _gdSetupFidget(gGameDialogHeadFid, FIDGET_NEUTRAL);
+            _gdSetupFidget(headFromFid(gGameDialogHeadFid), FIDGET_NEUTRAL);
             break;
         }
         break;
@@ -3080,15 +3080,15 @@ void _talk_to_critter_reacts(int reaction)
         switch (gGameDialogFidgetReaction) {
         case FIDGET_GOOD:
             _gdPlayTransition(HEAD_ANIMATION_GOOD_TO_NEUTRAL);
-            _gdSetupFidget(gGameDialogHeadFid, FIDGET_NEUTRAL);
+            _gdSetupFidget(headFromFid(gGameDialogHeadFid), FIDGET_NEUTRAL);
             break;
         case FIDGET_NEUTRAL:
             _gdPlayTransition(HEAD_ANIMATION_NEUTRAL_TO_BAD);
-            _gdSetupFidget(gGameDialogHeadFid, FIDGET_BAD);
+            _gdSetupFidget(headFromFid(gGameDialogHeadFid), FIDGET_BAD);
             break;
         case FIDGET_BAD:
             _gdPlayTransition(HEAD_ANIMATION_VERY_BAD_REACTION);
-            _gdSetupFidget(gGameDialogHeadFid, FIDGET_BAD);
+            _gdSetupFidget(headFromFid(gGameDialogHeadFid), FIDGET_BAD);
             break;
         }
         break;

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -2615,13 +2615,16 @@ void _gdSetupFidget(Head head, HeadFidget reaction)
         return;
     }
 
-    HeadAnimation anim = HEAD_ANIMATION_NEUTRAL_PHONEMES;
+    HeadAnimation anim;
     switch (reaction) {
     case FIDGET_GOOD:
         anim = HEAD_ANIMATION_GOOD_PHONEMES;
         break;
     case FIDGET_BAD:
         anim = HEAD_ANIMATION_BAD_PHONEMES;
+        break;
+    default:
+        anim = HEAD_ANIMATION_NEUTRAL_PHONEMES;
         break;
     }
 
@@ -3072,6 +3075,8 @@ void _talk_to_critter_reacts(int reaction)
             _gdPlayTransition(HEAD_ANIMATION_BAD_TO_NEUTRAL);
             _gdSetupFidget(headFromFid(gGameDialogHeadFid), FIDGET_NEUTRAL);
             break;
+        default:
+            break;
         }
         break;
     case GAME_DIALOG_REACTION_NEUTRAL:
@@ -3089,6 +3094,8 @@ void _talk_to_critter_reacts(int reaction)
         case FIDGET_BAD:
             _gdPlayTransition(HEAD_ANIMATION_VERY_BAD_REACTION);
             _gdSetupFidget(headFromFid(gGameDialogHeadFid), FIDGET_BAD);
+            break;
+        default:
             break;
         }
         break;

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -445,7 +445,7 @@ static int _head_phoneme_lookup[PHONEME_COUNT] = {
 };
 
 // 0x518900 phone_anim
-static int _phone_anim = 0;
+static HeadAnimation _phone_anim = HEAD_ANIMATION_VERY_GOOD_REACTION;
 
 // 0x518904 loop_cnt
 static int _loop_cnt = -1;
@@ -671,7 +671,7 @@ static int _gdCreateHeadWindow();
 static void _gdDestroyHeadWindow();
 static void _gdSetupFidget(int headFid, HeadFidget reaction);
 static void gameDialogWaitForFidgetToComplete();
-static void _gdPlayTransition(int animation);
+static void _gdPlayTransition(HeadAnimation animation);
 static void _reply_arrow_up(int btn, int keyCode);
 static void _reply_arrow_down(int btn, int keyCode);
 static void _reply_arrow_restore(int btn, int keyCode);
@@ -2615,7 +2615,7 @@ void _gdSetupFidget(int headFrmId, HeadFidget reaction)
         return;
     }
 
-    int anim = HEAD_ANIMATION_NEUTRAL_PHONEMES;
+    HeadAnimation anim = HEAD_ANIMATION_NEUTRAL_PHONEMES;
     switch (reaction) {
     case FIDGET_GOOD:
         anim = HEAD_ANIMATION_GOOD_PHONEMES;
@@ -2736,7 +2736,7 @@ void gameDialogWaitForFidgetToComplete()
 }
 
 // 0x447614
-void _gdPlayTransition(int anim)
+void _gdPlayTransition(HeadAnimation anim)
 {
     if (gGameDialogFidgetFrm == nullptr) {
         return;

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -216,7 +216,7 @@ static CacheEntry* gGameDialogFidgetFrmHandle = nullptr;
 static Art* gGameDialogFidgetFrm = nullptr;
 
 // 0x518700 backgroundIndex
-static int gGameDialogBackground = 2;
+static Background gGameDialogBackground = BACKGROUND_2;
 
 // 0x518704 lipsFID
 static int _lipsFID = 0;
@@ -1118,9 +1118,9 @@ int _gdialogExitFromScript()
 }
 
 // 0x445438
-void gameDialogSetBackground(int background)
+void gameDialogSetBackground(Background background)
 {
-    if (background != -1) {
+    if (backgroundIsValid(background)) {
         gGameDialogBackground = background;
     }
 }

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -669,7 +669,7 @@ static void gameDialogRenderReply();
 static void _gdProcessUpdate();
 static int _gdCreateHeadWindow();
 static void _gdDestroyHeadWindow();
-static void _gdSetupFidget(Head head, HeadFidget reaction);
+static void _gdSetupFidget(int headFid, HeadFidget reaction);
 static void gameDialogWaitForFidgetToComplete();
 static void _gdPlayTransition(HeadAnimation animation);
 static void _reply_arrow_up(int btn, int keyCode);
@@ -965,7 +965,7 @@ int gameDialogDisable()
 }
 
 // 0x44510C
-int _gdialogInitFromScript(Head head, HeadFidget reaction)
+int _gdialogInitFromScript(int headFid, HeadFidget reaction)
 {
     if (dialogMode == GAME_DIALOG_MODE_TALK) {
         return -1;
@@ -1005,11 +1005,11 @@ int _gdialogInitFromScript(Head head, HeadFidget reaction)
     // CE: Fix Barter button.
     _gdCreateHeadWindow();
     tickersAdd(gameDialogTicker);
-    _gdSetupFidget(head, reaction);
+    _gdSetupFidget(headFid, reaction);
     _gdialog_state = GAME_DIALOG_ACTIVE;
     _gmouse_disable_scrolling();
 
-    if (!headIsValid(head)) {
+    if (headFid == -1) {
         // SFALL: Fix the music volume when entering the dialog.
         gGameDialogOldMusicVolume = _gsound_background_volume_get_set(gMusicVolume / 2);
     } else {
@@ -2597,11 +2597,11 @@ void _gdDestroyHeadWindow()
 }
 
 // 0x447300
-void _gdSetupFidget(Head head, HeadFidget reaction)
+void _gdSetupFidget(int headFid, HeadFidget reaction)
 {
     gGameDialogFidgetFrmCurrentFrame = 0;
 
-    if (!headIsValid(head)) {
+    if (headFid == -1) {
         gGameDialogFidgetFid = -1;
         gGameDialogFidgetFrm = nullptr;
         gGameDialogFidgetFrmHandle = INVALID_CACHE_ENTRY;
@@ -2641,7 +2641,7 @@ void _gdSetupFidget(Head head, HeadFidget reaction)
 
     if (_lipsFID == 0) {
         _phone_anim = anim;
-        _lipsFID = buildFid(OBJ_TYPE_HEAD, head, anim);
+        _lipsFID = buildFid(OBJ_TYPE_HEAD, headFromFid(headFid), anim);
         _lipsFp = artLock(_lipsFID, &_lipsKey);
         if (_lipsFp == nullptr) {
             debugPrint("failure!\n");
@@ -2652,7 +2652,7 @@ void _gdSetupFidget(Head head, HeadFidget reaction)
         }
     }
 
-    int fid = buildFid(OBJ_TYPE_HEAD, head, reaction);
+    int fid = buildFid(OBJ_TYPE_HEAD, headFromFid(headFid), reaction);
     int fidgetCount = artGetFidgetCount(fid);
     if (fidgetCount == -1) {
         debugPrint("\tError - No available fidgets for given frame id\n");
@@ -2693,7 +2693,7 @@ void _gdSetupFidget(Head head, HeadFidget reaction)
         }
     }
 
-    gGameDialogFidgetFid = buildFid(OBJ_TYPE_HEAD, head, reaction, fidget);
+    gGameDialogFidgetFid = buildFid(OBJ_TYPE_HEAD, headFromFid(headFid), reaction, fidget);
     gGameDialogFidgetFrmCurrentFrame = 0;
     gGameDialogFidgetFrm = artLock(gGameDialogFidgetFid, &gGameDialogFidgetFrmHandle);
     if (gGameDialogFidgetFrm == nullptr) {
@@ -3026,7 +3026,7 @@ void gameDialogTicker()
             _can_start_new_fidget = false;
             _dialogue_seconds_since_last_input += _tocksWaiting / 1000;
             _tocksWaiting = 1000 * (randomBetween(0, 3) + 4);
-            _gdSetupFidget(headFromFid(gGameDialogFidgetFid), headFidgetFromFid(gGameDialogFidgetFid));
+            _gdSetupFidget(gGameDialogFidgetFid, headFidgetFromFid(gGameDialogFidgetFid));
         }
         return;
     }
@@ -3065,15 +3065,15 @@ void _talk_to_critter_reacts(int reaction)
         switch (gGameDialogFidgetReaction) {
         case FIDGET_GOOD:
             _gdPlayTransition(HEAD_ANIMATION_VERY_GOOD_REACTION);
-            _gdSetupFidget(headFromFid(gGameDialogHeadFid), FIDGET_GOOD);
+            _gdSetupFidget(gGameDialogHeadFid, FIDGET_GOOD);
             break;
         case FIDGET_NEUTRAL:
             _gdPlayTransition(HEAD_ANIMATION_NEUTRAL_TO_GOOD);
-            _gdSetupFidget(headFromFid(gGameDialogHeadFid), FIDGET_GOOD);
+            _gdSetupFidget(gGameDialogHeadFid, FIDGET_GOOD);
             break;
         case FIDGET_BAD:
             _gdPlayTransition(HEAD_ANIMATION_BAD_TO_NEUTRAL);
-            _gdSetupFidget(headFromFid(gGameDialogHeadFid), FIDGET_NEUTRAL);
+            _gdSetupFidget(gGameDialogHeadFid, FIDGET_NEUTRAL);
             break;
         default:
             break;
@@ -3085,15 +3085,15 @@ void _talk_to_critter_reacts(int reaction)
         switch (gGameDialogFidgetReaction) {
         case FIDGET_GOOD:
             _gdPlayTransition(HEAD_ANIMATION_GOOD_TO_NEUTRAL);
-            _gdSetupFidget(headFromFid(gGameDialogHeadFid), FIDGET_NEUTRAL);
+            _gdSetupFidget(gGameDialogHeadFid, FIDGET_NEUTRAL);
             break;
         case FIDGET_NEUTRAL:
             _gdPlayTransition(HEAD_ANIMATION_NEUTRAL_TO_BAD);
-            _gdSetupFidget(headFromFid(gGameDialogHeadFid), FIDGET_BAD);
+            _gdSetupFidget(gGameDialogHeadFid, FIDGET_BAD);
             break;
         case FIDGET_BAD:
             _gdPlayTransition(HEAD_ANIMATION_VERY_BAD_REACTION);
-            _gdSetupFidget(headFromFid(gGameDialogHeadFid), FIDGET_BAD);
+            _gdSetupFidget(gGameDialogHeadFid, FIDGET_BAD);
             break;
         default:
             break;

--- a/src/game_dialog.h
+++ b/src/game_dialog.h
@@ -20,7 +20,7 @@ void _gdialogSystemEnter();
 void gameDialogStartLips(const char* audioFileName);
 int gameDialogEnable();
 int gameDialogDisable();
-int _gdialogInitFromScript(int headFid, int reaction);
+int _gdialogInitFromScript(int headFid, HeadFidget reaction);
 int _gdialogExitFromScript();
 void gameDialogSetBackground(int background);
 void gameDialogRenderSupplementaryMessage(const char* msg);

--- a/src/game_dialog.h
+++ b/src/game_dialog.h
@@ -22,7 +22,7 @@ int gameDialogEnable();
 int gameDialogDisable();
 int _gdialogInitFromScript(int headFid, HeadFidget reaction);
 int _gdialogExitFromScript();
-void gameDialogSetBackground(int background);
+void gameDialogSetBackground(Background background);
 void gameDialogRenderSupplementaryMessage(const char* msg);
 int _gdialogStart();
 int _gdialogSayMessage();

--- a/src/game_dialog.h
+++ b/src/game_dialog.h
@@ -20,7 +20,7 @@ void _gdialogSystemEnter();
 void gameDialogStartLips(const char* audioFileName);
 int gameDialogEnable();
 int gameDialogDisable();
-int _gdialogInitFromScript(int headFid, HeadFidget reaction);
+int _gdialogInitFromScript(Head head, HeadFidget reaction);
 int _gdialogExitFromScript();
 void gameDialogSetBackground(Background background);
 void gameDialogRenderSupplementaryMessage(const char* msg);

--- a/src/game_dialog.h
+++ b/src/game_dialog.h
@@ -20,7 +20,7 @@ void _gdialogSystemEnter();
 void gameDialogStartLips(const char* audioFileName);
 int gameDialogEnable();
 int gameDialogDisable();
-int _gdialogInitFromScript(Head head, HeadFidget reaction);
+int _gdialogInitFromScript(int headFid, HeadFidget reaction);
 int _gdialogExitFromScript();
 void gameDialogSetBackground(Background background);
 void gameDialogRenderSupplementaryMessage(const char* msg);

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -1919,7 +1919,7 @@ static void opAttackComplex(Program* program)
 // 0x456DF0 op_start_gdialog
 static void opStartGameDialog(Program* program)
 {
-    int backgroundId = programStackPopInteger(program);
+    Background background = static_cast<Background>(programStackPopInteger(program)); // no valiadation here as called often with -1
     int headId = programStackPopInteger(program);
     int reactionLevel = programStackPopInteger(program);
     Object* obj = static_cast<Object*>(programStackPopPointer(program));
@@ -1946,7 +1946,7 @@ static void opStartGameDialog(Program* program)
         gGameDialogHeadFid = buildFid(OBJ_TYPE_HEAD, headId);
     }
 
-    gameDialogSetBackground(backgroundId);
+    gameDialogSetBackground(background);
     gGameDialogReactionOrFidget = reactionLevel;
 
     // SFALL: Use the start_gdialog target instead of the current dialog target,

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -1971,7 +1971,7 @@ static void opStartGameDialog(Program* program)
 
     gGameDialogSid = scriptGetSid(program);
     gGameDialogSpeaker = scriptGetSelf(program);
-    _gdialogInitFromScript(gGameDialogHeadFid, gGameDialogReactionOrFidget);
+    _gdialogInitFromScript(gGameDialogHeadFid, static_cast<HeadFidget>(gGameDialogReactionOrFidget));
 }
 
 // end_dialogue

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -1971,7 +1971,7 @@ static void opStartGameDialog(Program* program)
 
     gGameDialogSid = scriptGetSid(program);
     gGameDialogSpeaker = scriptGetSelf(program);
-    _gdialogInitFromScript(headFromFid(gGameDialogHeadFid), static_cast<HeadFidget>(gGameDialogReactionOrFidget));
+    _gdialogInitFromScript(gGameDialogHeadFid, static_cast<HeadFidget>(gGameDialogReactionOrFidget));
 }
 
 // end_dialogue

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -1920,7 +1920,7 @@ static void opAttackComplex(Program* program)
 static void opStartGameDialog(Program* program)
 {
     Background background = static_cast<Background>(programStackPopInteger(program)); // no valiadation here as called often with -1
-    int headId = programStackPopInteger(program);
+    Head head = static_cast<Head>(programStackPopInteger(program)); // no valiadation here as called often with -1
     int reactionLevel = programStackPopInteger(program);
     Object* obj = static_cast<Object*>(programStackPopPointer(program));
     programStackPopInteger(program);
@@ -1942,8 +1942,8 @@ static void opStartGameDialog(Program* program)
         }
     }
 
-    if (headId != -1) {
-        gGameDialogHeadFid = buildFid(OBJ_TYPE_HEAD, headId);
+    if (headIsValid(head)) {
+        gGameDialogHeadFid = buildFid(OBJ_TYPE_HEAD, head);
     }
 
     gameDialogSetBackground(background);
@@ -1971,7 +1971,7 @@ static void opStartGameDialog(Program* program)
 
     gGameDialogSid = scriptGetSid(program);
     gGameDialogSpeaker = scriptGetSelf(program);
-    _gdialogInitFromScript(gGameDialogHeadFid, static_cast<HeadFidget>(gGameDialogReactionOrFidget));
+    _gdialogInitFromScript(headFromFid(gGameDialogHeadFid), static_cast<HeadFidget>(gGameDialogReactionOrFidget));
 }
 
 // end_dialogue

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -1919,8 +1919,8 @@ static void opAttackComplex(Program* program)
 // 0x456DF0 op_start_gdialog
 static void opStartGameDialog(Program* program)
 {
-    Background background = static_cast<Background>(programStackPopInteger(program)); // no valiadation here as called often with -1
-    Head head = static_cast<Head>(programStackPopInteger(program)); // no valiadation here as called often with -1
+    Background background = static_cast<Background>(programStackPopInteger(program)); // no validation here as called often with -1
+    Head head = static_cast<Head>(programStackPopInteger(program)); // no validation here as called often with -1
     int reactionLevel = programStackPopInteger(program);
     Object* obj = static_cast<Object*>(programStackPopPointer(program));
     programStackPopInteger(program);


### PR DESCRIPTION
### Description

Another bunch of typesafe usages of `AudioFlags`, `AudioOpenMode`, `CacheEntryFlags`, `HeadFidget`, `Background`, `HeadAnimation` and `Head` enums.

Had to extract `HeadFidget` values from `HeadAnimation` as it's handled independently.

Removed the `_COUNT` guards from `Head` and `Background` enums as those are overridable in TC mods thus it means that enum value naming convention is valid only for vanilla or RPU. That's also the reason why `headIsValid` and `backgroundIsValid` functions are checking only the lower bound.

Fixed behavior in `gameDialogTicker` where potentially invalid `gGameDialogFidgetFid == -1` would be translated to `4095` due to the  `gGameDialogFidgetFid & 0xFFF` and the check `headFid == -1` in `_gdSetupFidget` would not stop it. 

This is related to #668