### PR TITLE
adds ui cursor pump for game loads

### DIFF
--- a/src/game.cc
+++ b/src/game.cc
@@ -1759,17 +1759,17 @@ void renderLoadingScreenCursor()
     }
     lastRenderTime = currentTime;
 
-    // 1. Wipe out any partial map rendering by restoring the clean menu background
+    // Wipe out any partial map rendering by restoring the clean menu background
     restoreLoadingScreenFreeze();
 
-    // 2. Leverage original Fallout GNW blitters to draw the animated planet/spinner
+    // Set mouse position
     SDL_PumpEvents();
     int x, y;
     SDL_GetMouseState(&x, &y);
     _mouse_set_position(x, y);
     mouseShowCursor();
 
-    // 3. Present the compiled frame onto the display
+    // Present the compiled frame onto the display
     renderPresent();
 }
 

--- a/src/game.cc
+++ b/src/game.cc
@@ -1743,25 +1743,13 @@ void gameHandleSkilldexResult(SkilldexRC rc)
 
 void renderLoadingScreenCursor()
 {
-    // Safety check: Exit immediately if the freeze buffer wasn't initialized,
+    // Exit immediately if the freeze buffer wasn't initialized,
     // or if the function is accidentally called outside the loading sequence.
     if (gLoadingScreenPixelsBackup == nullptr || gSdlTextureSurface == nullptr || gSdlTextureSurface->pixels == nullptr) {
         return;
     }
-
-    // Frame rate throttling to achieve ~60 FPS for the spinner animation
-    static uint32_t lastRenderTime = 0;
-    uint32_t currentTime = SDL_GetTicks();
-
-    // If less than 16ms passed since the last frame, skip rendering to prevent GPU overhead
-    if (currentTime - lastRenderTime < 16) {
-        return;
-    }
-    lastRenderTime = currentTime;
-
     // Wipe out any partial map rendering by restoring the clean menu background
     restoreLoadingScreenFreeze();
-
     // Set mouse position
     SDL_PumpEvents();
     int x, y;

--- a/src/game.cc
+++ b/src/game.cc
@@ -1741,4 +1741,37 @@ void gameHandleSkilldexResult(SkilldexRC rc)
     }
 }
 
+void renderLoadingScreenCursor()
+{
+    // Safety check: Exit immediately if the freeze buffer wasn't initialized,
+    // or if the function is accidentally called outside the loading sequence.
+    if (gLoadingScreenPixelsBackup == nullptr || gSdlTextureSurface == nullptr || gSdlTextureSurface->pixels == nullptr) {
+        return;
+    }
+
+    // Frame rate throttling to achieve ~60 FPS for the spinner animation
+    static uint32_t lastRenderTime = 0;
+    uint32_t currentTime = SDL_GetTicks();
+
+    // If less than 16ms passed since the last frame, skip rendering to prevent GPU overhead
+    if (currentTime - lastRenderTime < 16) {
+        return;
+    }
+    lastRenderTime = currentTime;
+
+    // Optional: Forcefully sync mouse state from OS if the hardware cursor lag becomes noticeable
+    // int x, y;
+    // SDL_GetMouseState(&x, &y);
+    // gMouseCursorX = x; gMouseCursorY = y;
+
+    // 1. Wipe out any partial map rendering by restoring the clean menu background
+    restoreLoadingScreenFreeze();
+
+    // 2. Leverage original Fallout GNW blitters to draw the animated planet/spinner
+    mouseShowCursor();
+
+    // 3. Present the compiled frame onto the display
+    renderPresent();
+}
+
 } // namespace fallout

--- a/src/game.cc
+++ b/src/game.cc
@@ -1759,15 +1759,14 @@ void renderLoadingScreenCursor()
     }
     lastRenderTime = currentTime;
 
