### PR TITLE
Allow premade characters with less than 2 traits

### DIFF
--- a/src/character_selector.cc
+++ b/src/character_selector.cc
@@ -866,10 +866,13 @@ static bool characterSelectorWindowRenderStats()
     traitsGetSelected(&(traits[0]), &(traits[1]));
 
     for (int index = 0; index < TRAITS_MAX_SELECTED_COUNT; index++) {
-        y += vh;
-
         str = traitGetName(traits[index]);
+        if (str == nullptr) {
+            continue;
+        }
         strcpy(text, str);
+
+        y += vh;
 
         length = fontGetStringWidth(text);
         fontDrawText(gCharacterSelectorWindowBuffer + CS_WINDOW_WIDTH * y + CS_WINDOW_SECONDARY_STAT_MID_X - length, text, length, CS_WINDOW_WIDTH, COLOR_GREEN);


### PR DESCRIPTION
Porting a tweak I made in sfall. Originally, a premade character must have two traits, or the game will crash upon switching to the character. Now people can create their premade characters without having to select two traits.
<img width="640" height="480" alt="scr00004" src="https://github.com/user-attachments/assets/52379c9f-8a81-415b-8582-fd0b809c0790" />

Premade character file for testing: [premade_stealth.zip](https://github.com/user-attachments/files/31209092/premade_stealth.zip)