### PR TITLE
Port selected fission stability fixes

### DIFF
--- a/src/animation.cc
+++ b/src/animation.cc
@@ -1878,6 +1878,10 @@ int pathfinderFindPath(Object* object, int from, int to, unsigned char* rotation
 
         for (Rotation rotation = ROTATION_FIRST; rotation < ROTATION_COUNT; rotation++) {
             int tile = tileGetTileInDirection(temp.tile, rotation, 1);
+            if (tile < 0 || tile >= HEX_GRID_SIZE) {
+                continue;
+            }
+
             int bit = 1 << (tile & 7);
             if ((gPathfinderProcessedTiles[tile / 8] & bit) != 0) {
                 continue;
@@ -1903,6 +1907,10 @@ int pathfinderFindPath(Object* object, int from, int to, unsigned char* rotation
                 if (gOpenPathNodeList[v25].tile == -1) {
                     break;
                 }
+            }
+
+            if (v25 == PATH_NODE_CAPACITY) {
+                return 0;
             }
 
             openPathNodeListLength += 1;

--- a/src/audio_engine.cc
+++ b/src/audio_engine.cc
@@ -106,7 +106,10 @@ bool audioEngineInit()
     desiredSpec.samples = 1024;
     desiredSpec.callback = audioEngineMixin;
 
-    gAudioEngineDeviceId = SDL_OpenAudioDevice(nullptr, 0, &desiredSpec, &gAudioEngineSpec, SDL_AUDIO_ALLOW_ANY_CHANGE);
+    int allowedChanges = SDL_AUDIO_ALLOW_FREQUENCY_CHANGE
+        | SDL_AUDIO_ALLOW_FORMAT_CHANGE
+        | SDL_AUDIO_ALLOW_SAMPLES_CHANGE;
+    gAudioEngineDeviceId = SDL_OpenAudioDevice(nullptr, 0, &desiredSpec, &gAudioEngineSpec, allowedChanges);
     if (gAudioEngineDeviceId == 0) {
         gAudioEngineDeviceId = -1;
         return false;

--- a/src/dinput.cc
+++ b/src/dinput.cc
@@ -198,4 +198,20 @@ void mouseDeviceRefreshWindowMapping()
     }
 }
 
+void mouseDeviceSetLogicalPosition(int x, int y)
+{
+    if (mouseDeviceUsesRelativeMode()
+        || gSdlWindow == nullptr
+        || mouseWindowMappingLogicalWidth <= 0
+        || mouseWindowMappingLogicalHeight <= 0
+        || mouseWindowMappingWindowWidth <= 0
+        || mouseWindowMappingWindowHeight <= 0) {
+        return;
+    }
+
+    int windowX = x * mouseWindowMappingWindowWidth / mouseWindowMappingLogicalWidth;
+    int windowY = y * mouseWindowMappingWindowHeight / mouseWindowMappingLogicalHeight;
+    SDL_WarpMouseInWindow(gSdlWindow, windowX, windowY);
+}
+
 } // namespace fallout

--- a/src/dinput.h
+++ b/src/dinput.h
@@ -23,6 +23,7 @@ void directInputFree();
 bool mouseDeviceUsesRelativeMode();
 bool mouseDeviceInitMode();
 void mouseDeviceRefreshWindowMapping();
+void mouseDeviceSetLogicalPosition(int x, int y);
 bool mouseDeviceAcquire();
 bool mouseDeviceUnacquire();
 bool mouseDeviceGetData(MouseData* mouseData);

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -2678,6 +2678,10 @@ void _gdSetupFidget(int headFid, HeadFidget reaction)
         }
     }
 
