### PR TITLE
Scoped TileFrameId enum and usage hardened

### DIFF
--- a/src/animation.cc
+++ b/src/animation.cc
@@ -3389,8 +3389,8 @@ static int _check_gravity(int tile, int elevation)
         tileToScreenXY(tile, &x, &y);
 
         int squareTile = squareTileFromScreenXY(x + 2, y + 8, elevation);
-        FrmId fid = FrmId(tileFrameIdFromFid(_square[elevation]->fid[squareTile]));
-        if (fid != FrmId(TILE_FRM_ID_1)) {
+        const TileFrmId frmId = FrmId(_square[elevation]->fid[squareTile]).frameId().tile;
+        if (frmId != TileFrmId(TileFrameId::Grid)) {
             break;
         }
     }

--- a/src/animation.cc
+++ b/src/animation.cc
@@ -3389,7 +3389,7 @@ static int _check_gravity(int tile, int elevation)
         tileToScreenXY(tile, &x, &y);
 
         int squareTile = squareTileFromScreenXY(x + 2, y + 8, elevation);
-        const TileFrmId frmId = FrmId(_square[elevation]->fid[squareTile]).frameId().tile;
+        const TileFrmId frmId = static_cast<TileFrameId>(frameIdFromFid(_square[elevation]->fid[squareTile]));
         if (frmId != TileFrmId(TileFrameId::Grid)) {
             break;
         }

--- a/src/art_defs.h
+++ b/src/art_defs.h
@@ -389,38 +389,11 @@ inline ItemFrameId itemFrameIdFromPid(int pid)
     return static_cast<ItemFrameId>(frameIdFromPid(pid));
 }
 
