### PR TITLE
[Et tu] Re-check door blocking after confirming door use

### DIFF
--- a/src/animation.cc
+++ b/src/animation.cc
@@ -2701,7 +2701,10 @@ static void _object_move(int index)
                 }
                 nextTile = -1;
             } else {
-                objectUseDoor(object, obstacle, 0);
+                objectUseDoor(object, obstacle, false);
+                if (_obj_blocking_at(object, nextTile, object->elevation) == obstacle) {
+                    nextTile = -1;
+                }
             }
         }
 


### PR DESCRIPTION
This makes Et Tu's auto-open door script work as intended; no longer can you bypass Killian's storeroom door