-    // Optional: Forcefully sync mouse state from OS if the hardware cursor lag becomes noticeable
-    // int x, y;
-    // SDL_GetMouseState(&x, &y);
-    // gMouseCursorX = x; gMouseCursorY = y;
-
     // 1. Wipe out any partial map rendering by restoring the clean menu background
     restoreLoadingScreenFreeze();
 
     // 2. Leverage original Fallout GNW blitters to draw the animated planet/spinner
+    SDL_PumpEvents();
+    int x, y;
+    SDL_GetMouseState(&x, &y);
+    _mouse_set_position(x, y);
     mouseShowCursor();
 
     // 3. Present the compiled frame onto the display

--- a/src/game.h
+++ b/src/game.h
@@ -105,6 +105,8 @@ private:
     int gameMode;
 };
 
+void renderLoadingScreenCursor();
+
 } // namespace fallout
 
 #endif /* GAME_H */

--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -1987,8 +1987,13 @@ static int lsgLoadGameInSlot(int slot)
     if (isInCombat()) {
         interfaceBarEndButtonsHide(false);
         _combat_over_from_load();
-        gameMouseSetCursor(MOUSE_CURSOR_WAIT_PLANET);
     }
+
+    // Snapshot the screen layout right before the asset parsing begins
+    initLoadingScreenFreeze();
+
+    // Switch cursor look to the planet spinner
+    gameMouseSetCursor(MOUSE_CURSOR_WAIT_PLANET);
 
     // SFALL: Call "before start" event
     sfallOnBeforeGameStart();
@@ -2019,6 +2024,9 @@ static int lsgLoadGameInSlot(int slot)
     debugPrint("LOADSAVE: Load file header size read: %d bytes.\n", fileTell(_flptr) - pos);
 
     for (int index = 0; index < LOAD_SAVE_HANDLER_COUNT; index += 1) {
+        // Keep the cursor responsive and planet spinning between sub-system reads
+        renderLoadingScreenCursor();
+
         long pos = fileTell(_flptr);
         LoadGameHandler* handler = _master_load_list[index];
         if (handler(_flptr) == -1) {
@@ -2029,6 +2037,7 @@ static int lsgLoadGameInSlot(int slot)
             gameReset();
             _loadingGame = false;
             _loadingMapId = -1;
+            freeLoadingScreenFreeze();
             return -1;
         }
 
@@ -2036,6 +2045,8 @@ static int lsgLoadGameInSlot(int slot)
     }
 
     _loadingMapId = -1;
+    // Clean up the backup textures as we are ready to reveal the loaded map
+    freeLoadingScreenFreeze();
 
     debugPrint("LOADSAVE: Total load data read: %ld bytes.\n", fileTell(_flptr));
     fileClose(_flptr);
@@ -2955,6 +2966,8 @@ static int _SlotMap2Game(File* stream)
             debugPrint("LOADSAVE: returning 7\n");
             return -1;
         }
+
+        renderLoadingScreenCursor();
     }
 
     const char* automapFileName = _strmfe(_str1, "AUTOMAP.DB", "SAV");

--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -2966,8 +2966,6 @@ static int _SlotMap2Game(File* stream)
             debugPrint("LOADSAVE: returning 7\n");
             return -1;
         }
-
-        renderLoadingScreenCursor();
     }
 
     const char* automapFileName = _strmfe(_str1, "AUTOMAP.DB", "SAV");

--- a/src/svga.cc
+++ b/src/svga.cc
@@ -422,6 +422,7 @@ unsigned char* gLoadingScreenPixelsBackup = nullptr;
 
 void initLoadingScreenFreeze()
 {
+    mouseHideCursor();
     // Calculate the total size of the screen surface buffer
     gLoadingScreenBackupSize = gSdlTextureSurface->pitch * gSdlTextureSurface->h;
 
@@ -450,6 +451,8 @@ void freeLoadingScreenFreeze()
     if (gLoadingScreenPixelsBackup != nullptr) {
         free(gLoadingScreenPixelsBackup);
         gLoadingScreenPixelsBackup = nullptr;
+
+        mouseShowCursor();
     }
 }
 

