### PR TITLE
Scoped BackgroundFrameId values

### DIFF
--- a/src/art.cc
+++ b/src/art.cc
@@ -1645,8 +1645,8 @@ FrmId::FrmId(ObjectType objectType, int frmId, AnimationType animType, WeaponAni
 
 FrmId::FrmId(Object* object, AnimationType animType, WeaponAnimation weaponAnimation, Rotation rotation)
     : _objectType(object == nullptr ? OBJ_TYPE_INVALID : objectTypeFromFid(object->fid))
-    , _fid(object == nullptr ? EmptyFid : buildObjectFid(objectTypeFromFid(object->fid), frameIdFromFid(object->fid), animType, weaponAnimation, rotation))
-    , _frameId { object == nullptr ? EmptyFid : frameIdFromFid(object->fid) }
+    , _fid(object == nullptr ? kEmptyFid : buildObjectFid(objectTypeFromFid(object->fid), frameIdFromFid(object->fid), animType, weaponAnimation, rotation))
+    , _frameId { object == nullptr ? kInvalidFrameId : frameIdFromFid(object->fid) }
     , _path(nullptr)
 {
 }

--- a/src/art.h
+++ b/src/art.h
@@ -45,15 +45,15 @@ std::shared_ptr<NamedCacheEntry> artLockNamedFrameData(const char* path);
 
 class FrmId {
 public:
-    static constexpr int EmptyFid = -1;
-    static constexpr short InvalidFrameId = -1;
-    static constexpr short MinFrameId = 0;
-    static constexpr short MaxFrameId = 4095;
+    static constexpr int kEmptyFid = -1;
+    static constexpr short kInvalidFrameId = -1;
+    static constexpr short kMinFrameId = 0;
+    static constexpr short kMaxFrameId = 4095;
 
     constexpr FrmId()
         : _objectType(OBJ_TYPE_INVALID)
-        , _fid(EmptyFid)
-        , _frameId { InvalidFrameId }
+        , _fid(kEmptyFid)
+        , _frameId { kInvalidFrameId }
         , _path(nullptr)
     {
     }
@@ -151,8 +151,8 @@ public:
 
     constexpr explicit FrmId(ObjectType objType, const char* path)
         : _objectType(objType)
-        , _fid(EmptyFid)
-        , _frameId { InvalidFrameId }
+        , _fid(kEmptyFid)
+        , _frameId { kInvalidFrameId }
         , _path(path)
 
     {
@@ -171,7 +171,7 @@ public:
 
     constexpr const char* filePath() const { return _path; }
 
-    bool valid() const { return !empty() && ((_frameId.id >= MinFrameId && _frameId.id <= MaxFrameId) || _path != nullptr); }
+    bool valid() const { return !empty() && ((_frameId.id >= kMinFrameId && _frameId.id <= kMaxFrameId) || _path != nullptr); }
 
     bool empty() const { return (*this) == Empty(); }
 
@@ -222,7 +222,7 @@ private:
     */
     constexpr int buildFid(ObjectType objectType, int frmId, unsigned char animType = 0, unsigned char weaponAnimation = 0, Rotation rotation = ROTATION_NE)
     {
-        return ((rotation << 28) & 0x70000000) | (objectType << 24) | ((animType << 16) & 0xFF0000) | ((weaponAnimation << 12) & 0xF000) | (frmId & 0xFFF);
+        return ((rotation << 28) & 0x70000000) | (objectType << 24) | ((animType << 16) & 0xFF0000) | ((weaponAnimation << 12) & 0xF000) | (frmId & kMaxFrameId);
     }
 
     int buildObjectFid(ObjectType objectType, int frmId, AnimationType animType, WeaponAnimation weaponCode, Rotation rotation);

--- a/src/art.h
+++ b/src/art.h
@@ -46,11 +46,14 @@ std::shared_ptr<NamedCacheEntry> artLockNamedFrameData(const char* path);
 class FrmId {
 public:
     static constexpr int EmptyFid = -1;
+    static constexpr short InvalidFrameId = -1;
+    static constexpr short MinFrameId = 0;
+    static constexpr short MaxFrameId = 4095;
 
     constexpr FrmId()
         : _objectType(OBJ_TYPE_INVALID)
         , _fid(EmptyFid)
-        , _frameId { EmptyFid }
+        , _frameId { InvalidFrameId }
         , _path(nullptr)
     {
     }
@@ -149,7 +152,7 @@ public:
     constexpr explicit FrmId(ObjectType objType, const char* path)
         : _objectType(objType)
         , _fid(EmptyFid)
-        , _frameId { EmptyFid }
+        , _frameId { InvalidFrameId }
         , _path(path)
 
     {
@@ -167,6 +170,8 @@ public:
     }
 
     constexpr const char* filePath() const { return _path; }
+
+    bool valid() const { return !empty() && ((_frameId.id >= MinFrameId && _frameId.id <= MaxFrameId) || _path != nullptr); }
 
     bool empty() const { return (*this) == Empty(); }
 

--- a/src/art.h
+++ b/src/art.h
@@ -140,7 +140,7 @@ public:
 
     constexpr explicit FrmId(BackgroundFrameId background)
         : _objectType(OBJ_TYPE_BACKGROUND)
-        , _fid(buildFid(OBJ_TYPE_BACKGROUND, background))
+        , _fid(buildFid(OBJ_TYPE_BACKGROUND, static_cast<int>(background)))
         , _frameId { static_cast<int>(background) }
         , _path(nullptr)
     {

--- a/src/art_defs.h
+++ b/src/art_defs.h
@@ -98,11 +98,6 @@ enum class BackgroundFrameId : int {
     Adobe = 20, //adobe.frm
 };
 
-inline bool backgroundFrameIdIsValid(int background)
-{
-    return background > static_cast<int>(BackgroundFrameId::Invalid);
-}
-
 enum DudeNativeLook : int {
     // Hero looks as one the tribals (before finishing Temple of Trails).
     DUDE_NATIVE_LOOK_TRIBAL,

--- a/src/art_defs.h
+++ b/src/art_defs.h
@@ -73,7 +73,7 @@ inline HeadAnimation headAnimationFromHeadFidget(HeadFidget fidget)
     return fidget != FIDGET_INVALID ? static_cast<HeadAnimation>(fidget) : HEAD_ANIMATION_VERY_GOOD_REACTION;
 }
 
-enum BackgroundFrameId : int {
+enum class BackgroundFrameId : int {
     BACKGROUND_INVALID = -1,
     BACKGROUND_0,
     BACKGROUND_1,
@@ -100,7 +100,7 @@ enum BackgroundFrameId : int {
 
 inline bool backgroundFrameIdIsValid(int background)
 {
-    return background >= BACKGROUND_0;
+    return background > static_cast<int>(BackgroundFrameId::BACKGROUND_INVALID);
 }
 
 enum DudeNativeLook : int {

--- a/src/art_defs.h
+++ b/src/art_defs.h
@@ -74,33 +74,33 @@ inline HeadAnimation headAnimationFromHeadFidget(HeadFidget fidget)
 }
 
 enum class BackgroundFrameId : int {
-    BACKGROUND_INVALID = -1,
-    BACKGROUND_0,
-    BACKGROUND_1,
-    BACKGROUND_2,
-    BACKGROUND_HUB,
-    BACKGROUND_NECROPOLIS,
-    BACKGROUND_BROTHERHOOD,
-    BACKGROUND_MILITARY_BASE,
-    BACKGROUND_JUNK_TOWN,
-    BACKGROUND_CATHEDRAL,
-    BACKGROUND_SHADY_SANDS,
-    BACKGROUND_VAULT,
-    BACKGROUND_MASTER,
-    BACKGROUND_FOLLOWER,
-    BACKGROUND_RAIDERS,
-    BACKGROUND_CAVE,
-    BACKGROUND_ENCLAVE,
-    BACKGROUND_WASTELAND,
-    BACKGROUND_BOSS,
-    BACKGROUND_PRESIDENT,
-    BACKGROUND_TENT,
-    BACKGROUND_ADOBE,
+    Invalid = -1, // invalid frame id
+    Reserved = 0, // reserved.frm - not working in game
+    Background = 1, //back1.frm - not working in game
+    RustyMetal = 2, // rstymetl.frm
+    Hub = 3, //hub.frm
+    Necropolis = 4, //necro.frm
+    Brotherhood = 5, // bhood.frm
+    MilitaryBase = 6, //military.frm
+    JunkTown = 7, //junktown.frm
+    Cathedral = 8, // cath.frm
+    ShadySands = 9, // shady.frm
+    Vault = 10, // vault.frm
+    Master = 11, // master.frm
+    Followers = 12, // follow.frm
+    Raiders = 13, // raider.frm
+    Cave = 14, // cave0001.frm
+    Enclave = 15, // enclave.frm
+    Wasteland = 16, //wastelnd.frm
+    EnclaveBoss = 17, // boss.frm
+    President = 18, // pres.frm
+    Tent = 19, // tent.frm
+    Adobe = 20, //adobe.frm
 };
 
 inline bool backgroundFrameIdIsValid(int background)
 {
-    return background > static_cast<int>(BackgroundFrameId::BACKGROUND_INVALID);
+    return background > static_cast<int>(BackgroundFrameId::Invalid);
 }
 
 enum DudeNativeLook : int {

--- a/src/art_defs.h
+++ b/src/art_defs.h
@@ -76,13 +76,13 @@ inline HeadAnimation headAnimationFromHeadFidget(HeadFidget fidget)
 enum class BackgroundFrameId : int {
     Invalid = -1, // invalid frame id
     Reserved = 0, // reserved.frm - not working in game
-    Background = 1, //back1.frm - not working in game
+    Background = 1, // back1.frm - not working in game
     RustyMetal = 2, // rstymetl.frm
-    Hub = 3, //hub.frm
-    Necropolis = 4, //necro.frm
+    Hub = 3, // hub.frm
+    Necropolis = 4, // necro.frm
     Brotherhood = 5, // bhood.frm
-    MilitaryBase = 6, //military.frm
-    JunkTown = 7, //junktown.frm
+    MilitaryBase = 6, // military.frm
+    JunkTown = 7, // junktown.frm
     Cathedral = 8, // cath.frm
     ShadySands = 9, // shady.frm
     Vault = 10, // vault.frm
@@ -91,11 +91,11 @@ enum class BackgroundFrameId : int {
     Raiders = 13, // raider.frm
     Cave = 14, // cave0001.frm
     Enclave = 15, // enclave.frm
-    Wasteland = 16, //wastelnd.frm
+    Wasteland = 16, // wastelnd.frm
     EnclaveBoss = 17, // boss.frm
     President = 18, // pres.frm
     Tent = 19, // tent.frm
-    Adobe = 20, //adobe.frm
+    Adobe = 20, // adobe.frm
 };
 
 enum DudeNativeLook : int {

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -256,7 +256,7 @@ static CacheEntry* gGameDialogFidgetFrmHandle = nullptr;
 static Art* gGameDialogFidgetFrm = nullptr;
 
 // 0x518700 backgroundIndex
-static BackgroundFrameId gGameDialogBackground = BackgroundFrameId::BACKGROUND_2;
+static BackgroundFrameId gGameDialogBackground = BackgroundFrameId::RustyMetal;
 
 // 0x518704 lipsFID
 static int _lipsFID = 0;

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -256,7 +256,7 @@ static CacheEntry* gGameDialogFidgetFrmHandle = nullptr;
 static Art* gGameDialogFidgetFrm = nullptr;
 
 // 0x518700 backgroundIndex
-static BackgroundFrameId gGameDialogBackground = BackgroundFrameId::RustyMetal;
+static FrmId gGameDialogBackgroundFrmId = FrmId(BackgroundFrameId::RustyMetal);
 
 // 0x518704 lipsFID
 static int _lipsFID = 0;
@@ -1165,10 +1165,10 @@ int _gdialogExitFromScript()
 }
 
 // 0x445438
-void gameDialogSetBackground(BackgroundFrameId background)
+void gameDialogSetBackground(const FrmId& background)
 {
-    if (backgroundFrameIdIsValid(static_cast<int>(background))) {
-        gGameDialogBackground = background;
+    if (background.valid()) {
+        gGameDialogBackgroundFrmId = background;
     }
 }
 
@@ -4814,8 +4814,7 @@ void gameDialogRenderTalkingHead(Art* headFrm, int frame)
         }
 
         FrmImage backgroundFrmImage;
-        FrmId backgroundFid = FrmId(gGameDialogBackground);
-        if (!backgroundFrmImage.lock(backgroundFid)) {
+        if (!backgroundFrmImage.lock(gGameDialogBackgroundFrmId)) {
             debugPrint("\tError locking background in display...\n");
         }
 

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -255,7 +255,7 @@ static CacheEntry* gGameDialogFidgetFrmHandle = nullptr;
 // 0x5186FC fidgetFp
 static Art* gGameDialogFidgetFrm = nullptr;
 
-// 0x518700 backgroundIndex
+// 0x518700 backgroundFrmId
 static FrmId gGameDialogBackgroundFrmId = FrmId(BackgroundFrameId::RustyMetal);
 
 // 0x518704 lipsFID

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -256,7 +256,7 @@ static CacheEntry* gGameDialogFidgetFrmHandle = nullptr;
 static Art* gGameDialogFidgetFrm = nullptr;
 
 // 0x518700 backgroundIndex
-static BackgroundFrameId gGameDialogBackground = BACKGROUND_2;
+static BackgroundFrameId gGameDialogBackground = BackgroundFrameId::BACKGROUND_2;
 
 // 0x518704 lipsFID
 static int _lipsFID = 0;
@@ -1167,7 +1167,7 @@ int _gdialogExitFromScript()
 // 0x445438
 void gameDialogSetBackground(BackgroundFrameId background)
 {
-    if (backgroundFrameIdIsValid(background)) {
+    if (backgroundFrameIdIsValid(static_cast<int>(background))) {
         gGameDialogBackground = background;
     }
 }

--- a/src/game_dialog.h
+++ b/src/game_dialog.h
@@ -1,6 +1,7 @@
 #ifndef GAME_DIALOG_H
 #define GAME_DIALOG_H
 
+#include "art.h"
 #include "interpreter.h"
 #include "obj_types.h"
 
@@ -22,7 +23,7 @@ int gameDialogEnable();
 int gameDialogDisable();
 int _gdialogInitFromScript(int headFid, HeadFidget reaction);
 int _gdialogExitFromScript();
-void gameDialogSetBackground(BackgroundFrameId background);
+void gameDialogSetBackground(const FrmId& background);
 void gameDialogRenderSupplementaryMessage(const char* msg);
 int _gdialogStart();
 int _gdialogSayMessage();

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -1943,7 +1943,7 @@ static void opStartGameDialog(Program* program)
         gGameDialogHeadFid = FrmId(head).fid();
     }
 
-    gameDialogSetBackground(background);
+    gameDialogSetBackground(FrmId(background));
     gGameDialogReactionOrFidget = reactionLevel;
 
     // SFALL: Use the start_gdialog target instead of the current dialog target,


### PR DESCRIPTION
### Description
`BackgroundFrameId` has been changed to scoped enum and the few usages it had been reworked to use `FrmId` instead.

`FrmId` class has been extended with `valid` method which checks that `_frameId` fits into range `0 - 4095` as that's anyway the mask `0xFFF` in `buildFid`.

When all the FrameId enums are converted to scoped, whole `_frameId` will be switched from `int` to `short` as in vanilla code.

Related to #668 