### PR TITLE
Fix start time of RPU

### DIFF
--- a/SFALL_COMPATIBILITY.md
+++ b/SFALL_COMPATIBILITY.md
@@ -43,6 +43,10 @@ The following settings were moved into [`<DAT>/config/game.cfg`](files/ce.dat/co
 | ddraw.ini section | ddraw.ini key | game.cfg section | game.cfg key |
 | --- | --- | --- | --- |
 | `Misc` | `StartingMap` | `start` | `map` |
+| `Misc` | `StartYear` | `start` | `year` |
+| `Misc` | `StartMonth` | `start` | `month` |
+| `Misc` | `StartDay` | `start` | `day` |
+| `Misc` | `StartTime` | `start` | `time` |
 | `Misc` | `StartXPos` | `start` | `worldmap_x` |
 | `Misc` | `StartYPos` | `start` | `worldmap_y` |
 | `Misc` | `ViewXPos` | `start` | `worldmap_view_x` |

--- a/src/config.cc
+++ b/src/config.cc
@@ -35,6 +35,7 @@ static bool configParseLine(Config* config, char* string);
 static bool configParseKeyValue(char* string, std::string& key, std::string& value);
 static bool configEnsureSectionExists(Config* config, const char* sectionKey);
 static bool configTrimString(char* string);
+static bool configGetIntImpl(Config* config, const char* sectionKey, const char* key, int* valuePtr, int base);
 static std::string configGetTrimmedString(const char* string);
 
 static bool configWriteDb(Config* config, const char* filePath);
@@ -217,7 +218,12 @@ bool configSetString(Config* config, const char* sectionKey, const char* key, co
 }
 
 // 0x42C05C
-bool configGetInt(Config* config, const char* sectionKey, const char* key, int* valuePtr, unsigned char base /* = 0 */)
+bool configGetInt(Config* config, const char* sectionKey, const char* key, int* valuePtr)
+{
+    return configGetIntImpl(config, sectionKey, key, valuePtr, 0);
+}
+
+static bool configGetIntImpl(Config* config, const char* sectionKey, const char* key, int* valuePtr, int base)
 {
     if (valuePtr == nullptr) {
         return false;
@@ -248,12 +254,17 @@ bool configGetInt(Config* config, const char* sectionKey, const char* key, int* 
     return true;
 }
 
-bool configGetInt(Config* config, const char* sectionKey, const char* key, int* valuePtr, const int defaultValue, unsigned char base)
+bool configGetInt(Config* config, const char* sectionKey, const char* key, int* valuePtr, const int defaultValue)
+{
+    return configGetIntBase(config, sectionKey, key, valuePtr, defaultValue, 0);
+}
+
+bool configGetIntBase(Config* config, const char* sectionKey, const char* key, int* valuePtr, const int defaultValue, int base)
 {
     if (config == nullptr || sectionKey == nullptr || key == nullptr || valuePtr == nullptr) {
         return false;
     }
-    if (!configGetInt(config, sectionKey, key, valuePtr, base)) {
+    if (!configGetIntImpl(config, sectionKey, key, valuePtr, base)) {
         *valuePtr = defaultValue;
     }
     return true;

--- a/src/config.h
+++ b/src/config.h
@@ -40,14 +40,15 @@ bool configGetString(Config* config, const char* sectionKey, const char* key, ch
 // No copy is performed. The returned pointer may refer either to an internal string or to defaultValue; it must be treated as read-only, and callers must ensure defaultValue remains valid for the duration of use.
 bool configGetString(Config* config, const char* sectionKey, const char* key, char** valuePtr, const char* defaultValue);
 bool configSetString(Config* config, const char* sectionKey, const char* key, const char* value);
-bool configGetInt(Config* config, const char* sectionKey, const char* key, int* valuePtr, unsigned char base = 0);
-bool configGetInt(Config* config, const char* sectionKey, const char* key, int* valuePtr, int defaultValue, unsigned char base = 0);
+bool configGetInt(Config* config, const char* sectionKey, const char* key, int* valuePtr);
+bool configGetInt(Config* config, const char* sectionKey, const char* key, int* valuePtr, int defaultValue);
+bool configGetIntBase(Config* config, const char* sectionKey, const char* key, int* valuePtr, int defaultValue, int base);
 
 template <typename T>
-inline bool configGetEnum(Config* config, const char* sectionKey, const char* key, T* valuePtr, unsigned char base = 0)
+inline bool configGetEnum(Config* config, const char* sectionKey, const char* key, T* valuePtr)
 {
     int temp = 0;
-    bool result = configGetInt(config, sectionKey, key, &temp, base);
+    bool result = configGetInt(config, sectionKey, key, &temp);
     if (result) {
         *valuePtr = static_cast<T>(temp);
     }
@@ -56,10 +57,10 @@ inline bool configGetEnum(Config* config, const char* sectionKey, const char* ke
 }
 
 template <typename T>
-inline bool configGetEnum(Config* config, const char* sectionKey, const char* key, T* valuePtr, T defaultValue, unsigned char base = 0)
+inline bool configGetEnum(Config* config, const char* sectionKey, const char* key, T* valuePtr, T defaultValue)
 {
     int temp = 0;
-    bool result = configGetInt(config, sectionKey, key, &temp, static_cast<int>(defaultValue), base);
+    bool result = configGetInt(config, sectionKey, key, &temp, static_cast<int>(defaultValue));
     if (result) {
         *valuePtr = static_cast<T>(temp);
     }

--- a/src/game_config_migration.cc
+++ b/src/game_config_migration.cc
@@ -354,10 +354,9 @@ static bool contentConfigMigrateFromSfall(Config* sfallConfig, const char* conte
     // Migrate start date/time only when explicitly set (not the sfall -1 sentinel).
     auto migrateStartInt = [&](const char* sfallKey, const char* targetKey, int defaultValue) {
         int value;
-        if (configGetInt(sfallConfig, kSfallMisc, sfallKey, &value, 10) && value >= 0 && value != defaultValue) {
-            char buf[32];
-            snprintf(buf, sizeof(buf), "%d", value);
-            configSetString(&migratedConfig, CONTENT_CONFIG_START_SECTION, targetKey, buf);
+        configGetIntBase(sfallConfig, kSfallMisc, sfallKey, &value, -1, 10);
+        if (value >= 0 && value != defaultValue) {
+            configSetInt(&migratedConfig, CONTENT_CONFIG_START_SECTION, targetKey, value);
             migrated = true;
         }
     };

--- a/src/scripts.cc
+++ b/src/scripts.cc
@@ -1843,11 +1843,11 @@ int scriptsInit()
 
     messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_SCRIPT, &gScrMessageList);
 
-    configGetInt(&gContentConfig, CONTENT_CONFIG_START_SECTION, "year", &gStartYear, 2241);
-    configGetInt(&gContentConfig, CONTENT_CONFIG_START_SECTION, "month", &gStartMonth, 6);
-    configGetInt(&gContentConfig, CONTENT_CONFIG_START_SECTION, "day", &gStartDay, 24);
+    configGetIntBase(&gContentConfig, CONTENT_CONFIG_START_SECTION, "year", &gStartYear, 2241, 10);
+    configGetIntBase(&gContentConfig, CONTENT_CONFIG_START_SECTION, "month", &gStartMonth, 6, 10);
+    configGetIntBase(&gContentConfig, CONTENT_CONFIG_START_SECTION, "day", &gStartDay, 24, 10);
     int startTime;
-    configGetInt(&gContentConfig, CONTENT_CONFIG_START_SECTION, "time", &startTime, kDefaultStartTime, 10);
+    configGetIntBase(&gContentConfig, CONTENT_CONFIG_START_SECTION, "time", &startTime, kDefaultStartTime, 10);
     int startTimeHour = startTime / 100;
     int startTimeMinute = startTime % 100;
     if (startTimeHour < 0 || startTimeHour > 23 || startTimeMinute < 0 || startTimeMinute > 59) {


### PR DESCRIPTION
The config reading functions where interpreting base (10) as default values.  Fixed the api shape so that isn't an easy mistake to make in the future