--- a/src/svga.cc
+++ b/src/svga.cc
@@ -416,4 +416,41 @@ void renderPresent()
     SDL_RenderPresent(gSdlRenderer);
 }
 
+// Buffer size and raw pixel data for freezing the loading screen
+static int gLoadingScreenBackupSize = 0;
+unsigned char* gLoadingScreenPixelsBackup = nullptr;
+
+void initLoadingScreenFreeze()
+{
+    // Calculate the total size of the screen surface buffer
+    gLoadingScreenBackupSize = gSdlTextureSurface->pitch * gSdlTextureSurface->h;
+
+    if (gLoadingScreenPixelsBackup != nullptr) {
+        free(gLoadingScreenPixelsBackup);
+    }
+
+    // Allocate memory and make a deep copy of clean screen pixels
+    gLoadingScreenPixelsBackup = (unsigned char*)malloc(gLoadingScreenBackupSize);
+    if (gSdlTextureSurface->pixels && gLoadingScreenPixelsBackup) {
+        memcpy(gLoadingScreenPixelsBackup, gSdlTextureSurface->pixels, gLoadingScreenBackupSize);
+    }
+}
+
+void restoreLoadingScreenFreeze()
+{
+    // Completely overwrite any intermediate map loading artifacts
+    // with the original frozen menu pixels before drawing the cursor
+    if (gSdlTextureSurface->pixels && gLoadingScreenPixelsBackup) {
+        memcpy(gSdlTextureSurface->pixels, gLoadingScreenPixelsBackup, gLoadingScreenBackupSize);
+    }
+}
+
+void freeLoadingScreenFreeze()
+{
+    if (gLoadingScreenPixelsBackup != nullptr) {
+        free(gLoadingScreenPixelsBackup);
+        gLoadingScreenPixelsBackup = nullptr;
+    }
+}
+
 } // namespace fallout

--- a/src/svga.cc
+++ b/src/svga.cc
@@ -439,7 +439,7 @@ void initLoadingScreenFreeze()
 
 void restoreLoadingScreenFreeze()
 {
-    // Completely overwrite any intermediate map loading artifacts
+    // Overwrite any intermediate map loading artifacts
     // with the original frozen menu pixels before drawing the cursor
     if (gSdlTextureSurface->pixels && gLoadingScreenPixelsBackup) {
         memcpy(gSdlTextureSurface->pixels, gLoadingScreenPixelsBackup, gLoadingScreenBackupSize);

--- a/src/svga.h
+++ b/src/svga.h
@@ -19,6 +19,18 @@ extern SDL_Texture* gSdlTexture;
 extern SDL_Surface* gSdlTextureSurface;
 extern FpsLimiter sharedFpsLimiter;
 
+// Safely backed up pixels of the interface before heavy loading starts
+extern unsigned char* gLoadingScreenPixelsBackup;
+
+// Allocates memory and takes a deep snapshot of the current screen surface
+void initLoadingScreenFreeze();
+
+// Restores the screen surface back to the clean snapshot state
+void restoreLoadingScreenFreeze();
+
+// Frees the allocated loading screen backup buffer
+void freeLoadingScreenFreeze();
+
 enum class WindowMode : int {
     Fullscreen = 0,
     Windowed = 1,


### PR DESCRIPTION
Hi everyone!
So the idea is to make loading screen a little bit more responsive (because right now it's somewhat choppy: interface freezes for a while (especially on a larger maps (at least on linux)).

To do that we would need to pump cursor movement through loading sequence, which is ofc very complicated. So I was thinking of adding a call `renderLoadingScreenCursor()` that could be potentially safely added to larger loops (later).

The idea is that we copy loading screen pixels initially and render cursor on top of that (so that user doesn't see parts of map loading in case of normal `renderPresent()`.

The change is purely for the sake of aesthetics so nothing  critical/important ofc.

EDIT:
I've removed throttling to keep it as simple as possible, the call was only added to `master_load` sequence loop. It makes loading look a little bit better on linux, potentially I'm thinking this could be used elsewhere if we make it safer