### PR TITLE
Allow reloading with different ammo types+skipping qty

### DIFF
--- a/files/fallout2.cfg
+++ b/files/fallout2.cfg
@@ -204,3 +204,6 @@ party_trade_from_menu=1
 
 ; Allow switching to companions' inventories in loot screens (and barter, in the future)
 party_loot_and_barter=1
+
+; Load ammo without quantity prompts, and unload currently loaded ammo when dropping a different compatible ammo type on a weapon.
+fast_ammo_load=1

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -382,6 +382,7 @@ static void barterDisplayTables(int win, Object* leftTable, Object* rightTable, 
 static void _container_enter(int keyCode, int inventoryWindowType);
 static void _container_exit(int keyCode, int inventoryWindowType);
 static int _drop_into_container(Object* container, Object* item, int sourceIndex, Object** itemSlot, int quantity);
+static void inventoryUnloadWeaponToOwner(Object* owner, Object* weapon);
 static InventoryAmmoMoveResult _drop_ammo_into_weapon(Object* weapon, Object* ammo, Object** ammoItemSlot, int quantity, int keyCode);
 static void _draw_amount(int value, int inventoryWindowType);
 static int inventoryQuantitySelect(int inventoryWindowType, Object* item, int maximum, int defaultValue = 1);
@@ -4656,16 +4657,7 @@ static void inventoryWindowOpenContextMenu(int keyCode, int inventoryWindowType)
             itemRemoveWithReason(owner, item, 1, RemoveInventoryObjectHookReason::UnloadWeapon);
         }
 
