### PR TITLE
Optional FPS counter

### DIFF
--- a/files/fallout2.cfg
+++ b/files/fallout2.cfg
@@ -2,6 +2,8 @@
 ; disturbing your game config, copy everything from [ui] and [qol] into your fallout2.cfg
 
 [debug]
+; Set to 1 to show an FPS counter in the top-left corner during gameplay and worldmap.
+show_fps=0
 ;Set this to a valid path to save a copy of the console contents
 console_output_path=
 mode=log

--- a/src/main.cc
+++ b/src/main.cc
@@ -461,6 +461,7 @@ static void mainLoop()
             _game_user_wants_to_quit = GAME_QUIT_REQUEST_MAIN_MENU;
         }
 
+        renderFpsCounter();
         renderPresent();
         sharedFpsLimiter.throttle();
     }

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -235,6 +235,7 @@ void initSettingsRegistry(bool isMapper)
 
 #define SECT debug
     SETTING(mode);
+    SETTING(show_fps);
     SETTING(show_tile_num);
     SETTING(show_script_messages);
     SETTING(show_load_info);

--- a/src/settings.h
+++ b/src/settings.h
@@ -152,6 +152,7 @@ struct SoundSettings {
 
 struct DebugSettings {
     std::string mode = "environment";
+    bool show_fps = false;
     bool show_tile_num = false;
     bool show_script_messages = false;
     bool show_load_info = false;

--- a/src/svga.cc
+++ b/src/svga.cc
@@ -6,8 +6,8 @@
 
 #include <SDL.h>
 
-#include "config.h"
 #include "color.h"
+#include "config.h"
 #include "dinput.h"
 #include "draw.h"
 #include "game.h"
@@ -463,7 +463,6 @@ void renderFpsCounter()
     rect.w = width;
     rect.h = height;
     SDL_BlitSurface(gSdlSurface, &rect, gSdlTextureSurface, &rect);
-
 }
 
 void renderPresent()

--- a/src/svga.cc
+++ b/src/svga.cc
@@ -1,11 +1,13 @@
 #include "svga.h"
 
 #include <limits.h>
+#include <stdio.h>
 #include <string.h>
 
 #include <SDL.h>
 
 #include "config.h"
+#include "color.h"
 #include "dinput.h"
 #include "draw.h"
 #include "game.h"
@@ -15,6 +17,7 @@
 #include "movie.h"
 #include "scan_unimplemented.h"
 #include "settings.h"
+#include "text_font.h"
 #include "tile.h"
 #include "win32.h"
 #include "window_manager.h"
@@ -404,6 +407,63 @@ void handleWindowSizeChanged()
     destroyRenderer();
     createRenderer(screenGetWidth(), screenGetHeight());
     mouseDeviceRefreshWindowMapping();
+}
+
+void renderFpsCounter()
+{
+    if (!settings.debug.show_fps || gSdlSurface == nullptr || gSdlTextureSurface == nullptr || fontDrawText == nullptr) {
+        return;
+    }
+
+    static unsigned int sampleStartTicks = 0;
+    static int sampleFrames = 0;
+    static double fps = 0.0;
+
+    unsigned int now = SDL_GetTicks();
+    if (sampleStartTicks == 0) {
+        sampleStartTicks = now;
+    }
+
+    sampleFrames++;
+
+    unsigned int elapsed = now - sampleStartTicks;
+    if (elapsed >= 500) {
+        fps = sampleFrames * 1000.0 / elapsed;
+        sampleFrames = 0;
+        sampleStartTicks = now;
+    }
+
+    char text[32];
+    snprintf(text, sizeof(text), "FPS: %.1f", fps);
+
+    ScopedFont font(101);
+
+    constexpr int kPadding = 2;
+    int textWidth = fontGetStringWidth(text);
+    int textHeight = fontGetLineHeight();
+    int width = textWidth + kPadding * 2;
+    int height = textHeight + kPadding * 2;
+
+    if (width > gSdlSurface->w) {
+        width = gSdlSurface->w;
+    }
+
+    if (height > gSdlSurface->h) {
+        height = gSdlSurface->h;
+    }
+
+    bufferFill(static_cast<unsigned char*>(gSdlSurface->pixels), width, height, gSdlSurface->pitch, COLOR_BLACK);
+    if (width > kPadding * 2 && height > kPadding * 2) {
+        fontDrawText(static_cast<unsigned char*>(gSdlSurface->pixels) + gSdlSurface->pitch * kPadding + kPadding, text, width - kPadding * 2, gSdlSurface->pitch, COLOR_LIGHT_GREY);
+    }
+
+    SDL_Rect rect;
+    rect.x = 0;
+    rect.y = 0;
+    rect.w = width;
+    rect.h = height;
+    SDL_BlitSurface(gSdlSurface, &rect, gSdlTextureSurface, &rect);
+
 }
 
 void renderPresent()

--- a/src/svga.h
+++ b/src/svga.h
@@ -50,6 +50,7 @@ int screenGetWidth();
 int screenGetHeight();
 int screenGetVisibleHeight();
 void handleWindowSizeChanged();
+void renderFpsCounter();
 void renderPresent();
 bool screenIsExclusiveFullscreen();
 

--- a/src/worldmap.cc
+++ b/src/worldmap.cc
@@ -3536,6 +3536,7 @@ static int wmWorldMapFunc(int a1)
                 if (!wmGenData.isWalking && !mousePressed && abs(wmGenData.worldPosX - worldX) < 5 && abs(wmGenData.worldPosY - worldY) < 5) {
                     mousePressed = true;
                     wmInterfaceRefresh();
+                    renderFpsCounter();
                     renderPresent();
                 }
             } else {
@@ -3691,6 +3692,7 @@ static int wmWorldMapFunc(int a1)
             break;
         }
 
+        renderFpsCounter();
         renderPresent();
         sharedFpsLimiter.throttle();
     }
@@ -6589,6 +6591,7 @@ static int wmTownMapFunc(int* mapIdxPtr)
             }
         }
 
+        renderFpsCounter();
         renderPresent();
         sharedFpsLimiter.throttle();
     }


### PR DESCRIPTION
<img width="507" height="349" alt="image" src="https://github.com/user-attachments/assets/15153685-a399-4cae-9784-3099b3340cab" />

Enable using `[debug] show_fps=1`

This is to make it easier to see when fps is struggling.  It's not in every game loop (Fallout has dozens), but it's easy enough to add to new places if needed