### PR TITLE
Ability to override window title

### DIFF
--- a/files/ce.dat/config/game.cfg
+++ b/files/ce.dat/config/game.cfg
@@ -55,6 +55,10 @@ gender_words=0
 ; When set to 0, CE still applies sfall's crash fix for calling start_gdialog outside talk_p_proc.
 start_gdialog_fix=0
 
+[misc]
+; Custom title for the OS window in windowed mode. Falls back to version_string when empty.
+window_title=
+
 [main_menu]
 ; Custom version string shown on the main menu. Supports up to two %d placeholders for the game version numbers.
 ; Example: FALLOUT II v1.02d

--- a/src/content_config.h
+++ b/src/content_config.h
@@ -10,6 +10,7 @@ namespace fallout {
 #define CONTENT_CONFIG_ITEMS_SECTION "items"
 #define CONTENT_CONFIG_MAPS_SECTION "maps"
 #define CONTENT_CONFIG_DIALOG_SECTION "dialog"
+#define CONTENT_CONFIG_MISC_SECTION "misc"
 #define CONTENT_CONFIG_MAIN_MENU_SECTION "main_menu"
 #define CONTENT_CONFIG_SOUND_SECTION "sound"
 #define CONTENT_CONFIG_MOVIES_SECTION "movies"

--- a/src/game.cc
+++ b/src/game.cc
@@ -167,24 +167,22 @@ int gameInitWithOptions(const char* windowTitle, bool isMapper, int font, int fl
     // it should be initialized early in the process.
     messageListRepositoryInit();
 
-    const char* programWindowTitle = windowTitle;
+    programWindowSetTitle(windowTitle);
+
+    const char* visibleWindowTitle = windowTitle;
     char versionWindowTitle[256];
     if (settings.screen.windowed == WindowMode::Windowed) {
         char* configuredWindowTitle = nullptr;
         configGetString(&gContentConfig, CONTENT_CONFIG_MISC_SECTION, "window_title", &configuredWindowTitle, "");
         if (configuredWindowTitle != nullptr && configuredWindowTitle[0] != '\0') {
-            programWindowTitle = configuredWindowTitle;
+            visibleWindowTitle = configuredWindowTitle;
         } else {
-            char* versionString = nullptr;
-            configGetString(&gContentConfig, CONTENT_CONFIG_MAIN_MENU_SECTION, "version_string", &versionString, "");
-            if (versionString != nullptr && versionString[0] != '\0') {
-                versionGetVersion(versionWindowTitle, sizeof(versionWindowTitle));
-                programWindowTitle = versionWindowTitle;
-            }
+            versionGetVersion(versionWindowTitle, sizeof(versionWindowTitle));
+            visibleWindowTitle = versionWindowTitle;
         }
     }
 
-    programWindowSetTitle(programWindowTitle);
+    programWindowSetTitle(visibleWindowTitle);
     windowInit(1, flags);
     paletteInit();
 

--- a/src/game.cc
+++ b/src/game.cc
@@ -167,7 +167,24 @@ int gameInitWithOptions(const char* windowTitle, bool isMapper, int font, int fl
     // it should be initialized early in the process.
     messageListRepositoryInit();
 
-    programWindowSetTitle(windowTitle);
+    const char* programWindowTitle = windowTitle;
+    char versionWindowTitle[256];
+    if (settings.screen.windowed == WindowMode::Windowed) {
+        char* configuredWindowTitle = nullptr;
+        configGetString(&gContentConfig, CONTENT_CONFIG_MISC_SECTION, "window_title", &configuredWindowTitle, "");
+        if (configuredWindowTitle != nullptr && configuredWindowTitle[0] != '\0') {
+            programWindowTitle = configuredWindowTitle;
+        } else {
+            char* versionString = nullptr;
+            configGetString(&gContentConfig, CONTENT_CONFIG_MAIN_MENU_SECTION, "version_string", &versionString, "");
+            if (versionString != nullptr && versionString[0] != '\0') {
+                versionGetVersion(versionWindowTitle, sizeof(versionWindowTitle));
+                programWindowTitle = versionWindowTitle;
+            }
+        }
+    }
+
+    programWindowSetTitle(programWindowTitle);
     windowInit(1, flags);
     paletteInit();
 


### PR DESCRIPTION
Falls back to `version_string`

<img width="383" height="194" alt="image" src="https://github.com/user-attachments/assets/551a962b-61bf-4af6-92a4-8d41a1b73afe" />

<img width="493" height="209" alt="image" src="https://github.com/user-attachments/assets/6d6077d3-d675-4b49-98cd-09cdf11072c5" />


