### PR TITLE
Missed color typesafe usages

### DIFF
--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -323,8 +323,8 @@ static int characterEditorFolderViewInit();
 static void characterEditorFolderViewScroll(int direction);
 static void characterEditorFolderViewClear();
 static int characterEditorFolderViewDrawHeading(const char* string);
-static void characterEditorDrawPerkProgressBar(int y, int currentRank, int maxRank, int colorIndex);
-static void perkDialogDrawProgressBar(int y, int currentRank, int maxRank, int colorIndex);
+static void characterEditorDrawPerkProgressBar(int y, int currentRank, int maxRank, Color color);
+static void perkDialogDrawProgressBar(int y, int currentRank, int maxRank, Color color);
 static bool characterEditorFolderViewDrawString(const char* string);
 static bool characterEditorFolderViewDrawKillsEntry(const char* name, int kills);
 static int karmaInit();
@@ -3370,7 +3370,7 @@ static int characterEditorEditName()
     char nameCopy[64];
     strcpy(nameCopy, name);
 
-    if (_get_input_str(win, 500, nameCopy, 11, 23, 19, COLOR_GREEN | DRAW_TEXT_FLAG_NONE, static_cast<Color>(100), 0) != -1) {
+    if (_get_input_str(win, 500, nameCopy, 11, 23, 19, COLOR_GREEN | DRAW_TEXT_FLAG_NONE, Color(100), 0) != -1) {
         if (nameCopy[0] != '\0') {
             dudeSetName(nameCopy);
             characterEditorDrawName();
@@ -7335,17 +7335,17 @@ static void drawPerkProgressBarGeneric(
     int targetY,
     int currentRank,
     int maxRank,
-    int colorIndex)
+    Color color)
 {
     int segmentWidth = 4;
     int segmentHeight = 7;
     int padding = 2;
 
-    unsigned char inactiveColor = (colorIndex == COLOR_LIGHT_YELLOW) ? COLOR_DARK_YELLOW_3 : COLOR_DARK_GREY_3;
+    Color inactiveColor = (color == COLOR_LIGHT_YELLOW) ? COLOR_DARK_YELLOW_3 : COLOR_DARK_GREY_3;
 
     for (int i = 0; i < maxRank; i++) {
         int currentSegmentX = startX + (i * (segmentWidth + padding));
-        unsigned char drawColor = (i < currentRank) ? colorIndex : inactiveColor;
+        Color drawColor = (i < currentRank) ? color : inactiveColor;
 
         for (int h = 0; h < segmentHeight; h++) {
             for (int w = 0; w < segmentWidth; w++) {
@@ -7360,7 +7360,7 @@ static void drawPerkProgressBarGeneric(
     }
 }
 
-static void characterEditorDrawPerkProgressBar(int y, int currentRank, int maxRank, int colorIndex)
+static void characterEditorDrawPerkProgressBar(int y, int currentRank, int maxRank, Color color)
 {
     if (!settings.ui.perks_progress_bar) return;
 
@@ -7383,15 +7383,15 @@ static void characterEditorDrawPerkProgressBar(int y, int currentRank, int maxRa
         targetY,
         currentRank,
         maxRank,
-        colorIndex);
+        color);
 }
 
-static void perkDialogDrawProgressBar(int y, int currentRank, int maxRank, int colorIndex)
+static void perkDialogDrawProgressBar(int y, int currentRank, int maxRank, Color color)
 {
     if (!settings.ui.perks_progress_bar) return;
 
     int finalRankToDraw = currentRank;
-    if (colorIndex == COLOR_LIGHT_YELLOW) {
+    if (color == COLOR_LIGHT_YELLOW) {
         finalRankToDraw = currentRank + 1;
         if (finalRankToDraw > maxRank) finalRankToDraw = maxRank;
     }
@@ -7413,7 +7413,7 @@ static void perkDialogDrawProgressBar(int y, int currentRank, int maxRank, int c
         targetY,
         finalRankToDraw,
         maxRank,
-        colorIndex);
+        color);
 }
 
 // 0x43E470 folder_print_kill

--- a/src/dbox.cc
+++ b/src/dbox.cc
@@ -1111,7 +1111,7 @@ int showSaveFileDialog(char* title, char** fileList, char* dest, int fileListLen
 
     unsigned char* fileNameBufferPtr = windowBuffer + backgroundWidth * 190 + 57;
 
-    bufferFill(fileNameBufferPtr, fontGetStringWidth(fileNameCopy), cursorHeight, backgroundWidth, static_cast<Color>(100));
+    bufferFill(fileNameBufferPtr, fontGetStringWidth(fileNameCopy), cursorHeight, backgroundWidth, Color(100));
     fontDrawText(fileNameBufferPtr, fileNameCopy, backgroundWidth, backgroundWidth, COLOR_GREEN);
 
     windowRefresh(win);
@@ -1144,7 +1144,7 @@ int showSaveFileDialog(char* title, char** fileList, char* dest, int fileListLen
         } else if (keyCode == 501 || keyCode == KEY_ESCAPE) {
             rc = 1;
         } else if ((keyCode == KEY_DELETE || keyCode == KEY_BACKSPACE) && fileNameCopyLength > 0) {
-            bufferFill(fileNameBufferPtr, fontGetStringWidth(fileNameCopy), cursorHeight, backgroundWidth, static_cast<Color>(100));
+            bufferFill(fileNameBufferPtr, fontGetStringWidth(fileNameCopy), cursorHeight, backgroundWidth, Color(100));
             fileNameCopy[fileNameCopyLength - 1] = ' ';
             fileNameCopy[fileNameCopyLength] = '\0';
             fontDrawText(fileNameBufferPtr, fileNameCopy, backgroundWidth, backgroundWidth, COLOR_GREEN);
@@ -1185,7 +1185,7 @@ int showSaveFileDialog(char* title, char** fileList, char* dest, int fileListLen
                     rc = 2;
                 } else {
                     doubleClickSelectedFileIndex = selectedFileIndex;
-                    bufferFill(fileNameBufferPtr, fontGetStringWidth(fileNameCopy), cursorHeight, backgroundWidth, static_cast<Color>(100));
+                    bufferFill(fileNameBufferPtr, fontGetStringWidth(fileNameCopy), cursorHeight, backgroundWidth, Color(100));
                     strncpy(fileNameCopy, fileList[selectedFileIndex + pageOffset], 16);
 
                     int index;
@@ -1260,7 +1260,7 @@ int showSaveFileDialog(char* title, char** fileList, char* dest, int fileListLen
                 }
             }
         } else if (_isdoschar(keyCode)) {
-            bufferFill(fileNameBufferPtr, fontGetStringWidth(fileNameCopy), cursorHeight, backgroundWidth, static_cast<Color>(100));
+            bufferFill(fileNameBufferPtr, fontGetStringWidth(fileNameCopy), cursorHeight, backgroundWidth, Color(100));
 
             fileNameCopy[fileNameCopyLength] = keyCode & 0xFF;
             fileNameCopy[fileNameCopyLength + 1] = ' ';
@@ -1327,7 +1327,7 @@ int showSaveFileDialog(char* title, char** fileList, char* dest, int fileListLen
                 if (blinkingCounter == 0) {
                     blinkingCounter = 3;
 
-                    Color color = blink ? static_cast<Color>(100) : COLOR_GREEN;
+                    Color color = blink ? Color(100) : COLOR_GREEN;
                     blink = !blink;
 
                     bufferFill(fileNameBufferPtr + fontGetStringWidth(fileNameCopy) - cursorWidth, cursorWidth, cursorHeight - 2, backgroundWidth, color);
@@ -1355,7 +1355,7 @@ int showSaveFileDialog(char* title, char** fileList, char* dest, int fileListLen
             if (blinkingCounter == 0) {
                 blinkingCounter = 3;
 
-                Color color = blink ? static_cast<Color>(100) : COLOR_GREEN;
+                Color color = blink ? Color(100) : COLOR_GREEN;
                 blink = !blink;
 
                 bufferFill(fileNameBufferPtr + fontGetStringWidth(fileNameCopy) - cursorWidth, cursorWidth, cursorHeight - 2, backgroundWidth, color);

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -2244,12 +2244,12 @@ static void interfaceUpdateAlternateAmmoMeterRow(unsigned char* dest, bool fille
     dest[0] = kAmmoAlternateMeterLeftBorderColor;
 
     if (filled) {
-        unsigned char color = lowerHalf ? kAmmoAlternateMeterFillShadeColor : kAmmoAlternateMeterFillColor;
+        Color color = lowerHalf ? kAmmoAlternateMeterFillShadeColor : kAmmoAlternateMeterFillColor;
         dest[1] = color;
         dest[2] = color;
         dest[3] = kAmmoAlternateMeterFillShadeColor;
     } else {
-        unsigned char color = lowerHalf ? kAmmoAlternateMeterEmptyLightColor : kAmmoAlternateMeterEmptyDarkColor;
+        Color color = lowerHalf ? kAmmoAlternateMeterEmptyLightColor : kAmmoAlternateMeterEmptyDarkColor;
         dest[1] = color;
         dest[2] = color;
         dest[3] = kAmmoAlternateMeterEmptyLightColor;

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -119,13 +119,13 @@ constexpr int kAmmoAlternateMeterWidth = 4;
 constexpr int kAmmoAlternateMeterTopBorder = kAmmoBarTop - 1;
 constexpr int kAmmoAlternateMeterMaxSegmentCount = 12;
 constexpr int kAmmoAlternateMeterMaxSingleShotSegmentCount = 6;
-constexpr unsigned char kAmmoAlternateMeterLeftBorderColor = 11;
-constexpr unsigned char kAmmoAlternateMeterTopBorderColor = 15;
-constexpr unsigned char kAmmoAlternateMeterBottomBorderColor = 10;
-constexpr unsigned char kAmmoAlternateMeterEmptyDarkColor = 13;
-constexpr unsigned char kAmmoAlternateMeterEmptyLightColor = 15;
-constexpr unsigned char kAmmoAlternateMeterFillColor = 196;
-constexpr unsigned char kAmmoAlternateMeterFillShadeColor = 75;
+constexpr Color kAmmoAlternateMeterLeftBorderColor = Color(11);
+constexpr Color kAmmoAlternateMeterTopBorderColor = Color(15);
+constexpr Color kAmmoAlternateMeterBottomBorderColor = Color(10);
+constexpr Color kAmmoAlternateMeterEmptyDarkColor = Color(13);
+constexpr Color kAmmoAlternateMeterEmptyLightColor = Color(15);
+constexpr Color kAmmoAlternateMeterFillColor = Color(196);
+constexpr Color kAmmoAlternateMeterFillShadeColor = Color(75);
 
 struct CustomIndicatorDescription {
     bool isActive;

--- a/src/mapper/map_edge_setup.cc
+++ b/src/mapper/map_edge_setup.cc
@@ -585,7 +585,6 @@ void mapEdgeSetupToggleOverlay()
 // Shared dialog palette indices.
 constexpr int kWinBgColor = 3082; // dark blue
 constexpr int kTextColor = 16344; // lighter gray
-constexpr int kTitleColor = 32767; // white
 
 constexpr int kDialogWidth = 230;
 constexpr int kDialogHeight = 250;
@@ -612,7 +611,7 @@ static SetupWindow openSetupWindow(const char* title, int elevation)
     }
 
     windowDrawBorder(win);
-    windowDrawText(win, title, 0, (kDialogWidth - fontGetStringWidth(title)) / 2, 8, _colorTable[kTitleColor] | DRAW_TEXT_FLAG_NONE);
+    windowDrawText(win, title, 0, (kDialogWidth - fontGetStringWidth(title)) / 2, 8, COLOR_WHITE | DRAW_TEXT_FLAG_NONE);
     windowDrawText(win, gMapHeader.name[0] != '\0' ? gMapHeader.name : "<unnamed>", 130, 13, 30, _colorTable[kTextColor] | DRAW_TEXT_FLAG_NONE);
 
     char elev[32];

--- a/src/mapper/mapper.cc
+++ b/src/mapper/mapper.cc
@@ -267,7 +267,7 @@ static ToolbarInfo toolbar_info[6];
 static int tool_active = -1;
 
 // Color (palette index) used to draw the selection box around the active slot.
-static Color toolbar_selection_color = static_cast<Color>(21);
+static Color toolbar_selection_color = Color(21);
 
 // Highlighted object on screen — used by mapper_destroy_highlight_obj.
 static Object* _screen_obj = nullptr;
@@ -942,7 +942,7 @@ int mapper_edit_init(int argc, char** argv)
     for (index = 0; index < ROTATION_COUNT; index++) {
         int x = rotate_arrows_x_offs[index] + 285;
         int y = rotate_arrows_y_offs[index] + 25;
-        unsigned char bgColor = lbm_buf[27 * lbmBufWidth + 287];
+        Color bgColor = static_cast<Color>(lbm_buf[27 * lbmBufWidth + 287]);
         int k;
 
         blitBufferToBuffer(lbm_buf + y * lbmBufWidth + x, 10, 10, lbmBufWidth, rotate_arrows[1][index], 10);
@@ -2517,7 +2517,7 @@ void update_art(ObjectType type, int offset)
     // Clear all slot backgrounds.
     unsigned char* p = slot_start;
     for (int i = 0; i < max_art_buttons; i++, p += slot_stride) {
-        bufferFill(p, art_scale_width, art_scale_height, screen_width, static_cast<Color>(106));
+        bufferFill(p, art_scale_width, art_scale_height, screen_width, Color(106));
     }
 
     // Render thumbnails for visible slots.

--- a/src/mapper/mp_proto.cc
+++ b/src/mapper/mp_proto.cc
@@ -59,7 +59,7 @@ static char* yesno[] = {
 };
 
 // 0x559C58
-Color edit_window_color = static_cast<Color>(1);
+Color edit_window_color = Color(1);
 
 // 0x559C60
 bool can_modify_protos = false;

--- a/src/object.cc
+++ b/src/object.cc
@@ -2813,8 +2813,8 @@ void _dark_trans_buf_to_buf(unsigned char* src, int srcWidth, int srcHeight, int
 
     for (int y = 0; y < srcHeight; y++) {
         for (int x = 0; x < srcWidth; x++) {
-            unsigned char color = *sp;
-            if (color != 0) {
+            Color color = static_cast<Color>(*sp);
+            if (color != COLOR_FIRST) {
                 if (color < 0xE5) {
                     color = intensityColorTable[color][intensityIndex];
                 }
@@ -4759,7 +4759,7 @@ static void objectDrawOutline(Object* object, Rect* rect)
 
         switch (outlineType) {
         case OUTLINE_TYPE_HOSTILE:
-            color = static_cast<Color>(243);
+            color = Color(243);
             isOutlinePalleted = 0;
             animatedColorCount = 5;
             animatedColorBandHeight = frameHeight / 5;
@@ -4783,7 +4783,7 @@ static void objectDrawOutline(Object* object, Rect* rect)
         case OUTLINE_TYPE_FRIENDLY:
             animatedColorCount = 4;
             animatedColorBandHeight = frameHeight / 4;
-            color = static_cast<Color>(229);
+            color = Color(229);
             isOutlinePalleted = 0;
             break;
         case OUTLINE_TYPE_ITEM:
@@ -4795,7 +4795,7 @@ static void objectDrawOutline(Object* object, Rect* rect)
             }
             break;
         case OUTLINE_TYPE_BLOCKED:
-            color = static_cast<Color>(61);
+            color = Color(61);
             isOutlinePalleted = 0;
             animatedColorCount = 1;
             animatedColorBandHeight = frameHeight;

--- a/src/worldmap.cc
+++ b/src/worldmap.cc
@@ -1040,7 +1040,7 @@ static bool worldmapTerrainInfo;
 static bool wmTerrainInfoIsVisible;
 static TrailMarkerState trailMarkerState = {};
 
-static const unsigned char worldmapTrailMarkerColor = 134;
+static const Color worldmapTrailMarkerColor = Color(134);
 static const TrailMarkerStyle worldmapTrailMarkerStyles[TRAIL_MARKER_STYLE_COUNT] = {
     { 1, 2 },
     { 2, 1 },


### PR DESCRIPTION
### Description

Some previously missed typesafe color usages, also changed some `static_cast<Color>()` to `Color()` as it's shorter.

Related to #668 
