### PR TITLE
gTileBorder runtime adjustments [concept]

### DIFF
--- a/src/tile.cc
+++ b/src/tile.cc
@@ -488,7 +488,7 @@ static bool tileIsInsideIsoBorders(int tile_x, int tile_y)
 {
     if (!gTileBorderInitialized) return false;
 
-    return (tile_x > tileIsoBorders[0] && tile_x < tileIsoBorders[2] && tile_y > tileIsoBorders[1] && tile_y < tileIsoBorders[3]);
+    return (tile_x >= tileIsoBorders[0] && tile_x <= tileIsoBorders[2] && tile_y >= tileIsoBorders[1] && tile_y <= tileIsoBorders[3]);
 }
 
 // Restores initial borders

--- a/src/tile.cc
+++ b/src/tile.cc
@@ -476,6 +476,34 @@ int tileInit(TileData** squareGrid, int squareGridWidth, int squareGridHeight, i
     return 0;
 }
 
+// Stores original calculated ISO borders:
+// 0 -> min_x, 1 -> min_y, 2 -> max_x, 3 -> max_y
+static int tileIsoBorders[4];
+
+// tileSetCenter might change calculated borders set by tileSetBorder
+static bool tileIsoBordersAdjusted = false;
+
+// Checks if tile_x, tile_y are inside ISO borders
+static bool tileIsInsideIsoBorders(int tile_x, int tile_y)
+{
+    if (!gTileBorderInitialized) return false;
+
+    return (tile_x > tileIsoBorders[0] && tile_x < tileIsoBorders[2] && tile_y > tileIsoBorders[1] && tile_y < tileIsoBorders[3]);
+}
+
+// Restores initial borders
+static void tileResetIsoBorders()
+{
+    if (!gTileBorderInitialized) return;
+
+    gTileBorderMinX = tileIsoBorders[0];
+    gTileBorderMinY = tileIsoBorders[1];
+    gTileBorderMaxX = tileIsoBorders[2];
+    gTileBorderMaxY = tileIsoBorders[3];
+
+    tileIsoBordersAdjusted = false;
+}
+
 // 0x4B11E4 tile_set_border
 static void tileSetBorder(int windowWidth, int windowHeight, int hexGridWidth, int hexGridHeight)
 {
@@ -498,6 +526,12 @@ static void tileSetBorder(int windowWidth, int windowHeight, int hexGridWidth, i
     if ((gTileBorderMaxX & 1) == 0) {
         gTileBorderMinX--;
     }
+
+    // Store original ISO borders
+    tileIsoBorders[0] = gTileBorderMinX;
+    tileIsoBorders[1] = gTileBorderMinY;
+    tileIsoBorders[2] = gTileBorderMaxX;
+    tileIsoBorders[3] = gTileBorderMaxY;
 
     gTileBorderInitialized = true;
 }
@@ -639,6 +673,22 @@ int tileSetCenter(int tile, int flags)
     if (_tile_y & 1) {
         _square_offy -= 12;
         _square_offx -= 16;
+    }
+
+    // Restores adjusted borders
+    if (tileIsoBordersAdjusted && tileIsInsideIsoBorders(tile_x, tile_y)) {
+        tileResetIsoBorders();
+    }
+
+    // The only way a code below should be able to execute for tile outside `tileSetBorder`
+    // is if gTileScrollBlocking is disabled (which is done by opMoveTo when setting location).
+    if (!tileIsInsideIsoBorders(tile_x, tile_y)) {
+        if (tile_x < gTileBorderMinX) gTileBorderMinX = tile_x - 1;
+        if (tile_y < gTileBorderMinY) gTileBorderMinY = tile_y - 1;
+        if (tile_x > gTileBorderMaxX) gTileBorderMaxX = tile_x + 1;
+        if (tile_y > gTileBorderMaxY) gTileBorderMaxY = tile_y + 1;
+
+        tileIsoBordersAdjusted = true;
     }
 
     gCenterTile = tile;


### PR DESCRIPTION
Fixes #726 

This is just an idea, please feel free to implement a better solution, I by no means insist on this one ofc!

So apparently is certain scenarios a player gets stuck inside `gTileBorder` constraints with scroll clamped. The idea is to allow temporary adjustments to original borders (so that a player could scroll out of trouble if he got teleported to a tile outside original borders)

```cpp
--- File: src/tile.cc ---
683 |     // The only way a code below should be able to execute for tile outside `tileSetBorder`
684 |     // is if gTileScrollBlocking is disabled (which is done by opMoveTo when setting location).
685 |     if (!tileIsInsideIsoBorders(tile_x, tile_y)) {
686 |         if (tile_x < gTileBorderMinX) gTileBorderMinX = tile_x - 1;
687 |         if (tile_y < gTileBorderMinY) gTileBorderMinY = tile_y - 1;
688 |         if (tile_x > gTileBorderMaxX) gTileBorderMaxX = tile_x + 1;
689 |         if (tile_y > gTileBorderMaxY) gTileBorderMaxY = tile_y + 1;
690 | 
691 |         tileIsoBordersAdjusted = true;
692 |     }
693 | 
694 |     gCenterTile = tile;
```

Effectively we store original borders calculated by `tileSetBorder` and restore it after `tileSetCenter` receives a valid tile.

This is just a possible alternative to figuring out `tileSetBorder` math, it seems like the padding values it's using are pretty common so I'm not sure if there's a better way to implement it. (aside from maybe v3, v4 to mirror v1, v2 but I'm not very familiar with fallout2 map geometry)

In practice for Navarro left vent entrance this would set borders to:
`INFO: borders: 38, 44, 156, 155`
And after a player scrolls out to original borders it would set it to original values:
`INFO: borders: 42, 44, 156, 155`

A little bit of explanation just in case: the idea is that we place adjustments code below scroll restricting code, so getting there thorough normal means should be impossible (you can't jump through tiles on scroll), but since `opMoveTo` disables scroll blocking - `tileSetCenter` gets a chance to adjust. Effectively this means we allow `opMoveTo` to adjust borders I guess. But it kind of makes sense