-        for (;;) {
-            Object* ammo = weaponUnload(item);
-            if (ammo == nullptr) {
-                break;
-            }
-
-            Rect rect;
-            _obj_disconnect(ammo, &rect);
-            itemAdd(owner, ammo, 1);
-        }
+        inventoryUnloadWeaponToOwner(owner, item);
 
         if (itemSlot == nullptr) {
             itemAdd(owner, item, 1);
@@ -6087,6 +6079,16 @@ static int _drop_into_container(Object* container, Object* item, int sourceIndex
     return rc;
 }
 
+static void inventoryUnloadWeaponToOwner(Object* owner, Object* weapon)
+{
+    Object* ammo;
+    while ((ammo = weaponUnload(weapon)) != nullptr) {
+        Rect rect;
+        _obj_disconnect(ammo, &rect);
+        itemAdd(owner, ammo, 1);
+    }
+}
+
 // 0x47650C drop ammo into weapon
 static InventoryAmmoMoveResult _drop_ammo_into_weapon(Object* weapon, Object* ammo, Object** ammoItemSlot, int quantity, int keyCode)
 {
@@ -6098,8 +6100,14 @@ static InventoryAmmoMoveResult _drop_ammo_into_weapon(Object* weapon, Object* am
         return INVENTORY_AMMO_MOVE_RESULT_FAILED;
     }
 
+    bool replaceAmmo = false;
     if (!weaponCanBeReloadedWith(weapon, ammo)) {
-        return INVENTORY_AMMO_MOVE_RESULT_FAILED;
+        if (!settings.qol.fast_ammo_load
+            || !weaponCanBeUnloaded(weapon)
+            || !weaponCanBeReloadedWithReplacingAmmo(weapon, ammo)) {
+            return INVENTORY_AMMO_MOVE_RESULT_FAILED;
+        }
+        replaceAmmo = true;
     }
 
     if (!scriptHooks_InventoryMove(HOOK_INVENTORYMOVE_WEAPON_RELOAD, ammo, weapon)) {
@@ -6107,7 +6115,9 @@ static InventoryAmmoMoveResult _drop_ammo_into_weapon(Object* weapon, Object* am
     }
 
     int quantityToMove;
-    if (quantity > 1) {
+    if (settings.qol.fast_ammo_load) {
+        quantityToMove = quantity;
+    } else if (quantity > 1) {
         quantityToMove = inventoryQuantitySelect(INVENTORY_WINDOW_TYPE_MOVE_ITEMS, ammo, quantity);
     } else {
         quantityToMove = 1;
@@ -6120,6 +6130,10 @@ static InventoryAmmoMoveResult _drop_ammo_into_weapon(Object* weapon, Object* am
     Object* sourceItem = ammo;
     bool isReloaded = false;
     int rc = itemRemoveQuietly(_inven_dude, weapon, 1);
+    if (replaceAmmo) {
+        inventoryUnloadWeaponToOwner(_inven_dude, weapon);
+    }
+
     for (int index = 0; index < quantityToMove; index++) {
         int rcReload = weaponReload(weapon, sourceItem);
         if (rcReload == 0) {

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "actions.h"
 #include "animation.h"
@@ -6130,8 +6131,12 @@ static InventoryAmmoMoveResult _drop_ammo_into_weapon(Object* weapon, Object* am
     Object* sourceItem = ammo;
     bool isReloaded = false;
     int rc = itemRemoveQuietly(_inven_dude, weapon, 1);
+    std::vector<Object*> unloadedAmmo;
     if (replaceAmmo) {
-        inventoryUnloadWeaponToOwner(_inven_dude, weapon);
+        Object* oldAmmo;
+        while ((oldAmmo = weaponUnload(weapon)) != nullptr) {
+            unloadedAmmo.push_back(oldAmmo);
+        }
     }
 
     for (int index = 0; index < quantityToMove; index++) {
@@ -6158,6 +6163,12 @@ static InventoryAmmoMoveResult _drop_ammo_into_weapon(Object* weapon, Object* am
 
     if (rc != -1) {
         itemAdd(_inven_dude, weapon, 1);
+    }
+
+    for (Object* oldAmmo : unloadedAmmo) {
+        Rect rect;
+        _obj_disconnect(oldAmmo, &rect);
+        itemAdd(_inven_dude, oldAmmo, 1);
     }
 
     if (!isReloaded) {

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -6084,8 +6084,6 @@ static void inventoryUnloadWeaponToOwner(Object* owner, Object* weapon)
 {
     Object* ammo;
     while ((ammo = weaponUnload(weapon)) != nullptr) {
-        Rect rect;
-        _obj_disconnect(ammo, &rect);
         itemAdd(owner, ammo, 1);
     }
 }
@@ -6166,8 +6164,6 @@ static InventoryAmmoMoveResult _drop_ammo_into_weapon(Object* weapon, Object* am
     }
 
     for (Object* oldAmmo : unloadedAmmo) {
-        Rect rect;
-        _obj_disconnect(oldAmmo, &rect);
         itemAdd(_inven_dude, oldAmmo, 1);
     }
 

--- a/src/item.cc
+++ b/src/item.cc
@@ -1570,11 +1570,13 @@ int weaponAttemptReload(Object* critter, Object* weapon)
     return 0;
 }
 
-// Checks if weapon can be reloaded with the specified ammo.
-//
 // 0x478874
-bool weaponCanBeReloadedWith(Object* weapon, Object* ammo)
+static bool weaponCanBeReloadedWithInternal(Object* weapon, Object* ammo, bool allowReplacingAmmo)
 {
+    if (weapon == nullptr) {
+        return false;
+    }
+
     if (weapon->pid == PROTO_ID_SOLAR_SCORCHER) {
         // Check light level to recharge solar scorcher.
         if (lightGetAmbientIntensity() > LIGHT_INTENSITY_MAX * 0.95) {
@@ -1613,13 +1615,26 @@ bool weaponCanBeReloadedWith(Object* weapon, Object* ammo)
     }
 
     // If weapon is not empty, we should only reload it with the same ammo.
-    if (ammoGetQuantity(weapon) != 0) {
+    if (!allowReplacingAmmo && ammoGetQuantity(weapon) != 0) {
         if (weapon->data.item.weapon.ammoTypePid != ammo->pid) {
             return false;
         }
     }
 
     return true;
+}
+
+// Checks if weapon can be reloaded with the specified ammo.
+//
+// 0x478874
+bool weaponCanBeReloadedWith(Object* weapon, Object* ammo)
+{
+    return weaponCanBeReloadedWithInternal(weapon, ammo, false);
+}
+
+bool weaponCanBeReloadedWithReplacingAmmo(Object* weapon, Object* ammo)
+{
+    return weaponCanBeReloadedWithInternal(weapon, ammo, true);
 }
 
 // 0x478918

--- a/src/item.h
+++ b/src/item.h
@@ -89,6 +89,7 @@ CaliberType ammoGetCaliber(Object* ammoOrWeapon);
 void ammoSetQuantity(Object* ammoOrWeapon, int quantity);
 int weaponAttemptReload(Object* critter, Object* weapon);
 bool weaponCanBeReloadedWith(Object* weapon, Object* ammo);
+bool weaponCanBeReloadedWithReplacingAmmo(Object* weapon, Object* ammo);
 int weaponReload(Object* weapon, Object* ammo);
 int weaponGetRange(Object* critter, HitMode hitMode);
 int weaponGetActionPointCost(Object* critter, HitMode hitMode, bool aiming);

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -257,6 +257,7 @@ void initSettingsRegistry(bool isMapper)
     SETTING(auto_open_doors);
     SETTING(party_trade_from_menu);
     SETTING(party_loot_and_barter);
+    SETTING(fast_ammo_load);
 #undef SECT
 
     if (isMapper) {

--- a/src/settings.h
+++ b/src/settings.h
@@ -181,6 +181,7 @@ struct QolSettings {
     bool auto_open_doors = false;
     bool party_trade_from_menu = true;
     bool party_loot_and_barter = false;
+    bool fast_ammo_load = true;
 };
 
 struct MapperSettings {


### PR DESCRIPTION
Make it easier to reload ammo in inventory:
* You can load ammo regardless of the current ammo in the weapon.  It'll auto unload the current ammo if it doesn't match
* Do not display quantity picker, but auto load to max
