### PR TITLE
FrmId constexpr support

### DIFF
--- a/src/actions.cc
+++ b/src/actions.cc
@@ -115,7 +115,7 @@ static bool actionRegisterUseAnimObj(Object* user, Object* targetObj, AnimationT
     }
 
     if (hookAnim != originalAnim) {
-        FrmId fid = FrmId(objectTypeFromFid(user->fid), frameIdFromFid(user->fid), hookAnim, weaponAnimationFromFid(user->fid), user->rotation + 1);
+        const FrmId fid = FrmId(user, hookAnim, weaponAnimationFromFid(user->fid), user->rotation + 1);
         if (!artExists(fid)) {
             hookAnim = originalAnim;
         }
@@ -135,8 +135,8 @@ int actionKnockdown(Object* obj, AnimationType* anim, int maxDistance, Rotation 
     }
 
     if (*anim == ANIM_FALL_FRONT) {
-        FrmId fid = FrmId(obj, *anim, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
-        if (!artExists(fid)) {
+        const FrmId frmId = FrmId(obj, *anim, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
+        if (!artExists(frmId)) {
             *anim = ANIM_FALL_BACK;
         }
     }
@@ -200,8 +200,8 @@ AnimationType actionBlood(Object* obj, AnimationType anim, int delay)
         return anim;
     }
 
-    FrmId fid = FrmId(obj, bloodyAnim, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
-    if (artExists(fid)) {
+    const FrmId frmId = FrmId(obj, bloodyAnim, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
+    if (artExists(frmId)) {
         animationRegisterAnimate(obj, bloodyAnim, delay);
     } else {
         bloodyAnim = anim;
@@ -303,11 +303,11 @@ AnimationType pickDeathAnim(Object* attacker, Object* defender, Object* weapon, 
 // 0x410814 check_death
 AnimationType checkDeathAnim(Object* obj, AnimationType anim, int minViolenceLevel, bool hitFromFront)
 {
-    FrmId fid;
+    FrmId frmId;
 
     if (settings.preferences.violence_level >= minViolenceLevel) {
-        fid = FrmId(obj, anim, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
-        if (artExists(fid)) {
+        frmId = FrmId(obj, anim, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
+        if (artExists(frmId)) {
             return anim;
         }
     }
@@ -316,9 +316,9 @@ AnimationType checkDeathAnim(Object* obj, AnimationType anim, int minViolenceLev
         return ANIM_FALL_BACK;
     }
 
-    fid = FrmId(obj, ANIM_FALL_FRONT, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
+    frmId = FrmId(obj, ANIM_FALL_FRONT, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
     // CE: fixed vanilla logic that returned ANIM_FALL_BACK if artExists for ANIM_FALL_FRONT returned true.
-    if (!artExists(fid)) {
+    if (!artExists(frmId)) {
         return ANIM_FALL_BACK;
     }
 
@@ -336,7 +336,7 @@ int _internal_destroy(Object* _, Object* toDestroy)
 // 0x4108D0 show_damage_to_object
 void showDamageToObject(Object* defender, int damage, int flags, Object* weapon, bool hitFromFront, int knockbackDistance, Rotation knockbackRotation, AnimationType attackerAnimation, Object* attacker, int delay)
 {
-    FrmId fid;
+    FrmId frmId;
     const char* sfx_name;
 
     if (critterFlagCheck(defender->pid, CRITTER_NO_KNOCKBACK)) {
@@ -365,8 +365,8 @@ void showDamageToObject(Object* defender, int damage, int flags, Object* weapon,
                     }
                 }
             } else {
-                fid = FrmId(defender, ANIM_FIRE_DANCE, weaponAnimationFromFid(defender->fid), defender->rotation + 1);
-                if (artExists(fid)) {
+                frmId = FrmId(defender, ANIM_FIRE_DANCE, weaponAnimationFromFid(defender->fid), defender->rotation + 1);
+                if (artExists(frmId)) {
                     sfx_name = sfxBuildCharName(defender, anim, CHARACTER_SOUND_EFFECT_UNUSED);
                     animationRegisterPlaySoundEffect(defender, sfx_name, delay);
 
@@ -446,8 +446,8 @@ void showDamageToObject(Object* defender, int damage, int flags, Object* weapon,
             } else if ((flags & DAM_ON_FIRE) != DAM_NONE && artExists(FrmId(defender, ANIM_FIRE_DANCE, weaponAnimationFromFid(defender->fid), defender->rotation + 1))) {
                 animationRegisterAnimate(defender, ANIM_FIRE_DANCE, delay);
 
-                fid = FrmId(defender, ANIM_STAND, weaponAnimationFromFid(defender->fid), defender->rotation + 1);
-                animationRegisterSetFid(defender, fid.fid(), -1);
+                frmId = FrmId(defender, ANIM_STAND, weaponAnimationFromFid(defender->fid), defender->rotation + 1);
+                animationRegisterSetFid(defender, frmId.fid(), -1);
             } else {
                 if (knockbackDistance != 0) {
                     anim = hitFromFront ? ANIM_FALL_BACK : ANIM_FALL_FRONT;
@@ -482,8 +482,7 @@ void showDamageToObject(Object* defender, int damage, int flags, Object* weapon,
     if (weapon != nullptr) {
         if ((flags & DAM_EXPLODE) != DAM_NONE) {
             animationRegisterCallbackForced(defender, weapon, (AnimationCallback*)objectDrop, -1);
-            fid = FrmId(MISC_FRM_ID_10);
-            animationRegisterSetFid(weapon, fid.fid(), 0);
+            animationRegisterSetFid(weapon, FrmId(MISC_FRM_ID_10).fid(), 0);
             animationRegisterAnimateAndHide(weapon, ANIM_STAND, 0);
 
             sfx_name = sfxBuildWeaponName(WEAPON_SOUND_EFFECT_HIT, weapon, HIT_MODE_RIGHT_WEAPON_PRIMARY, defender);
@@ -508,12 +507,11 @@ int _show_death(Object* obj, AnimationType anim)
 {
     Rect tempRect;
     Rect dirtyRect;
-    FrmId fid;
 
     objectGetRect(obj, &dirtyRect);
     if (anim < ANIM_FALL_BACK_SF && anim > ANIM_FALL_FRONT_BLOOD_SF) {
-        fid = FrmId(obj, static_cast<AnimationType>(anim + 28), weaponAnimationFromFid(obj->fid), obj->rotation + 1);
-        if (objectSetFid(obj, fid.fid(), &tempRect) == 0) {
+        const FrmId frmId = FrmId(obj, static_cast<AnimationType>(anim + 28), weaponAnimationFromFid(obj->fid), obj->rotation + 1);
+        if (objectSetFid(obj, frmId.fid(), &tempRect) == 0) {
             rectUnion(&dirtyRect, &tempRect, &dirtyRect);
         }
 
@@ -636,7 +634,7 @@ int _action_attack(Attack* attack)
 // 0x4112B4
 int _action_melee(Attack* attack, AnimationType anim)
 {
-    FrmId fid;
+    FrmId frmId;
     Art* art;
     CacheEntry* cache_entry;
     int delay;
@@ -646,8 +644,8 @@ int _action_melee(Attack* attack, AnimationType anim)
     reg_anim_begin(ANIMATION_REQUEST_RESERVED);
     _register_priority(1);
 
-    fid = FrmId(attack->attacker, anim, weaponAnimationFromFid(attack->attacker->fid), attack->attacker->rotation + 1);
-    art = artLock(fid, &cache_entry);
+    frmId = FrmId(attack->attacker, anim, weaponAnimationFromFid(attack->attacker->fid), attack->attacker->rotation + 1);
+    art = artLock(frmId, &cache_entry);
     if (art != nullptr) {
         delay = artGetActionFrame(art);
     } else {
@@ -686,8 +684,8 @@ int _action_melee(Attack* attack, AnimationType anim)
             animationRegisterPlaySoundEffect(attack->attacker, sfx_name_temp, -1);
             animationRegisterAnimate(attack->attacker, anim, 0);
         } else {
-            fid = FrmId(attack->defender, ANIM_DODGE_ANIM, weaponAnimationFromFid(attack->defender->fid), attack->defender->rotation + 1);
-            art = artLock(fid, &cache_entry);
+            frmId = FrmId(attack->defender, ANIM_DODGE_ANIM, weaponAnimationFromFid(attack->defender->fid), attack->defender->rotation + 1);
+            art = artLock(frmId, &cache_entry);
             if (art != nullptr) {
                 int dodgeDelay = artGetActionFrame(art);
                 artUnlock(cache_entry);
@@ -746,9 +744,9 @@ int _action_ranged(Attack* attack, AnimationType anim)
     Object* weapon = attack->weapon;
     protoGetProto(weapon->pid, &weaponProto);
 
-    FrmId fid = FrmId(attack->attacker, anim, weaponAnimationFromFid(attack->attacker->fid), attack->attacker->rotation + 1);
+    const FrmId frmId = FrmId(attack->attacker, anim, weaponAnimationFromFid(attack->attacker->fid), attack->attacker->rotation + 1);
     CacheEntry* artHandle;
-    Art* art = artLock(fid, &artHandle);
+    Art* art = artLock(frmId, &artHandle);
     int delay = (art != nullptr) ? artGetActionFrame(art) : 0;
     artUnlock(artHandle);
 
@@ -995,8 +993,8 @@ int _action_ranged(Attack* attack, AnimationType anim)
             }
 
             if (!takeOutAnimationRegistered) {
-                FrmId fid = FrmId(attack->attacker, ANIM_STAND, WEAPON_ANIMATION_NONE, attack->attacker->rotation + 1);
-                animationRegisterSetFid(attack->attacker, fid.fid(), -1);
+                const FrmId frmId = FrmId(attack->attacker, ANIM_STAND, WEAPON_ANIMATION_NONE, attack->attacker->rotation + 1);
+                animationRegisterSetFid(attack->attacker, frmId.fid(), -1);
             }
         } else {
             animationRegisterAnimate(attack->attacker, ANIM_UNPOINT, -1);
@@ -1234,11 +1232,11 @@ int actionPickUp(Object* critter, Object* item)
     if (itemProto->item.type != ITEM_TYPE_CONTAINER || _proto_action_can_pickup(item->pid)) {
         animationRegisterAnimate(critter, ANIM_MAGIC_HANDS_GROUND, 0);
 
-        FrmId fid = FrmId(critter, ANIM_MAGIC_HANDS_GROUND, weaponAnimationFromFid(critter->fid), critter->rotation + 1);
+        const FrmId frmId = FrmId(critter, ANIM_MAGIC_HANDS_GROUND, weaponAnimationFromFid(critter->fid), critter->rotation + 1);
 
         int actionFrame;
         CacheEntry* cacheEntry;
-        Art* art = artLock(fid, &cacheEntry);
+        Art* art = artLock(frmId, &cacheEntry);
         if (art != nullptr) {
             actionFrame = artGetActionFrame(art);
         } else {
@@ -1266,12 +1264,12 @@ int actionPickUp(Object* critter, Object* item)
             : ANIM_MAGIC_HANDS_GROUND;
         bool animateUse = actionRegisterUseAnimObj(critter, item, &anim, 0);
 
-        FrmId fid = FrmId(critter, anim, WEAPON_ANIMATION_NONE, critter->rotation + 1);
+        const FrmId frmId = FrmId(critter, anim, WEAPON_ANIMATION_NONE, critter->rotation + 1);
 
         int actionFrame = -1;
         CacheEntry* cacheEntry;
         if (animateUse) {
-            Art* art = artLock(fid, &cacheEntry);
+            Art* art = artLock(frmId, &cacheEntry);
             if (art != nullptr) {
                 actionFrame = artGetActionFrame(art);
                 artUnlock(cacheEntry);
@@ -1542,10 +1540,10 @@ int actionUseSkill(Object* user, Object* target, Skill skill)
     animationRegisterCallbackForced(performer, target, (AnimationCallback*)_is_next_to, -1);
 
     AnimationType anim = (objectTypeFromFid(target->fid) == OBJ_TYPE_CRITTER && critterIsProne(target)) ? ANIM_MAGIC_HANDS_GROUND : ANIM_MAGIC_HANDS_MIDDLE;
-    FrmId fid = FrmId(performer, anim, WEAPON_ANIMATION_NONE, performer->rotation + 1);
+    const FrmId frmId = FrmId(performer, anim, WEAPON_ANIMATION_NONE, performer->rotation + 1);
 
     CacheEntry* artHandle;
-    Art* art = artLock(fid, &artHandle);
+    Art* art = artLock(frmId, &artHandle);
     if (art != nullptr) {
         artGetActionFrame(art);
         artUnlock(artHandle);
@@ -1641,8 +1639,7 @@ int actionExplode(int tile, int elevation, int minDamage, int maxDamage, Object*
     }
 
     Object* explosion;
-    FrmId fid = FrmId(MISC_FRM_ID_10);
-    if (objectCreateWithFidPid(&explosion, fid.fid(), -1) == -1) {
+    if (objectCreateWithFidPid(&explosion, FrmId(MISC_FRM_ID_10).fid(), -1) == -1) {
         internal_free(attack);
         return -1;
     }
@@ -1654,8 +1651,7 @@ int actionExplode(int tile, int elevation, int minDamage, int maxDamage, Object*
 
     Object* adjacentExplosions[ROTATION_COUNT];
     for (Rotation rotation = ROTATION_FIRST; rotation < ROTATION_COUNT; rotation++) {
-        FrmId fid = FrmId(MISC_FRM_ID_10);
-        if (objectCreateWithFidPid(&(adjacentExplosions[rotation]), fid.fid(), -1) == -1) {
+        if (objectCreateWithFidPid(&(adjacentExplosions[rotation]), FrmId(MISC_FRM_ID_10).fid(), -1) == -1) {
             while (--rotation >= ROTATION_FIRST) {
                 objectDestroy(adjacentExplosions[rotation], nullptr);
             }

--- a/src/art.cc
+++ b/src/art.cc
@@ -1598,7 +1598,7 @@ std::shared_ptr<NamedCacheEntry> artLockNamedFrameData(const char* path)
 FrmId::FrmId(CritterFrameId critter, AnimationType animType, WeaponAnimation weaponAnimation, Rotation rotation)
     : _objectType(OBJ_TYPE_CRITTER)
     , _fid(buildObjectFid(OBJ_TYPE_CRITTER, critter, animType, weaponAnimation, rotation))
-    , _frameId{critter}
+    , _frameId { critter }
     , _path(nullptr)
 {
 }
@@ -1606,7 +1606,7 @@ FrmId::FrmId(CritterFrameId critter, AnimationType animType, WeaponAnimation wea
 FrmId::FrmId(ObjectType objectType, int frmId, AnimationType animType, WeaponAnimation weaponAnimation, Rotation rotation)
     : _objectType(objectType)
     , _fid(buildObjectFid(objectType, frmId, animType, weaponAnimation, rotation))
-    , _frameId{frmId}
+    , _frameId { frmId }
     , _path(nullptr)
 {
     assert(objectTypeIsValid(objectType));
@@ -1615,7 +1615,7 @@ FrmId::FrmId(ObjectType objectType, int frmId, AnimationType animType, WeaponAni
 FrmId::FrmId(Object* object, AnimationType animType, WeaponAnimation weaponAnimation, Rotation rotation)
     : _objectType(object == nullptr ? OBJ_TYPE_INVALID : objectTypeFromFid(object->fid))
     , _fid(object == nullptr ? EmptyFid : buildObjectFid(objectTypeFromFid(object->fid), frameIdFromFid(object->fid), animType, weaponAnimation, rotation))
-    , _frameId{object == nullptr ? EmptyFid : frameIdFromFid(object->fid)}
+    , _frameId { object == nullptr ? EmptyFid : frameIdFromFid(object->fid) }
     , _path(nullptr)
 {
 }

--- a/src/art.cc
+++ b/src/art.cc
@@ -49,7 +49,6 @@ static int artReadHeader(Art* art, File* stream);
 static int artGetDataSize(const Art* art);
 static int paddingForSize(int size);
 static char artGetCritterWeaponCode(WeaponAnimation weaponType);
-static int buildFid(ObjectType objectType, int frmId, int animType = 0, int weaponCode = 0, Rotation rotation = ROTATION_NE);
 
 // A frame is laid out like [ArtFrame header][pixel bytes][padding].
 // These functions return a pointer to the pixel bytes, but must be given a pointer to a frame header,
@@ -1081,39 +1080,6 @@ static void artCacheFreeImpl(void* ptr)
     internal_free(ptr);
 }
 
-/* FID Structure:
-    3 bits for rotation
-    4 bits for object type
-    8 bits for animation type
-    4 bits for weapon code
-    12 bits for frame ID
-*/
-static int buildFidInternal(int frmId, unsigned char weaponCode, unsigned char animType, ObjectType objectType, Rotation rotation)
-{
-    return ((rotation << 28) & 0x70000000) | (objectType << 24) | ((animType << 16) & 0xFF0000) | ((weaponCode << 12) & 0xF000) | (frmId & 0xFFF);
-}
-
-// 0x419C88
-// animType doesn't have to be of AnimationType enum only but also HeadAnimation
-// weaponCode doesn't have to be WeaponAnimation enum only but also Fidget or flags
-int buildFid(ObjectType objectType, int frmId, int animType, int weaponCode, Rotation rotation)
-{
-    // Always use rotation 0 (NE) for non-critters, for certain critter animations.
-    // For other critter animations, check if art for the given rotation exists, if not try rotation 1 (E) and if that also doesn't exist, then default to 0 (NE).
-    if (objectType != OBJ_TYPE_CRITTER
-        || animType == ANIM_FIRE_DANCE
-        || animType < ANIM_FALL_BACK
-        || animType > ANIM_FALL_FRONT_BLOOD) {
-        rotation = ROTATION_NE;
-    } else if (!artExists(buildFidInternal(frmId, weaponCode, animType, OBJ_TYPE_CRITTER, rotation))) {
-        rotation = rotation != ROTATION_E
-                && artExists(buildFidInternal(frmId, weaponCode, animType, OBJ_TYPE_CRITTER, ROTATION_E))
-            ? ROTATION_E
-            : ROTATION_NE;
-    }
-    return buildFidInternal(frmId, weaponCode, animType, objectType, rotation);
-}
-
 // 0x419D60
 static int artReadFrameData(unsigned char* data, File* stream, int count, int* paddingPtr)
 {
@@ -1629,90 +1595,51 @@ std::shared_ptr<NamedCacheEntry> artLockNamedFrameData(const char* path)
     return gNamedArtCache.emplace(path, std::move(entry)).first->second;
 }
 
-FrmId::FrmId(MiscFrameId misc, AnimationType animType)
-    : _objectType(OBJ_TYPE_MISC)
-    , _fid(buildFid(OBJ_TYPE_MISC, misc, animType))
-{
-}
-
-FrmId::FrmId(SceneryFrameId scenery)
-    : _objectType(OBJ_TYPE_SCENERY)
-    , _fid(buildFid(OBJ_TYPE_SCENERY, scenery))
-{
-}
-
-FrmId::FrmId(WallFrameId wall)
-    : _objectType(OBJ_TYPE_WALL)
-    , _fid(buildFid(OBJ_TYPE_WALL, wall))
-{
-}
-
-FrmId::FrmId(ItemFrameId item)
-    : _objectType(OBJ_TYPE_ITEM)
-    , _fid(buildFid(OBJ_TYPE_ITEM, item))
-{
-}
-
-FrmId::FrmId(TileFrameId tile)
-    : _objectType(OBJ_TYPE_TILE)
-    , _fid(buildFid(OBJ_TYPE_TILE, tile))
-{
-}
-
-FrmId::FrmId(SkillDexFrameId skilldex)
-    : _objectType(OBJ_TYPE_SKILLDEX)
-    , _fid(buildFid(OBJ_TYPE_SKILLDEX, skilldex))
-{
-}
-
-FrmId::FrmId(InterfaceFrameId interface)
-    : _objectType(OBJ_TYPE_INTERFACE)
-    , _fid(buildFid(OBJ_TYPE_INTERFACE, interface))
-{
-}
-
 FrmId::FrmId(CritterFrameId critter, AnimationType animType, WeaponAnimation weaponAnimation, Rotation rotation)
     : _objectType(OBJ_TYPE_CRITTER)
-    , _fid(buildFid(OBJ_TYPE_CRITTER, critter, animType, weaponAnimation, rotation))
+    , _fid(buildObjectFid(OBJ_TYPE_CRITTER, critter, animType, weaponAnimation, rotation))
+    , _frameId{critter}
+    , _path(nullptr)
 {
 }
 
-FrmId::FrmId(ObjectType objectType, int frmId, int animType, int weaponCode, Rotation rotation)
+FrmId::FrmId(ObjectType objectType, int frmId, AnimationType animType, WeaponAnimation weaponAnimation, Rotation rotation)
     : _objectType(objectType)
-    , _fid(buildFid(objectType, frmId, animType, weaponCode, rotation))
+    , _fid(buildObjectFid(objectType, frmId, animType, weaponAnimation, rotation))
+    , _frameId{frmId}
+    , _path(nullptr)
 {
     assert(objectTypeIsValid(objectType));
 }
 
 FrmId::FrmId(Object* object, AnimationType animType, WeaponAnimation weaponAnimation, Rotation rotation)
     : _objectType(object == nullptr ? OBJ_TYPE_INVALID : objectTypeFromFid(object->fid))
-    , _fid(object == nullptr ? EmptyFid : buildFid(objectTypeFromFid(object->fid), frameIdFromFid(object->fid), animType, weaponAnimation, rotation))
+    , _fid(object == nullptr ? EmptyFid : buildObjectFid(objectTypeFromFid(object->fid), frameIdFromFid(object->fid), animType, weaponAnimation, rotation))
+    , _frameId{object == nullptr ? EmptyFid : frameIdFromFid(object->fid)}
+    , _path(nullptr)
 {
 }
 
-FrmId::FrmId(HeadFrameId head, HeadAnimation headAnimation, int fidget)
-    : _objectType(OBJ_TYPE_HEAD)
-    , _fid(buildFid(OBJ_TYPE_HEAD, head, headAnimation, fidget))
+// 0x419C88
+// animType doesn't have to be of AnimationType enum only but also HeadAnimation
+// weaponCode doesn't have to be WeaponAnimation enum only but also Fidget or flags
+int FrmId::buildObjectFid(ObjectType objectType, int frmId, AnimationType animType, WeaponAnimation weaponAnimation, Rotation rotation)
 {
-}
+    // Always use rotation 0 (NE) for non-critters, for certain critter animations.
+    // For other critter animations, check if art for the given rotation exists, if not try rotation 1 (E) and if that also doesn't exist, then default to 0 (NE).
+    if (objectType != OBJ_TYPE_CRITTER
+        || animType == ANIM_FIRE_DANCE
+        || animType < ANIM_FALL_BACK
+        || animType > ANIM_FALL_FRONT_BLOOD) {
+        rotation = ROTATION_NE;
+    } else if (!artExists(buildFid(OBJ_TYPE_CRITTER, frmId, animType, weaponAnimation, rotation))) {
+        rotation = rotation != ROTATION_E
+                && artExists(buildFid(OBJ_TYPE_CRITTER, frmId, animType, weaponAnimation, ROTATION_E))
+            ? ROTATION_E
+            : ROTATION_NE;
+    }
 
-FrmId::FrmId(BackgroundFrameId background)
-    : _objectType(OBJ_TYPE_BACKGROUND)
-    , _fid(buildFid(OBJ_TYPE_BACKGROUND, background))
-{
-}
-
-FrmId::FrmId(ObjectType objType, const char* path)
-    : _objectType(objType)
-    , _path(path)
-{
-    assert(objectTypeIsValid(objType));
-}
-
-ObjectType FrmId::objectType() const
-{
-    assert(hasObjectType());
-    return static_cast<ObjectType>(_objectType);
+    return buildFid(objectType, frmId, animType, weaponAnimation, rotation);
 }
 
 FrmImage::FrmImage()

--- a/src/art.h
+++ b/src/art.h
@@ -1,6 +1,7 @@
 #ifndef ART_H
 #define ART_H
 
+#include <cassert>
 #include <cstring>
 #include <memory>
 
@@ -50,6 +51,7 @@ public:
         : _objectType(OBJ_TYPE_INVALID)
         , _fid(EmptyFid)
         , _path(nullptr)
+        , _frameId{ EmptyFid }
     {
     }
 
@@ -59,30 +61,112 @@ public:
         return emptyInstance;
     }
 
-    explicit FrmId(int fid)
+    constexpr explicit FrmId(int fid)
         : _objectType(objectTypeFromFid(fid))
         , _fid(fid)
+        , _frameId{frameIdFromFid(fid)}
+        , _path(nullptr)
     {
     }
 
-    explicit FrmId(MiscFrameId misc, AnimationType animType = ANIM_STAND);
-    explicit FrmId(SceneryFrameId scenery);
-    explicit FrmId(WallFrameId wall);
-    explicit FrmId(ItemFrameId item);
-    explicit FrmId(TileFrameId tile);
-    explicit FrmId(SkillDexFrameId skilldex);
-    explicit FrmId(InterfaceFrameId interface);
+    constexpr explicit FrmId(MiscFrameId misc, AnimationType animType = ANIM_STAND)
+        : _objectType(OBJ_TYPE_MISC)
+        , _fid(buildFid(OBJ_TYPE_MISC, misc, animType))
+        , _frameId{ static_cast<int>(misc) }
+        , _path(nullptr)
+    {
+    }
+
+    constexpr explicit FrmId(SceneryFrameId scenery)
+        : _objectType(OBJ_TYPE_SCENERY)
+        , _fid(buildFid(OBJ_TYPE_SCENERY, scenery))
+        , _frameId{ static_cast<int>(scenery) }
+        , _path(nullptr)
+    {
+    }
+
+    constexpr explicit FrmId(WallFrameId wall)
+        : _objectType(OBJ_TYPE_WALL)
+        , _fid(buildFid(OBJ_TYPE_WALL, wall))
+        , _frameId{ static_cast<int>(wall) }
+        , _path(nullptr)
+    {
+    }
+
+    constexpr explicit FrmId(ItemFrameId item)
+        : _objectType(OBJ_TYPE_ITEM)
+        , _fid(buildFid(OBJ_TYPE_ITEM, item))
+        , _frameId{ static_cast<int>(item) }
+        , _path(nullptr)
+    {
+    }
+
+    constexpr explicit FrmId(TileFrameId tile)
+        : _objectType(OBJ_TYPE_TILE)
+        , _fid(buildFid(OBJ_TYPE_TILE, tile))
+        , _frameId{ static_cast<int>(tile) }
+        , _path(nullptr)
+    {
+    }
+
+    constexpr explicit FrmId(SkillDexFrameId skilldex)
+        : _objectType(OBJ_TYPE_SKILLDEX)
+        , _fid(buildFid(OBJ_TYPE_SKILLDEX, skilldex))
+        , _frameId{ static_cast<int>(skilldex) }
+        , _path(nullptr)
+    {
+    }
+
+    constexpr explicit FrmId(InterfaceFrameId interface)
+        : _objectType(OBJ_TYPE_INTERFACE)
+        , _fid(buildFid(OBJ_TYPE_INTERFACE, interface))
+        , _frameId{ static_cast<int>(interface) }
+        , _path(nullptr)
+    {
+    }
+
+    // cannot be made constexpr as internally calls artExists which cannot be constexpr
     explicit FrmId(CritterFrameId critter, AnimationType animType, WeaponAnimation weaponAnimation, Rotation rotation);
     explicit FrmId(Object* object, AnimationType animType, WeaponAnimation weaponAnimation, Rotation rotation);
-    explicit FrmId(HeadFrameId head, HeadAnimation headAnimation = HEAD_ANIMATION_VERY_GOOD_REACTION, int fidget = 0);
-    explicit FrmId(BackgroundFrameId background);
-    explicit FrmId(ObjectType objType, const char* path);
-    explicit FrmId(ObjectType objectType, int frmId, int animType = 0, int weaponCode = 0, Rotation rotation = ROTATION_NE);
+    explicit FrmId(ObjectType objectType, int frmId, AnimationType animType = ANIM_STAND, WeaponAnimation weaponAnimation = WEAPON_ANIMATION_NONE, Rotation rotation = ROTATION_NE);
 
-    int fid() const { return _fid; }
-    bool hasObjectType() const { return objectTypeIsValid(_objectType); }
-    ObjectType objectType() const;
-    const char* filePath() const { return _path; }
+    constexpr explicit FrmId(HeadFrameId head, HeadAnimation headAnimation = HEAD_ANIMATION_VERY_GOOD_REACTION, int fidget = 0)
+        : _objectType(OBJ_TYPE_HEAD)
+        , _fid(buildFid(OBJ_TYPE_HEAD, head, headAnimation, fidget))
+        , _frameId{ static_cast<int>(head) }
+        , _path(nullptr)
+    {
+    }
+    
+    constexpr explicit FrmId(BackgroundFrameId background)
+        : _objectType(OBJ_TYPE_BACKGROUND)
+        , _fid(buildFid(OBJ_TYPE_BACKGROUND, background))
+        , _frameId{ static_cast<int>(background) }
+        , _path(nullptr)
+    {
+    }
+
+    constexpr explicit FrmId(ObjectType objType, const char* path)
+    : _objectType(objType)
+    , _fid(EmptyFid)
+    , _frameId{EmptyFid}
+    , _path(path)
+    
+    {
+        assert(objectTypeIsValid(objType));
+    }
+
+    constexpr int fid() const { return _fid; }
+
+    constexpr bool hasObjectType() const { return objectTypeIsValid(_objectType); }
+    
+    constexpr ObjectType objectType() const
+    {
+        assert(hasObjectType());
+        return _objectType;
+    }
+
+    constexpr const char* filePath() const { return _path; }
 
     bool empty() const { return (*this) == Empty(); }
 
@@ -102,9 +186,41 @@ public:
     }
 
 private:
-    int _fid = EmptyFid;
-    ObjectType _objectType = OBJ_TYPE_INVALID;
-    const char* _path = nullptr;
+    int _fid;
+    ObjectType _objectType;
+
+    union {
+        int id;
+        MiscFrameId misc;
+        SceneryFrameId scenery;
+        WallFrameId wall;
+        ItemFrameId item;
+        TileFrameId tile;
+        SkillDexFrameId skilldex;
+        InterfaceFrameId interface;
+        CritterFrameId critter;
+        HeadFrameId head;
+        BackgroundFrameId background;
+    } _frameId;
+
+    const char* _path;
+
+    /* FID Structure:
+        3 bits for rotation
+        4 bits for object type
+        8 bits for animation type
+        4 bits for weapon code
+        12 bits for frame ID
+
+        animType doesn't have to be of AnimationType enum only but also HeadAnimation
+        weaponAnimation doesn't have to be WeaponAnimation enum only but also Fidget or flags
+    */
+    constexpr int buildFid(ObjectType objectType, int frmId, unsigned char animType = 0, unsigned char weaponAnimation = 0, Rotation rotation = ROTATION_NE)
+    {
+        return ((rotation << 28) & 0x70000000) | (objectType << 24) | ((animType << 16) & 0xFF0000) | ((weaponAnimation << 12) & 0xF000) | (frmId & 0xFFF);
+    }
+
+    int buildObjectFid(ObjectType objectType, int frmId, AnimationType animType, WeaponAnimation weaponCode, Rotation rotation);
 };
 
 int artInit();

--- a/src/art.h
+++ b/src/art.h
@@ -50,8 +50,8 @@ public:
     constexpr FrmId()
         : _objectType(OBJ_TYPE_INVALID)
         , _fid(EmptyFid)
-        , _path(nullptr)
         , _frameId { EmptyFid }
+        , _path(nullptr)
     {
     }
 
@@ -186,8 +186,8 @@ public:
     }
 
 private:
-    int _fid;
     ObjectType _objectType;
+    int _fid;
 
     union {
         int id;

--- a/src/art.h
+++ b/src/art.h
@@ -51,7 +51,7 @@ public:
         : _objectType(OBJ_TYPE_INVALID)
         , _fid(EmptyFid)
         , _path(nullptr)
-        , _frameId{ EmptyFid }
+        , _frameId { EmptyFid }
     {
     }
 
@@ -64,7 +64,7 @@ public:
     constexpr explicit FrmId(int fid)
         : _objectType(objectTypeFromFid(fid))
         , _fid(fid)
-        , _frameId{frameIdFromFid(fid)}
+        , _frameId { frameIdFromFid(fid) }
         , _path(nullptr)
     {
     }
@@ -72,7 +72,7 @@ public:
     constexpr explicit FrmId(MiscFrameId misc, AnimationType animType = ANIM_STAND)
         : _objectType(OBJ_TYPE_MISC)
         , _fid(buildFid(OBJ_TYPE_MISC, misc, animType))
-        , _frameId{ static_cast<int>(misc) }
+        , _frameId { static_cast<int>(misc) }
         , _path(nullptr)
     {
     }
@@ -80,7 +80,7 @@ public:
     constexpr explicit FrmId(SceneryFrameId scenery)
         : _objectType(OBJ_TYPE_SCENERY)
         , _fid(buildFid(OBJ_TYPE_SCENERY, scenery))
-        , _frameId{ static_cast<int>(scenery) }
+        , _frameId { static_cast<int>(scenery) }
         , _path(nullptr)
     {
     }
@@ -88,7 +88,7 @@ public:
     constexpr explicit FrmId(WallFrameId wall)
         : _objectType(OBJ_TYPE_WALL)
         , _fid(buildFid(OBJ_TYPE_WALL, wall))
-        , _frameId{ static_cast<int>(wall) }
+        , _frameId { static_cast<int>(wall) }
         , _path(nullptr)
     {
     }
@@ -96,7 +96,7 @@ public:
     constexpr explicit FrmId(ItemFrameId item)
         : _objectType(OBJ_TYPE_ITEM)
         , _fid(buildFid(OBJ_TYPE_ITEM, item))
-        , _frameId{ static_cast<int>(item) }
+        , _frameId { static_cast<int>(item) }
         , _path(nullptr)
     {
     }
@@ -104,7 +104,7 @@ public:
     constexpr explicit FrmId(TileFrameId tile)
         : _objectType(OBJ_TYPE_TILE)
         , _fid(buildFid(OBJ_TYPE_TILE, tile))
-        , _frameId{ static_cast<int>(tile) }
+        , _frameId { static_cast<int>(tile) }
         , _path(nullptr)
     {
     }
@@ -112,7 +112,7 @@ public:
     constexpr explicit FrmId(SkillDexFrameId skilldex)
         : _objectType(OBJ_TYPE_SKILLDEX)
         , _fid(buildFid(OBJ_TYPE_SKILLDEX, skilldex))
-        , _frameId{ static_cast<int>(skilldex) }
+        , _frameId { static_cast<int>(skilldex) }
         , _path(nullptr)
     {
     }
@@ -120,7 +120,7 @@ public:
     constexpr explicit FrmId(InterfaceFrameId interface)
         : _objectType(OBJ_TYPE_INTERFACE)
         , _fid(buildFid(OBJ_TYPE_INTERFACE, interface))
-        , _frameId{ static_cast<int>(interface) }
+        , _frameId { static_cast<int>(interface) }
         , _path(nullptr)
     {
     }
@@ -133,25 +133,25 @@ public:
     constexpr explicit FrmId(HeadFrameId head, HeadAnimation headAnimation = HEAD_ANIMATION_VERY_GOOD_REACTION, int fidget = 0)
         : _objectType(OBJ_TYPE_HEAD)
         , _fid(buildFid(OBJ_TYPE_HEAD, head, headAnimation, fidget))
-        , _frameId{ static_cast<int>(head) }
+        , _frameId { static_cast<int>(head) }
         , _path(nullptr)
     {
     }
-    
+
     constexpr explicit FrmId(BackgroundFrameId background)
         : _objectType(OBJ_TYPE_BACKGROUND)
         , _fid(buildFid(OBJ_TYPE_BACKGROUND, background))
-        , _frameId{ static_cast<int>(background) }
+        , _frameId { static_cast<int>(background) }
         , _path(nullptr)
     {
     }
 
     constexpr explicit FrmId(ObjectType objType, const char* path)
-    : _objectType(objType)
-    , _fid(EmptyFid)
-    , _frameId{EmptyFid}
-    , _path(path)
-    
+        : _objectType(objType)
+        , _fid(EmptyFid)
+        , _frameId { EmptyFid }
+        , _path(path)
+
     {
         assert(objectTypeIsValid(objType));
     }
@@ -159,7 +159,7 @@ public:
     constexpr int fid() const { return _fid; }
 
     constexpr bool hasObjectType() const { return objectTypeIsValid(_objectType); }
-    
+
     constexpr ObjectType objectType() const
     {
         assert(hasObjectType());

--- a/src/art_defs.h
+++ b/src/art_defs.h
@@ -3,12 +3,12 @@
 
 namespace fallout {
 
-inline int frameIdFromFid(int fid)
+constexpr inline int frameIdFromFid(int fid)
 {
     return fid & 0xFFF;
 }
 
-inline int frameIdFromPid(int pid)
+constexpr inline int frameIdFromPid(int pid)
 {
     return pid & 0xFFFFFF;
 }

--- a/src/automap.cc
+++ b/src/automap.cc
@@ -243,12 +243,12 @@ static int _displayMapList[AUTOMAP_MAP_COUNT] = {
 };
 
 // 0x41B7E0
-static const InterfaceFrameId gAutomapFrmIds[AUTOMAP_FRM_COUNT] = {
-    INTF_FRM_ID_171, // automap.frm - automap window
-    INTF_FRM_ID_8, // lilredup.frm - little red button up
-    INTF_FRM_ID_9, // lilreddn.frm - little red button down
-    INTF_FRM_ID_172, // autoup.frm - switch up
-    INTF_FRM_ID_173, // autodwn.frm - switch down
+static constexpr FrmId kAutomapFrmIds[AUTOMAP_FRM_COUNT] = {
+    FrmId(INTF_FRM_ID_171), // automap.frm - automap window
+    FrmId(INTF_FRM_ID_8), // lilredup.frm - little red button up
+    FrmId(INTF_FRM_ID_9), // lilreddn.frm - little red button down
+    FrmId(INTF_FRM_ID_172), // autoup.frm - switch up
+    FrmId(INTF_FRM_ID_173), // autodwn.frm - switch down
 };
 
 // 0x5108C4 autoflags
@@ -312,13 +312,9 @@ void automapShow(bool isInGame, bool isUsingScanner)
 {
     ScopedGameMode gm(GameMode::kAutomap);
 
-    InterfaceFrameId frmIds[AUTOMAP_FRM_COUNT];
-    memcpy(frmIds, gAutomapFrmIds, sizeof(gAutomapFrmIds));
-
     FrmImage frmImages[AUTOMAP_FRM_COUNT];
     for (int index = 0; index < AUTOMAP_FRM_COUNT; index++) {
-        FrmId fid = FrmId(frmIds[index]);
-        if (!frmImages[index].lock(fid)) {
+        if (!frmImages[index].lock(kAutomapFrmIds[index])) {
             return;
         }
     }

--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -342,57 +342,57 @@ static void customTownReputationInit();
 static void customTownReputationFree();
 
 // 0x431C40 grph_id
-static InterfaceFrameId gCharacterEditorFrmIds[EDITOR_GRAPHIC_COUNT] = {
-    INTF_FRM_ID_170,
-    INTF_FRM_ID_175,
-    INTF_FRM_ID_176,
-    INTF_FRM_ID_181,
-    INTF_FRM_ID_182,
-    INTF_FRM_ID_183,
-    INTF_FRM_ID_184,
-    INTF_FRM_ID_185,
-    INTF_FRM_ID_186,
-    INTF_FRM_ID_187,
-    INTF_FRM_ID_188,
-    INTF_FRM_ID_189,
-    INTF_FRM_ID_190,
-    INTF_FRM_ID_191,
-    INTF_FRM_ID_192,
-    INTF_FRM_ID_193,
-    INTF_FRM_ID_194,
-    INTF_FRM_ID_195,
-    INTF_FRM_ID_196,
-    INTF_FRM_ID_197,
-    INTF_FRM_ID_198,
-    INTF_FRM_ID_199,
-    INTF_FRM_ID_200,
-    INTF_FRM_ID_8,
-    INTF_FRM_ID_9,
-    INTF_FRM_ID_204,
-    INTF_FRM_ID_205,
-    INTF_FRM_ID_206,
-    INTF_FRM_ID_207,
-    INTF_FRM_ID_208,
-    INTF_FRM_ID_209,
-    INTF_FRM_ID_210,
-    INTF_FRM_ID_211,
-    INTF_FRM_ID_212,
-    INTF_FRM_ID_213,
-    INTF_FRM_ID_214,
-    INTF_FRM_ID_122,
-    INTF_FRM_ID_123,
-    INTF_FRM_ID_124,
-    INTF_FRM_ID_125,
-    INTF_FRM_ID_219,
-    INTF_FRM_ID_220,
-    INTF_FRM_ID_221,
-    INTF_FRM_ID_222,
-    INTF_FRM_ID_178,
-    INTF_FRM_ID_179,
-    INTF_FRM_ID_180,
-    INTF_FRM_ID_38,
-    INTF_FRM_ID_215,
-    INTF_FRM_ID_216,
+static constexpr FrmId kCharacterEditorFrmIds[EDITOR_GRAPHIC_COUNT] = {
+    FrmId(INTF_FRM_ID_170),
+    FrmId(INTF_FRM_ID_175),
+    FrmId(INTF_FRM_ID_176),
+    FrmId(INTF_FRM_ID_181),
+    FrmId(INTF_FRM_ID_182),
+    FrmId(INTF_FRM_ID_183),
+    FrmId(INTF_FRM_ID_184),
+    FrmId(INTF_FRM_ID_185),
+    FrmId(INTF_FRM_ID_186),
+    FrmId(INTF_FRM_ID_187),
+    FrmId(INTF_FRM_ID_188),
+    FrmId(INTF_FRM_ID_189),
+    FrmId(INTF_FRM_ID_190),
+    FrmId(INTF_FRM_ID_191),
+    FrmId(INTF_FRM_ID_192),
+    FrmId(INTF_FRM_ID_193),
+    FrmId(INTF_FRM_ID_194),
+    FrmId(INTF_FRM_ID_195),
+    FrmId(INTF_FRM_ID_196),
+    FrmId(INTF_FRM_ID_197),
+    FrmId(INTF_FRM_ID_198),
+    FrmId(INTF_FRM_ID_199),
+    FrmId(INTF_FRM_ID_200),
+    FrmId(INTF_FRM_ID_8),
+    FrmId(INTF_FRM_ID_9),
+    FrmId(INTF_FRM_ID_204),
+    FrmId(INTF_FRM_ID_205),
+    FrmId(INTF_FRM_ID_206),
+    FrmId(INTF_FRM_ID_207),
+    FrmId(INTF_FRM_ID_208),
+    FrmId(INTF_FRM_ID_209),
+    FrmId(INTF_FRM_ID_210),
+    FrmId(INTF_FRM_ID_211),
+    FrmId(INTF_FRM_ID_212),
+    FrmId(INTF_FRM_ID_213),
+    FrmId(INTF_FRM_ID_214),
+    FrmId(INTF_FRM_ID_122),
+    FrmId(INTF_FRM_ID_123),
+    FrmId(INTF_FRM_ID_124),
+    FrmId(INTF_FRM_ID_125),
+    FrmId(INTF_FRM_ID_219),
+    FrmId(INTF_FRM_ID_220),
+    FrmId(INTF_FRM_ID_221),
+    FrmId(INTF_FRM_ID_222),
+    FrmId(INTF_FRM_ID_178),
+    FrmId(INTF_FRM_ID_179),
+    FrmId(INTF_FRM_ID_180),
+    FrmId(INTF_FRM_ID_38),
+    FrmId(INTF_FRM_ID_215),
+    FrmId(INTF_FRM_ID_216),
 };
 
 // flags to preload fid
@@ -1278,7 +1278,6 @@ static int characterEditorWindowInit()
     int v1;
     int v3;
     char path[COMPAT_MAX_PATH];
-    FrmId fid;
     char* str;
     int len;
     int btn;
@@ -1356,7 +1355,7 @@ static int characterEditorWindowInit()
     }
     messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_EDITOR, &gCharacterEditorMessageList);
 
-    fid = FrmId(gCharacterEditorIsCreationMode ? INTF_FRM_ID_169 : INTF_FRM_ID_177);
+    const FrmId fid = gCharacterEditorIsCreationMode ? FrmId(INTF_FRM_ID_169) : FrmId(INTF_FRM_ID_177);
     if (!_editorBackgroundFrmImage.lock(fid)) {
         characterEditorMessageListReset();
         characterEditorWindowRestoreState();
@@ -1388,8 +1387,7 @@ static int characterEditorWindowInit()
     soundContinueAll();
 
     for (i = 0; i < EDITOR_GRAPHIC_COUNT; i++) {
-        fid = FrmId(gCharacterEditorFrmIds[i]);
-        if (!_editorFrmImages[i].lock(fid)) {
+        if (!_editorFrmImages[i].lock(kCharacterEditorFrmIds[i])) {
             break;
         }
     }
@@ -5043,8 +5041,8 @@ static char* _itostndn(int value, char* dest)
 static int characterEditorDrawCardWithOptions(SkillDexFrameId graphicId, const char* name, const char* attributes, char* description)
 {
     FrmImage frmImage;
-    FrmId fid = FrmId(graphicId);
-    if (!frmImage.lock(fid)) {
+    const FrmId frmId = FrmId(graphicId);
+    if (!frmImage.lock(frmId)) {
         return -1;
     }
 
@@ -6138,8 +6136,7 @@ static int perkDialogShow()
         previousPerkRanks[perk] = perkGetRank(gDude, perk);
     }
 
-    FrmId backgroundFid = FrmId(INTF_FRM_ID_86);
-    if (!_perkDialogBackgroundFrmImage.lock(backgroundFid)) {
+    if (!_perkDialogBackgroundFrmImage.lock(FrmId(INTF_FRM_ID_86))) {
         debugPrint("\n *** Error running perks dialog window ***\n");
         return -1;
     }
@@ -7010,8 +7007,7 @@ static int perkDialogOptionCompare(const void* a1, const void* a2)
 static int perkDialogDrawCard(SkillDexFrameId frmId, const char* name, const char* rank, char* description)
 {
     FrmImage frmImage;
-    FrmId fid = FrmId(frmId);
-    if (!frmImage.lock(fid)) {
+    if (!frmImage.lock(FrmId(frmId))) {
         return -1;
     }
 

--- a/src/character_selector.cc
+++ b/src/character_selector.cc
@@ -295,8 +295,7 @@ static bool characterSelectorWindowInit()
     }
 
     FrmImage backgroundFrmImage;
-    FrmId backgroundFid = FrmId(INTF_FRM_ID_174);
-    if (!backgroundFrmImage.lock(backgroundFid)) {
+    if (!backgroundFrmImage.lock(FrmId(INTF_FRM_ID_174))) {
         return characterSelectorWindowFatalError(false);
     }
 
@@ -320,16 +319,12 @@ static bool characterSelectorWindowInit()
 
     backgroundFrmImage.unlock();
 
-    FrmId fid;
-
     // Setup "Previous" button.
-    fid = FrmId(INTF_FRM_ID_122);
-    if (!_previousButtonNormalFrmImage.lock(fid)) {
+    if (!_previousButtonNormalFrmImage.lock(FrmId(INTF_FRM_ID_122))) {
         return characterSelectorWindowFatalError(false);
     }
 
-    fid = FrmId(INTF_FRM_ID_123);
-    if (!_previousButtonPressedFrmImage.lock(fid)) {
+    if (!_previousButtonPressedFrmImage.lock(FrmId(INTF_FRM_ID_123))) {
         return characterSelectorWindowFatalError(false);
     }
 
@@ -353,13 +348,11 @@ static bool characterSelectorWindowInit()
     buttonSetCallbacks(gCharacterSelectorWindowPreviousButton, _gsound_med_butt_press, _gsound_med_butt_release);
 
     // Setup "Next" button.
-    fid = FrmId(INTF_FRM_ID_124);
-    if (!_nextButtonNormalFrmImage.lock(fid)) {
+    if (!_nextButtonNormalFrmImage.lock(FrmId(INTF_FRM_ID_124))) {
         return characterSelectorWindowFatalError(false);
     }
 
-    fid = FrmId(INTF_FRM_ID_125);
-    if (!_nextButtonPressedFrmImage.lock(fid)) {
+    if (!_nextButtonPressedFrmImage.lock(FrmId(INTF_FRM_ID_125))) {
         return characterSelectorWindowFatalError(false);
     }
 
@@ -383,13 +376,11 @@ static bool characterSelectorWindowInit()
     buttonSetCallbacks(gCharacterSelectorWindowNextButton, _gsound_med_butt_press, _gsound_med_butt_release);
 
     // Setup "Take" button.
-    fid = FrmId(INTF_FRM_ID_8);
-    if (!_takeButtonNormalFrmImage.lock(fid)) {
+    if (!_takeButtonNormalFrmImage.lock(FrmId(INTF_FRM_ID_8))) {
         return characterSelectorWindowFatalError(false);
     }
 
-    fid = FrmId(INTF_FRM_ID_9);
-    if (!_takeButtonPressedFrmImage.lock(fid)) {
+    if (!_takeButtonPressedFrmImage.lock(FrmId(INTF_FRM_ID_9))) {
         return characterSelectorWindowFatalError(false);
     }
 
@@ -413,12 +404,10 @@ static bool characterSelectorWindowInit()
     buttonSetCallbacks(gCharacterSelectorWindowTakeButton, _gsound_red_butt_press, _gsound_red_butt_release);
 
     // Setup "Modify" button.
-    fid = FrmId(INTF_FRM_ID_8);
-    if (!_modifyButtonNormalFrmImage.lock(fid))
+    if (!_modifyButtonNormalFrmImage.lock(FrmId(INTF_FRM_ID_8)))
         return characterSelectorWindowFatalError(false);
 
-    fid = FrmId(INTF_FRM_ID_9);
-    if (!_modifyButtonPressedFrmImage.lock(fid)) {
+    if (!_modifyButtonPressedFrmImage.lock(FrmId(INTF_FRM_ID_9))) {
         return characterSelectorWindowFatalError(false);
     }
 
@@ -442,13 +431,11 @@ static bool characterSelectorWindowInit()
     buttonSetCallbacks(gCharacterSelectorWindowModifyButton, _gsound_red_butt_press, _gsound_red_butt_release);
 
     // Setup "Create" button.
-    fid = FrmId(INTF_FRM_ID_8);
-    if (!_createButtonNormalFrmImage.lock(fid)) {
+    if (!_createButtonNormalFrmImage.lock(FrmId(INTF_FRM_ID_8))) {
         return characterSelectorWindowFatalError(false);
     }
 
-    fid = FrmId(INTF_FRM_ID_9);
-    if (!_createButtonPressedFrmImage.lock(fid)) {
+    if (!_createButtonPressedFrmImage.lock(FrmId(INTF_FRM_ID_9))) {
         return characterSelectorWindowFatalError(false);
     }
 
@@ -472,13 +459,11 @@ static bool characterSelectorWindowInit()
     buttonSetCallbacks(gCharacterSelectorWindowCreateButton, _gsound_red_butt_press, _gsound_red_butt_release);
 
     // Setup "Back" button.
-    fid = FrmId(INTF_FRM_ID_8);
-    if (!_backButtonNormalFrmImage.lock(fid)) {
+    if (!_backButtonNormalFrmImage.lock(FrmId(INTF_FRM_ID_8))) {
         return characterSelectorWindowFatalError(false);
     }
 
-    fid = FrmId(INTF_FRM_ID_9);
-    if (!_backButtonPressedFrmImage.lock(fid)) {
+    if (!_backButtonPressedFrmImage.lock(FrmId(INTF_FRM_ID_9))) {
         return characterSelectorWindowFatalError(false);
     }
 
@@ -613,8 +598,8 @@ static bool characterSelectorWindowRenderFace()
     bool success = false;
 
     FrmImage faceFrmImage;
-    FrmId faceFid = FrmId(gCustomPremadeCharacterDescriptions[gCurrentPremadeCharacter].face);
-    if (faceFrmImage.lock(faceFid)) {
+    const FrmId faceFrmId = FrmId(gCustomPremadeCharacterDescriptions[gCurrentPremadeCharacter].face);
+    if (faceFrmImage.lock(faceFrmId)) {
         unsigned char* data = faceFrmImage.getData();
         if (data != nullptr) {
             int width = faceFrmImage.getWidth();

--- a/src/combat.cc
+++ b/src/combat.cc
@@ -3575,8 +3575,8 @@ void attackInit(Attack* attack, Object* attacker, Object* defender, HitMode hitM
 int _combat_attack(Object* attacker, Object* defender, HitMode hitMode, HitLocation hitLocation)
 {
     if (attacker != gDude && hitMode == HIT_MODE_PUNCH && randomBetween(1, 4) == 1) {
-        FrmId fid = FrmId(attacker, ANIM_KICK_LEG, weaponAnimationFromFid(attacker->fid), rotationFromFid(attacker->fid));
-        if (artExists(fid)) {
+        const FrmId frmId = FrmId(attacker, ANIM_KICK_LEG, weaponAnimationFromFid(attacker->fid), rotationFromFid(attacker->fid));
+        if (artExists(frmId)) {
             hitMode = HIT_MODE_KICK;
         }
     }
@@ -5530,8 +5530,7 @@ static void _combat_standup(Object* a1)
 static void _print_tohit(unsigned char* dest, int destPitch, int accuracy)
 {
     FrmImage numbersFrmImage;
-    FrmId numbersFid = FrmId(INTF_FRM_ID_82);
-    if (!numbersFrmImage.lock(numbersFid)) {
+    if (!numbersFrmImage.lock(FrmId(INTF_FRM_ID_82))) {
         return;
     }
 
@@ -5619,8 +5618,7 @@ static int calledShotSelectHitLocation(Object* critter, HitLocation* hitLocation
     unsigned char* windowBuffer = windowGetBuffer(gCalledShotWindow);
 
     FrmImage backgroundFrm;
-    FrmId backgroundFid = FrmId(INTF_FRM_ID_118);
-    if (!backgroundFrm.lock(backgroundFid)) {
+    if (!backgroundFrm.lock(FrmId(INTF_FRM_ID_118))) {
         windowDestroy(gCalledShotWindow);
         return -1;
     }
@@ -5633,8 +5631,8 @@ static int calledShotSelectHitLocation(Object* critter, HitLocation* hitLocation
         CALLED_SHOT_WINDOW_WIDTH);
 
     FrmImage critterFrm;
-    FrmId critterFid = FrmId(critter, ANIM_CALLED_SHOT_PIC, WEAPON_ANIMATION_NONE, ROTATION_NE);
-    if (critterFrm.lock(critterFid)) {
+    const FrmId critterFrmId = FrmId(critter, ANIM_CALLED_SHOT_PIC, WEAPON_ANIMATION_NONE, ROTATION_NE);
+    if (critterFrm.lock(critterFrmId)) {
         blitBufferToBuffer(critterFrm.getData(),
             170,
             225,
@@ -5644,15 +5642,13 @@ static int calledShotSelectHitLocation(Object* critter, HitLocation* hitLocation
     }
 
     FrmImage cancelButtonNormalFrmImage;
-    FrmId cancelButtonNormalFid = FrmId(INTF_FRM_ID_8);
-    if (!cancelButtonNormalFrmImage.lock(cancelButtonNormalFid)) {
+    if (!cancelButtonNormalFrmImage.lock(FrmId(INTF_FRM_ID_8))) {
         windowDestroy(gCalledShotWindow);
         return -1;
     }
 
     FrmImage cancelButtonPressedFrmImage;
-    FrmId cancelButtonPressedFid = FrmId(INTF_FRM_ID_9);
-    if (!cancelButtonPressedFrmImage.lock(cancelButtonPressedFid)) {
+    if (!cancelButtonPressedFrmImage.lock(FrmId(INTF_FRM_ID_9))) {
         windowDestroy(gCalledShotWindow);
         return -1;
     }

--- a/src/dbox.cc
+++ b/src/dbox.cc
@@ -90,9 +90,9 @@ typedef enum FileDialogScrollDirection {
 static void fileDialogRenderFileList(unsigned char* buffer, char** fileList, int pageOffset, int fileListLength, int selectedIndex, int pitch);
 
 // 0x5108C8 dbox
-static const InterfaceFrameId gDialogBoxBackgroundFrmIds[DIALOG_TYPE_COUNT] = {
-    INTF_FRM_ID_218, // MEDIALOG.FRM - Medium generic dialog box
-    INTF_FRM_ID_217, // LGDIALOG.FRM - Large generic dialog box
+static constexpr FrmId kDialogBoxBackgroundFrmIds[DIALOG_TYPE_COUNT] = {
+    FrmId(INTF_FRM_ID_218), // MEDIALOG.FRM - Medium generic dialog box
+    FrmId(INTF_FRM_ID_217), // LGDIALOG.FRM - Large generic dialog box
 };
 
 // 0x5108D0 ytable
@@ -126,25 +126,25 @@ static const int _dblines[DIALOG_TYPE_COUNT] = {
 };
 
 // 0x510900 flgids
-static InterfaceFrameId gLoadFileDialogFrmIds[FILE_DIALOG_FRM_COUNT] = {
-    INTF_FRM_ID_224, // loadbox.frm - character editor
-    INTF_FRM_ID_8, // lilredup.frm - little red button up
-    INTF_FRM_ID_9, // lilreddn.frm - little red button down
-    INTF_FRM_ID_181, // dnarwoff.frm - character editor
-    INTF_FRM_ID_182, // dnarwon.frm - character editor
-    INTF_FRM_ID_199, // uparwoff.frm - character editor
-    INTF_FRM_ID_200, // uparwon.frm - character editor
+static constexpr FrmId kLoadFileDialogFrmIds[FILE_DIALOG_FRM_COUNT] = {
+    FrmId(INTF_FRM_ID_224), // loadbox.frm - character editor
+    FrmId(INTF_FRM_ID_8), // lilredup.frm - little red button up
+    FrmId(INTF_FRM_ID_9), // lilreddn.frm - little red button down
+    FrmId(INTF_FRM_ID_181), // dnarwoff.frm - character editor
+    FrmId(INTF_FRM_ID_182), // dnarwon.frm - character editor
+    FrmId(INTF_FRM_ID_199), // uparwoff.frm - character editor
+    FrmId(INTF_FRM_ID_200), // uparwon.frm - character editor
 };
 
 // 0x51091C flgids2
-static InterfaceFrameId gSaveFileDialogFrmIds[FILE_DIALOG_FRM_COUNT] = {
-    INTF_FRM_ID_225, // savebox.frm - character editor
-    INTF_FRM_ID_8, // lilredup.frm - little red button up
-    INTF_FRM_ID_9, // lilreddn.frm - little red button down
-    INTF_FRM_ID_181, // dnarwoff.frm - character editor
-    INTF_FRM_ID_182, // dnarwon.frm - character editor
-    INTF_FRM_ID_199, // uparwoff.frm - character editor
-    INTF_FRM_ID_200, // uparwon.frm - character editor
+static constexpr FrmId kSaveFileDialogFrmIds[FILE_DIALOG_FRM_COUNT] = {
+    FrmId(INTF_FRM_ID_225), // savebox.frm - character editor
+    FrmId(INTF_FRM_ID_8), // lilredup.frm - little red button up
+    FrmId(INTF_FRM_ID_9), // lilreddn.frm - little red button down
+    FrmId(INTF_FRM_ID_181), // dnarwoff.frm - character editor
+    FrmId(INTF_FRM_ID_182), // dnarwon.frm - character editor
+    FrmId(INTF_FRM_ID_199), // uparwoff.frm - character editor
+    FrmId(INTF_FRM_ID_200), // uparwon.frm - character editor
 };
 
 // 0x41CF20 dialog_out
@@ -201,7 +201,7 @@ int showDialogBox(const char* title, const char** body, int bodyLength, int x, i
     }
 
     FrmImage backgroundFrmImage;
-    FrmId backgroundFid = FrmId(gDialogBoxBackgroundFrmIds[dialogType]);
+    const FrmId backgroundFid = kDialogBoxBackgroundFrmIds[dialogType];
     if (!backgroundFrmImage.lock(backgroundFid)) {
         fontSetCurrent(savedFont);
         return -1;
@@ -229,22 +229,19 @@ int showDialogBox(const char* title, const char** body, int bodyLength, int x, i
     FrmImage buttonPressedFrmImage;
 
     if ((flags & DIALOG_BOX_NO_BUTTONS) == 0) {
-        FrmId doneBoxFid = FrmId(INTF_FRM_ID_209);
-        if (!doneBoxFrmImage.lock(doneBoxFid)) {
+        if (!doneBoxFrmImage.lock(FrmId(INTF_FRM_ID_209))) {
             fontSetCurrent(savedFont);
             windowDestroy(win);
             return -1;
         }
 
-        FrmId pressedFid = FrmId(INTF_FRM_ID_9);
-        if (!buttonPressedFrmImage.lock(pressedFid)) {
+        if (!buttonPressedFrmImage.lock(FrmId(INTF_FRM_ID_9))) {
             fontSetCurrent(savedFont);
             windowDestroy(win);
             return -1;
         }
 
-        FrmId normalFid = FrmId(INTF_FRM_ID_8);
-        if (!buttonNormalFrmImage.lock(normalFid)) {
+        if (!buttonNormalFrmImage.lock(FrmId(INTF_FRM_ID_8))) {
             fontSetCurrent(savedFont);
             windowDestroy(win);
             return -1;
@@ -346,22 +343,19 @@ int showDialogBox(const char* title, const char** body, int bodyLength, int x, i
                 buttonSetCallbacks(btn, _gsound_red_butt_press, _gsound_red_butt_release);
             }
         } else {
-            FrmId doneBoxFid = FrmId(INTF_FRM_ID_209);
-            if (!doneBoxFrmImage.lock(doneBoxFid)) {
+            if (!doneBoxFrmImage.lock(FrmId(INTF_FRM_ID_209))) {
                 fontSetCurrent(savedFont);
                 windowDestroy(win);
                 return -1;
             }
 
-            FrmId pressedFid = FrmId(INTF_FRM_ID_9);
-            if (!buttonPressedFrmImage.lock(pressedFid)) {
+            if (!buttonPressedFrmImage.lock(FrmId(INTF_FRM_ID_9))) {
                 fontSetCurrent(savedFont);
                 windowDestroy(win);
                 return -1;
             }
 
-            FrmId normalFid = FrmId(INTF_FRM_ID_8);
-            if (!buttonNormalFrmImage.lock(normalFid)) {
+            if (!buttonNormalFrmImage.lock(FrmId(INTF_FRM_ID_8))) {
                 fontSetCurrent(savedFont);
                 windowDestroy(win);
                 return -1;
@@ -588,8 +582,7 @@ int showLoadFileDialog(char* title, char** fileList, char* dest, int fileListLen
     FrmImage frmImages[FILE_DIALOG_FRM_COUNT];
 
     for (int index = 0; index < FILE_DIALOG_FRM_COUNT; index++) {
-        FrmId fid = FrmId(gLoadFileDialogFrmIds[index]);
-        if (!frmImages[index].lock(fid)) {
+        if (!frmImages[index].lock(kLoadFileDialogFrmIds[index])) {
             return -1;
         }
     }
@@ -953,8 +946,7 @@ int showSaveFileDialog(char* title, char** fileList, char* dest, int fileListLen
     FrmImage frmImages[FILE_DIALOG_FRM_COUNT];
 
     for (int index = 0; index < FILE_DIALOG_FRM_COUNT; index++) {
-        FrmId fid = FrmId(gSaveFileDialogFrmIds[index]);
-        if (!frmImages[index].lock(fid)) {
+        if (!frmImages[index].lock(kSaveFileDialogFrmIds[index])) {
             return -1;
         }
     }

--- a/src/display_monitor.cc
+++ b/src/display_monitor.cc
@@ -133,8 +133,7 @@ int displayMonitorInit()
                 DISPLAY_MONITOR_WIDTH);
         } else {
             FrmImage backgroundFrmImage;
-            FrmId backgroundFid = FrmId(INTF_FRM_ID_16);
-            if (!backgroundFrmImage.lock(backgroundFid)) {
+            if (!backgroundFrmImage.lock(FrmId(INTF_FRM_ID_16))) {
                 internal_free(gDisplayMonitorBackgroundFrmData);
                 return -1;
             }

--- a/src/elevator.cc
+++ b/src/elevator.cc
@@ -60,10 +60,10 @@ static int elevatorGetLevelFromKeyCode(int elevator, int keyCode);
 static int elevatorGetLevelFromEscKey(int elevator, int map);
 
 // 0x43E950 grph_id_2
-static const InterfaceFrameId gElevatorFrmIds[ELEVATOR_FRM_COUNT] = {
-    INTF_FRM_ID_141, // ebut_in.frm - map elevator screen
-    INTF_FRM_ID_142, // ebut_out.frm - map elevator screen
-    INTF_FRM_ID_149, // gaj000.frm - map elevator screen
+static constexpr FrmId kElevatorFrmIds[ELEVATOR_FRM_COUNT] = {
+    FrmId(INTF_FRM_ID_141), // ebut_in.frm - map elevator screen
+    FrmId(INTF_FRM_ID_142), // ebut_out.frm - map elevator screen
+    FrmId(INTF_FRM_ID_149), // gaj000.frm - map elevator screen
 };
 
 // 0x43E95C intotal
@@ -519,8 +519,7 @@ static int elevatorWindowInit(int elevator)
 
     int index;
     for (index = 0; index < ELEVATOR_FRM_COUNT; index++) {
-        FrmId fid = FrmId(gElevatorFrmIds[index]);
-        if (!_elevatorFrmImages[index].lock(fid)) {
+        if (!_elevatorFrmImages[index].lock(kElevatorFrmIds[index])) {
             break;
         }
     }
@@ -542,11 +541,11 @@ static int elevatorWindowInit(int elevator)
     const ElevatorBackground* elevatorBackground = &(gElevatorBackgrounds[elevator]);
     bool backgroundsLoaded = true;
 
-    FrmId backgroundFid = FrmId(elevatorBackground->backgroundFrmId);
-    if (_elevatorBackgroundFrmImage.lock(backgroundFid)) {
+    const FrmId backgroundFrmId = FrmId(elevatorBackground->backgroundFrmId);
+    if (_elevatorBackgroundFrmImage.lock(backgroundFrmId)) {
         if (elevatorBackground->panelFrmId != -1) {
-            FrmId panelFid = FrmId(elevatorBackground->panelFrmId);
-            if (!_elevatorPanelFrmImage.lock(panelFid)) {
+            const FrmId panelFrmId = FrmId(elevatorBackground->panelFrmId);
+            if (!_elevatorPanelFrmImage.lock(panelFrmId)) {
                 backgroundsLoaded = false;
             }
         }

--- a/src/endgame.cc
+++ b/src/endgame.cc
@@ -224,8 +224,8 @@ void endgamePlaySlideshow()
             if (ending->art_num == INTF_FRM_ID_327) {
                 endgameEndingRenderPanningScene(ending->direction, ending->voiceOverBaseName);
             } else {
-                FrmId fid = FrmId(ending->art_num);
-                endgameEndingRenderStaticScene(fid.fid(), ending->voiceOverBaseName);
+                const FrmId frmId = FrmId(ending->art_num);
+                endgameEndingRenderStaticScene(frmId.fid(), ending->voiceOverBaseName);
             }
         }
     }
@@ -345,10 +345,8 @@ static int endgameEndingHandleContinuePlaying()
 // 0x43FBDC endgame_pan_desert
 static void endgameEndingRenderPanningScene(int direction, const char* narratorFileName)
 {
-    FrmId fid = FrmId(INTF_FRM_ID_327);
-
     CacheEntry* backgroundHandle;
-    Art* background = artLock(fid, &backgroundHandle);
+    Art* background = artLock(FrmId(INTF_FRM_ID_327), &backgroundHandle);
     if (background != nullptr) {
         int width = artGetWidth(background);
         int height = artGetHeight(background);

--- a/src/game.cc
+++ b/src/game.cc
@@ -1240,8 +1240,7 @@ void showHelp()
         unsigned char* windowBuffer = windowGetBuffer(win);
         if (windowBuffer != nullptr) {
             FrmImage backgroundFrmImage;
-            FrmId backgroundFid = FrmId(INTF_FRM_ID_297);
-            if (backgroundFrmImage.lock(backgroundFid)) {
+            if (backgroundFrmImage.lock(FrmId(INTF_FRM_ID_297))) {
                 paletteSetEntries(gPaletteBlack);
                 blitBufferToBuffer(backgroundFrmImage.getData(), HELP_SCREEN_WIDTH, HELP_SCREEN_HEIGHT, HELP_SCREEN_WIDTH, windowBuffer, HELP_SCREEN_WIDTH);
 

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -4662,8 +4662,7 @@ void _gdialog_window_destroy()
     int offset = (GAME_DIALOG_WINDOW_WIDTH) * (480 - _dialogue_subwin_len);
     unsigned char* backgroundWindowBuffer = windowGetBuffer(gGameDialogBackgroundWindow) + offset;
 
-    const FrmId backgroundFid = gGameDialogSpeakerIsPartyMember ?
-        FrmId(INTF_FRM_ID_389) : // di_talkp.frm - dialog screen subwindow (party members)
+    const FrmId backgroundFid = gGameDialogSpeakerIsPartyMember ? FrmId(INTF_FRM_ID_389) : // di_talkp.frm - dialog screen subwindow (party members)
         FrmId(INTF_FRM_ID_99); // di_talk.frm - dialog screen subwindow (NPC's)
 
     FrmImage backgroundFrmImage;

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -415,13 +415,13 @@ static const int gGameDialogReviewWindowButtonHeights[GAME_DIALOG_REVIEW_WINDOW_
 };
 
 // 0x518830 reviewFids
-static InterfaceFrameId gGameDialogReviewWindowButtonFrmIds[GAME_DIALOG_REVIEW_WINDOW_BUTTON_FRM_COUNT] = {
-    INTF_FRM_ID_89, // di_bgdn1.frm - dialog big down arrow
-    INTF_FRM_ID_90, // di_bgdn2.frm - dialog big down arrow
-    INTF_FRM_ID_87, // di_bgup1.frm - dialog big up arrow
-    INTF_FRM_ID_88, // di_bgup2.frm - dialog big up arrow
-    INTF_FRM_ID_91, // di_done1.frm - dialog big done button up
-    INTF_FRM_ID_92, // di_done2.frm - dialog big done button down
+static constexpr FrmId kGameDialogReviewWindowButtonFrmIds[GAME_DIALOG_REVIEW_WINDOW_BUTTON_FRM_COUNT] = {
+    FrmId(INTF_FRM_ID_89), // di_bgdn1.frm - dialog big down arrow
+    FrmId(INTF_FRM_ID_90), // di_bgdn2.frm - dialog big down arrow
+    FrmId(INTF_FRM_ID_87), // di_bgup1.frm - dialog big up arrow
+    FrmId(INTF_FRM_ID_88), // di_bgup2.frm - dialog big up arrow
+    FrmId(INTF_FRM_ID_91), // di_done1.frm - dialog big done button up
+    FrmId(INTF_FRM_ID_92), // di_done2.frm - dialog big done button down
 };
 
 // 0x518848 dialog_target
@@ -1499,8 +1499,7 @@ int gameDialogReviewWindowInit(int* win)
     }
 
     FrmImage backgroundFrmImage;
-    FrmId fid = FrmId(INTF_FRM_ID_102);
-    if (!backgroundFrmImage.lock(fid)) {
+    if (!backgroundFrmImage.lock(FrmId(INTF_FRM_ID_102))) {
         windowDestroy(*win);
         *win = -1;
         return -1;
@@ -1518,8 +1517,8 @@ int gameDialogReviewWindowInit(int* win)
 
     int index;
     for (index = 0; index < GAME_DIALOG_REVIEW_WINDOW_BUTTON_FRM_COUNT; index++) {
-        FrmId fid = FrmId(gGameDialogReviewWindowButtonFrmIds[index]);
-        if (!_reviewFrmImages[index].lock(fid)) {
+        const FrmId frmId = kGameDialogReviewWindowButtonFrmIds[index];
+        if (!_reviewFrmImages[index].lock(frmId)) {
             break;
         }
     }
@@ -1595,8 +1594,7 @@ int gameDialogReviewWindowInit(int* win)
 
     tickersRemove(gameDialogTicker);
 
-    FrmId backgroundFid = FrmId(INTF_FRM_ID_102);
-    if (!_reviewBackgroundFrmImage.lock(backgroundFid)) {
+    if (!_reviewBackgroundFrmImage.lock(FrmId(INTF_FRM_ID_102))) {
         gameDialogReviewWindowFree(win);
         return -1;
     }
@@ -3442,10 +3440,9 @@ int gameDialogCreateBarterWindow()
     gBarterWindowExpanded = gExpandedBarterEnabled && backgroundFrmImage.lock(OBJ_TYPE_INTERFACE, expandedBarterFrmName());
 
     if (!gBarterWindowExpanded) {
-        InterfaceFrameId frmId = gGameDialogSpeakerIsPartyMember
-            ? INTF_FRM_ID_420 // trade.frm - party member barter/trade interface
-            : INTF_FRM_ID_111; // barter.frm - barter window
-        FrmId backgroundFid = FrmId(frmId);
+        const FrmId backgroundFid = gGameDialogSpeakerIsPartyMember
+            ? FrmId(INTF_FRM_ID_420) // trade.frm - party member barter/trade interface
+            : FrmId(INTF_FRM_ID_111); // barter.frm - barter window
         backgroundFrmImage.lock(backgroundFid);
     }
 
@@ -3603,8 +3600,7 @@ void gameDialogBarterCleanupTables()
 int partyMemberControlWindowInit()
 {
     FrmImage backgroundFrmImage;
-    FrmId backgroundFid = FrmId(INTF_FRM_ID_390);
-    if (!backgroundFrmImage.lock(backgroundFid)) {
+    if (!backgroundFrmImage.lock(FrmId(INTF_FRM_ID_390))) {
         return -1;
     }
 
@@ -3776,8 +3772,7 @@ void partyMemberControlWindowFree()
 
     // control.frm - party member control interface
     FrmImage backgroundFrmImage;
-    FrmId backgroundFid = FrmId(INTF_FRM_ID_390);
-    if (backgroundFrmImage.lock(backgroundFid)) {
+    if (backgroundFrmImage.lock(FrmId(INTF_FRM_ID_390))) {
         _gdialog_scroll_subwin(gGameDialogWindow, false, backgroundFrmImage.getData(), windowGetBuffer(gGameDialogWindow), windowGetBuffer(gGameDialogBackgroundWindow) + (GAME_DIALOG_WINDOW_WIDTH) * (480 - _dialogue_subwin_len), _dialogue_subwin_len);
     }
 
@@ -3795,8 +3790,7 @@ void partyMemberControlWindowUpdate()
     int windowWidth = windowGetWidth(gGameDialogWindow);
 
     FrmImage backgroundFrmImage;
-    FrmId backgroundFid = FrmId(INTF_FRM_ID_390);
-    if (backgroundFrmImage.lock(backgroundFid)) {
+    if (backgroundFrmImage.lock(FrmId(INTF_FRM_ID_390))) {
         int width = backgroundFrmImage.getWidth();
         unsigned char* buffer = backgroundFrmImage.getData();
 
@@ -4057,8 +4051,7 @@ int partyMemberCustomizationWindowInit()
     messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_CUSTOM, &gCustomMessageList);
 
     FrmImage backgroundFrmImage;
-    FrmId backgroundFid = FrmId(INTF_FRM_ID_391);
-    if (!backgroundFrmImage.lock(backgroundFid)) {
+    if (!backgroundFrmImage.lock(FrmId(INTF_FRM_ID_391))) {
         partyMemberCustomizationMessageListReset();
         return -1;
     }
@@ -4201,8 +4194,7 @@ void partyMemberCustomizationWindowFree()
 
     FrmImage backgroundFrmImage;
     // custom.frm - party member control interface
-    FrmId backgroundFid = FrmId(INTF_FRM_ID_391);
-    if (backgroundFrmImage.lock(backgroundFid)) {
+    if (backgroundFrmImage.lock(FrmId(INTF_FRM_ID_391))) {
         _gdialog_scroll_subwin(gGameDialogWindow, false, backgroundFrmImage.getData(), windowGetBuffer(gGameDialogWindow), windowGetBuffer(gGameDialogBackgroundWindow) + (GAME_DIALOG_WINDOW_WIDTH) * (480 - _dialogue_subwin_len), _dialogue_subwin_len);
     }
 
@@ -4254,8 +4246,7 @@ void partyMemberCustomizationWindowUpdate()
     int windowWidth = windowGetWidth(gGameDialogWindow);
 
     FrmImage backgroundFrmImage;
-    FrmId backgroundFid = FrmId(INTF_FRM_ID_391);
-    if (!backgroundFrmImage.lock(backgroundFid)) {
+    if (!backgroundFrmImage.lock(FrmId(INTF_FRM_ID_391))) {
         return;
     }
 
@@ -4361,8 +4352,7 @@ int _gdCustomSelect(int option)
     int oldFont = fontGetCurrent();
 
     FrmImage backgroundFrmImage;
-    FrmId backgroundFid = FrmId(INTF_FRM_ID_419);
-    if (!backgroundFrmImage.lock(backgroundFid)) {
+    if (!backgroundFrmImage.lock(FrmId(INTF_FRM_ID_419))) {
         return -1;
     }
 
@@ -4606,7 +4596,7 @@ int _gdialog_window_create()
     FrmImage backgroundFrmImage;
     // 389 - di_talkp.frm - dialog screen subwindow (party members)
     // 99 - di_talk.frm - dialog screen subwindow (NPC's)
-    FrmId backgroundFid = FrmId(gGameDialogSpeakerIsPartyMember ? INTF_FRM_ID_389 : INTF_FRM_ID_99);
+    const FrmId backgroundFid = gGameDialogSpeakerIsPartyMember ? FrmId(INTF_FRM_ID_389) : FrmId(INTF_FRM_ID_99);
     if (!backgroundFrmImage.lock(backgroundFid)) return -1;
 
     unsigned char* backgroundFrmData = backgroundFrmImage.getData();
@@ -4672,17 +4662,11 @@ void _gdialog_window_destroy()
     int offset = (GAME_DIALOG_WINDOW_WIDTH) * (480 - _dialogue_subwin_len);
     unsigned char* backgroundWindowBuffer = windowGetBuffer(gGameDialogBackgroundWindow) + offset;
 
-    InterfaceFrameId frmId;
-    if (gGameDialogSpeakerIsPartyMember) {
-        // di_talkp.frm - dialog screen subwindow (party members)
-        frmId = INTF_FRM_ID_389;
-    } else {
-        // di_talk.frm - dialog screen subwindow (NPC's)
-        frmId = INTF_FRM_ID_99;
-    }
+    const FrmId backgroundFid = gGameDialogSpeakerIsPartyMember ?
+        FrmId(INTF_FRM_ID_389) : // di_talkp.frm - dialog screen subwindow (party members)
+        FrmId(INTF_FRM_ID_99); // di_talk.frm - dialog screen subwindow (NPC's)
 
     FrmImage backgroundFrmImage;
-    FrmId backgroundFid = FrmId(frmId);
     if (backgroundFrmImage.lock(backgroundFid)) {
         unsigned char* windowBuffer = windowGetBuffer(gGameDialogWindow);
         _gdialog_scroll_subwin(gGameDialogWindow, false, backgroundFrmImage.getData(), windowBuffer, backgroundWindowBuffer, _dialogue_subwin_len);
@@ -4966,12 +4950,10 @@ void gameDialogHighlightsInit()
     _dark_BlendTable = _getColorBlendTable(COLOR_OLIVE);
 
     // hilight1.frm - dialogue upper hilight
-    FrmId upperHighlightFid = FrmId(INTF_FRM_ID_115);
-    _upperHighlightFrmImage.lock(upperHighlightFid);
+    _upperHighlightFrmImage.lock(FrmId(INTF_FRM_ID_115));
 
     // hilight2.frm - dialogue lower hilight
-    FrmId lowerHighlightFid = FrmId(INTF_FRM_ID_116);
-    _lowerHighlightFrmImage.lock(lowerHighlightFid);
+    _lowerHighlightFrmImage.lock(FrmId(INTF_FRM_ID_116));
 }
 
 // NOTE: Inlined.

--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -74,34 +74,34 @@ static int gGameMouseCursor = MOUSE_CURSOR_NONE;
 static CacheEntry* gGameMouseCursorFrmHandle = INVALID_CACHE_ENTRY;
 
 // 0x518C14 gmouse_cursor_nums
-static const InterfaceFrameId gGameMouseCursorFrmIds[MOUSE_CURSOR_TYPE_COUNT] = {
-    INTF_FRM_ID_266,
-    INTF_FRM_ID_267,
-    INTF_FRM_ID_268,
-    INTF_FRM_ID_269,
-    INTF_FRM_ID_270,
-    INTF_FRM_ID_271,
-    INTF_FRM_ID_272,
-    INTF_FRM_ID_273,
-    INTF_FRM_ID_274,
-    INTF_FRM_ID_275,
-    INTF_FRM_ID_276,
-    INTF_FRM_ID_277,
-    INTF_FRM_ID_330,
-    INTF_FRM_ID_331,
-    INTF_FRM_ID_329,
-    INTF_FRM_ID_328,
-    INTF_FRM_ID_332,
-    INTF_FRM_ID_334,
-    INTF_FRM_ID_333,
-    INTF_FRM_ID_335,
-    INTF_FRM_ID_279,
-    INTF_FRM_ID_280,
-    INTF_FRM_ID_281,
-    INTF_FRM_ID_293,
-    INTF_FRM_ID_310,
-    INTF_FRM_ID_278,
-    INTF_FRM_ID_295,
+static constexpr FrmId kGameMouseCursorFrmIds[MOUSE_CURSOR_TYPE_COUNT] = {
+    FrmId(INTF_FRM_ID_266),
+    FrmId(INTF_FRM_ID_267),
+    FrmId(INTF_FRM_ID_268),
+    FrmId(INTF_FRM_ID_269),
+    FrmId(INTF_FRM_ID_270),
+    FrmId(INTF_FRM_ID_271),
+    FrmId(INTF_FRM_ID_272),
+    FrmId(INTF_FRM_ID_273),
+    FrmId(INTF_FRM_ID_274),
+    FrmId(INTF_FRM_ID_275),
+    FrmId(INTF_FRM_ID_276),
+    FrmId(INTF_FRM_ID_277),
+    FrmId(INTF_FRM_ID_330),
+    FrmId(INTF_FRM_ID_331),
+    FrmId(INTF_FRM_ID_329),
+    FrmId(INTF_FRM_ID_328),
+    FrmId(INTF_FRM_ID_332),
+    FrmId(INTF_FRM_ID_334),
+    FrmId(INTF_FRM_ID_333),
+    FrmId(INTF_FRM_ID_335),
+    FrmId(INTF_FRM_ID_279),
+    FrmId(INTF_FRM_ID_280),
+    FrmId(INTF_FRM_ID_281),
+    FrmId(INTF_FRM_ID_293),
+    FrmId(INTF_FRM_ID_310),
+    FrmId(INTF_FRM_ID_278),
+    FrmId(INTF_FRM_ID_295),
 };
 
 // 0x518C80 gmouse_3d_initialized
@@ -230,7 +230,7 @@ static unsigned char* _gmouse_3d_menu_actions_start = nullptr;
 static unsigned char gGameMouseActionMenuHighlightedItemIndex = 0;
 
 // 0x518D1E gmouse_3d_action_nums
-static const InterfaceFrameId gGameMouseActionMenuItemFrmIds[GAME_MOUSE_ACTION_MENU_ITEM_COUNT] = {
+static constexpr InterfaceFrameId kGameMouseActionMenuItemFrmIds[GAME_MOUSE_ACTION_MENU_ITEM_COUNT] = {
     INTF_FRM_ID_253, // Cancel
     INTF_FRM_ID_255, // Drop
     INTF_FRM_ID_257, // Inventory
@@ -774,9 +774,8 @@ void gameMouseRefresh()
                     if (primaryAction != -1) {
                         if (gameMouseRenderPrimaryAction(mouseX, mouseY, primaryAction, _scr_size.right - _scr_size.left + 1, _scr_size.bottom - _scr_size.top - 99) == 0) {
                             Rect tmp;
-                            FrmId fid = FrmId(INTF_FRM_ID_282);
                             // NOTE: Uninline.
-                            if (gmouse_3d_set_flat_fid(fid.fid(), &tmp) == 0) {
+                            if (gmouse_3d_set_flat_fid(FrmId(INTF_FRM_ID_282).fid(), &tmp) == 0) {
                                 tileWindowRefreshRect(&tmp, gElevation);
                             }
                         }
@@ -836,9 +835,8 @@ void gameMouseRefresh()
 
                     if (gameMouseRenderAccuracy(formattedAccuracy, color) == 0) {
                         Rect tmp;
-                        FrmId fid = FrmId(INTF_FRM_ID_284);
                         // NOTE: Uninline.
-                        if (gmouse_3d_set_flat_fid(fid.fid(), &tmp) == 0) {
+                        if (gmouse_3d_set_flat_fid(FrmId(INTF_FRM_ID_284).fid(), &tmp) == 0) {
                             tileWindowRefreshRect(&tmp, gElevation);
                         }
                     }
@@ -901,8 +899,7 @@ void gameMouseRefresh()
     gGameMouseLastY = mouseY;
 
     if (!_gmouse_mapper_mode) {
-        FrmId fid = FrmId(INTF_FRM_ID_0);
-        gameMouseSetBouncingCursorFid(fid.fid());
+        gameMouseSetBouncingCursorFid(FrmId(INTF_FRM_ID_0).fid());
     }
 
     int v34 = 0;
@@ -1207,9 +1204,8 @@ void _gmouse_handle_event(int mouseX, int mouseY, int mouseState)
 
             if (gameMouseRenderActionMenuItems(mouseX, mouseY, actionMenuItems, actionMenuItemsCount, _scr_size.right - _scr_size.left + 1, _scr_size.bottom - _scr_size.top - 99) == 0) {
                 Rect cursorRect;
-                FrmId fid = FrmId(INTF_FRM_ID_283);
                 // NOTE: Uninline.
-                if (gmouse_3d_set_flat_fid(fid.fid(), &cursorRect) == 0 && _gmouse_3d_move_to(mouseX, mouseY, gElevation, &cursorRect) == 0) {
+                if (gmouse_3d_set_flat_fid(FrmId(INTF_FRM_ID_283).fid(), &cursorRect) == 0 && _gmouse_3d_move_to(mouseX, mouseY, gElevation, &cursorRect) == 0) {
                     tileWindowRefreshRect(&cursorRect, gElevation);
                     isoDisable();
 
@@ -1357,7 +1353,7 @@ int gameMouseSetCursor(int cursor)
     }
 
     CacheEntry* mouseCursorFrmHandle;
-    FrmId fid = FrmId(gGameMouseCursorFrmIds[cursor]);
+    const FrmId fid = kGameMouseCursorFrmIds[cursor];
     Art* mouseCursorFrm = artLock(fid, &mouseCursorFrmHandle);
     if (mouseCursorFrm == nullptr) {
         return -1;
@@ -1448,14 +1444,13 @@ void gameMouseSetMode(int mode)
         return;
     }
 
-    FrmId fid = FrmId(INTF_FRM_ID_0);
-    gameMouseSetBouncingCursorFid(fid.fid());
+    gameMouseSetBouncingCursorFid(FrmId(INTF_FRM_ID_0).fid());
 
-    fid = FrmId(gGameMouseModeFrmIds[mode]);
+    const FrmId frmId = FrmId(gGameMouseModeFrmIds[mode]);
 
     Rect rect;
     // NOTE: Uninline.
-    if (gmouse_3d_set_flat_fid(fid.fid(), &rect) == -1) {
+    if (gmouse_3d_set_flat_fid(frmId.fid(), &rect) == -1) {
         return;
     }
 
@@ -1603,8 +1598,7 @@ int gameMouseSetBouncingCursorFid(int fid)
 // 0x44CD0C gmouse_3d_reset_fid
 void gameMouseResetBouncingCursorFid()
 {
-    FrmId fid = FrmId(INTF_FRM_ID_0);
-    gameMouseSetBouncingCursorFid(fid.fid());
+    gameMouseSetBouncingCursorFid(FrmId(INTF_FRM_ID_0).fid());
 }
 
 // 0x44CD2C gmouse_3d_on
@@ -1751,15 +1745,15 @@ Object* gameMouseGetObjectUnderCursor(ObjectType objectType, bool includeDude, i
 int gameMouseRenderPrimaryAction(int x, int y, int menuItem, int width, int height)
 {
     CacheEntry* menuItemFrmHandle;
-    FrmId menuItemFid = FrmId(gGameMouseActionMenuItemFrmIds[menuItem]);
-    Art* menuItemFrm = artLock(menuItemFid, &menuItemFrmHandle);
+    const FrmId menuItemFrmId = FrmId(kGameMouseActionMenuItemFrmIds[menuItem]);
+    Art* menuItemFrm = artLock(menuItemFrmId, &menuItemFrmHandle);
     if (menuItemFrm == nullptr) {
         return -1;
     }
 
     CacheEntry* arrowFrmHandle;
-    FrmId arrowFid = FrmId(gGameMouseModeFrmIds[GAME_MOUSE_MODE_ARROW]);
-    Art* arrowFrm = artLock(arrowFid, &arrowFrmHandle);
+    const FrmId arrowFrmId = FrmId(gGameMouseModeFrmIds[GAME_MOUSE_MODE_ARROW]);
+    Art* arrowFrm = artLock(arrowFrmId, &arrowFrmHandle);
     if (arrowFrm == nullptr) {
         artUnlock(menuItemFrmHandle);
         return -1;
@@ -1820,8 +1814,7 @@ int gameMouseRenderPrimaryAction(int x, int y, int menuItem, int width, int heig
         // mirrored cursor for far-right side of screen
         artUnlock(arrowFrmHandle);
 
-        arrowFid = FrmId(INTF_FRM_ID_285);
-        arrowFrm = artLock(arrowFid, &arrowFrmHandle);
+        arrowFrm = artLock(FrmId(INTF_FRM_ID_285), &arrowFrmHandle);
         if (arrowFrm == nullptr) {
             artUnlock(menuItemFrmHandle);
             return -1;
@@ -1892,14 +1885,12 @@ int gameMouseRenderActionMenuItems(int x, int y, const int* menuItems, int menuI
             return -1;
         }
 
-        InterfaceFrameId frmId = gGameMouseActionMenuItemFrmIds[menuItems[index]];
+        InterfaceFrameId frmId = kGameMouseActionMenuItemFrmIds[menuItems[index]];
         if (index == 0) {
             frmId = frmId - 1;
         }
 
-        FrmId fid = FrmId(frmId);
-
-        menuItemFrms[index] = artLock(fid, &(menuItemFrmHandles[index]));
+        menuItemFrms[index] = artLock(FrmId(frmId), &(menuItemFrmHandles[index]));
         if (menuItemFrms[index] == nullptr) {
             while (--index >= 0) {
                 artUnlock(menuItemFrmHandles[index]);
@@ -1908,9 +1899,9 @@ int gameMouseRenderActionMenuItems(int x, int y, const int* menuItems, int menuI
         }
     }
 
-    FrmId fid = FrmId(gGameMouseModeFrmIds[GAME_MOUSE_MODE_ARROW]);
+    const FrmId frmId = FrmId(gGameMouseModeFrmIds[GAME_MOUSE_MODE_ARROW]);
     CacheEntry* arrowFrmHandle;
-    Art* arrowFrm = artLock(fid, &arrowFrmHandle);
+    Art* arrowFrm = artLock(frmId, &arrowFrmHandle);
     if (arrowFrm == nullptr) {
         for (int index = 0; index < menuItemsLength; index++) {
             artUnlock(menuItemFrmHandles[index]);
@@ -1973,8 +1964,7 @@ int gameMouseRenderActionMenuItems(int x, int y, const int* menuItems, int menuI
     } else {
         // Mirrored arrow (from left to right).
         artUnlock(arrowFrmHandle);
-        fid = FrmId(INTF_FRM_ID_285);
-        arrowFrm = artLock(fid, &arrowFrmHandle);
+        arrowFrm = artLock(FrmId(INTF_FRM_ID_285), &arrowFrmHandle);
         if (arrowFrm == nullptr) {
             for (int index = 0; index < menuItemsLength; index++) {
                 artUnlock(menuItemFrmHandles[index]);
@@ -2075,8 +2065,8 @@ int gameMouseHighlightActionMenuItemAtIndex(int menuItemIndex)
         return -1;
     }
 
-    FrmId fid = FrmId(gGameMouseActionMenuItemFrmIds[gGameMouseActionMenuItems[gGameMouseActionMenuHighlightedItemIndex]]);
-    Art* art = artLock(fid, &handle);
+    FrmId frmId = FrmId(kGameMouseActionMenuItemFrmIds[gGameMouseActionMenuItems[gGameMouseActionMenuHighlightedItemIndex]]);
+    Art* art = artLock(frmId, &handle);
     if (art == nullptr) {
         return -1;
     }
@@ -2097,8 +2087,8 @@ int gameMouseHighlightActionMenuItemAtIndex(int menuItemIndex)
         return -1;
     }
 
-    fid = FrmId(gGameMouseActionMenuItemFrmIds[gGameMouseActionMenuItems[menuItemIndex]] - 1);
-    art = artLock(fid, &handle);
+    frmId = FrmId(kGameMouseActionMenuItemFrmIds[gGameMouseActionMenuItems[menuItemIndex]] - 1);
+    art = artLock(frmId, &handle);
     if (art == nullptr) {
         return -1;
     }
@@ -2123,8 +2113,8 @@ int gameMouseHighlightActionMenuItemAtIndex(int menuItemIndex)
 int gameMouseRenderAccuracy(const char* string, Color color)
 {
     CacheEntry* crosshairFrmHandle;
-    FrmId fid = FrmId(gGameMouseModeFrmIds[GAME_MOUSE_MODE_CROSSHAIR]);
-    Art* crosshairFrm = artLock(fid, &crosshairFrmHandle);
+    const FrmId frmId = FrmId(gGameMouseModeFrmIds[GAME_MOUSE_MODE_CROSSHAIR]);
+    Art* crosshairFrm = artLock(frmId, &crosshairFrmHandle);
     if (crosshairFrm == nullptr) {
         return -1;
     }
@@ -2182,8 +2172,7 @@ int gameMouseRenderActionPoints(const char* string, Color color)
 
     fontSetCurrent(oldFont);
 
-    FrmId fid = FrmId(INTF_FRM_ID_1);
-    gameMouseSetBouncingCursorFid(fid.fid());
+    gameMouseSetBouncingCursorFid(FrmId(INTF_FRM_ID_1).fid());
 
     return 0;
 }
@@ -2197,19 +2186,15 @@ void gameMouseLoadItemHighlight()
 // 0x44D984 gmouse_3d_init
 int gameMouseObjectsInit()
 {
-    FrmId fid;
-
     if (gGameMouseObjectsInitialized) {
         return -1;
     }
 
-    fid = FrmId(INTF_FRM_ID_0);
-    if (objectCreateWithFidPid(&gGameMouseBouncingCursor, fid.fid(), -1) != 0) {
+    if (objectCreateWithFidPid(&gGameMouseBouncingCursor, FrmId(INTF_FRM_ID_0).fid(), -1) != 0) {
         return -1;
     }
 
-    fid = FrmId(INTF_FRM_ID_1);
-    if (objectCreateWithFidPid(&gGameMouseHexCursor, fid.fid(), -1) != 0) {
+    if (objectCreateWithFidPid(&gGameMouseHexCursor, FrmId(INTF_FRM_ID_1).fid(), -1) != 0) {
         return -1;
     }
 
@@ -2297,39 +2282,32 @@ void gameMouseObjectsFree()
 // 0x44DB78 gmouse_3d_lock_frames
 int gameMouseActionMenuInit()
 {
-    FrmId fid;
-
     // actmenu.frm - action menu
-    fid = FrmId(INTF_FRM_ID_283);
-    gGameMouseActionMenuFrm = artLock(fid, &gGameMouseActionMenuFrmHandle);
+    gGameMouseActionMenuFrm = artLock(FrmId(INTF_FRM_ID_283), &gGameMouseActionMenuFrmHandle);
     if (gGameMouseActionMenuFrm == nullptr) {
         goto err;
     }
 
     // actpick.frm - action pick
-    fid = FrmId(INTF_FRM_ID_282);
-    gGameMouseActionPickFrm = artLock(fid, &gGameMouseActionPickFrmHandle);
+    gGameMouseActionPickFrm = artLock(FrmId(INTF_FRM_ID_282), &gGameMouseActionPickFrmHandle);
     if (gGameMouseActionPickFrm == nullptr) {
         goto err;
     }
 
     // acttohit.frm - action to hit
-    fid = FrmId(INTF_FRM_ID_284);
-    gGameMouseActionHitFrm = artLock(fid, &gGameMouseActionHitFrmHandle);
+    gGameMouseActionHitFrm = artLock(FrmId(INTF_FRM_ID_284), &gGameMouseActionHitFrmHandle);
     if (gGameMouseActionHitFrm == nullptr) {
         goto err;
     }
 
     // blank.frm - used be mset000.frm for top of bouncing mouse cursor
-    fid = FrmId(INTF_FRM_ID_0);
-    gGameMouseBouncingCursorFrm = artLock(fid, &gGameMouseBouncingCursorFrmHandle);
+    gGameMouseBouncingCursorFrm = artLock(FrmId(INTF_FRM_ID_0), &gGameMouseBouncingCursorFrmHandle);
     if (gGameMouseBouncingCursorFrm == nullptr) {
         goto err;
     }
 
     // msef000.frm - hex mouse cursor
-    fid = FrmId(INTF_FRM_ID_1);
-    gGameMouseHexCursorFrm = artLock(fid, &gGameMouseHexCursorFrmHandle);
+    gGameMouseHexCursorFrm = artLock(FrmId(INTF_FRM_ID_1), &gGameMouseHexCursorFrmHandle);
     if (gGameMouseHexCursorFrm == nullptr) {
         goto err;
     }
@@ -2442,13 +2420,13 @@ static int gmouse_3d_set_flat_fid(int fid, Rect* rect)
 // 0x44DF40 gmouse_3d_reset_flat_fid
 int gameMouseUpdateHexCursorFid(Rect* rect)
 {
-    FrmId fid = FrmId(gGameMouseModeFrmIds[gGameMouseMode]);
-    if (gGameMouseHexCursor->fid == fid.fid()) {
+    const FrmId frmId = FrmId(gGameMouseModeFrmIds[gGameMouseMode]);
+    if (gGameMouseHexCursor->fid == frmId.fid()) {
         return -1;
     }
 
     // NOTE: Uninline.
-    return gmouse_3d_set_flat_fid(fid.fid(), rect);
+    return gmouse_3d_set_flat_fid(frmId.fid(), rect);
 }
 
 // 0x44DF94 gmouse_3d_move_to

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -381,8 +381,6 @@ static Buffer2D apBarBackgroundBuf2D()
 // 0x45D880 intface_init
 int interfaceInit()
 {
-    FrmId fid;
-
     if (gInterfaceBarWindow != -1) {
         return -1;
     }
@@ -414,8 +412,7 @@ int interfaceInit()
         blitBufferToBuffer(customInterfaceBarGetBackgroundImageData(), gInterfaceBarWidth, INTERFACE_BAR_HEIGHT - 1, gInterfaceBarWidth, gInterfaceWindowBuffer, gInterfaceBarWidth);
     } else {
         FrmImage backgroundFrmImage;
-        fid = FrmId(INTF_FRM_ID_16);
-        if (!backgroundFrmImage.lock(fid)) {
+        if (!backgroundFrmImage.lock(FrmId(INTF_FRM_ID_16))) {
             return intface_fatal_error(-1);
         }
 
@@ -425,14 +422,12 @@ int interfaceInit()
 
     extendedApBarInitToWindow();
 
-    fid = FrmId(INTF_FRM_ID_47);
-    if (!_inventoryButtonNormalFrmImage.lock(fid)) {
+    if (!_inventoryButtonNormalFrmImage.lock(FrmId(INTF_FRM_ID_47))) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    fid = FrmId(INTF_FRM_ID_46);
-    if (!_inventoryButtonPressedFrmImage.lock(fid)) {
+    if (!_inventoryButtonPressedFrmImage.lock(FrmId(INTF_FRM_ID_46))) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
@@ -445,14 +440,12 @@ int interfaceInit()
 
     buttonSetCallbacks(gInventoryButton, _gsound_med_butt_press, _gsound_med_butt_release);
 
-    fid = FrmId(INTF_FRM_ID_18);
-    if (!_optionsButtonNormalFrmImage.lock(fid)) {
+    if (!_optionsButtonNormalFrmImage.lock(FrmId(INTF_FRM_ID_18))) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    fid = FrmId(INTF_FRM_ID_17);
-    if (!_optionsButtonPressedFrmImage.lock(fid)) {
+    if (!_optionsButtonPressedFrmImage.lock(FrmId(INTF_FRM_ID_17))) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
@@ -465,20 +458,17 @@ int interfaceInit()
 
     buttonSetCallbacks(gOptionsButton, _gsound_med_butt_press, _gsound_med_butt_release);
 
-    fid = FrmId(INTF_FRM_ID_6);
-    if (!_skilldexButtonNormalFrmImage.lock(fid)) {
+    if (!_skilldexButtonNormalFrmImage.lock(FrmId(INTF_FRM_ID_6))) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    fid = FrmId(INTF_FRM_ID_7);
-    if (!_skilldexButtonPressedFrmImage.lock(fid)) {
+    if (!_skilldexButtonPressedFrmImage.lock(FrmId(INTF_FRM_ID_7))) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    fid = FrmId(INTF_FRM_ID_6);
-    if (!_skilldexButtonMaskFrmImage.lock(fid)) {
+    if (!_skilldexButtonMaskFrmImage.lock(FrmId(INTF_FRM_ID_6))) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
@@ -492,20 +482,17 @@ int interfaceInit()
     buttonSetMask(gSkilldexButton, _skilldexButtonMaskFrmImage.getData());
     buttonSetCallbacks(gSkilldexButton, _gsound_med_butt_press, _gsound_med_butt_release);
 
-    fid = FrmId(INTF_FRM_ID_13);
-    if (!_mapButtonNormalFrmImage.lock(fid)) {
+    if (!_mapButtonNormalFrmImage.lock(FrmId(INTF_FRM_ID_13))) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    fid = FrmId(INTF_FRM_ID_10);
-    if (!_mapButtonPressedFrmImage.lock(fid)) {
+    if (!_mapButtonPressedFrmImage.lock(FrmId(INTF_FRM_ID_10))) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    fid = FrmId(INTF_FRM_ID_13);
-    if (!_mapButtonMaskFrmImage.lock(fid)) {
+    if (!_mapButtonMaskFrmImage.lock(FrmId(INTF_FRM_ID_13))) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
@@ -519,14 +506,12 @@ int interfaceInit()
     buttonSetMask(gMapButton, _mapButtonMaskFrmImage.getData());
     buttonSetCallbacks(gMapButton, _gsound_med_butt_press, _gsound_med_butt_release);
 
-    fid = FrmId(INTF_FRM_ID_59);
-    if (!_pipboyButtonNormalFrmImage.lock(fid)) {
+    if (!_pipboyButtonNormalFrmImage.lock(FrmId(INTF_FRM_ID_59))) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    fid = FrmId(INTF_FRM_ID_58);
-    if (!_pipboyButtonPressedFrmImage.lock(fid)) {
+    if (!_pipboyButtonPressedFrmImage.lock(FrmId(INTF_FRM_ID_58))) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
@@ -540,14 +525,12 @@ int interfaceInit()
     buttonSetMask(gPipboyButton, _mapButtonMaskFrmImage.getData());
     buttonSetCallbacks(gPipboyButton, _gsound_med_butt_press, _gsound_med_butt_release);
 
-    fid = FrmId(INTF_FRM_ID_57);
-    if (!_characterButtonNormalFrmImage.lock(fid)) {
+    if (!_characterButtonNormalFrmImage.lock(FrmId(INTF_FRM_ID_57))) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    fid = FrmId(INTF_FRM_ID_56);
-    if (!_characterButtonPressedFrmImage.lock(fid)) {
+    if (!_characterButtonPressedFrmImage.lock(FrmId(INTF_FRM_ID_56))) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
@@ -561,20 +544,17 @@ int interfaceInit()
     buttonSetMask(gCharacterButton, _mapButtonMaskFrmImage.getData());
     buttonSetCallbacks(gCharacterButton, _gsound_med_butt_press, _gsound_med_butt_release);
 
-    fid = FrmId(INTF_FRM_ID_32);
-    if (!_itemButtonNormalFrmImage.lock(fid)) {
+    if (!_itemButtonNormalFrmImage.lock(FrmId(INTF_FRM_ID_32))) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    fid = FrmId(INTF_FRM_ID_31);
-    if (!_itemButtonPressedFrmImage.lock(fid)) {
+    if (!_itemButtonPressedFrmImage.lock(FrmId(INTF_FRM_ID_31))) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    fid = FrmId(INTF_FRM_ID_73);
-    if (!_itemButtonDisabledFrmImage.lock(fid)) {
+    if (!_itemButtonDisabledFrmImage.lock(FrmId(INTF_FRM_ID_73))) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
@@ -591,20 +571,17 @@ int interfaceInit()
     buttonSetRightMouseCallbacks(gSingleAttackButton, -1, KEY_LOWERCASE_N, nullptr, nullptr);
     buttonSetCallbacks(gSingleAttackButton, _gsound_lrg_butt_press, _gsound_lrg_butt_release);
 
-    fid = FrmId(INTF_FRM_ID_6);
-    if (!_changeHandsButtonNormalFrmImage.lock(fid)) {
+    if (!_changeHandsButtonNormalFrmImage.lock(FrmId(INTF_FRM_ID_6))) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    fid = FrmId(INTF_FRM_ID_7);
-    if (!_changeHandsButtonPressedFrmImage.lock(fid)) {
+    if (!_changeHandsButtonPressedFrmImage.lock(FrmId(INTF_FRM_ID_7))) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    fid = FrmId(INTF_FRM_ID_6);
-    if (!_changeHandsButtonMaskFrmImage.lock(fid)) {
+    if (!_changeHandsButtonMaskFrmImage.lock(FrmId(INTF_FRM_ID_6))) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
@@ -619,26 +596,22 @@ int interfaceInit()
     buttonSetMask(gChangeHandsButton, _changeHandsButtonMaskFrmImage.getData());
     buttonSetCallbacks(gChangeHandsButton, _gsound_med_butt_press, _gsound_med_butt_release);
 
-    fid = FrmId(INTF_FRM_ID_82);
-    if (!_numbersFrmImage.lock(fid)) {
+    if (!_numbersFrmImage.lock(FrmId(INTF_FRM_ID_82))) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    fid = FrmId(INTF_FRM_ID_83);
-    if (!_greenLightFrmImage.lock(fid)) {
+    if (!_greenLightFrmImage.lock(FrmId(INTF_FRM_ID_83))) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    fid = FrmId(INTF_FRM_ID_84);
-    if (!_yellowLightFrmImage.lock(fid)) {
+    if (!_yellowLightFrmImage.lock(FrmId(INTF_FRM_ID_84))) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    fid = FrmId(INTF_FRM_ID_85);
-    if (!_redLightFrmImage.lock(fid)) {
+    if (!_redLightFrmImage.lock(FrmId(INTF_FRM_ID_85))) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
@@ -1492,9 +1465,8 @@ void interfaceBarEndButtonsShow(bool animated)
         return;
     }
 
-    FrmId fid = FrmId(INTF_FRM_ID_104);
     CacheEntry* handle;
-    Art* art = artLock(fid, &handle);
+    Art* art = artLock(FrmId(INTF_FRM_ID_104), &handle);
     if (art == nullptr) {
         return;
     }
@@ -1550,9 +1522,8 @@ void interfaceBarEndButtonsHide(bool animated)
         return;
     }
 
-    FrmId fid = FrmId(INTF_FRM_ID_104);
     CacheEntry* handle;
-    Art* art = artLock(fid, &handle);
+    Art* art = artLock(FrmId(INTF_FRM_ID_104), &handle);
     if (art == nullptr) {
         return;
     }
@@ -1606,8 +1577,7 @@ void interfaceBarEndButtonsRenderGreenLights()
 
         FrmImage lightsFrmImage;
         // endltgrn.frm - green lights around end turn/combat window
-        FrmId lightsFid = FrmId(INTF_FRM_ID_109);
-        if (!lightsFrmImage.lock(lightsFid)) {
+        if (!lightsFrmImage.lock(FrmId(INTF_FRM_ID_109))) {
             return;
         }
 
@@ -1626,8 +1596,7 @@ void interfaceBarEndButtonsRenderRedLights()
 
         FrmImage lightsFrmImage;
         // endltred.frm - red lights around end turn/combat window
-        FrmId lightsFid = FrmId(INTF_FRM_ID_110);
-        if (!lightsFrmImage.lock(lightsFid)) {
+        if (!lightsFrmImage.lock(FrmId(INTF_FRM_ID_110))) {
             return;
         }
 
@@ -1670,20 +1639,20 @@ static int interfaceBarRefreshMainAction()
         memcpy(_itemButtonDown, _itemButtonPressedFrmImage.getData(), sizeof(_itemButtonDown));
 
         if (itemState->isWeapon == 0) {
-            FrmId fid;
+            FrmId frmId;
             if (_proto_action_can_use_on(itemState->item->pid)) {
                 // USE ON
-                fid = FrmId(INTF_FRM_ID_294);
+                frmId = FrmId(INTF_FRM_ID_294);
             } else if (_obj_action_can_use(itemState->item)) {
                 // USE
-                fid = FrmId(INTF_FRM_ID_292);
+                frmId = FrmId(INTF_FRM_ID_292);
             } else {
-                fid = FrmId::Empty();
+                frmId = FrmId::Empty();
             }
 
-            if (!fid.empty()) {
+            if (!frmId.empty()) {
                 FrmImage useTextFrmImage;
-                if (useTextFrmImage.lock(fid)) {
+                if (useTextFrmImage.lock(frmId)) {
                     int width = useTextFrmImage.getWidth();
                     int height = useTextFrmImage.getHeight();
                     unsigned char* data = useTextFrmImage.getData();
@@ -1693,36 +1662,36 @@ static int interfaceBarRefreshMainAction()
                 actionPoints = itemGetActionPointCost(gDude, itemState->primaryHitMode, false);
             }
         } else {
-            FrmId primaryFid = FrmId::Empty();
-            FrmId bullseyeFid = FrmId::Empty();
+            FrmId primaryFrmId = FrmId::Empty();
+            FrmId bullseyeFrmId = FrmId::Empty();
             HitMode hitMode = HIT_MODE_INVALID;
 
             // NOTE: This value is decremented at 0x45FEAC, probably to build
             // jump table.
             switch (itemState->action) {
             case INTERFACE_ITEM_ACTION_PRIMARY_AIMING:
-                bullseyeFid = FrmId(INTF_FRM_ID_288);
+                bullseyeFrmId = FrmId(INTF_FRM_ID_288);
                 // FALLTHROUGH
             case INTERFACE_ITEM_ACTION_PRIMARY:
                 hitMode = itemState->primaryHitMode;
                 break;
             case INTERFACE_ITEM_ACTION_SECONDARY_AIMING:
-                bullseyeFid = FrmId(INTF_FRM_ID_288);
+                bullseyeFrmId = FrmId(INTF_FRM_ID_288);
                 // FALLTHROUGH
             case INTERFACE_ITEM_ACTION_SECONDARY:
                 hitMode = itemState->secondaryHitMode;
                 break;
             case INTERFACE_ITEM_ACTION_RELOAD:
                 actionPoints = itemGetActionPointCost(gDude, gInterfaceCurrentHand == HAND_LEFT ? HIT_MODE_LEFT_WEAPON_RELOAD : HIT_MODE_RIGHT_WEAPON_RELOAD, false);
-                primaryFid = FrmId(INTF_FRM_ID_291);
+                primaryFrmId = FrmId(INTF_FRM_ID_291);
                 break;
             default:
                 break;
             }
 
-            if (!bullseyeFid.empty()) {
+            if (!bullseyeFrmId.empty()) {
                 FrmImage bullseyeFrmImage;
-                if (bullseyeFrmImage.lock(bullseyeFid)) {
+                if (bullseyeFrmImage.lock(bullseyeFrmId)) {
                     int width = bullseyeFrmImage.getWidth();
                     int height = bullseyeFrmImage.getHeight();
                     unsigned char* data = bullseyeFrmImage.getData();
@@ -1731,89 +1700,89 @@ static int interfaceBarRefreshMainAction()
             }
 
             if (hitMode != HIT_MODE_INVALID) {
-                actionPoints = weaponGetActionPointCost(gDude, hitMode, !bullseyeFid.empty());
+                actionPoints = weaponGetActionPointCost(gDude, hitMode, !bullseyeFrmId.empty());
 
-                InterfaceFrameId id = INTF_FRM_ID_INVALID;
+                FrmId frmId = FrmId::Empty();
                 AnimationType anim = critterGetAnimationForHitMode(gDude, hitMode);
                 switch (anim) {
                 case ANIM_THROW_PUNCH:
                     switch (hitMode) {
                     case HIT_MODE_STRONG_PUNCH:
-                        id = INTF_FRM_ID_432; // strong punch
+                        frmId = FrmId(INTF_FRM_ID_432); // strong punch
                         break;
                     case HIT_MODE_HAMMER_PUNCH:
-                        id = INTF_FRM_ID_425; // hammer punch
+                        frmId = FrmId(INTF_FRM_ID_425); // hammer punch
                         break;
                     case HIT_MODE_HAYMAKER:
-                        id = INTF_FRM_ID_428; // lightning punch
+                        frmId = FrmId(INTF_FRM_ID_428); // lightning punch
                         break;
                     case HIT_MODE_JAB:
-                        id = INTF_FRM_ID_421; // chop punch
+                        frmId = FrmId(INTF_FRM_ID_421); // chop punch
                         break;
                     case HIT_MODE_PALM_STRIKE:
-                        id = INTF_FRM_ID_423; // dragon punch
+                        frmId = FrmId(INTF_FRM_ID_423); // dragon punch
                         break;
                     case HIT_MODE_PIERCING_STRIKE:
-                        id = INTF_FRM_ID_424; // force punch
+                        frmId = FrmId(INTF_FRM_ID_424); // force punch
                         break;
                     default:
-                        id = INTF_FRM_ID_42; // punch
+                        frmId = FrmId(INTF_FRM_ID_42); // punch
                         break;
                     }
                     break;
                 case ANIM_KICK_LEG:
                     switch (hitMode) {
                     case HIT_MODE_STRONG_KICK:
-                        id = INTF_FRM_ID_430; // skick.frm - strong kick text
+                        frmId = FrmId(INTF_FRM_ID_430); // skick.frm - strong kick text
                         break;
                     case HIT_MODE_SNAP_KICK:
-                        id = INTF_FRM_ID_431; // snapkick.frm - snap kick text
+                        frmId = FrmId(INTF_FRM_ID_431); // snapkick.frm - snap kick text
                         break;
                     case HIT_MODE_POWER_KICK:
-                        id = INTF_FRM_ID_429; // cm_pwkck.frm - roundhouse kick text
+                        frmId = FrmId(INTF_FRM_ID_429); // cm_pwkck.frm - roundhouse kick text
                         break;
                     case HIT_MODE_HIP_KICK:
-                        id = INTF_FRM_ID_426; // hipk.frm - kip kick text
+                        frmId = FrmId(INTF_FRM_ID_426); // hipk.frm - kip kick text
                         break;
                     case HIT_MODE_HOOK_KICK:
-                        id = INTF_FRM_ID_427; // cm_hookk.frm - jump kick text
+                        frmId = FrmId(INTF_FRM_ID_427); // cm_hookk.frm - jump kick text
                         break;
                     case HIT_MODE_PIERCING_KICK:
-                        id = INTF_FRM_ID_422; // cm_prckk.frm - death blossom kick text
+                        frmId = FrmId(INTF_FRM_ID_422); // cm_prckk.frm - death blossom kick text
                         break;
                     default:
-                        id = INTF_FRM_ID_41; // kick.frm - kick text
+                        frmId = FrmId(INTF_FRM_ID_41); // kick.frm - kick text
                         break;
                     }
                     break;
                 case ANIM_THROW_ANIM:
-                    id = INTF_FRM_ID_117; // throw
+                    frmId = FrmId(INTF_FRM_ID_117); // throw
                     break;
                 case ANIM_THRUST_ANIM:
-                    id = INTF_FRM_ID_45; // thrust
+                    frmId = FrmId(INTF_FRM_ID_45); // thrust
                     break;
                 case ANIM_SWING_ANIM:
-                    id = INTF_FRM_ID_44; // swing
+                    frmId = FrmId(INTF_FRM_ID_44); // swing
                     break;
                 case ANIM_FIRE_SINGLE:
-                    id = INTF_FRM_ID_43; // single
+                    frmId = FrmId(INTF_FRM_ID_43); // single
                     break;
                 case ANIM_FIRE_BURST:
                 case ANIM_FIRE_CONTINUOUS:
-                    id = INTF_FRM_ID_40; // burst
+                    frmId = FrmId(INTF_FRM_ID_40); // burst
                     break;
                 default:
                     break;
                 }
 
-                if (id != INTF_FRM_ID_INVALID) {
-                    primaryFid = FrmId(id);
+                if (!frmId.empty()) {
+                    primaryFrmId = frmId;
                 }
             }
 
-            if (!primaryFid.empty()) {
+            if (!primaryFrmId.empty()) {
                 FrmImage primaryFrmImage;
-                if (primaryFrmImage.lock(primaryFid)) {
+                if (primaryFrmImage.lock(primaryFrmId)) {
                     int width = primaryFrmImage.getWidth();
                     int height = primaryFrmImage.getHeight();
                     unsigned char* data = primaryFrmImage.getData();
@@ -1825,10 +1794,8 @@ static int interfaceBarRefreshMainAction()
 
     if (actionPoints >= 0 && actionPoints < 10) {
         // movement point text
-        FrmId apFid = FrmId(INTF_FRM_ID_289);
-
         FrmImage apFrmImage;
-        if (apFrmImage.lock(apFid)) {
+        if (apFrmImage.lock(FrmId(INTF_FRM_ID_289))) {
             int width = apFrmImage.getWidth();
             int height = apFrmImage.getHeight();
             unsigned char* data = apFrmImage.getData();
@@ -1839,8 +1806,7 @@ static int interfaceBarRefreshMainAction()
 
             FrmImage apNumbersFrmImage;
             // movement point numbers - ten numbers 0 to 9, each 10 pixels wide.
-            FrmId apNumbersFid = FrmId(INTF_FRM_ID_290);
-            if (apNumbersFrmImage.lock(apNumbersFid)) {
+            if (apNumbersFrmImage.lock(FrmId(INTF_FRM_ID_290))) {
                 int width = apNumbersFrmImage.getWidth();
                 int height = apNumbersFrmImage.getHeight();
                 unsigned char* data = apNumbersFrmImage.getData();
@@ -1853,7 +1819,7 @@ static int interfaceBarRefreshMainAction()
         memcpy(_itemButtonDown, _itemButtonDisabledFrmImage.getData(), sizeof(_itemButtonDown));
     }
 
-    FrmId itemFrmId = FrmId(itemState->itemFid);
+    const FrmId itemFrmId = FrmId(itemState->itemFid);
     if (!itemFrmId.empty()) {
         FrmImage itemFrmImage;
         if (itemFrmImage.lock(itemFrmId)) {
@@ -1940,8 +1906,8 @@ static void interfaceBarSwapHandsAnimatePutAwayTakeOutSequence(WeaponAnimation p
     if (weaponAnimationCode != WEAPON_ANIMATION_NONE) {
         animationRegisterTakeOutWeapon(gDude, weaponAnimationCode, -1);
     } else {
-        FrmId fid = FrmId(gDude, ANIM_STAND, WEAPON_ANIMATION_NONE, gDude->rotation + 1);
-        animationRegisterSetFid(gDude, fid.fid(), -1);
+        const FrmId frmId = FrmId(gDude, ANIM_STAND, WEAPON_ANIMATION_NONE, gDude->rotation + 1);
+        animationRegisterSetFid(gDude, frmId.fid(), -1);
     }
 
     // TODO: Get rid of cast.
@@ -1983,8 +1949,6 @@ static void interfaceBarSwapHandsAnimatePutAwayTakeOutSequence(WeaponAnimation p
 // 0x4607E0 intface_create_end_turn_button
 static int endTurnButtonInit()
 {
-    FrmId fid;
-
     if (gInterfaceBarWindow == -1) {
         return -1;
     }
@@ -1993,13 +1957,11 @@ static int endTurnButtonInit()
         return -1;
     }
 
-    fid = FrmId(INTF_FRM_ID_105);
-    if (!_endTurnButtonNormalFrmImage.lock(fid)) {
+    if (!_endTurnButtonNormalFrmImage.lock(FrmId(INTF_FRM_ID_105))) {
         return -1;
     }
 
-    fid = FrmId(INTF_FRM_ID_106);
-    if (!_endTurnButtonPressedFrmImage.lock(fid)) {
+    if (!_endTurnButtonPressedFrmImage.lock(FrmId(INTF_FRM_ID_106))) {
         return -1;
     }
 
@@ -2035,8 +1997,6 @@ static int endTurnButtonFree()
 // 0x460940 intface_create_end_combat_button
 static int endCombatButtonInit()
 {
-    FrmId fid;
-
     if (gInterfaceBarWindow == -1) {
         return -1;
     }
@@ -2045,13 +2005,11 @@ static int endCombatButtonInit()
         return -1;
     }
 
-    fid = FrmId(INTF_FRM_ID_107);
-    if (!_endCombatButtonNormalFrmImage.lock(fid)) {
+    if (!_endCombatButtonNormalFrmImage.lock(FrmId(INTF_FRM_ID_107))) {
         return -1;
     }
 
-    fid = FrmId(INTF_FRM_ID_108);
-    if (!_endCombatButtonPressedFrmImage.lock(fid)) {
+    if (!_endCombatButtonPressedFrmImage.lock(FrmId(INTF_FRM_ID_108))) {
         return -1;
     }
 
@@ -2223,8 +2181,7 @@ static void interfaceRestoreAlternateAmmoMeterBackground(int x)
     if (gInterfaceBarIsCustom) {
         src = customInterfaceBarGetBackgroundImageData();
     } else {
-        FrmId fid = FrmId(INTF_FRM_ID_16);
-        if (!backgroundFrmImage.lock(fid)) {
+        if (!backgroundFrmImage.lock(FrmId(INTF_FRM_ID_16))) {
             return;
         }
         src = backgroundFrmImage.getData();
@@ -2473,8 +2430,7 @@ static int indicatorBarInit()
     }
 
     FrmImage indicatorBoxFrmImage;
-    FrmId indicatorBoxFid = FrmId(INTF_FRM_ID_126);
-    if (!indicatorBoxFrmImage.lock(indicatorBoxFid)) {
+    if (!indicatorBoxFrmImage.lock(FrmId(INTF_FRM_ID_126))) {
         debugPrint("\nINTRFACE: Error initializing indicator box graphics! **\n");
         messageListFree(&messageList);
         return -1;

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -441,11 +441,11 @@ static const Stat gSummaryStats2[7] = {
 };
 
 // 0x46E708
-static const InterfaceFrameId gInventoryArrowFrmIds[INVENTORY_ARROW_FRM_COUNT] = {
-    INTF_FRM_ID_122, // left arrow up
-    INTF_FRM_ID_123, // left arrow down
-    INTF_FRM_ID_124, // right arrow up
-    INTF_FRM_ID_125, // right arrow down
+static constexpr FrmId kInventoryArrowFrmIds[INVENTORY_ARROW_FRM_COUNT] = {
+    FrmId(INTF_FRM_ID_122), // left arrow up
+    FrmId(INTF_FRM_ID_123), // left arrow down
+    FrmId(INTF_FRM_ID_124), // right arrow up
+    FrmId(INTF_FRM_ID_125), // right arrow down
 };
 
 // The number of items to show in scroller.
@@ -506,12 +506,12 @@ static unsigned int gInventoryWindowDudeRotationTimestamp = 0;
 static Rotation gInventoryWindowDudeRotation = ROTATION_NE;
 
 // 0x5190FC num
-static const InterfaceFrameId gInventoryWindowCursorFrmIds[INVENTORY_WINDOW_CURSOR_COUNT] = {
-    INTF_FRM_ID_286, // pointing hand
-    INTF_FRM_ID_250, // action arrow
-    INTF_FRM_ID_282, // action pick
-    INTF_FRM_ID_283, // action menu
-    INTF_FRM_ID_266, // blank
+static constexpr FrmId kInventoryWindowCursorFrmIds[INVENTORY_WINDOW_CURSOR_COUNT] = {
+    FrmId(INTF_FRM_ID_286), // pointing hand
+    FrmId(INTF_FRM_ID_250), // action arrow
+    FrmId(INTF_FRM_ID_282), // action pick
+    FrmId(INTF_FRM_ID_283), // action menu
+    FrmId(INTF_FRM_ID_266), // blank
 };
 
 // 0x519110 last_target
@@ -2241,8 +2241,7 @@ static void _display_inventory(int stackOffset, int dragSlotIndex, int inventory
         pitch = INVENTORY_USE_ON_WINDOW_WIDTH;
 
         FrmImage backgroundFrmImage;
-        FrmId backgroundFid = FrmId(INTF_FRM_ID_113);
-        if (backgroundFrmImage.lock(backgroundFid)) {
+        if (backgroundFrmImage.lock(FrmId(INTF_FRM_ID_113))) {
             // Clear scroll view background.
             blitBufferToBuffer(backgroundFrmImage.getData() + pitch * INVENTORY_SCROLLER_Y + INVENTORY_SCROLLER_X,
                 INVENTORY_SLOT_WIDTH,
@@ -2561,7 +2560,7 @@ static void _display_body(int fid, int inventoryWindowType)
             rect.bottom = rect.top + INVENTORY_BODY_VIEW_HEIGHT - 1;
 
             FrmImage backgroundFrmImage;
-            FrmId backgroundFid = FrmId(gGameDialogSpeakerIsPartyMember ? INTF_FRM_ID_420 : INTF_FRM_ID_111);
+            const FrmId backgroundFid = gGameDialogSpeakerIsPartyMember ? FrmId(INTF_FRM_ID_420) : FrmId(INTF_FRM_ID_111);
             if (backgroundFrmImage.lock(backgroundFid)) {
                 blitBufferToBuffer(backgroundFrmImage.getData() + rect.top * 640 + rect.left,
                     INVENTORY_BODY_VIEW_WIDTH,
@@ -2666,8 +2665,7 @@ static int inventoryCommonInit()
     for (index = 0; index < INVENTORY_WINDOW_CURSOR_COUNT; index++) {
         InventoryCursorData* cursorData = &(gInventoryCursorData[index]);
 
-        FrmId fid = FrmId(gInventoryWindowCursorFrmIds[index]);
-        Art* frm = artLock(fid, &(cursorData->frmHandle));
+        Art* frm = artLock(kInventoryWindowCursorFrmIds[index], &(cursorData->frmHandle));
         if (frm == nullptr) {
             break;
         }
@@ -3893,8 +3891,8 @@ int inventoryEquipFunc(Object* critter, Object* item, Hand handIndex, bool anima
 
         if (critter == gDude) {
             if (!isoIsDisabled()) {
-                FrmId fid = FrmId(baseFrmId, ANIM_STAND, weaponAnimationFromFid(critter->fid), critter->rotation + 1);
-                animationRegisterSetFid(critter, fid.fid(), 0);
+                const FrmId frmId = FrmId(baseFrmId, ANIM_STAND, weaponAnimationFromFid(critter->fid), critter->rotation + 1);
+                animationRegisterSetFid(critter, frmId.fid(), 0);
             }
         } else {
             adjustCritterStatsOnArmorChange(critter, armor, item);
@@ -3909,8 +3907,8 @@ int inventoryEquipFunc(Object* critter, Object* item, Hand handIndex, bool anima
 
         WeaponAnimation weaponAnimationCode = weaponGetAnimationCode(item);
         AnimationType hitModeAnimationCode = weaponGetAnimationForHitMode(item, HIT_MODE_RIGHT_WEAPON_PRIMARY);
-        FrmId fid = FrmId(critter, hitModeAnimationCode, weaponAnimationCode, critter->rotation + 1);
-        if (!artExists(fid)) {
+        const FrmId frmId = FrmId(critter, hitModeAnimationCode, weaponAnimationCode, critter->rotation + 1);
+        if (!artExists(frmId)) {
             debugPrint("\ninven_wield failed!  ERROR ERROR ERROR!");
             return -1;
         }
@@ -3984,12 +3982,12 @@ int inventoryEquipFunc(Object* critter, Object* item, Hand handIndex, bool anima
                 if (weaponAnimationCode != WEAPON_ANIMATION_NONE) {
                     animationRegisterTakeOutWeapon(critter, weaponAnimationCode, -1);
                 } else {
-                    FrmId fid = FrmId(critter, ANIM_STAND, WEAPON_ANIMATION_NONE, critter->rotation + 1);
-                    animationRegisterSetFid(critter, fid.fid(), -1);
+                    const FrmId frmId = FrmId(critter, ANIM_STAND, WEAPON_ANIMATION_NONE, critter->rotation + 1);
+                    animationRegisterSetFid(critter, frmId.fid(), -1);
                 }
             } else {
-                FrmId fid = FrmId(critter, ANIM_STAND, weaponAnimationCode, critter->rotation + 1);
-                _dude_stand(critter, critter->rotation, fid.fid());
+                const FrmId frmId = FrmId(critter, ANIM_STAND, weaponAnimationCode, critter->rotation + 1);
+                _dude_stand(critter, critter->rotation, frmId.fid());
             }
         }
     }
@@ -4049,14 +4047,14 @@ int inventoryUnequipFunc(Object* critter, Hand hand, bool animate)
 
             animationRegisterAnimate(critter, ANIM_PUT_AWAY, 0);
 
-            FrmId fid = FrmId(critter, ANIM_STAND, WEAPON_ANIMATION_NONE, critter->rotation + 1);
-            animationRegisterSetFid(critter, fid.fid(), -1);
+            const FrmId frmId = FrmId(critter, ANIM_STAND, WEAPON_ANIMATION_NONE, critter->rotation + 1);
+            animationRegisterSetFid(critter, frmId.fid(), -1);
 
             return reg_anim_end();
         }
 
-        FrmId fid = FrmId(critter, ANIM_STAND, WEAPON_ANIMATION_NONE, critter->rotation + 1);
-        _dude_stand(critter, critter->rotation, fid.fid());
+        const FrmId frmId = FrmId(critter, ANIM_STAND, WEAPON_ANIMATION_NONE, critter->rotation + 1);
+        _dude_stand(critter, critter->rotation, frmId.fid());
     }
 
     return 0;
@@ -4791,8 +4789,8 @@ int inventoryOpenLooting(Object* looter, Object* target)
         }
         int btn = buttonCreateWithFrm(gInventoryWindow,
             x, y, -1, -1, -1, keyCode,
-            FrmId(gInventoryArrowFrmIds[upFrmId]),
-            FrmId(gInventoryArrowFrmIds[downFrmId]));
+            kInventoryArrowFrmIds[upFrmId],
+            kInventoryArrowFrmIds[downFrmId]);
         if (btn != -1) {
             buttonSetCallbacks(btn, _gsound_red_butt_press, _gsound_red_butt_release);
         }
@@ -6234,8 +6232,7 @@ static void _draw_amount(int value, int inventoryWindowType)
 {
     // BIGNUM.frm
     FrmImage numbersFrmImage;
-    FrmId numbersFid = FrmId(INTF_FRM_ID_170);
-    if (!numbersFrmImage.lock(numbersFid)) {
+    if (!numbersFrmImage.lock(FrmId(INTF_FRM_ID_170))) {
         return;
     }
 
@@ -6463,8 +6460,8 @@ static int inventoryQuantityWindowInit(int inventoryWindowType, Object* item)
     unsigned char* windowBuffer = windowGetBuffer(_mt_wid);
 
     FrmImage backgroundFrmImage;
-    FrmId backgroundFid = FrmId(windowDescription->frmId);
-    if (backgroundFrmImage.lock(backgroundFid)) {
+    const FrmId backgroundFrmId = FrmId(windowDescription->frmId);
+    if (backgroundFrmImage.lock(backgroundFrmId)) {
         blitBufferToBuffer(backgroundFrmImage.getData(),
             windowDescription->width,
             windowDescription->height,
@@ -6491,8 +6488,7 @@ static int inventoryQuantityWindowInit(int inventoryWindowType, Object* item)
 
         // Timer overlay
         FrmImage overlayFrmImage;
-        FrmId overlayFid = FrmId(INTF_FRM_ID_306);
-        if (overlayFrmImage.lock(overlayFid)) {
+        if (overlayFrmImage.lock(FrmId(INTF_FRM_ID_306))) {
             blitBufferToBuffer(overlayFrmImage.getData(),
                 105, 81, 105,
                 windowBuffer + 34 * windowDescription->width + 113, windowDescription->width);
@@ -6508,8 +6504,6 @@ static int inventoryQuantityWindowInit(int inventoryWindowType, Object* item)
         x = 200;
         y = 46;
     }
-
-    FrmId fid;
 
     // Plus button
     int btn = buttonCreateActionWithFrm(_mt_wid,
@@ -6528,11 +6522,8 @@ static int inventoryQuantityWindowInit(int inventoryWindowType, Object* item)
         148, 128, -1, KEY_ESCAPE, FrmId(INTF_FRM_ID_8), FrmId(INTF_FRM_ID_9));
 
     if (inventoryWindowType == INVENTORY_WINDOW_TYPE_MOVE_ITEMS) {
-        fid = FrmId(INTF_FRM_ID_307);
-        _moveFrmImages[6].lock(fid);
-
-        fid = FrmId(INTF_FRM_ID_308);
-        _moveFrmImages[7].lock(fid);
+        _moveFrmImages[6].lock(FrmId(INTF_FRM_ID_307));
+        _moveFrmImages[7].lock(FrmId(INTF_FRM_ID_308));
 
         if (_moveFrmImages[6].isLocked() && _moveFrmImages[7].isLocked()) {
             // ALL

--- a/src/loadsave.cc
+++ b/src/loadsave.cc
@@ -186,16 +186,16 @@ static int _SaveObjDudeCid(File* stream);
 static int _EraseSave();
 
 // 0x47B7C0 lsgrphs
-static const InterfaceFrameId gLoadSaveFrmIds[LOAD_SAVE_FRM_COUNT] = {
-    INTF_FRM_ID_237, // lsgame.frm - load/save game
-    INTF_FRM_ID_238, // lsgbox.frm - load/save game
-    INTF_FRM_ID_239, // lscover.frm - load/save game
-    INTF_FRM_ID_9, // lilreddn.frm - little red button down
-    INTF_FRM_ID_8, // lilredup.frm - little red button up
-    INTF_FRM_ID_181, // dnarwoff.frm - character editor
-    INTF_FRM_ID_182, // dnarwon.frm - character editor
-    INTF_FRM_ID_199, // uparwoff.frm - character editor
-    INTF_FRM_ID_200, // uparwon.frm - character editor
+static constexpr FrmId kLoadSaveFrmIds[LOAD_SAVE_FRM_COUNT] = {
+    FrmId(INTF_FRM_ID_237), // lsgame.frm - load/save game
+    FrmId(INTF_FRM_ID_238), // lsgbox.frm - load/save game
+    FrmId(INTF_FRM_ID_239), // lscover.frm - load/save game
+    FrmId(INTF_FRM_ID_9), // lilreddn.frm - little red button down
+    FrmId(INTF_FRM_ID_8), // lilredup.frm - little red button up
+    FrmId(INTF_FRM_ID_181), // dnarwoff.frm - character editor
+    FrmId(INTF_FRM_ID_182), // dnarwon.frm - character editor
+    FrmId(INTF_FRM_ID_199), // uparwoff.frm - character editor
+    FrmId(INTF_FRM_ID_200), // uparwon.frm - character editor
 };
 
 // Control max number of save/load pages
@@ -1665,8 +1665,7 @@ static int lsgWindowInit(int windowType)
     }
 
     for (int index = 0; index < LOAD_SAVE_FRM_COUNT; index++) {
-        FrmId fid = FrmId(gLoadSaveFrmIds[index]);
-        if (!_loadsaveFrmImages[index].lock(fid)) {
+        if (!_loadsaveFrmImages[index].lock(kLoadSaveFrmIds[index])) {
             while (--index >= 0) {
                 _loadsaveFrmImages[index].unlock();
             }

--- a/src/main.cc
+++ b/src/main.cc
@@ -502,8 +502,7 @@ static void showDeath()
 
             // DEATH.FRM
             FrmImage backgroundFrmImage;
-            FrmId fid = FrmId(INTF_FRM_ID_309);
-            if (!backgroundFrmImage.lock(fid)) {
+            if (!backgroundFrmImage.lock(FrmId(INTF_FRM_ID_309))) {
                 break;
             }
 

--- a/src/mainmenu.cc
+++ b/src/mainmenu.cc
@@ -201,20 +201,17 @@ static bool mainMenuLoadArt()
     }
 
     if (!mainMenuBackgroundFrmImage.isLocked()) {
-        FrmId backgroundFid = FrmId(INTF_FRM_ID_140);
-        if (!mainMenuBackgroundFrmImage.lock(backgroundFid)) {
+        if (!mainMenuBackgroundFrmImage.lock(FrmId(INTF_FRM_ID_140))) {
             debugPrint("MAINMENU: failed to load vanilla mainmenu.frm\n");
             return false;
         }
     }
 
-    FrmId fid = FrmId(INTF_FRM_ID_299);
-    if (!mainMenuButtonNormalFrmImage.lock(fid)) {
+    if (!mainMenuButtonNormalFrmImage.lock(FrmId(INTF_FRM_ID_299))) {
         return false;
     }
 
-    fid = FrmId(INTF_FRM_ID_300);
-    if (!mainMenuButtonPressedFrmImage.lock(fid)) {
+    if (!mainMenuButtonPressedFrmImage.lock(FrmId(INTF_FRM_ID_300))) {
         return false;
     }
 

--- a/src/map.cc
+++ b/src/map.cc
@@ -1061,8 +1061,7 @@ static int mapLoad(File* stream)
         }
 
         Object* object;
-        FrmId fid = FrmId(MISC_FRM_ID_12);
-        objectCreateWithFidPid(&object, fid.fid(), -1);
+        objectCreateWithFidPid(&object, FrmId(MISC_FRM_ID_12).fid(), -1);
         object->flags |= (OBJECT_LIGHT_THRU | OBJECT_NO_SAVE | OBJECT_HIDDEN);
         objectSetLocation(object, 1, 0, nullptr);
         object->sid = gMapSid;
@@ -1478,15 +1477,15 @@ static int _map_save_file(File* stream)
     for (int elevation = 0; elevation < ELEVATION_COUNT; elevation++) {
         int tile;
         for (tile = 0; tile < SQUARE_GRID_SIZE; tile++) {
-            FrmId fid;
+            FrmId frmId;
 
-            fid = FrmId(tileFrameIdFromFid(_square[elevation]->fid[tile]));
-            if (fid != FrmId(TILE_FRM_ID_1)) {
+            frmId = FrmId(tileFrameIdFromFid(_square[elevation]->fid[tile]));
+            if (frmId != FrmId(TILE_FRM_ID_1)) {
                 break;
             }
 
-            fid = FrmId(tileFrameIdFromFid(_square[elevation]->fid[tile] >> 16));
-            if (fid != FrmId(TILE_FRM_ID_1)) {
+            frmId = FrmId(tileFrameIdFromFid(_square[elevation]->fid[tile] >> 16));
+            if (frmId != FrmId(TILE_FRM_ID_1)) {
                 break;
             }
         }

--- a/src/mapper/map_func.cc
+++ b/src/mapper/map_func.cc
@@ -1223,7 +1223,7 @@ void mapper_shift_map_elev()
     // co-located with each script.
     Script* script = scriptGetFirstSpatialScript(gElevation);
     constexpr FrmId kExitGridFrmId = FrmId(INTF_FRM_ID_3);
-    
+
     while (script != nullptr) {
         int builtTile = script->sp.built_tile;
         int tile = builtTile & 0x3FFFFFF;

--- a/src/mapper/map_func.cc
+++ b/src/mapper/map_func.cc
@@ -881,12 +881,12 @@ void copyTile()
         return;
     }
 
-    FrmId srcFid[kMaxTiles];
+    FrmId srcFrmId[kMaxTiles];
     int srcDx[kMaxTiles];
     int srcDy[kMaxTiles];
     for (int i = 0; i < srcCount; i++) {
         TileFrameId floorArt = tileFrameIdFromFid(_square[gElevation]->fid[srcTiles[i]]);
-        srcFid[i] = FrmId(floorArt);
+        srcFrmId[i] = FrmId(floorArt);
 
         int sx, sy;
         squareTileToScreenXY(srcTiles[i], &sx, &sy, gElevation);
@@ -894,18 +894,18 @@ void copyTile()
         srcDy[i] = sy - region.top;
     }
 
-    FrmId blankFid = FrmId(TILE_FRM_ID_1);
+    constexpr FrmId kBlankFrmId = FrmId(TILE_FRM_ID_1);
 
     mp_run_placement_loop([&](int ix, int iy) {
         for (int i = 0; i < srcCount; i++) {
-            if (srcFid[i] == blankFid) continue;
+            if (srcFrmId[i] == kBlankFrmId) continue;
             int dstSx = ix + srcDx[i];
             int dstSy = iy + srcDy[i] + 12;
             int dstSquare = squareTileFromScreenXY(dstSx, dstSy, gElevation);
             if (dstSquare != -1) {
                 int* word = &_square[gElevation]->fid[dstSquare];
                 int rotBits = (*word & 0xF000) >> 12;
-                int newFloor = tileFrameIdFromFid(srcFid[i].fid()) | rotBits;
+                int newFloor = tileFrameIdFromFid(srcFrmId[i].fid()) | rotBits;
                 *word = (*word & 0xFFFF0000) | (newFloor & 0xFFFF);
             }
         }
@@ -954,8 +954,7 @@ void eraseObject()
 
                     if (hit != nullptr) {
                         // Don't destroy exit-grid markers (interface art, id=3).
-                        FrmId exitGridFid = FrmId(INTF_FRM_ID_3);
-                        if (hit->fid != exitGridFid.fid()) {
+                        if (hit->fid != FrmId(INTF_FRM_ID_3).fid()) {
                             Rect rect;
                             int elev = hit->elevation;
                             reg_anim_clear(hit);
@@ -1206,7 +1205,7 @@ void mapper_shift_map_elev()
     // tiles in the source elevation back to "blank" art (id=1).
     memcpy(_square[destElev]->fid, _square[gElevation]->fid, 40000);
 
-    FrmId blankFid = FrmId(TILE_FRM_ID_1);
+    constexpr FrmId kBlankFrmId = FrmId(TILE_FRM_ID_1);
 
     // Match the original mapper's tile word format (preserved here even though the rotation
     // bits end up overlapping the low nibble of the art id — same convention as placeTile).
@@ -1215,24 +1214,25 @@ void mapper_shift_map_elev()
         int v = src[i];
         int floorRot = (v & 0xF000) >> 12;
         int roofRot = ((v >> 16) & 0xF000) >> 12;
-        int newRoofWord = tileFrameIdFromFid(blankFid.fid()) | roofRot;
-        int newFloorWord = tileFrameIdFromFid(blankFid.fid()) | floorRot;
+        int newRoofWord = tileFrameIdFromFid(kBlankFrmId.fid()) | roofRot;
+        int newFloorWord = tileFrameIdFromFid(kBlankFrmId.fid()) | floorRot;
         src[i] = (newRoofWord << 16) | (newFloorWord & 0xFFFF);
     }
 
     // Move all spatial scripts from source elevation to destination, plus any exit-grid objects
     // co-located with each script.
     Script* script = scriptGetFirstSpatialScript(gElevation);
+    constexpr FrmId kExitGridFrmId = FrmId(INTF_FRM_ID_3);
+    
     while (script != nullptr) {
         int builtTile = script->sp.built_tile;
         int tile = builtTile & 0x3FFFFFF;
         int elevBits = (builtTile >> 26) & 0x7;
         int newBuiltTile = tile | (destElev << 29) | ((elevBits << 26) & 0x1C000000);
 
-        FrmId exitGridFid = FrmId(INTF_FRM_ID_3);
         Object* exitGrid = objectFindFirstAtLocation(gElevation, tile);
         while (exitGrid != nullptr) {
-            if (exitGrid->fid == exitGridFid.fid()) {
+            if (exitGrid->fid == kExitGridFrmId.fid()) {
                 objectSetLocation(exitGrid, tile, destElev, nullptr);
                 break;
             }

--- a/src/mapper/mapper.cc
+++ b/src/mapper/mapper.cc
@@ -1365,9 +1365,8 @@ void edit_mapper()
                             // create new highlight
                             update_high_obj_name(_screen_obj);
 
-                            FrmId hfid = FrmId(INTF_FRM_ID_1);
                             Object* hlObj;
-                            if (objectCreateWithFidPid(&hlObj, hfid.fid(), -1) != -1) {
+                            if (objectCreateWithFidPid(&hlObj, FrmId(INTF_FRM_ID_1).fid(), -1) != -1) {
                                 hlObj->flags |= OBJECT_SHOOT_THRU | OBJECT_LIGHT_THRU | OBJECT_NO_SAVE;
                                 _obj_toggle_flat(hlObj, nullptr);
 
@@ -2523,16 +2522,16 @@ void update_art(ObjectType type, int offset)
     // Render thumbnails for visible slots.
     p = slot_start;
     for (int i = offset; i < offset + max_art_buttons && i < limit; i++, p += slot_stride) {
-        FrmId fid;
+        FrmId frmId;
         if (settings.mapper.use_art_not_protos) {
-            fid = FrmId(type, i);
+            frmId = FrmId(type, i);
         } else {
             Proto* proto;
             int pid = toolbar_proto(type, i);
             if (protoGetProto(pid, &proto) == -1) continue;
-            fid = FrmId(proto->fid);
+            frmId = FrmId(proto->fid);
         }
-        artRender(fid.fid(), p, art_scale_width, art_scale_height, screen_width);
+        artRender(frmId.fid(), p, art_scale_width, art_scale_height, screen_width);
     }
 
     // Draw selection box around the active slot.
@@ -2605,7 +2604,7 @@ static int mapperPickTile(int* outOffset)
     } else {
         tileFid = tileFrameIdFromFid(packedTile);
     }
-    FrmId artFid = FrmId(tileFid);
+    const FrmId artFrmId = FrmId(tileFid);
 
     for (int idx = 0; idx < maxId; idx++) {
         int pid = (OBJ_TYPE_TILE << 24) | idx;
@@ -2613,7 +2612,7 @@ static int mapperPickTile(int* outOffset)
         if (protoGetProto(pid, &proto) == -1) {
             return -1;
         }
-        if (proto->fid == artFid.fid()) {
+        if (proto->fid == artFrmId.fid()) {
             *outOffset = std::min(idx, maxId - kScrollOffset);
             return 0;
         }
@@ -2673,8 +2672,8 @@ int mapper_inven_unwield(Object* obj, int right_hand)
 
     animationRegisterAnimate(obj, ANIM_PUT_AWAY, 0);
 
-    FrmId fid = FrmId(obj, ANIM_STAND, WEAPON_ANIMATION_NONE, rotationFromFid(obj->fid));
-    animationRegisterSetFid(obj, fid.fid(), 0);
+    const FrmId frmId = FrmId(obj, ANIM_STAND, WEAPON_ANIMATION_NONE, rotationFromFid(obj->fid));
+    animationRegisterSetFid(obj, frmId.fid(), 0);
 
     return reg_anim_end();
 }

--- a/src/mapper/mp_scrpt.cc
+++ b/src/mapper/mp_scrpt.cc
@@ -109,14 +109,14 @@ static int _scr_show_toggled = 0;
 // 0x4C26D0
 void map_scr_toggle_hexes()
 {
-    FrmId markerFid = FrmId(INTF_FRM_ID_3);
+    constexpr FrmId kMarkerFrmId = FrmId(INTF_FRM_ID_3);
 
     if (!_scr_show_toggled) {
         // REMOVE mode: erase all existing spatial marker objects
         for (int elev = 0; elev < ELEVATION_COUNT; elev++) {
             Object* obj = objectFindFirstAtElevation(elev);
             while (obj != nullptr) {
-                if (obj->fid == markerFid.fid()) {
+                if (obj->fid == kMarkerFrmId.fid()) {
                     objectDestroy(obj, nullptr);
                     obj = objectFindFirstAtElevation(elev);
                     continue;
@@ -136,7 +136,7 @@ void map_scr_toggle_hexes()
                 }
 
                 Object* obj;
-                if (objectCreateWithFidPid(&obj, markerFid.fid(), -1) != -1) {
+                if (objectCreateWithFidPid(&obj, kMarkerFrmId.fid(), -1) != -1) {
                     obj->flags |= OBJECT_NO_SAVE;
                     Rect rect;
                     _obj_toggle_flat(obj, &rect);
@@ -312,9 +312,9 @@ int map_scr_add_spatial(int tile, int elevation)
         return -1;
     }
 
-    FrmId markerFid = FrmId(INTF_FRM_ID_3);
+    constexpr FrmId kMarkerFrmId = FrmId(INTF_FRM_ID_3);
     Object* obj;
-    if (objectCreateWithFidPid(&obj, markerFid.fid(), -1) != -1) {
+    if (objectCreateWithFidPid(&obj, kMarkerFrmId.fid(), -1) != -1) {
         obj->flags |= OBJECT_NO_SAVE;
         Rect rect;
         _obj_toggle_flat(obj, &rect);
@@ -342,8 +342,7 @@ void map_set_script(int scriptIndex)
     if (newIndex <= 0 || scriptAdd(&gMapSid, SCRIPT_TYPE_SYSTEM) == -1) return;
 
     Object* obj;
-    FrmId fid = FrmId(MISC_FRM_ID_12);
-    objectCreateWithFidPid(&obj, fid.fid(), -1);
+    objectCreateWithFidPid(&obj, FrmId(MISC_FRM_ID_12).fid(), -1);
     obj->flags |= (OBJECT_LIGHT_THRU | OBJECT_NO_SAVE | OBJECT_HIDDEN);
     objectSetLocation(obj, 1, 0, nullptr);
     obj->sid = gMapSid;
@@ -422,7 +421,7 @@ void scr_debug_print_scripts()
     }
 
     // Phase 2: Scripts WITHOUT owners — find marker object at script's built_tile
-    const FrmId kMarkerFid = FrmId(INTF_FRM_ID_3);
+    constexpr FrmId kMarkerFrmId = FrmId(INTF_FRM_ID_3);
     for (int type = 0; type < SCRIPT_TYPE_COUNT; type++) {
         for (int id = 0; id < kMaxScriptId; id++) {
             int sid = (type << 24) | id;
@@ -437,7 +436,7 @@ void scr_debug_print_scripts()
 
                 Object* obj = objectFindFirstAtLocation(elevation, tile);
                 while (obj != nullptr) {
-                    if (obj->fid == kMarkerFid.fid()) break;
+                    if (obj->fid == kMarkerFrmId.fid()) break;
                     obj = objectFindNextAtLocation();
                 }
 

--- a/src/obj_types.h
+++ b/src/obj_types.h
@@ -83,18 +83,18 @@ inline ObjectType operator++(ObjectType& e, int)
     return result;
 }
 
-inline bool objectTypeIsValid(int type)
+constexpr inline bool objectTypeIsValid(int type)
 {
     return type >= OBJ_TYPE_FIRST && type < OBJ_TYPE_COUNT;
 }
 
-inline ObjectType objectTypeFromFid(int fid)
+constexpr inline ObjectType objectTypeFromFid(int fid)
 {
     int objectType = (fid & 0xF000000) >> 24;
     return static_cast<ObjectType>(objectType);
 }
 
-inline ObjectType objectTypeFromPid(int pid)
+constexpr inline ObjectType objectTypeFromPid(int pid)
 {
     int objectType = pid >> 24;
     return static_cast<ObjectType>(objectType);

--- a/src/object.cc
+++ b/src/object.cc
@@ -301,8 +301,8 @@ static char _obj_seen[5001];
 // 0x488780 obj_init
 int objectsInit(unsigned char* buf, int width, int height, int pitch)
 {
-    FrmId dudeFid;
-    FrmId eggFid;
+    const FrmId dudeFrmId = FrmId(_art_vault_guy_num, ANIM_STAND, WEAPON_ANIMATION_NONE, ROTATION_NE);
+    const FrmId eggFrmId = FrmId(INTF_FRM_ID_2);
 
     memset(_obj_seen, 0, 5001);
     gObjectsUpdateAreaPixelBounds.right = width + 320;
@@ -352,8 +352,7 @@ int objectsInit(unsigned char* buf, int width, int height, int pitch)
     gObjectsWindowBufferSize = height * width;
     gObjectsWindowPitch = pitch;
 
-    dudeFid = FrmId(_art_vault_guy_num, ANIM_STAND, WEAPON_ANIMATION_NONE, ROTATION_NE);
-    objectCreateWithFidPid(&gDude, dudeFid.fid(), 0x1000000);
+    objectCreateWithFidPid(&gDude, dudeFrmId.fid(), 0x1000000);
 
     gDude->flags |= OBJECT_NO_REMOVE;
     gDude->flags |= OBJECT_NO_SAVE;
@@ -366,8 +365,7 @@ int objectsInit(unsigned char* buf, int width, int height, int pitch)
         exit(1);
     }
 
-    eggFid = FrmId(INTF_FRM_ID_2);
-    objectCreateWithFidPid(&gEgg, eggFid.fid(), -1);
+    objectCreateWithFidPid(&gEgg, eggFrmId.fid(), -1);
     gEgg->flags |= OBJECT_NO_REMOVE;
     gEgg->flags |= OBJECT_NO_SAVE;
     gEgg->flags |= OBJECT_HIDDEN;
@@ -3248,8 +3246,7 @@ void _obj_preload_art_cache(MapHeaderFlags flags)
 
     for (TileFrameId i = TILE_FRM_ID_FIRST; i <= TILE_FRM_ID_LAST; i++) {
         if (arr[i] != 0) {
-            FrmId fid = FrmId(i);
-            if (artLock(fid, &cache_handle) != nullptr) {
+            if (artLock(FrmId(i), &cache_handle) != nullptr) {
                 artUnlock(cache_handle);
             }
         }

--- a/src/options.cc
+++ b/src/options.cc
@@ -59,18 +59,18 @@ struct OptionsMenuButtonSpec {
 };
 
 // 0x48FC0C
-static const InterfaceFrameId pauseWindowFrmIds[PAUSE_WINDOW_FRM_COUNT] = {
-    INTF_FRM_ID_208, // charwin.frm - character editor
-    INTF_FRM_ID_209, // donebox.frm - character editor
-    INTF_FRM_ID_8, // lilredup.frm - little red button up
-    INTF_FRM_ID_9, // lilreddn.frm - little red button down
+static constexpr FrmId kPauseWindowFrmIds[PAUSE_WINDOW_FRM_COUNT] = {
+    FrmId(INTF_FRM_ID_208), // charwin.frm - character editor
+    FrmId(INTF_FRM_ID_209), // donebox.frm - character editor
+    FrmId(INTF_FRM_ID_8), // lilredup.frm - little red button up
+    FrmId(INTF_FRM_ID_9), // lilreddn.frm - little red button down
 };
 
 // 0x5197C0 opgrphs
-static const InterfaceFrameId optionsWindowFrmIds[OPTIONS_WINDOW_FRM_COUNT] = {
-    INTF_FRM_ID_220, // opbase.frm - character editor
-    INTF_FRM_ID_222, // opbtnon.frm - character editor
-    INTF_FRM_ID_221, // opbtnoff.frm - character editor
+static constexpr FrmId kOptionsWindowFrmIds[OPTIONS_WINDOW_FRM_COUNT] = {
+    FrmId(INTF_FRM_ID_220), // opbase.frm - character editor
+    FrmId(INTF_FRM_ID_222), // opbtnon.frm - character editor
+    FrmId(INTF_FRM_ID_221), // opbtnoff.frm - character editor
 };
 
 // 0x6637E8 optn_msgfl
@@ -256,8 +256,7 @@ static int optionsWindowInit()
         }
 
         if (!loaded) {
-            FrmId fid = FrmId(optionsWindowFrmIds[index]);
-            loaded = _optionsFrmImages[index].lock(fid);
+            loaded = _optionsFrmImages[index].lock(kOptionsWindowFrmIds[index]);
         }
 
         if (!loaded) {
@@ -432,8 +431,7 @@ int showPause(bool preserveWorldState)
 
     FrmImage frmImages[PAUSE_WINDOW_FRM_COUNT];
     for (int index = 0; index < PAUSE_WINDOW_FRM_COUNT; index++) {
-        FrmId fid = FrmId(pauseWindowFrmIds[index]);
-        if (!frmImages[index].lock(fid)) {
+        if (!frmImages[index].lock(kPauseWindowFrmIds[index])) {
             debugPrint("\n** Error loading pause window graphics! **\n");
             return -1;
         }

--- a/src/pipboy.cc
+++ b/src/pipboy.cc
@@ -265,18 +265,18 @@ const Rect gPipboyWindowContentRect = {
 };
 
 // 0x496FD0 pipgrphs
-const InterfaceFrameId gPipboyFrmIds[PIPBOY_FRM_COUNT] = {
-    INTF_FRM_ID_8,
-    INTF_FRM_ID_9,
-    INTF_FRM_ID_82,
-    INTF_FRM_ID_127,
-    INTF_FRM_ID_128,
-    INTF_FRM_ID_129,
-    INTF_FRM_ID_130,
-    INTF_FRM_ID_131,
-    INTF_FRM_ID_132,
-    INTF_FRM_ID_133,
-    INTF_FRM_ID_226,
+static constexpr FrmId kPipboyFrmIds[PIPBOY_FRM_COUNT] = {
+    FrmId(INTF_FRM_ID_8),
+    FrmId(INTF_FRM_ID_9),
+    FrmId(INTF_FRM_ID_82),
+    FrmId(INTF_FRM_ID_127),
+    FrmId(INTF_FRM_ID_128),
+    FrmId(INTF_FRM_ID_129),
+    FrmId(INTF_FRM_ID_130),
+    FrmId(INTF_FRM_ID_131),
+    FrmId(INTF_FRM_ID_132),
+    FrmId(INTF_FRM_ID_133),
+    FrmId(INTF_FRM_ID_226),
 };
 
 // 0x51C128 quests
@@ -668,8 +668,7 @@ static int pipboyWindowInit(int intent)
 
     int index;
     for (index = 0; index < PIPBOY_FRM_COUNT; index++) {
-        FrmId fid = FrmId(gPipboyFrmIds[index]);
-        if (!_pipboyFrmImages[index].lock(fid)) {
+        if (!_pipboyFrmImages[index].lock(kPipboyFrmIds[index])) {
             break;
         }
     }

--- a/src/preferences.cc
+++ b/src/preferences.cc
@@ -214,17 +214,17 @@ static const double kTextLineDelayScale = 0.2;
 static const double kTextLineDelayRange = 2.0;
 
 // 0x5197CC prfgrphs
-static const InterfaceFrameId gPreferencesWindowFrmIds[PREFERENCES_WINDOW_FRM_COUNT] = {
-    INTF_FRM_ID_240, // prefscrn.frm - options screen
-    INTF_FRM_ID_241, // prfsldof.frm - options screen
-    INTF_FRM_ID_242, // prfbknbs.frm - options screen
-    INTF_FRM_ID_243, // prflknbs.frm - options screen
-    INTF_FRM_ID_244, // prfxin.frm - options screen
-    INTF_FRM_ID_245, // prfxout.frm - options screen
-    INTF_FRM_ID_246, // prefcvr.frm - options screen
-    INTF_FRM_ID_247, // prfsldon.frm - options screen
-    INTF_FRM_ID_8, // lilredup.frm - little red button up
-    INTF_FRM_ID_9, // lilreddn.frm - little red button down
+static constexpr FrmId kPreferencesWindowFrmIds[PREFERENCES_WINDOW_FRM_COUNT] = {
+    FrmId(INTF_FRM_ID_240), // prefscrn.frm - options screen
+    FrmId(INTF_FRM_ID_241), // prfsldof.frm - options screen
+    FrmId(INTF_FRM_ID_242), // prfbknbs.frm - options screen
+    FrmId(INTF_FRM_ID_243), // prflknbs.frm - options screen
+    FrmId(INTF_FRM_ID_244), // prfxin.frm - options screen
+    FrmId(INTF_FRM_ID_245), // prfxout.frm - options screen
+    FrmId(INTF_FRM_ID_246), // prefcvr.frm - options screen
+    FrmId(INTF_FRM_ID_247), // prfsldon.frm - options screen
+    FrmId(INTF_FRM_ID_8), // lilredup.frm - little red button up
+    FrmId(INTF_FRM_ID_9), // lilreddn.frm - little red button down
 };
 
 // 0x6637E8 optn_msgfl
@@ -981,7 +981,6 @@ void brightnessDecrease()
 static int preferencesWindowInit()
 {
     int i;
-    FrmId fid;
     char* messageItemText;
     int x;
     int y;
@@ -1006,8 +1005,7 @@ static int preferencesWindowInit()
     _SaveSettings();
 
     for (i = 0; i < PREFERENCES_WINDOW_FRM_COUNT; i++) {
-        fid = FrmId(gPreferencesWindowFrmIds[i]);
-        if (!_preferencesFrmImages[i].lock(fid)) {
+        if (!_preferencesFrmImages[i].lock(kPreferencesWindowFrmIds[i])) {
             while (--i >= 0) {
                 _preferencesFrmImages[i].unlock();
             }

--- a/src/scripts.cc
+++ b/src/scripts.cc
@@ -684,8 +684,7 @@ Object* scriptGetSelf(Program* program)
     }
 
     Object* object;
-    FrmId fid = FrmId(INTF_FRM_ID_3);
-    objectCreateWithFidPid(&object, fid.fid(), -1);
+    objectCreateWithFidPid(&object, FrmId(INTF_FRM_ID_3).fid(), -1);
     objectHide(object, nullptr);
     _obj_toggle_flat(object, nullptr);
     object->sid = sid;

--- a/src/skilldex.cc
+++ b/src/skilldex.cc
@@ -61,13 +61,13 @@ static void skilldexWindowFree();
 static bool gSkilldexWindowIsoWasEnabled = false;
 
 // 0x51D440 grphfid
-static const InterfaceFrameId gSkilldexFrmIds[SKILLDEX_FRM_COUNT] = {
-    INTF_FRM_ID_121,
-    INTF_FRM_ID_119,
-    INTF_FRM_ID_120,
-    INTF_FRM_ID_8,
-    INTF_FRM_ID_9,
-    INTF_FRM_ID_170,
+static constexpr FrmId kSkilldexFrmIds[SKILLDEX_FRM_COUNT] = {
+    FrmId(INTF_FRM_ID_121),
+    FrmId(INTF_FRM_ID_119),
+    FrmId(INTF_FRM_ID_120),
+    FrmId(INTF_FRM_ID_8),
+    FrmId(INTF_FRM_ID_9),
+    FrmId(INTF_FRM_ID_170),
 };
 
 // Maps Skilldex options into skills.
@@ -175,8 +175,7 @@ static int skilldexWindowInit()
 
     int frmIndex;
     for (frmIndex = 0; frmIndex < SKILLDEX_FRM_COUNT; frmIndex++) {
-        FrmId fid = FrmId(gSkilldexFrmIds[frmIndex]);
-        if (!_skilldexFrmImages[frmIndex].lock(fid)) {
+        if (!_skilldexFrmImages[frmIndex].lock(kSkilldexFrmIds[frmIndex])) {
             break;
         }
     }

--- a/src/tile.cc
+++ b/src/tile.cc
@@ -1313,15 +1313,15 @@ void tileRenderRoofsInRect(Rect* rect, int elevation)
     for (int y = minY; y <= maxY; y++) {
         for (int x = minX; x <= maxX; x++) {
             int squareTile = baseSquareTile + x;
-            int frmId = gTileSquares[elevation]->fid[squareTile];
-            frmId >>= 16;
-            if ((((frmId & 0xF000) >> 12) & 0x01) == 0) {
-                FrmId fid = FrmId(tileFrameIdFromFid(frmId));
-                if (fid != FrmId(TILE_FRM_ID_1)) {
+            int fid = gTileSquares[elevation]->fid[squareTile];
+            fid >>= 16;
+            if ((((fid & 0xF000) >> 12) & 0x01) == 0) {
+                const FrmId frmId = FrmId(tileFrameIdFromFid(fid));
+                if (frmId != FrmId(TILE_FRM_ID_1)) {
                     int screenX;
                     int screenY;
                     squareTileToRoofScreenXY(squareTile, &screenX, &screenY, elevation);
-                    tileRenderRoof(fid.fid(), screenX, screenY, rect, light);
+                    tileRenderRoof(frmId.fid(), screenX, screenY, rect, light);
                 }
             }
         }
@@ -1525,13 +1525,13 @@ void tileRenderFloorsInRect(Rect* rect, int elevation)
     for (int y = minY; y <= maxY; y++) {
         for (int x = minX; x <= maxX; x++) {
             int squareTile = baseSquareTile + x;
-            int frmId = gTileSquares[elevation]->fid[squareTile];
-            if ((((frmId & 0xF000) >> 12) & 0x01) == 0) {
+            int fid = gTileSquares[elevation]->fid[squareTile];
+            if ((((fid & 0xF000) >> 12) & 0x01) == 0) {
                 int tileScreenX;
                 int tileScreenY;
                 squareTileToScreenXY(squareTile, &tileScreenX, &tileScreenY, elevation);
-                FrmId fid = FrmId(tileFrameIdFromFid(frmId));
-                tileRenderFloor(fid.fid(), tileScreenX, tileScreenY, rect);
+                const FrmId frmId = FrmId(tileFrameIdFromFid(fid));
+                tileRenderFloor(frmId.fid(), tileScreenX, tileScreenY, rect);
             }
         }
         baseSquareTile += gSquareGridWidth;
@@ -1568,7 +1568,7 @@ void tileRenderEdgeBlackSquares(Rect* rect, int elevation, bool drawOnTop)
     bool drawRight = clipSides.right == drawOnTop;
     bool drawBottom = clipSides.bottom == drawOnTop;
 
-    const FrmId kEdgeFid = FrmId(TILE_FRM_ID_1);
+    constexpr FrmId kEdgeFid = FrmId(TILE_FRM_ID_1);
     int baseSquareTile = gSquareGridWidth * minY;
 
     for (int y = minY; y < maxY; y++) {
@@ -1602,12 +1602,12 @@ bool _square_roof_intersect(int x, int y, int elevation)
     TileData* ptr = gTileSquares[elevation];
     int idx = gSquareGridWidth * tileY + tileX;
     int upper = ptr->fid[gSquareGridWidth * tileY + tileX] >> 16;
-    FrmId fid = FrmId(tileFrameIdFromFid(upper));
-    if (fid != FrmId(TILE_FRM_ID_1)) {
+    FrmId frmId = FrmId(tileFrameIdFromFid(upper));
+    if (frmId != FrmId(TILE_FRM_ID_1)) {
         if ((((upper & 0xF000) >> 12) & 1) == 0) {
-            FrmId fid = FrmId(tileFrameIdFromFid(upper));
+            frmId = FrmId(tileFrameIdFromFid(upper));
             CacheEntry* handle;
-            Art* art = artLock(fid, &handle);
+            Art* art = artLock(frmId, &handle);
             if (art != nullptr) {
                 unsigned char* data = artGetFrameData(art);
                 if (data != nullptr) {

--- a/src/worldmap.cc
+++ b/src/worldmap.cc
@@ -809,11 +809,11 @@ static const char* wmFormationStrs[ENCOUNTER_FORMATION_TYPE_COUNT] = {
 };
 
 // 0x51DE84 wmRndCursorFids
-static const InterfaceFrameId wmRndCursorFids[WORLD_MAP_ENCOUNTER_FRM_COUNT] = {
-    INTF_FRM_ID_154,
-    INTF_FRM_ID_155,
-    INTF_FRM_ID_438,
-    INTF_FRM_ID_439,
+constexpr FrmId wmRndCursorFids[WORLD_MAP_ENCOUNTER_FRM_COUNT] = {
+    FrmId(INTF_FRM_ID_154),
+    FrmId(INTF_FRM_ID_155),
+    FrmId(INTF_FRM_ID_438),
+    FrmId(INTF_FRM_ID_439),
 };
 
 #define MAX_TRAIL_LENGTH 1000
@@ -5005,8 +5005,7 @@ static int wmInterfaceInit()
         return -1;
     }
 
-    FrmId fid = FrmId(INTF_FRM_ID_136);
-    if (!_backgroundFrmImage.lock(fid)) {
+    if (!_backgroundFrmImage.lock(FrmId(INTF_FRM_ID_136))) {
         return -1;
     }
 
@@ -5036,32 +5035,27 @@ static int wmInterfaceInit()
     }
 
     // hotspot1.frm - town map selector shape #1
-    fid = FrmId(INTF_FRM_ID_168);
-    if (!wmGenData.hotspotNormalFrmImage.lock(fid)) {
+    if (!wmGenData.hotspotNormalFrmImage.lock(FrmId(INTF_FRM_ID_168))) {
         return -1;
     }
 
     // hotspot2.frm - town map selector shape #2
-    fid = FrmId(INTF_FRM_ID_223);
-    if (!wmGenData.hotspotPressedFrmImage.lock(fid)) {
+    if (!wmGenData.hotspotPressedFrmImage.lock(FrmId(INTF_FRM_ID_223))) {
         return -1;
     }
 
     // wmaptarg.frm - world map move target maker #1
-    fid = FrmId(INTF_FRM_ID_139);
-    if (!wmGenData.destinationMarkerFrmImage.lock(fid)) {
+    if (!wmGenData.destinationMarkerFrmImage.lock(FrmId(INTF_FRM_ID_139))) {
         return -1;
     }
 
     // wmaploc.frm - world map location marker
-    fid = FrmId(INTF_FRM_ID_138);
-    if (!wmGenData.locationMarkerFrmImage.lock(fid)) {
+    if (!wmGenData.locationMarkerFrmImage.lock(FrmId(INTF_FRM_ID_138))) {
         return -1;
     }
 
     for (int index = 0; index < WORLD_MAP_ENCOUNTER_FRM_COUNT; index++) {
-        fid = FrmId(wmRndCursorFids[index]);
-        if (!wmGenData.encounterCursorFrmImages[index].lock(fid)) {
+        if (!wmGenData.encounterCursorFrmImages[index].lock(wmRndCursorFids[index])) {
             return -1;
         }
     }
@@ -5071,20 +5065,17 @@ static int wmInterfaceInit()
     }
 
     // wmtabs.frm - worldmap town tabs underlay
-    fid = FrmId(INTF_FRM_ID_364);
-    if (!wmGenData.tabsBackgroundFrmImage.lock(fid)) {
+    if (!wmGenData.tabsBackgroundFrmImage.lock(FrmId(INTF_FRM_ID_364))) {
         return -1;
     }
 
     // wmtbedge.frm - worldmap town tabs edging overlay
-    fid = FrmId(INTF_FRM_ID_367);
-    if (!wmGenData.tabsBorderFrmImage.lock(fid)) {
+    if (!wmGenData.tabsBorderFrmImage.lock(FrmId(INTF_FRM_ID_367))) {
         return -1;
     }
 
     // wmdial.frm - worldmap night/day dial
-    fid = FrmId(INTF_FRM_ID_365);
-    wmGenData.dialFrm = artLock(fid, &(wmGenData.dialFrmHandle));
+    wmGenData.dialFrm = artLock(FrmId(INTF_FRM_ID_365), &(wmGenData.dialFrmHandle));
     if (wmGenData.dialFrm == nullptr) {
         return -1;
     }
@@ -5093,34 +5084,28 @@ static int wmInterfaceInit()
     wmGenData.dialFrmHeight = artGetHeight(wmGenData.dialFrm);
 
     // wmscreen - worldmap overlay screen
-    fid = FrmId(INTF_FRM_ID_363);
-    if (!wmGenData.carOverlayFrmImage.lock(fid)) {
+    if (!wmGenData.carOverlayFrmImage.lock(FrmId(INTF_FRM_ID_363))) {
         return -1;
     }
 
     // wmglobe.frm - worldmap globe stamp overlay
-    fid = FrmId(INTF_FRM_ID_366);
-    if (!wmGenData.globeOverlayFrmImage.lock(fid)) {
+    if (!wmGenData.globeOverlayFrmImage.lock(FrmId(INTF_FRM_ID_366))) {
         return -1;
     }
 
     // lilredup.frm - little red button up
-    fid = FrmId(INTF_FRM_ID_8);
-    wmGenData.redButtonNormalFrmImage.lock(fid);
+    wmGenData.redButtonNormalFrmImage.lock(FrmId(INTF_FRM_ID_8));
 
     // lilreddn.frm - little red button down
-    fid = FrmId(INTF_FRM_ID_9);
-    wmGenData.redButtonPressedFrmImage.lock(fid);
+    wmGenData.redButtonPressedFrmImage.lock(FrmId(INTF_FRM_ID_9));
 
     // months.frm - month strings for pip boy
-    fid = FrmId(INTF_FRM_ID_129);
-    if (!wmGenData.monthsFrmImage.lock(fid)) {
+    if (!wmGenData.monthsFrmImage.lock(FrmId(INTF_FRM_ID_129))) {
         return -1;
     }
 
     // numbers.frm - numbers for the hit points and fatigue counters
-    fid = FrmId(INTF_FRM_ID_82);
-    if (!wmGenData.numbersFrmImage.lock(fid)) {
+    if (!wmGenData.numbersFrmImage.lock(FrmId(INTF_FRM_ID_82))) {
         return -1;
     }
 
@@ -5169,8 +5154,7 @@ static int wmInterfaceInit()
         // 200 - uparwon.frm - character editor
         // 199 - uparwoff.frm - character editor
         // SFALL: Fix images for scroll buttons.
-        fid = FrmId(INTF_FRM_ID_199 + index);
-        if (!wmGenData.scrollUpButtonFrmImages[index].lock(fid)) {
+        if (!wmGenData.scrollUpButtonFrmImages[index].lock(FrmId(INTF_FRM_ID_199 + index))) {
             return -1;
         }
     }
@@ -5179,8 +5163,7 @@ static int wmInterfaceInit()
         // 182 - dnarwon.frm - character editor
         // 181 - dnarwoff.frm - character editor
         // SFALL: Fix images for scroll buttons.
-        fid = FrmId(INTF_FRM_ID_181 + index);
-        if (!wmGenData.scrollDownButtonFrmImages[index].lock(fid)) {
+        if (!wmGenData.scrollDownButtonFrmImages[index].lock(FrmId(INTF_FRM_ID_181 + index))) {
             return -1;
         }
     }
@@ -6876,8 +6859,8 @@ static bool wmLockCarInterfaceArt(InterfaceFrameId artIndex, Art** artPtr, Cache
     }
 
     CacheEntry* handle = INVALID_CACHE_ENTRY;
-    FrmId fid = FrmId(artIndex);
-    Art* art = artLock(fid, &handle);
+    const FrmId frmId = FrmId(artIndex);
+    Art* art = artLock(frmId, &handle);
     if (art == nullptr) {
         return false;
     }
@@ -7173,7 +7156,7 @@ static int wmRefreshTabs()
 
     if (firstVisibleLabelIndex < wmLabelCount) {
         city = &(wmAreaInfoList[wmLabelList[firstVisibleLabelIndex]]);
-        FrmId cityLabelFrmId = FrmId(city->labelFid);
+        const FrmId cityLabelFrmId = FrmId(city->labelFid);
         if (!cityLabelFrmId.empty()) {
             if (!labelFrm.lock(cityLabelFrmId)) {
                 return -1;
@@ -7204,7 +7187,7 @@ static int wmRefreshTabs()
     for (int labelIndex = firstVisibleLabelIndex + 1; labelIndex < lastLabelIndexToDraw; labelIndex++) {
         if (labelIndex < wmLabelCount) {
             city = &(wmAreaInfoList[wmLabelList[labelIndex]]);
-            FrmId cityLabelFrmId = FrmId(city->labelFid);
+            const FrmId cityLabelFrmId = FrmId(city->labelFid);
             if (!cityLabelFrmId.empty()) {
                 if (!labelFrm.lock(cityLabelFrmId)) {
                     return -1;
@@ -7225,7 +7208,7 @@ static int wmRefreshTabs()
 
     if (lastLabelIndexToDraw < wmLabelCount) {
         city = &(wmAreaInfoList[wmLabelList[lastLabelIndexToDraw]]);
-        FrmId cityLabelFrmId = FrmId(city->labelFid);
+        const FrmId cityLabelFrmId = FrmId(city->labelFid);
         if (!cityLabelFrmId.empty()) {
             if (!labelFrm.lock(cityLabelFrmId)) {
                 return -1;


### PR DESCRIPTION
### Description
After the recent unification of `FrmId` usage was added `constexpr` support for some `ObjecTypes` FrameIds. `OBJ_TYPE_CRITTER` is one exception which is always computed in the runtime due to the inner usage of `artExist` within `FrmId::buildObjectFid` functionality.

Changed some `FrmId fid` variables to `const FrmId frmId`.
`buildFid` and `buildFidInternal` has been moved as private methods into `FrmId` class.

Added union for `_frameId` visibility into the `FrmId` class to have a proper view of the enum values, not much interesting to see there now as the enums are still numeric value based but there's potential where the enums are properly described.
Idea is that it will be used instead of `headFrameIdFromFid` kind of functions in future when the `int fid` is replaced by by `FrmId frmId` in the APIs.

Main changes are in `art.h` and `art.cc`.

Most of the constant global arrays which stored a list of FrameIds has been changed to `constexpr FrmId` so the `int fid` is computed during compile time.

Didn't touch rest of `int fid` APIs yet as it will be bit bigger and would explode PR size even further.

As a proof that `constexpr FrmId` works ok is the screenshot below where you can see `Fid`, `ObjectType` and `FrmId` computed from the `INT_FRM_ID_XXX` values even out of debugging session.

<img width="1124" height="299" alt="image" src="https://github.com/user-attachments/assets/07dc999a-90fc-4284-88e9-cd380ff29759" />