-enum TileFrameId : int {
-    TILE_FRM_ID_FIRST = 0,
-    TILE_FRM_ID_1 = 1,
-    TILE_FRM_ID_LAST = 4095
+enum class TileFrameId : int {
+    Invalid = -1, // invalid frame id
+    Reserved = 0, // reserved.frm
+    Grid = 1, // grid000.frm
 };
-
-inline constexpr TileFrameId operator+(TileFrameId lhs, int rhs)
-{
-    return static_cast<TileFrameId>(static_cast<int>(lhs) + rhs);
-}
-
-inline constexpr TileFrameId operator-(TileFrameId lhs, int rhs)
-{
-    return static_cast<TileFrameId>(static_cast<int>(lhs) - rhs);
-}
-
-inline TileFrameId operator++(TileFrameId& e, int)
-{
-    TileFrameId result = e;
-    e = e + 1;
-    return result;
-}
-
-inline TileFrameId tileFrameIdFromFid(int fid)
-{
-    return static_cast<TileFrameId>(frameIdFromFid(fid));
-}
-
-inline TileFrameId tileFrameIdFromPid(int pid)
-{
-    return static_cast<TileFrameId>(frameIdFromPid(pid));
-}
 
 enum MiscFrameId : int {
     MISC_FRM_ID_INVALID = -1,

--- a/src/map.cc
+++ b/src/map.cc
@@ -1477,15 +1477,15 @@ static int _map_save_file(File* stream)
     for (int elevation = 0; elevation < ELEVATION_COUNT; elevation++) {
         int tile;
         for (tile = 0; tile < SQUARE_GRID_SIZE; tile++) {
-            FrmId frmId;
+            TileFrmId frmId;
 
-            frmId = FrmId(tileFrameIdFromFid(_square[elevation]->fid[tile]));
-            if (frmId != FrmId(TILE_FRM_ID_1)) {
+            frmId = FrmId(_square[elevation]->fid[tile]).frameId().tile;
+            if (frmId != TileFrmId(TileFrameId::Grid)) {
                 break;
             }
 
-            frmId = FrmId(tileFrameIdFromFid(_square[elevation]->fid[tile] >> 16));
-            if (frmId != FrmId(TILE_FRM_ID_1)) {
+            frmId = FrmId(_square[elevation]->fid[tile] >> 16).frameId().tile;
+            if (frmId != TileFrmId(TileFrameId::Grid)) {
                 break;
             }
         }
@@ -1825,6 +1825,8 @@ static void square_init()
 // 0x484210
 static void _square_reset()
 {
+    constexpr int kGridFrameId = static_cast<int>(TileFrameId::Grid);
+
     for (int elevation = 0; elevation < ELEVATION_COUNT; elevation++) {
         int* p = _square[elevation]->fid;
         for (int y = 0; y < SQUARE_GRID_HEIGHT; y++) {
@@ -1833,11 +1835,11 @@ static void _square_reset()
                 // check subsequent calls.
                 int fid = *p;
                 fid &= ~0xFFFF;
-                *p = ((tileFrameIdFromFid(FrmId(TILE_FRM_ID_1).fid()) | (((fid >> 16) & 0xF000) >> 12)) << 16) | (fid & 0xFFFF);
+                *p = ((kGridFrameId | (((fid >> 16) & 0xF000) >> 12)) << 16) | (fid & 0xFFFF);
 
                 fid = *p;
                 int tileFlags = (fid & 0xF000) >> 12;
-                int updatedLowerTile = tileFrameIdFromFid(FrmId(TILE_FRM_ID_1).fid()) | tileFlags;
+                int updatedLowerTile = kGridFrameId | tileFlags;
 
                 fid &= ~0xFFFF;
 
@@ -1874,7 +1876,7 @@ static int _square_load(File* stream, MapHeaderFlags flags)
                 upperTileFlags = (upperTileWord & 0xF000) >> 12;
                 upperTileFlags &= ~(0x01);
 
-                upperTileArtId = tileFrameIdFromFid(upperTileWord);
+                upperTileArtId = frameIdFromFid(upperTileWord);
                 lowerTileWord = arr[tile] & 0xFFFF;
                 arr[tile] = ((upperTileArtId | (upperTileFlags << 12)) << 16) | lowerTileWord;
             }

--- a/src/map.cc
+++ b/src/map.cc
@@ -1481,12 +1481,12 @@ static int _map_save_file(File* stream)
         for (tile = 0; tile < SQUARE_GRID_SIZE; tile++) {
             TileFrmId frmId;
 
-            frmId = FrmId(_square[elevation]->fid[tile]).frameId().tile;
+            frmId = static_cast<TileFrameId>(frameIdFromFid(_square[elevation]->fid[tile]));
             if (frmId != TileFrmId(TileFrameId::Grid)) {
                 break;
             }
 
-            frmId = FrmId(_square[elevation]->fid[tile] >> 16).frameId().tile;
+            frmId = static_cast<TileFrameId>(frameIdFromFid(_square[elevation]->fid[tile] >> 16));
             if (frmId != TileFrmId(TileFrameId::Grid)) {
                 break;
             }

--- a/src/mapper/map_func.cc
+++ b/src/mapper/map_func.cc
@@ -463,8 +463,8 @@ void placeTile(int pid, const FrmId& frmId)
     int oldValue = *squarePtr;
 
     if (tileRoofIsVisible()) {
-        const TileFrmId oldRoofFid = FrmId(oldValue >> 16).frameId().tile;
-        if (oldRoofFid == frmId) {
+        const TileFrmId oldRoofFrmId = FrmId(oldValue >> 16).frameId().tile;
+        if (oldRoofFrmId == frmId) {
             return;
         }
 
@@ -478,8 +478,8 @@ void placeTile(int pid, const FrmId& frmId)
         Rect rect = { sx, sy, sx + 80, sy + 36 };
         tileWindowRefreshRect(&rect, gElevation);
     } else {
-        const TileFrmId oldFloorFid = FrmId(oldValue).frameId().tile;
-        if (oldFloorFid == frmId) {
+        const TileFrmId oldFloorFrmId = FrmId(oldValue).frameId().tile;
+        if (oldFloorFrmId == frmId) {
             return;
         }
 

--- a/src/mapper/map_func.cc
+++ b/src/mapper/map_func.cc
@@ -449,7 +449,7 @@ void placeObject(int pid, int fid)
 }
 
 // place_tile_
-void placeTile(int pid, int fid)
+void placeTile(int pid, const FrmId& frmId)
 {
     int x, y;
     mouseGetPosition(&x, &y);
@@ -458,13 +458,13 @@ void placeTile(int pid, int fid)
         return;
     }
 
-    int newArt = tileFrameIdFromFid(fid);
+    int newArt = frmId.frameId().id;
     int* squarePtr = &_square[gElevation]->fid[squareTile];
     int oldValue = *squarePtr;
 
     if (tileRoofIsVisible()) {
-        FrmId oldRoofFid = FrmId(tileFrameIdFromFid(oldValue >> 16));
-        if (oldRoofFid == FrmId(fid)) {
+        const TileFrmId oldRoofFid = FrmId(oldValue >> 16).frameId().tile;
+        if (oldRoofFid == frmId) {
             return;
         }
 
@@ -478,8 +478,8 @@ void placeTile(int pid, int fid)
         Rect rect = { sx, sy, sx + 80, sy + 36 };
         tileWindowRefreshRect(&rect, gElevation);
     } else {
-        FrmId oldFloorFid = FrmId(tileFrameIdFromFid(oldValue));
-        if (oldFloorFid == FrmId(fid)) {
+        const TileFrmId oldFloorFid = FrmId(oldValue).frameId().tile;
+        if (oldFloorFid == frmId) {
             return;
         }
 
@@ -881,12 +881,12 @@ void copyTile()
         return;
     }
 
-    FrmId srcFrmId[kMaxTiles];
+    TileFrmId srcFrmId[kMaxTiles];
     int srcDx[kMaxTiles];
     int srcDy[kMaxTiles];
     for (int i = 0; i < srcCount; i++) {
-        TileFrameId floorArt = tileFrameIdFromFid(_square[gElevation]->fid[srcTiles[i]]);
-        srcFrmId[i] = FrmId(floorArt);
+        TileFrameId floorArt = FrmId(_square[gElevation]->fid[srcTiles[i]]).frameId().tile;
+        srcFrmId[i] = floorArt;
 
         int sx, sy;
         squareTileToScreenXY(srcTiles[i], &sx, &sy, gElevation);
@@ -894,7 +894,7 @@ void copyTile()
         srcDy[i] = sy - region.top;
     }
 
-    constexpr FrmId kBlankFrmId = FrmId(TILE_FRM_ID_1);
+    constexpr TileFrmId kBlankFrmId = TileFrameId::Grid;
 
     mp_run_placement_loop([&](int ix, int iy) {
         for (int i = 0; i < srcCount; i++) {
@@ -905,7 +905,7 @@ void copyTile()
             if (dstSquare != -1) {
                 int* word = &_square[gElevation]->fid[dstSquare];
                 int rotBits = (*word & 0xF000) >> 12;
-                int newFloor = tileFrameIdFromFid(srcFrmId[i].fid()) | rotBits;
+                int newFloor = srcFrmId[i].frameId().id | rotBits;
                 *word = (*word & 0xFFFF0000) | (newFloor & 0xFFFF);
             }
         }
@@ -1205,7 +1205,7 @@ void mapper_shift_map_elev()
     // tiles in the source elevation back to "blank" art (id=1).
     memcpy(_square[destElev]->fid, _square[gElevation]->fid, 40000);
 
-    constexpr FrmId kBlankFrmId = FrmId(TILE_FRM_ID_1);
+    constexpr int kBlankFrameId = static_cast<int>(TileFrameId::Grid);
 
     // Match the original mapper's tile word format (preserved here even though the rotation
     // bits end up overlapping the low nibble of the art id — same convention as placeTile).
@@ -1214,15 +1214,15 @@ void mapper_shift_map_elev()
         int v = src[i];
         int floorRot = (v & 0xF000) >> 12;
         int roofRot = ((v >> 16) & 0xF000) >> 12;
-        int newRoofWord = tileFrameIdFromFid(kBlankFrmId.fid()) | roofRot;
-        int newFloorWord = tileFrameIdFromFid(kBlankFrmId.fid()) | floorRot;
+        int newRoofWord = kBlankFrameId | roofRot;
+        int newFloorWord = kBlankFrameId | floorRot;
         src[i] = (newRoofWord << 16) | (newFloorWord & 0xFFFF);
     }
 
     // Move all spatial scripts from source elevation to destination, plus any exit-grid objects
     // co-located with each script.
     Script* script = scriptGetFirstSpatialScript(gElevation);
-    constexpr FrmId kExitGridFrmId = FrmId(InterfaceFrameId::ExitGridMarker);
+    constexpr InterfaceFrmId kExitGridFrmId = InterfaceFrameId::ExitGridMarker;
 
     while (script != nullptr) {
         int builtTile = script->sp.built_tile;

--- a/src/mapper/map_func.cc
+++ b/src/mapper/map_func.cc
@@ -478,7 +478,7 @@ void placeTile(int pid, const FrmId& frmId)
         Rect rect = { sx, sy, sx + 80, sy + 36 };
         tileWindowRefreshRect(&rect, gElevation);
     } else {
-        const TileFrmId oldFloorFrmId = FrmId(oldValue).frameId().tile;
+        const TileFrmId oldFloorFrmId = static_cast<TileFrameId>(frameIdFromFid(oldValue));
         if (oldFloorFrmId == frmId) {
             return;
         }

--- a/src/mapper/map_func.cc
+++ b/src/mapper/map_func.cc
@@ -463,7 +463,7 @@ void placeTile(int pid, const FrmId& frmId)
     int oldValue = *squarePtr;
 
     if (tileRoofIsVisible()) {
-        const TileFrmId oldRoofFrmId = FrmId(oldValue >> 16).frameId().tile;
+        const TileFrmId oldRoofFrmId = static_cast<TileFrameId>(frameIdFromFid(oldValue >> 16));
         if (oldRoofFrmId == frmId) {
             return;
         }
@@ -885,7 +885,7 @@ void copyTile()
     int srcDx[kMaxTiles];
     int srcDy[kMaxTiles];
     for (int i = 0; i < srcCount; i++) {
-        TileFrameId floorArt = FrmId(_square[gElevation]->fid[srcTiles[i]]).frameId().tile;
+        TileFrameId floorArt = static_cast<TileFrameId>(frameIdFromFid(_square[gElevation]->fid[srcTiles[i]]));
         srcFrmId[i] = floorArt;
 
         int sx, sy;

--- a/src/mapper/map_func.h
+++ b/src/mapper/map_func.h
@@ -1,6 +1,7 @@
 #ifndef FALLOUT_MAPPER_MAP_FUNC_H_
 #define FALLOUT_MAPPER_MAP_FUNC_H_
 
+#include "art.h"
 #include "geometry.h"
 #include "obj_types.h"
 
@@ -32,7 +33,7 @@ void mapper_flush_cache();
 int pickHex();
 ObjectType pickToolbar(int topY);
 void placeObject(int pid, int fid);
-void placeTile(int pid, int fid);
+void placeTile(int pid, const FrmId& frmId);
 // Pass the current toolbar type to filter the region copy by type, or -1 to copy all object
 // types in the picked region (mirrors the original mapper's `copy_object(arg1)` arg).
 void copyObject(int filterType);

--- a/src/mapper/mapper.cc
+++ b/src/mapper/mapper.cc
@@ -1303,7 +1303,7 @@ void edit_mapper()
                     if (tool_active != -1) {
                         if (selectedPid != -1) {
                             if (objectTypeFromPid(selectedPid) == OBJ_TYPE_TILE) {
-                                placeTile(selectedPid, gGameMouseBouncingCursor->fid);
+                                placeTile(selectedPid, FrmId(gGameMouseBouncingCursor->fid));
                             } else {
                                 placeObject(selectedPid, gGameMouseBouncingCursor->fid);
                             }
@@ -1345,7 +1345,7 @@ void edit_mapper()
                     } else if (tool_active != -1) {
                         if (selectedPid != -1) {
                             if (objectTypeFromPid(selectedPid) == OBJ_TYPE_TILE) {
-                                placeTile(selectedPid, gGameMouseBouncingCursor->fid);
+                                placeTile(selectedPid, FrmId(gGameMouseBouncingCursor->fid));
                             } else {
                                 placeObject(selectedPid, gGameMouseBouncingCursor->fid);
                             }
@@ -2598,13 +2598,13 @@ static int mapperPickTile(int* outOffset)
     }
 
     int packedTile = _square[gElevation]->fid[tileNum];
-    TileFrameId tileFid;
+    TileFrameId tileFrmId;
     if (tileRoofIsVisible()) {
-        tileFid = tileFrameIdFromFid(packedTile >> 16);
+        tileFrmId = FrmId(packedTile >> 16).frameId().tile;
     } else {
-        tileFid = tileFrameIdFromFid(packedTile);
+        tileFrmId = FrmId(packedTile).frameId().tile;
     }
-    const FrmId artFrmId = FrmId(tileFid);
+    const FrmId artFrmId = FrmId(tileFrmId);
 
     for (int idx = 0; idx < maxId; idx++) {
         int pid = (OBJ_TYPE_TILE << 24) | idx;

--- a/src/mapper/mapper.cc
+++ b/src/mapper/mapper.cc
@@ -2600,9 +2600,9 @@ static int mapperPickTile(int* outOffset)
     int packedTile = _square[gElevation]->fid[tileNum];
     TileFrameId tileFrmId;
     if (tileRoofIsVisible()) {
-        tileFrmId = FrmId(packedTile >> 16).frameId().tile;
+        tileFrmId = static_cast<TileFrameId>(frameIdFromFid(packedTile >> 16));
     } else {
-        tileFrmId = FrmId(packedTile).frameId().tile;
+        tileFrmId = static_cast<TileFrameId>(frameIdFromFid(packedTile));
     }
     const FrmId artFrmId = FrmId(tileFrmId);
 

--- a/src/object.cc
+++ b/src/object.cc
@@ -3244,7 +3244,7 @@ void _obj_preload_art_cache(MapHeaderFlags flags)
         }
     }
 
-    for (int i = FrmId::kMinFrameId; i <= FrmId::kMaxFrameId ; i++) {
+    for (int i = FrmId::kMinFrameId; i <= FrmId::kMaxFrameId; i++) {
         if (arr[i] != 0) {
             if (artLock(TileFrmId(static_cast<TileFrameId>(i)), &cache_handle) != nullptr) {
                 artUnlock(cache_handle);

--- a/src/object.cc
+++ b/src/object.cc
@@ -1468,12 +1468,12 @@ int objectSetLocation(Object* obj, int tile, int elevation, Rect* rect)
         int roofY = tile / 200 / 2;
         if (roofX != _obj_last_roof_x || roofY != _obj_last_roof_y || elevation != _obj_last_elev) {
             int currentSquare = _square[elevation]->fid[roofX + 100 * roofY];
-            FrmId currentSquareFid = FrmId(tileFrameIdFromFid(currentSquare >> 16));
+            const TileFrmId currentSquareFid = FrmId(currentSquare >> 16).frameId().tile;
             // CE: Add additional checks for -1 to prevent array lookup at index -101.
             int previousSquare = _obj_last_roof_x != -1 && _obj_last_roof_y != -1
                 ? _square[elevation]->fid[_obj_last_roof_x + 100 * _obj_last_roof_y]
                 : 0;
-            bool isEmpty = FrmId(TILE_FRM_ID_1) == currentSquareFid;
+            bool isEmpty = TileFrmId(TileFrameId::Grid) == currentSquareFid;
 
             if (isEmpty != _obj_last_is_empty || (((currentSquare >> 16) & 0xF000) >> 12) != (((previousSquare >> 16) & 0xF000) >> 12)) {
                 if (!_obj_last_is_empty) {
@@ -1525,8 +1525,8 @@ int objectSetLocation(Object* obj, int tile, int elevation, Rect* rect)
 // 0x48A9A0 obj_reset_roof
 int _obj_reset_roof()
 {
-    FrmId fid = FrmId(tileFrameIdFromFid(_square[gDude->elevation]->fid[_obj_last_roof_x + 100 * _obj_last_roof_y] >> 16));
-    if (fid != FrmId(TILE_FRM_ID_1)) {
+    const TileFrmId frmId = FrmId(_square[gDude->elevation]->fid[_obj_last_roof_x + 100 * _obj_last_roof_y] >> 16).frameId().tile;
+    if (frmId != TileFrmId(TileFrameId::Grid)) {
         tile_fill_roof(_obj_last_roof_x, _obj_last_roof_y, gDude->elevation, 1);
     }
     return 0;
@@ -3189,7 +3189,7 @@ void _obj_preload_art_cache(MapHeaderFlags flags)
         return;
     }
 
-    unsigned char arr[4096];
+    unsigned char arr[FrmId::kMaxFrameId + 1];
     memset(arr, 0, sizeof(arr));
 
     if ((flags & MAP_HEADER_ELEVATION_0) == MAP_HEADER_NONE) {
@@ -3244,9 +3244,9 @@ void _obj_preload_art_cache(MapHeaderFlags flags)
         }
     }
 
-    for (TileFrameId i = TILE_FRM_ID_FIRST; i <= TILE_FRM_ID_LAST; i++) {
+    for (int i = FrmId::kMinFrameId; i <= FrmId::kMaxFrameId ; i++) {
         if (arr[i] != 0) {
-            if (artLock(FrmId(i), &cache_handle) != nullptr) {
+            if (artLock(TileFrmId(static_cast<TileFrameId>(i)), &cache_handle) != nullptr) {
                 artUnlock(cache_handle);
             }
         }

--- a/src/object.cc
+++ b/src/object.cc
@@ -1472,12 +1472,12 @@ int objectSetLocation(Object* obj, int tile, int elevation, Rect* rect)
         int roofY = tile / 200 / 2;
         if (roofX != _obj_last_roof_x || roofY != _obj_last_roof_y || elevation != _obj_last_elev) {
             int currentSquare = _square[elevation]->fid[roofX + 100 * roofY];
-            const TileFrmId currentSquareFid = FrmId(currentSquare >> 16).frameId().tile;
+            const TileFrmId currentSquareFrmId = static_cast<TileFrameId>(frameIdFromFid(currentSquare >> 16));
             // CE: Add additional checks for -1 to prevent array lookup at index -101.
             int previousSquare = _obj_last_roof_x != -1 && _obj_last_roof_y != -1
                 ? _square[elevation]->fid[_obj_last_roof_x + 100 * _obj_last_roof_y]
                 : 0;
-            bool isEmpty = TileFrmId(TileFrameId::Grid) == currentSquareFid;
+            bool isEmpty = TileFrmId(TileFrameId::Grid) == currentSquareFrmId;
 
             if (isEmpty != _obj_last_is_empty || (((currentSquare >> 16) & 0xF000) >> 12) != (((previousSquare >> 16) & 0xF000) >> 12)) {
                 if (!_obj_last_is_empty) {
@@ -1529,7 +1529,7 @@ int objectSetLocation(Object* obj, int tile, int elevation, Rect* rect)
 // 0x48A9A0 obj_reset_roof
 int _obj_reset_roof()
 {
-    const TileFrmId frmId = FrmId(_square[gDude->elevation]->fid[_obj_last_roof_x + 100 * _obj_last_roof_y] >> 16).frameId().tile;
+    const TileFrmId frmId = static_cast<TileFrameId>(frameIdFromFid(_square[gDude->elevation]->fid[_obj_last_roof_x + 100 * _obj_last_roof_y] >> 16));
     if (frmId != TileFrmId(TileFrameId::Grid)) {
         tile_fill_roof(_obj_last_roof_x, _obj_last_roof_y, gDude->elevation, 1);
     }

--- a/src/proto.cc
+++ b/src/proto.cc
@@ -1029,13 +1029,13 @@ int proto_wall_init(Proto* proto, int pid)
 // 0x49FD84 proto_tile_init
 int proto_tile_init(Proto* proto, int pid)
 {
-    TileFrameId num = tileFrameIdFromPid(pid);
+    int num = frameIdFromPid(pid);
 
     proto->tile.pid = -1;
     proto->tile.messageId = 100 * num;
-    proto->tile.fid = FrmId(num - 1).fid();
+    proto->tile.fid = TileFrmId(static_cast<TileFrameId>(num - 1)).fid();
     if (!artExists(proto->tile.fid)) {
-        proto->tile.fid = FrmId(TILE_FRM_ID_FIRST).fid();
+        proto->tile.fid = TileFrmId(TileFrameId::Reserved).fid();
     }
     proto->tile.flags = PROTO_FLAG_NONE;
     proto->tile.extendedFlags = PROTO_EXT_FLAG_LOOK;

--- a/src/tile.cc
+++ b/src/tile.cc
@@ -61,9 +61,9 @@ static void tileRefreshMapper(Rect* rect, int elevation);
 static void tileRefreshGame(Rect* rect, int elevation);
 static void roof_fill_push_task_if_in_bounds(std::stack<roof_fill_task>& tasks_stack, int x, int y);
 static void roof_fill_off_process_task(std::stack<roof_fill_task>& tasks_stack, int elevation, bool on);
-static void tileRenderRoof(int fid, int x, int y, Rect* rect, int light);
+static void tileRenderRoof(const TileFrmId& frmId, int x, int y, Rect* rect, int light);
 static void _draw_grid(int tile, int elevation, Rect* rect);
-static void tileRenderFloor(int fid, int x, int y, Rect* rect);
+static void tileRenderFloor(const TileFrmId& frmId, int x, int y, Rect* rect);
 static int _tile_make_line(int currentCenterTile, int newCenterTile, int* tiles, int tilesCapacity);
 
 // 0x50E7C7 minus_4_0f
@@ -1316,12 +1316,12 @@ void tileRenderRoofsInRect(Rect* rect, int elevation)
             int fid = gTileSquares[elevation]->fid[squareTile];
             fid >>= 16;
             if ((((fid & 0xF000) >> 12) & 0x01) == 0) {
-                const FrmId frmId = FrmId(tileFrameIdFromFid(fid));
-                if (frmId != FrmId(TILE_FRM_ID_1)) {
+                const TileFrmId frmId = FrmId(fid).frameId().tile;
+                if (frmId != TileFrmId(TileFrameId::Grid)) {
                     int screenX;
                     int screenY;
                     squareTileToRoofScreenXY(squareTile, &screenX, &screenY, elevation);
-                    tileRenderRoof(frmId.fid(), screenX, screenY, rect, light);
+                    tileRenderRoof(frmId, screenX, screenY, rect, light);
                 }
             }
         }
@@ -1345,8 +1345,8 @@ static void roof_fill_off_process_task(std::stack<roof_fill_task>& tasks_stack, 
     int squareTile = gTileSquares[elevation]->fid[squareTileIndex];
     int roof = (squareTile >> 16) & 0xFFFF;
 
-    TileFrameId id = tileFrameIdFromFid(roof);
-    if (FrmId(id) != FrmId(TILE_FRM_ID_1)) {
+    const TileFrmId frmId = FrmId(roof).frameId().tile;
+    if (frmId != TileFrmId(TileFrameId::Grid)) {
         int flag = (roof & 0xF000) >> 12;
 
         if (on ? ((flag & 0x01) != 0) : ((flag & 0x03) == 0)) {
@@ -1356,7 +1356,7 @@ static void roof_fill_off_process_task(std::stack<roof_fill_task>& tasks_stack, 
                 flag |= 0x01;
             }
 
-            gTileSquares[elevation]->fid[squareTileIndex] = (squareTile & 0xFFFF) | (((flag << 12) | id) << 16);
+            gTileSquares[elevation]->fid[squareTileIndex] = (squareTile & 0xFFFF) | (((flag << 12) | frmId.frameId().id) << 16);
 
             roof_fill_push_task_if_in_bounds(tasks_stack, x - 1, y);
             roof_fill_push_task_if_in_bounds(tasks_stack, x + 1, y);
@@ -1379,10 +1379,10 @@ void tile_fill_roof(int x, int y, int elevation, bool on)
 }
 
 // 0x4B24E0 roof_draw
-static void tileRenderRoof(int fid, int x, int y, Rect* rect, int light)
+static void tileRenderRoof(const TileFrmId& frmId, int x, int y, Rect* rect, int light)
 {
     CacheEntry* tileFrmHandle;
-    Art* tileFrm = artLock(fid, &tileFrmHandle);
+    Art* tileFrm = artLock(frmId, &tileFrmHandle);
     if (tileFrm == nullptr) {
         return;
     }
@@ -1530,8 +1530,8 @@ void tileRenderFloorsInRect(Rect* rect, int elevation)
                 int tileScreenX;
                 int tileScreenY;
                 squareTileToScreenXY(squareTile, &tileScreenX, &tileScreenY, elevation);
-                const FrmId frmId = FrmId(tileFrameIdFromFid(fid));
-                tileRenderFloor(frmId.fid(), tileScreenX, tileScreenY, rect);
+                const TileFrmId frmId = FrmId(fid).frameId().tile;
+                tileRenderFloor(frmId, tileScreenX, tileScreenY, rect);
             }
         }
         baseSquareTile += gSquareGridWidth;
@@ -1568,7 +1568,7 @@ void tileRenderEdgeBlackSquares(Rect* rect, int elevation, bool drawOnTop)
     bool drawRight = clipSides.right == drawOnTop;
     bool drawBottom = clipSides.bottom == drawOnTop;
 
-    constexpr FrmId kEdgeFid = FrmId(TILE_FRM_ID_1);
+    constexpr TileFrmId kEdgeFrmId = TileFrameId::Grid;
     int baseSquareTile = gSquareGridWidth * minY;
 
     for (int y = minY; y < maxY; y++) {
@@ -1579,7 +1579,7 @@ void tileRenderEdgeBlackSquares(Rect* rect, int elevation, bool drawOnTop)
                 || (drawBottom && y > squareRect.bottom)) {
                 int sx, sy;
                 squareTileToScreenXY(baseSquareTile + x, &sx, &sy, elevation);
-                tileRenderFloor(kEdgeFid.fid(), sx, sy, rect);
+                tileRenderFloor(kEdgeFrmId, sx, sy, rect);
             }
         }
         baseSquareTile += gSquareGridWidth;
@@ -1602,10 +1602,10 @@ bool _square_roof_intersect(int x, int y, int elevation)
     TileData* ptr = gTileSquares[elevation];
     int idx = gSquareGridWidth * tileY + tileX;
     int upper = ptr->fid[gSquareGridWidth * tileY + tileX] >> 16;
-    FrmId frmId = FrmId(tileFrameIdFromFid(upper));
-    if (frmId != FrmId(TILE_FRM_ID_1)) {
+    TileFrmId frmId = FrmId(upper).frameId().tile;
+    if (frmId != TileFrmId(TileFrameId::Grid)) {
         if ((((upper & 0xF000) >> 12) & 1) == 0) {
-            frmId = FrmId(tileFrameIdFromFid(upper));
+            frmId = FrmId(upper).frameId().tile;
             CacheEntry* handle;
             Art* art = artLock(frmId, &handle);
             if (art != nullptr) {
@@ -1697,14 +1697,14 @@ static void _draw_grid(int tile, int elevation, Rect* rect)
 }
 
 // 0x4B30C4 floor_draw
-static void tileRenderFloor(int fid, int x, int y, Rect* rect)
+static void tileRenderFloor(const TileFrmId& frmId, int x, int y, Rect* rect)
 {
-    if (artIsObjectTypeHidden(objectTypeFromFid(fid)) != 0) {
+    if (artIsObjectTypeHidden(frmId.objectType()) != 0) {
         return;
     }
 
     CacheEntry* cacheEntry;
-    Art* art = artLock(fid, &cacheEntry);
+    Art* art = artLock(frmId, &cacheEntry);
     if (art == nullptr) {
         return;
     }

--- a/src/tile.cc
+++ b/src/tile.cc
@@ -1605,7 +1605,7 @@ bool _square_roof_intersect(int x, int y, int elevation)
     TileFrmId frmId = static_cast<TileFrameId>(frameIdFromFid(upper));
     if (frmId != TileFrmId(TileFrameId::Grid)) {
         if ((((upper & 0xF000) >> 12) & 1) == 0) {
-            frmId = FrmId(upper).frameId().tile;
+            frmId = static_cast<TileFrameId>(frameIdFromFid(upper));
             CacheEntry* handle;
             Art* art = artLock(frmId, &handle);
             if (art != nullptr) {

--- a/src/tile.cc
+++ b/src/tile.cc
@@ -1316,7 +1316,7 @@ void tileRenderRoofsInRect(Rect* rect, int elevation)
             int fid = gTileSquares[elevation]->fid[squareTile];
             fid >>= 16;
             if ((((fid & 0xF000) >> 12) & 0x01) == 0) {
-                const TileFrmId frmId = FrmId(fid).frameId().tile;
+                const TileFrmId frmId = static_cast<TileFrameId>(frameIdFromFid(fid));
                 if (frmId != TileFrmId(TileFrameId::Grid)) {
                     int screenX;
                     int screenY;
@@ -1530,7 +1530,7 @@ void tileRenderFloorsInRect(Rect* rect, int elevation)
                 int tileScreenX;
                 int tileScreenY;
                 squareTileToScreenXY(squareTile, &tileScreenX, &tileScreenY, elevation);
-                const TileFrmId frmId = FrmId(fid).frameId().tile;
+                const TileFrmId frmId = static_cast<TileFrameId>(frameIdFromFid(fid));
                 tileRenderFloor(frmId, tileScreenX, tileScreenY, rect);
             }
         }
@@ -1602,7 +1602,7 @@ bool _square_roof_intersect(int x, int y, int elevation)
     TileData* ptr = gTileSquares[elevation];
     int idx = gSquareGridWidth * tileY + tileX;
     int upper = ptr->fid[gSquareGridWidth * tileY + tileX] >> 16;
-    TileFrmId frmId = FrmId(upper).frameId().tile;
+    TileFrmId frmId = static_cast<TileFrameId>(frameIdFromFid(upper));
     if (frmId != TileFrmId(TileFrameId::Grid)) {
         if ((((upper & 0xF000) >> 12) & 1) == 0) {
             frmId = FrmId(upper).frameId().tile;


### PR DESCRIPTION
### Description

Changed `TileFrameId` to scoped enum and few APIs changed to use `TileFrameId` or `FrmId` instead of `fid`.

Related to #668 