### PR TITLE
Scoped Scenery/Wall/ItemFrameId enums

### DIFF
--- a/src/actions.cc
+++ b/src/actions.cc
@@ -219,7 +219,7 @@ AnimationType pickDeathAnim(Object* attacker, Object* defender, Object* weapon, 
     if (attacker->pid == PROTO_ID_FORCE_FIELD_NS) { // Forcefield North/South
         return checkDeathAnim(defender, ANIM_ELECTRIFIED_TO_NOTHING, VIOLENCE_LEVEL_MAXIMUM_BLOOD, hitFromFront);
     }
-    if (attacker->fid == FRAME_ID_FORCE_FIELD_NS) { // ffield03.frm
+    if (FrmId(attacker->fid) == SceneryFrmId(SceneryFrameId::ForceField1)) {
         return checkDeathAnim(defender, attackerAnimation, VIOLENCE_LEVEL_MAXIMUM_BLOOD, hitFromFront);
     }
 
@@ -592,7 +592,7 @@ void showDamage(Attack* attack, AnimationType attackerAnimation, int delay)
 
             if (objectTypeFromFid(attack->defender->fid) == OBJ_TYPE_CRITTER) {
                 Rotation knockbackRotation = tileGetRotationTo(attack->attacker->tile, attack->defender->tile);
-                AnimationType attackerAnimForShow = attack->attacker->fid == FRAME_ID_FORCE_FIELD_NS
+                AnimationType attackerAnimForShow = FrmId(attack->attacker->fid) == SceneryFrmId(SceneryFrameId::ForceField1)
                     ? attackerAnimation
                     : critterGetAnimationForHitMode(attack->attacker, attack->hitMode);
 
@@ -1941,7 +1941,7 @@ void actionDamage(int tile, int elevation, int minDamage, int maxDamage, DamageT
     }
 
     Object* attacker;
-    if (objectCreateWithFidPid(&attacker, FRAME_ID_FORCE_FIELD_NS, -1) == -1) {
+    if (objectCreateWithFidPid(&attacker, SceneryFrmId(SceneryFrameId::ForceField1).fid(), -1) == -1) {
         internal_free(attack);
         return;
     }

--- a/src/actions.cc
+++ b/src/actions.cc
@@ -219,7 +219,7 @@ AnimationType pickDeathAnim(Object* attacker, Object* defender, Object* weapon, 
     if (attacker->pid == PROTO_ID_FORCE_FIELD_NS) { // Forcefield North/South
         return checkDeathAnim(defender, ANIM_ELECTRIFIED_TO_NOTHING, VIOLENCE_LEVEL_MAXIMUM_BLOOD, hitFromFront);
     }
-    if (FrmId(attacker->fid) == SceneryFrmId(SceneryFrameId::ForceField1)) {
+    if (FrmId(attacker->fid) == SceneryFrmId(SceneryFrameId::ForceField3)) {
         return checkDeathAnim(defender, attackerAnimation, VIOLENCE_LEVEL_MAXIMUM_BLOOD, hitFromFront);
     }
 
@@ -592,7 +592,7 @@ void showDamage(Attack* attack, AnimationType attackerAnimation, int delay)
 
             if (objectTypeFromFid(attack->defender->fid) == OBJ_TYPE_CRITTER) {
                 Rotation knockbackRotation = tileGetRotationTo(attack->attacker->tile, attack->defender->tile);
-                AnimationType attackerAnimForShow = FrmId(attack->attacker->fid) == SceneryFrmId(SceneryFrameId::ForceField1)
+                AnimationType attackerAnimForShow = FrmId(attack->attacker->fid) == SceneryFrmId(SceneryFrameId::ForceField3)
                     ? attackerAnimation
                     : critterGetAnimationForHitMode(attack->attacker, attack->hitMode);
 
@@ -1940,7 +1940,7 @@ void actionDamage(int tile, int elevation, int minDamage, int maxDamage, DamageT
     }
 
     Object* attacker;
-    if (objectCreateWithFidPid(&attacker, SceneryFrmId(SceneryFrameId::ForceField1).fid(), -1) == -1) {
+    if (objectCreateWithFidPid(&attacker, SceneryFrmId(SceneryFrameId::ForceField3).fid(), -1) == -1) {
         internal_free(attack);
         return;
     }

--- a/src/art_defs.h
+++ b/src/art_defs.h
@@ -347,19 +347,10 @@ inline CritterFrameId critterFrameIdFromPid(int pid)
     return static_cast<CritterFrameId>(frameIdFromPid(pid));
 }
 
-enum SceneryFrameId : int {
-    SCENERY_FRM_ID_FIRST = 0,
+enum class SceneryFrameId : int {
+    Invalid = -1, // invalid frame id
+    Reserved = 0, // reserved.frm
 };
-
-inline constexpr SceneryFrameId operator-(SceneryFrameId lhs, int rhs)
-{
-    return static_cast<SceneryFrameId>(static_cast<int>(lhs) - rhs);
-}
-
-inline SceneryFrameId sceneryFrameIdFromPid(int pid)
-{
-    return static_cast<SceneryFrameId>(frameIdFromPid(pid));
-}
 
 enum WallFrameId : int {
     WALL_FRM_ID_FIRST = 0,

--- a/src/art_defs.h
+++ b/src/art_defs.h
@@ -350,6 +350,7 @@ inline CritterFrameId critterFrameIdFromPid(int pid)
 enum class SceneryFrameId : int {
     Invalid = -1, // invalid frame id
     Reserved = 0, // reserved.frm
+    ForceField1 = 501, // ffield01.frm
 };
 
 enum class WallFrameId : int {

--- a/src/art_defs.h
+++ b/src/art_defs.h
@@ -357,19 +357,10 @@ enum class WallFrameId : int {
     Reserved = 0, // reserved.frm
 };
 
-enum ItemFrameId : int {
-    ITEM_FRM_ID_FIRST = 0,
+enum class ItemFrameId : int {
+    Invalid = -1, // invalid frame id
+    Reserved = 0, // reserved.frm
 };
-
-inline constexpr ItemFrameId operator-(ItemFrameId lhs, int rhs)
-{
-    return static_cast<ItemFrameId>(static_cast<int>(lhs) - rhs);
-}
-
-inline ItemFrameId itemFrameIdFromPid(int pid)
-{
-    return static_cast<ItemFrameId>(frameIdFromPid(pid));
-}
 
 enum TileFrameId : int {
     TILE_FRM_ID_FIRST = 0,

--- a/src/art_defs.h
+++ b/src/art_defs.h
@@ -352,19 +352,10 @@ enum class SceneryFrameId : int {
     Reserved = 0, // reserved.frm
 };
 
-enum WallFrameId : int {
-    WALL_FRM_ID_FIRST = 0,
+enum class WallFrameId : int {
+    Invalid = -1, // invalid frame id
+    Reserved = 0, // reserved.frm
 };
-
-inline constexpr WallFrameId operator-(WallFrameId lhs, int rhs)
-{
-    return static_cast<WallFrameId>(static_cast<int>(lhs) - rhs);
-}
-
-inline WallFrameId wallFrameIdFromPid(int pid)
-{
-    return static_cast<WallFrameId>(frameIdFromPid(pid));
-}
 
 enum ItemFrameId : int {
     ITEM_FRM_ID_FIRST = 0,

--- a/src/art_defs.h
+++ b/src/art_defs.h
@@ -322,7 +322,7 @@ inline CritterFrameId critterFrameIdFromPid(int pid)
 enum class SceneryFrameId : int {
     Invalid = -1, // invalid frame id
     Reserved = 0, // reserved.frm
-    ForceField1 = 501, // ffield01.frm - Marker frame id for special hidden "attacker" object created by `critter_dmg` opcode handler.
+    ForceField3 = 501, // ffield03.frm - Marker frame id for special hidden "attacker" object created by `critter_dmg` opcode handler.
 };
 
 enum class WallFrameId : int {

--- a/src/art_defs.h
+++ b/src/art_defs.h
@@ -322,7 +322,7 @@ inline CritterFrameId critterFrameIdFromPid(int pid)
 enum class SceneryFrameId : int {
     Invalid = -1, // invalid frame id
     Reserved = 0, // reserved.frm
-    ForceField1 = 501, // ffield01.frm
+    ForceField1 = 501, // ffield01.frm - Marker frame id for special hidden "attacker" object created by `critter_dmg` opcode handler.
 };
 
 enum class WallFrameId : int {

--- a/src/proto.cc
+++ b/src/proto.cc
@@ -1008,13 +1008,13 @@ int proto_scenery_subdata_init(Proto* proto, SceneryType type)
 // 0x49FCFC proto_wall_init
 int proto_wall_init(Proto* proto, int pid)
 {
-    WallFrameId num = wallFrameIdFromPid(pid);
+    int num = frameIdFromPid(pid);
 
     proto->wall.pid = -1;
     proto->wall.messageId = 100 * num;
-    proto->wall.fid = FrmId(num - 1).fid();
+    proto->wall.fid = WallFrmId(static_cast<WallFrameId>(num - 1)).fid();
     if (!artExists(proto->wall.fid)) {
-        proto->wall.fid = FrmId(WALL_FRM_ID_FIRST).fid();
+        proto->wall.fid = WallFrmId(WallFrameId::Reserved).fid();
     }
     proto->wall.lightDistance = 0;
     proto->wall.lightIntensity = 0;

--- a/src/proto.cc
+++ b/src/proto.cc
@@ -371,13 +371,13 @@ char* protoGetDescription(int pid)
 // 0x49EB2C proto_item_init
 int proto_item_init(Proto* proto, int pid)
 {
-    ItemFrameId protoNum = itemFrameIdFromPid(pid);
+    int protoNum = frameIdFromPid(pid);
 
     proto->item.pid = -1;
     proto->item.messageId = 100 * protoNum;
-    proto->item.fid = FrmId(protoNum - 1).fid();
+    proto->item.fid = ItemFrmId(static_cast<ItemFrameId>(protoNum - 1)).fid();
     if (!artExists(proto->item.fid)) {
-        proto->item.fid = FrmId(ITEM_FRM_ID_FIRST).fid();
+        proto->item.fid = ItemFrmId(ItemFrameId::Reserved).fid();
     }
     proto->item.lightDistance = 0;
     proto->item.lightIntensity = 0;

--- a/src/proto.cc
+++ b/src/proto.cc
@@ -951,13 +951,13 @@ int _proto_dude_init(const char* path)
 // 0x49FBBC proto_scenery_init
 int proto_scenery_init(Proto* proto, int pid)
 {
-    SceneryFrameId num = sceneryFrameIdFromPid(pid);
+    int num = frameIdFromPid(pid);
 
     proto->scenery.pid = -1;
     proto->scenery.messageId = 100 * num;
-    proto->scenery.fid = FrmId(num - 1).fid();
+    proto->scenery.fid = SceneryFrmId(static_cast<SceneryFrameId>(num - 1)).fid();
     if (!artExists(proto->scenery.fid)) {
-        proto->scenery.fid = FrmId(SCENERY_FRM_ID_FIRST).fid();
+        proto->scenery.fid = SceneryFrmId(SceneryFrameId::Reserved).fid();
     }
     proto->scenery.lightDistance = 0;
     proto->scenery.lightIntensity = 0;

--- a/src/proto_types.h
+++ b/src/proto_types.h
@@ -299,9 +299,6 @@ enum {
 #define FIRST_RADIOACTIVE_GOO_PID 0x20003D9
 #define LAST_RADIOACTIVE_GOO_PID 0x20003DC
 
-// FID of one of the Force Field sceneries. Used as a marker for special hidden "attacker" object created by `critter_dmg` opcode handler.
-#define FRAME_ID_FORCE_FIELD_NS 0x20001F5
-
 enum ProtoFlags : unsigned int {
     PROTO_FLAG_NONE = 0x00,
     PROTO_FLAG_FLAT = 0x08,


### PR DESCRIPTION
### Description

Changes the `SceneryFrameId`, `WallFrameId` and `ItemFrameId` enums to be scoped, removed not needed operators and helper functions.
Replaced `#define FRAME_ID_FORCE_FIELD_NS 0x20001F5` macro by `SceneryFrmId(SceneryFrameId::ForceField1)`.

Related to #668 