+    if (_lipsFp == nullptr) {
+        _lipsFID = 0;
+    }
+
     if (_lipsFID == 0) {
         _phone_anim = anim;
         _lipsFID = buildFid(OBJ_TYPE_HEAD, headFromFid(headFid), anim);

--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -17,6 +17,7 @@
 #include "combat.h"
 #include "content_config.h"
 #include "critter.h"
+#include "dinput.h"
 #include "draw.h"
 #include "game.h"
 #include "game_sound.h"
@@ -1253,6 +1254,7 @@ void _gmouse_handle_event(int mouseX, int mouseY, int mouseState)
                     gGameMouseLastY = mouseY;
                     _gmouse_3d_last_move_time = getTicks();
 
+                    mouseDeviceSetLogicalPosition(mouseX, mouseY);
                     _mouse_set_position(mouseX, mouseY);
 
                     if (gameMouseUpdateHexCursorFid(&cursorRect) == 0) {
@@ -1760,8 +1762,7 @@ int gameMouseRenderPrimaryAction(int x, int y, int menuItem, int width, int heig
     Art* arrowFrm = artLock(arrowFid, &arrowFrmHandle);
     if (arrowFrm == nullptr) {
         artUnlock(menuItemFrmHandle);
-        // FIXME: Why this is success?
-        return 0;
+        return -1;
     }
 
     unsigned char* arrowFrmData = artGetFrameData(arrowFrm);
@@ -1771,6 +1772,22 @@ int gameMouseRenderPrimaryAction(int x, int y, int menuItem, int width, int heig
     unsigned char* menuItemFrmData = artGetFrameData(menuItemFrm);
     int menuItemFrmWidth = artGetWidth(menuItemFrm);
     int menuItemFrmHeight = artGetHeight(menuItemFrm);
+
+    if (gGameMouseActionPickFrm == nullptr
+        || gGameMouseActionPickFrmData == nullptr
+        || gGameMouseActionPickFrmDataSize <= 0
+        || arrowFrmData == nullptr
+        || menuItemFrmData == nullptr
+        || arrowFrmWidth <= 0
+        || arrowFrmHeight <= 0
+        || menuItemFrmWidth <= 0
+        || menuItemFrmHeight <= 0
+        || arrowFrmWidth + menuItemFrmWidth > gGameMouseActionPickFrmWidth
+        || std::max(arrowFrmHeight, menuItemFrmHeight) > gGameMouseActionPickFrmHeight) {
+        artUnlock(arrowFrmHandle);
+        artUnlock(menuItemFrmHandle);
+        return -1;
+    }
 
     unsigned char* arrowFrmDest = gGameMouseActionPickFrmData;
     unsigned char* menuItemFrmDest = gGameMouseActionPickFrmData;
@@ -1784,6 +1801,13 @@ int gameMouseRenderPrimaryAction(int x, int y, int menuItem, int width, int heig
     int maxX = x + menuItemFrmWidth + arrowFrmWidth - 1;
     int maxY = y + menuItemFrmHeight - 1;
     int shiftY = maxY - height + 2;
+    int maxShiftY = gGameMouseActionPickFrmHeight - arrowFrmHeight;
+    if (maxShiftY < 0) {
+        artUnlock(arrowFrmHandle);
+        artUnlock(menuItemFrmHandle);
+        return -1;
+    }
+    shiftY = std::clamp(shiftY, 0, maxShiftY);
 
     if (maxX < width) {
         menuItemFrmDest += arrowFrmWidth;
@@ -1798,7 +1822,18 @@ int gameMouseRenderPrimaryAction(int x, int y, int menuItem, int width, int heig
 
         arrowFid = buildFid(OBJ_TYPE_INTERFACE, 285);
         arrowFrm = artLock(arrowFid, &arrowFrmHandle);
+        if (arrowFrm == nullptr) {
+            artUnlock(menuItemFrmHandle);
+            return -1;
+        }
+
         arrowFrmData = artGetFrameData(arrowFrm);
+        if (arrowFrmData == nullptr) {
+            artUnlock(arrowFrmHandle);
+            artUnlock(menuItemFrmHandle);
+            return -1;
+        }
+
         arrowFrmDest += menuItemFrmWidth;
 
         gGameMouseActionPickFrm->xOffsets[0] = -gGameMouseActionPickFrm->xOffsets[0];
@@ -1850,6 +1885,13 @@ int gameMouseRenderActionMenuItems(int x, int y, const int* menuItems, int menuI
     Art* menuItemFrms[GAME_MOUSE_ACTION_MENU_ITEM_COUNT];
 
     for (int index = 0; index < menuItemsLength; index++) {
+        if (menuItems[index] < 0 || menuItems[index] >= GAME_MOUSE_ACTION_MENU_ITEM_COUNT) {
+            while (--index >= 0) {
+                artUnlock(menuItemFrmHandles[index]);
+            }
+            return -1;
+        }
+
         int frmId = gGameMouseActionMenuItemFrmIds[menuItems[index]] & 0xFFFF;
         if (index == 0) {
             frmId -= 1;
@@ -1878,9 +1920,27 @@ int gameMouseRenderActionMenuItems(int x, int y, const int* menuItems, int menuI
 
     int arrowWidth = artGetWidth(arrowFrm);
     int arrowHeight = artGetHeight(arrowFrm);
+    unsigned char* arrowData = artGetFrameData(arrowFrm);
 
     int menuItemWidth = artGetWidth(menuItemFrms[0]);
     int menuItemHeight = artGetHeight(menuItemFrms[0]);
+
+    if (gGameMouseActionMenuFrm == nullptr
+        || gGameMouseActionMenuFrmData == nullptr
+        || gGameMouseActionMenuFrmDataSize <= 0
+        || arrowData == nullptr
+        || arrowWidth <= 0
+        || arrowHeight <= 0
+        || menuItemWidth <= 0
+        || menuItemHeight <= 0
+        || arrowWidth + menuItemWidth > gGameMouseActionMenuFrmWidth
+        || menuItemsLength * menuItemHeight > gGameMouseActionMenuFrmHeight) {
+        artUnlock(arrowFrmHandle);
+        for (int index = 0; index < menuItemsLength; index++) {
+            artUnlock(menuItemFrmHandles[index]);
+        }
+        return -1;
+    }
 
     _gmouse_3d_menu_frame_hot_x = 0;
     _gmouse_3d_menu_frame_hot_y = 0;
@@ -1890,12 +1950,20 @@ int gameMouseRenderActionMenuItems(int x, int y, const int* menuItems, int menuI
 
     int maxY = y + menuItemsLength * menuItemHeight - 1;
     int shiftY = maxY - height + 2;
+    int maxShiftY = gGameMouseActionMenuFrmHeight - arrowHeight;
+    if (maxShiftY < 0) {
+        artUnlock(arrowFrmHandle);
+        for (int index = 0; index < menuItemsLength; index++) {
+            artUnlock(menuItemFrmHandles[index]);
+        }
+        return -1;
+    }
+    shiftY = std::clamp(shiftY, 0, maxShiftY);
+
     unsigned char* arrowFrmDest = gGameMouseActionMenuFrmData;
     unsigned char* menuItemFrmDest = arrowFrmDest;
 
-    unsigned char* arrowData;
     if (x + arrowWidth + menuItemWidth - 1 < width) {
-        arrowData = artGetFrameData(arrowFrm);
         menuItemFrmDest = arrowFrmDest + arrowWidth;
         if (height <= maxY) {
             _gmouse_3d_menu_frame_hot_y += shiftY;
@@ -1907,7 +1975,22 @@ int gameMouseRenderActionMenuItems(int x, int y, const int* menuItems, int menuI
         artUnlock(arrowFrmHandle);
         fid = buildFid(OBJ_TYPE_INTERFACE, 285);
         arrowFrm = artLock(fid, &arrowFrmHandle);
+        if (arrowFrm == nullptr) {
+            for (int index = 0; index < menuItemsLength; index++) {
+                artUnlock(menuItemFrmHandles[index]);
+            }
+            return -1;
+        }
+
         arrowData = artGetFrameData(arrowFrm);
+        if (arrowData == nullptr) {
+            artUnlock(arrowFrmHandle);
+            for (int index = 0; index < menuItemsLength; index++) {
+                artUnlock(menuItemFrmHandles[index]);
+            }
+            return -1;
+        }
+
         arrowFrmDest += menuItemWidth;
 
         gGameMouseActionMenuFrm->xOffsets[0] = -gGameMouseActionMenuFrm->xOffsets[0];
@@ -1920,12 +2003,20 @@ int gameMouseRenderActionMenuItems(int x, int y, const int* menuItems, int menuI
     }
 
     memset(gGameMouseActionMenuFrmData, 0, gGameMouseActionMenuFrmDataSize);
-    blitBufferToBuffer(arrowData, arrowWidth, arrowHeight, arrowWidth, arrowFrmDest, gGameMouseActionPickFrmWidth);
+    blitBufferToBuffer(arrowData, arrowWidth, arrowHeight, arrowWidth, arrowFrmDest, gGameMouseActionMenuFrmWidth);
 
     unsigned char* dest = menuItemFrmDest;
     for (int index = 0; index < menuItemsLength; index++) {
         unsigned char* data = artGetFrameData(menuItemFrms[index]);
-        blitBufferToBuffer(data, menuItemWidth, menuItemHeight, menuItemWidth, dest, gGameMouseActionPickFrmWidth);
+        if (data == nullptr) {
+            artUnlock(arrowFrmHandle);
+            for (int index = 0; index < menuItemsLength; index++) {
+                artUnlock(menuItemFrmHandles[index]);
+            }
+            return -1;
+        }
+
+        blitBufferToBuffer(data, menuItemWidth, menuItemHeight, menuItemWidth, dest, gGameMouseActionMenuFrmWidth);
         dest += gGameMouseActionMenuFrmWidth * menuItemHeight;
     }
 
@@ -1954,7 +2045,36 @@ int gameMouseHighlightActionMenuItemAtIndex(int menuItemIndex)
         return -1;
     }
 
+    if (_gmouse_3d_menu_actions_start == nullptr
+        || gGameMouseActionMenuFrmData == nullptr
+        || gGameMouseActionMenuFrmDataSize <= 0
+        || gGameMouseActionMenuHighlightedItemIndex >= gGameMouseActionMenuItemsLength) {
+        return -1;
+    }
+
+    auto canBlitActionMenuItem = [](int index, int width, int height) {
+        if (width <= 0 || height <= 0 || index < 0) {
+            return false;
+        }
+
+        int baseOffset = static_cast<int>(_gmouse_3d_menu_actions_start - gGameMouseActionMenuFrmData);
+        if (baseOffset < 0 || baseOffset >= gGameMouseActionMenuFrmDataSize) {
+            return false;
+        }
+
+        int rowOffset = gGameMouseActionMenuFrmWidth * height * index;
+        int needed = gGameMouseActionMenuFrmWidth * (height - 1) + width;
+        return rowOffset >= 0
+            && needed > 0
+            && baseOffset + rowOffset <= gGameMouseActionMenuFrmDataSize - needed;
+    };
+
     CacheEntry* handle;
+    if (gGameMouseActionMenuItems[gGameMouseActionMenuHighlightedItemIndex] < 0
+        || gGameMouseActionMenuItems[gGameMouseActionMenuHighlightedItemIndex] >= GAME_MOUSE_ACTION_MENU_ITEM_COUNT) {
+        return -1;
+    }
+
     int fid = buildFid(OBJ_TYPE_INTERFACE, gGameMouseActionMenuItemFrmIds[gGameMouseActionMenuItems[gGameMouseActionMenuHighlightedItemIndex]]);
     Art* art = artLock(fid, &handle);
     if (art == nullptr) {
@@ -1964,8 +2084,18 @@ int gameMouseHighlightActionMenuItemAtIndex(int menuItemIndex)
     int width = artGetWidth(art);
     int height = artGetHeight(art);
     unsigned char* data = artGetFrameData(art);
+    if (data == nullptr || !canBlitActionMenuItem(gGameMouseActionMenuHighlightedItemIndex, width, height)) {
+        artUnlock(handle);
+        return -1;
+    }
+
     blitBufferToBuffer(data, width, height, width, _gmouse_3d_menu_actions_start + gGameMouseActionMenuFrmWidth * height * gGameMouseActionMenuHighlightedItemIndex, gGameMouseActionMenuFrmWidth);
     artUnlock(handle);
+
+    if (gGameMouseActionMenuItems[menuItemIndex] < 0
+        || gGameMouseActionMenuItems[menuItemIndex] >= GAME_MOUSE_ACTION_MENU_ITEM_COUNT) {
+        return -1;
+    }
 
     fid = buildFid(OBJ_TYPE_INTERFACE, gGameMouseActionMenuItemFrmIds[gGameMouseActionMenuItems[menuItemIndex]] - 1);
     art = artLock(fid, &handle);
@@ -1973,7 +2103,14 @@ int gameMouseHighlightActionMenuItemAtIndex(int menuItemIndex)
         return -1;
     }
 
+    width = artGetWidth(art);
+    height = artGetHeight(art);
     data = artGetFrameData(art);
+    if (data == nullptr || !canBlitActionMenuItem(menuItemIndex, width, height)) {
+        artUnlock(handle);
+        return -1;
+    }
+
     blitBufferToBuffer(data, width, height, width, _gmouse_3d_menu_actions_start + gGameMouseActionMenuFrmWidth * height * menuItemIndex, gGameMouseActionMenuFrmWidth);
     artUnlock(handle);
 
@@ -2242,24 +2379,40 @@ void gameMouseActionMenuFree()
     }
     gGameMouseBouncingCursorFrm = nullptr;
     gGameMouseBouncingCursorFrmHandle = INVALID_CACHE_ENTRY;
+    gGameMouseBouncingCursorFrmData = nullptr;
+    gGameMouseBouncingCursorFrmWidth = 0;
+    gGameMouseBouncingCursorFrmHeight = 0;
+    gGameMouseBouncingCursorFrmDataSize = 0;
 
     if (gGameMouseHexCursorFrmHandle != INVALID_CACHE_ENTRY) {
         artUnlock(gGameMouseHexCursorFrmHandle);
     }
     gGameMouseHexCursorFrm = nullptr;
     gGameMouseHexCursorFrmHandle = INVALID_CACHE_ENTRY;
+    gGameMouseHexCursorFrmData = nullptr;
+    gGameMouseHexCursorFrmWidth = 0;
+    gGameMouseHexCursorHeight = 0;
+    gGameMouseHexCursorDataSize = 0;
 
     if (gGameMouseActionHitFrmHandle != INVALID_CACHE_ENTRY) {
         artUnlock(gGameMouseActionHitFrmHandle);
     }
     gGameMouseActionHitFrm = nullptr;
     gGameMouseActionHitFrmHandle = INVALID_CACHE_ENTRY;
+    gGameMouseActionHitFrmData = nullptr;
+    gGameMouseActionHitFrmWidth = 0;
+    gGameMouseActionHitFrmHeight = 0;
+    gGameMouseActionHitFrmDataSize = 0;
 
     if (gGameMouseActionMenuFrmHandle != INVALID_CACHE_ENTRY) {
         artUnlock(gGameMouseActionMenuFrmHandle);
     }
     gGameMouseActionMenuFrm = nullptr;
     gGameMouseActionMenuFrmHandle = INVALID_CACHE_ENTRY;
+    gGameMouseActionMenuFrmData = nullptr;
+    gGameMouseActionMenuFrmWidth = 0;
+    gGameMouseActionMenuFrmHeight = 0;
+    gGameMouseActionMenuFrmDataSize = 0;
 
     if (gGameMouseActionPickFrmHandle != INVALID_CACHE_ENTRY) {
         artUnlock(gGameMouseActionPickFrmHandle);

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -4442,7 +4442,8 @@ static void inventoryWindowOpenContextMenu(int keyCode, int inventoryWindowType)
 
     if (gameMouseRenderActionMenuItems(x, y, actionMenuItems, actionMenuItemsLength,
             windowWidth + inventoryWindowX,
-            windowHeight + inventoryWindowY) == -1) {
+            windowHeight + inventoryWindowY)
+        == -1) {
         inventorySetCursor(INVENTORY_WINDOW_CURSOR_ARROW);
         return;
     }

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -4440,9 +4440,12 @@ static void inventoryWindowOpenContextMenu(int keyCode, int inventoryWindowType)
     int inventoryWindowX = windowRect.left;
     int inventoryWindowY = windowRect.top;
 
-    gameMouseRenderActionMenuItems(x, y, actionMenuItems, actionMenuItemsLength,
-        windowWidth + inventoryWindowX,
-        windowHeight + inventoryWindowY);
+    if (gameMouseRenderActionMenuItems(x, y, actionMenuItems, actionMenuItemsLength,
+            windowWidth + inventoryWindowX,
+            windowHeight + inventoryWindowY) == -1) {
+        inventorySetCursor(INVENTORY_WINDOW_CURSOR_ARROW);
+        return;
+    }
 
     InventoryCursorData* cursorData = &(gInventoryCursorData[INVENTORY_WINDOW_CURSOR_MENU]);
 

--- a/src/scripts.cc
+++ b/src/scripts.cc
@@ -1588,6 +1588,11 @@ int scriptExecProc(int sid, int proc)
     }
 
     if (procedureIndex == -1) {
+        Script* executedScript;
+        if (scriptGetScript(sid, &executedScript) != -1) {
+            executedScript->source = nullptr;
+        }
+
         return -1;
     }
 

--- a/src/skill.cc
+++ b/src/skill.cc
@@ -471,6 +471,10 @@ int skillGetValue(Object* critter, Skill skill)
         return -5;
     }
 
+    if (critter == nullptr || objectTypeFromPid(critter->pid) != OBJ_TYPE_CRITTER) {
+        return 0;
+    }
+
     Proto* proto;
     if (protoGetProto(critter->pid, &proto) == -1) {
         debugPrint("\nError: Failed to get a proto in skillGetValue for critter %d with a pid %d!", critter->id, critter->pid);

--- a/src/worldmap.cc
+++ b/src/worldmap.cc
@@ -622,7 +622,8 @@ static int wmTabsCompareNames(const void* a1, const void* a2);
 static int wmFreeTabsLabelList(int** quickDestinationsListPtr, int* quickDestinationsLengthPtr);
 static void wmRefreshInterfaceDial(bool shouldRefreshWindow);
 static void wmInterfaceDialSyncTime(bool shouldRefreshWindow);
-static int wmAreaFindFirstValidMap(Map* mapIdxPtr);
+static int wmAreaFindFirstValidMap(Map* mapIdxPtr, int* elevationPtr, int* tilePtr, Rotation* rotationPtr);
+static void wmRunLocalMapEnterHook(Map* mapIdxPtr);
 static void wmFadeOut();
 static void wmFadeIn();
 static void wmFadeReset();
@@ -3563,10 +3564,15 @@ static int wmWorldMapFunc(int a1)
                                 break;
                             }
                         } else {
-                            if (wmAreaFindFirstValidMap(&map) == -1) {
+                            int elevation;
+                            int tile;
+                            Rotation rotation;
+                            if (wmAreaFindFirstValidMap(&map, &elevation, &tile, &rotation) == -1) {
                                 rc = -1;
                                 break;
                             }
+
+                            mapSetEnteringLocation(elevation, tile, rotation);
 
                             // SFALL/CE: LocalMapEnter runs after this first-entry
                             // state transition, so a hook that redirects to a
@@ -3579,7 +3585,7 @@ static int wmWorldMapFunc(int a1)
                     }
 
                     if (map != MAP_INVALID) {
-                        scriptHooks_Encounter(EncounterHookEventType::LocalMapEnter, &map, false, -1, -1);
+                        wmRunLocalMapEnterHook(&map);
                         if (wmGenData.isInCar) {
                             wmGenData.isInCar = false;
                             if (wmGenData.currentAreaId == CITY_INVALID) {
@@ -3617,7 +3623,7 @@ static int wmWorldMapFunc(int a1)
                     }
 
                     if (map != MAP_INVALID) {
-                        scriptHooks_Encounter(EncounterHookEventType::LocalMapEnter, &map, false, -1, -1);
+                        wmRunLocalMapEnterHook(&map);
                         if (wmGenData.isInCar) {
                             // SFALL: Fix for the car being lost when entering a
                             // location via the Town/World button and then
@@ -7284,10 +7290,22 @@ static void wmInterfaceDialSyncTime(bool shouldRefreshWindow)
     }
 }
 
+static void wmRunLocalMapEnterHook(Map* mapIdxPtr)
+{
+    Map originalMap = *mapIdxPtr;
+    scriptHooks_Encounter(EncounterHookEventType::LocalMapEnter, mapIdxPtr, false, -1, -1);
+    if (*mapIdxPtr != originalMap) {
+        mapSetEnteringLocation(-1, -1, ROTATION_INVALID);
+    }
+}
+
 // 0x4C5804 wmAreaFindFirstValidMap
-static int wmAreaFindFirstValidMap(Map* mapIdxPtr)
+static int wmAreaFindFirstValidMap(Map* mapIdxPtr, int* elevationPtr, int* tilePtr, Rotation* rotationPtr)
 {
     *mapIdxPtr = MAP_INVALID;
+    *elevationPtr = -1;
+    *tilePtr = -1;
+    *rotationPtr = ROTATION_INVALID;
 
     if (wmGenData.currentAreaId == CITY_INVALID) {
         return -1;
@@ -7302,6 +7320,9 @@ static int wmAreaFindFirstValidMap(Map* mapIdxPtr)
         EntranceInfo* entrance = &(city->entrances[index]);
         if (entrance->state != 0) {
             *mapIdxPtr = entrance->map;
+            *elevationPtr = entrance->elevation;
+            *tilePtr = entrance->tile;
+            *rotationPtr = entrance->rotation;
             return 0;
         }
     }
@@ -7310,6 +7331,9 @@ static int wmAreaFindFirstValidMap(Map* mapIdxPtr)
     entrance->state = 1;
 
     *mapIdxPtr = entrance->map;
+    *elevationPtr = entrance->elevation;
+    *tilePtr = entrance->tile;
+    *rotationPtr = entrance->rotation;
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- port selected crash/corruption fixes identified in fission-ce, adapted to CE's current APIs and hook behavior
- fix action-menu buffer pitch, add action-menu/pathfinder validation, and keep SDL cursor state in sync after context menus
- preserve world-map entrance elevation/tile/rotation on first local-map entry and clear stale entrance state when LocalMapEnter redirects
- prevent SDL audio backends from changing the mixer channel count

## Fission references
- fission-ce 37201ec: guard skill lookups for non-critter objects
- fission-ce e80e85f: avoid stale script source cleanup after skipped/removed scripts
- fission-ce cdff5f6: reset failed lipsync art locks so later heads retry
- fission-ce 55d1f29: prevent mouse jump after context menus, reimplemented with CE scale-aware window mapping
- fission-ce ee38601: action-menu pitch heap corruption fix plus selected menu/pathfinder hardening
- fission-ce 24ec918: prevent audio drivers from changing channel count
- fission-ce 1e96352: preserve configured world-map entrance rotation/tile/elevation on first entry
