### PR TITLE
Implicit FrmId ctors from FrameId and additional FrmId operators for FrameId comparison

### DIFF
--- a/src/actions.cc
+++ b/src/actions.cc
@@ -213,13 +213,13 @@ AnimationType actionBlood(Object* obj, AnimationType anim, int delay)
 // 0x41060C pick_death
 AnimationType pickDeathAnim(Object* attacker, Object* defender, Object* weapon, int damage, AnimationType attackerAnimation, bool hitFromFront)
 {
-    if (FrmId(attacker->fid) == MiscFrmId(MiscFrameId::RocketExplosion)) {
+    if (FrmId(attacker->fid) == MiscFrameId::RocketExplosion) {
         return checkDeathAnim(defender, ANIM_EXPLODED_TO_NOTHING, VIOLENCE_LEVEL_MAXIMUM_BLOOD, hitFromFront);
     }
     if (attacker->pid == PROTO_ID_FORCE_FIELD_NS) { // Forcefield North/South
         return checkDeathAnim(defender, ANIM_ELECTRIFIED_TO_NOTHING, VIOLENCE_LEVEL_MAXIMUM_BLOOD, hitFromFront);
     }
-    if (FrmId(attacker->fid) == SceneryFrmId(SceneryFrameId::ForceField3)) {
+    if (FrmId(attacker->fid) == SceneryFrameId::ForceField3) {
         return checkDeathAnim(defender, attackerAnimation, VIOLENCE_LEVEL_MAXIMUM_BLOOD, hitFromFront);
     }
 
@@ -592,7 +592,7 @@ void showDamage(Attack* attack, AnimationType attackerAnimation, int delay)
 
             if (objectTypeFromFid(attack->defender->fid) == OBJ_TYPE_CRITTER) {
                 Rotation knockbackRotation = tileGetRotationTo(attack->attacker->tile, attack->defender->tile);
-                AnimationType attackerAnimForShow = FrmId(attack->attacker->fid) == SceneryFrmId(SceneryFrameId::ForceField3)
+                AnimationType attackerAnimForShow = FrmId(attack->attacker->fid) == SceneryFrameId::ForceField3
                     ? attackerAnimation
                     : critterGetAnimationForHitMode(attack->attacker, attack->hitMode);
 

--- a/src/animation.cc
+++ b/src/animation.cc
@@ -3390,7 +3390,7 @@ static int _check_gravity(int tile, int elevation)
 
         int squareTile = squareTileFromScreenXY(x + 2, y + 8, elevation);
         const TileFrmId frmId = static_cast<TileFrameId>(frameIdFromFid(_square[elevation]->fid[squareTile]));
-        if (frmId != TileFrmId(TileFrameId::Grid)) {
+        if (frmId != TileFrameId::Grid) {
             break;
         }
     }

--- a/src/art.h
+++ b/src/art.h
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <cstring>
 #include <memory>
+#include <type_traits>
 
 #include "animation.h"
 #include "art_defs.h"
@@ -42,6 +43,46 @@ extern Cache gArtCache;
 
 class NamedCacheEntry;
 std::shared_ptr<NamedCacheEntry> artLockNamedFrameData(const char* path);
+
+template <typename T>
+struct MapFrameIdToObjectType;
+
+template <>
+struct MapFrameIdToObjectType<SceneryFrameId> {
+    static constexpr ObjectType value = OBJ_TYPE_SCENERY;
+};
+template <>
+struct MapFrameIdToObjectType<WallFrameId> {
+    static constexpr ObjectType value = OBJ_TYPE_WALL;
+};
+template <>
+struct MapFrameIdToObjectType<ItemFrameId> {
+    static constexpr ObjectType value = OBJ_TYPE_ITEM;
+};
+template <>
+struct MapFrameIdToObjectType<TileFrameId> {
+    static constexpr ObjectType value = OBJ_TYPE_TILE;
+};
+template <>
+struct MapFrameIdToObjectType<SkillDexFrameId> {
+    static constexpr ObjectType value = OBJ_TYPE_SKILLDEX;
+};
+template <>
+struct MapFrameIdToObjectType<InterfaceFrameId> {
+    static constexpr ObjectType value = OBJ_TYPE_INTERFACE;
+};
+template <>
+struct MapFrameIdToObjectType<BackgroundFrameId> {
+    static constexpr ObjectType value = OBJ_TYPE_BACKGROUND;
+};
+template <>
+struct MapFrameIdToObjectType<MiscFrameId> {
+    static constexpr ObjectType value = OBJ_TYPE_MISC;
+};
+template <>
+struct MapFrameIdToObjectType<HeadFrameId> {
+    static constexpr ObjectType value = OBJ_TYPE_HEAD;
+};
 
 class FrmId {
 public:
@@ -208,24 +249,15 @@ public:
         return !(*this == other);
     }
 
-    constexpr bool operator==(InterfaceFrameId frameId) const { return _fid == FrmId(frameId).fid(); }
-    constexpr bool operator!=(InterfaceFrameId frameId) const { return !(*this == frameId); }
-    constexpr bool operator==(SceneryFrameId frameId) const { return _fid == FrmId(frameId).fid(); }
-    constexpr bool operator!=(SceneryFrameId frameId) const { return !(*this == frameId); }
-    constexpr bool operator==(WallFrameId frameId) const { return _fid == FrmId(frameId).fid(); }
-    constexpr bool operator!=(WallFrameId frameId) const { return !(*this == frameId); }
-    constexpr bool operator==(ItemFrameId frameId) const { return _fid == FrmId(frameId).fid(); }
-    constexpr bool operator!=(ItemFrameId frameId) const { return !(*this == frameId); }
-    constexpr bool operator==(TileFrameId frameId) const { return _fid == FrmId(frameId).fid(); }
-    constexpr bool operator!=(TileFrameId frameId) const { return !(*this == frameId); }
-    constexpr bool operator==(SkillDexFrameId frameId) const { return _fid == FrmId(frameId).fid(); }
-    constexpr bool operator!=(SkillDexFrameId frameId) const { return !(*this == frameId); }
-    constexpr bool operator==(BackgroundFrameId frameId) const { return _fid == FrmId(frameId).fid(); }
-    constexpr bool operator!=(BackgroundFrameId frameId) const { return !(*this == frameId); }
-    constexpr bool operator==(HeadFrameId frameId) const { return _fid == FrmId(frameId).fid(); }
-    constexpr bool operator!=(HeadFrameId frameId) const { return !(*this == frameId); }
-    constexpr bool operator==(MiscFrameId frameId) const { return _fid == FrmId(frameId).fid(); }
-    constexpr bool operator!=(MiscFrameId frameId) const { return !(*this == frameId); }
+    template <typename TFrameId,
+        typename = std::void_t<
+            decltype(MapFrameIdToObjectType<TFrameId>::value)>>
+    constexpr bool operator==(TFrameId frameId) const { return _fid == buildFid(MapFrameIdToObjectType<TFrameId>::value, static_cast<int>(frameId)); }
+
+    template <typename TFrameId,
+        typename = std::void_t<
+            decltype(MapFrameIdToObjectType<TFrameId>::value)>>
+    constexpr bool operator!=(TFrameId frameId) const { return !(*this == frameId); }
 
 private:
     ObjectType _objectType;
@@ -270,37 +302,6 @@ private:
     static bool exist(int fid, char* path);
 };
 
-template <typename T>
-struct MapFrameIdToObjectType;
-
-template <>
-struct MapFrameIdToObjectType<SceneryFrameId> {
-    static constexpr ObjectType value = OBJ_TYPE_SCENERY;
-};
-template <>
-struct MapFrameIdToObjectType<WallFrameId> {
-    static constexpr ObjectType value = OBJ_TYPE_WALL;
-};
-template <>
-struct MapFrameIdToObjectType<ItemFrameId> {
-    static constexpr ObjectType value = OBJ_TYPE_ITEM;
-};
-template <>
-struct MapFrameIdToObjectType<TileFrameId> {
-    static constexpr ObjectType value = OBJ_TYPE_TILE;
-};
-template <>
-struct MapFrameIdToObjectType<SkillDexFrameId> {
-    static constexpr ObjectType value = OBJ_TYPE_SKILLDEX;
-};
-template <>
-struct MapFrameIdToObjectType<InterfaceFrameId> {
-    static constexpr ObjectType value = OBJ_TYPE_INTERFACE;
-};
-template <>
-struct MapFrameIdToObjectType<BackgroundFrameId> {
-    static constexpr ObjectType value = OBJ_TYPE_BACKGROUND;
-};
 
 template <ObjectType ObjType, typename TFrameId>
 class TypedFrmId : public FrmId {

--- a/src/art.h
+++ b/src/art.h
@@ -208,6 +208,25 @@ public:
         return !(*this == other);
     }
 
+    constexpr bool operator==(InterfaceFrameId frameId) const { return _fid == FrmId(frameId).fid(); }
+    constexpr bool operator!=(InterfaceFrameId frameId) const { return !(*this == frameId); }
+    constexpr bool operator==(SceneryFrameId frameId) const { return _fid == FrmId(frameId).fid(); }
+    constexpr bool operator!=(SceneryFrameId frameId) const { return !(*this == frameId); }
+    constexpr bool operator==(WallFrameId frameId) const { return _fid == FrmId(frameId).fid(); }
+    constexpr bool operator!=(WallFrameId frameId) const { return !(*this == frameId); }
+    constexpr bool operator==(ItemFrameId frameId) const { return _fid == FrmId(frameId).fid(); }
+    constexpr bool operator!=(ItemFrameId frameId) const { return !(*this == frameId); }
+    constexpr bool operator==(TileFrameId frameId) const { return _fid == FrmId(frameId).fid(); }
+    constexpr bool operator!=(TileFrameId frameId) const { return !(*this == frameId); }
+    constexpr bool operator==(SkillDexFrameId frameId) const { return _fid == FrmId(frameId).fid(); }
+    constexpr bool operator!=(SkillDexFrameId frameId) const { return !(*this == frameId); }
+    constexpr bool operator==(BackgroundFrameId frameId) const { return _fid == FrmId(frameId).fid(); }
+    constexpr bool operator!=(BackgroundFrameId frameId) const { return !(*this == frameId); }
+    constexpr bool operator==(HeadFrameId frameId) const { return _fid == FrmId(frameId).fid(); }
+    constexpr bool operator!=(HeadFrameId frameId) const { return !(*this == frameId); }
+    constexpr bool operator==(MiscFrameId frameId) const { return _fid == FrmId(frameId).fid(); }
+    constexpr bool operator!=(MiscFrameId frameId) const { return !(*this == frameId); }
+
 private:
     ObjectType _objectType;
     int _fid;

--- a/src/art.h
+++ b/src/art.h
@@ -249,22 +249,22 @@ public:
         return !(*this == other);
     }
 
-template <typename TFrameId,
-    typename = std::void_t<
-        decltype(MapFrameIdToObjectType<TFrameId>::value)>>
-constexpr bool operator==(TFrameId frameId) const
-{
-    // Path-backed IDs are not comparable to enum FrameIds via FID.
-    return _path == nullptr && _fid == buildFid(MapFrameIdToObjectType<TFrameId>::value, static_cast<int>(frameId));
-}
+    template <typename TFrameId,
+        typename = std::void_t<
+            decltype(MapFrameIdToObjectType<TFrameId>::value)>>
+    constexpr bool operator==(TFrameId frameId) const
+    {
+        // Path-backed IDs are not comparable to enum FrameIds via FID.
+        return _path == nullptr && _fid == buildFid(MapFrameIdToObjectType<TFrameId>::value, static_cast<int>(frameId));
+    }
 
-template <typename TFrameId,
-    typename = std::void_t<
-        decltype(MapFrameIdToObjectType<TFrameId>::value)>>
-constexpr bool operator!=(TFrameId frameId) const
-{
-    return !(*this == frameId);
-}
+    template <typename TFrameId,
+        typename = std::void_t<
+            decltype(MapFrameIdToObjectType<TFrameId>::value)>>
+    constexpr bool operator!=(TFrameId frameId) const
+    {
+        return !(*this == frameId);
+    }
 
 private:
     ObjectType _objectType;

--- a/src/art.h
+++ b/src/art.h
@@ -183,10 +183,10 @@ public:
     {
     }
 
-    // cannot be made constexpr as internally calls exists which cannot be constexpr
+    // cannot be made constexpr as internally calls FrmId::exist and that checks file system
     FrmId(CritterFrameId critter, AnimationType animType = ANIM_STAND, WeaponAnimation weaponAnimation = WEAPON_ANIMATION_NONE, Rotation rotation = ROTATION_NE);
-    FrmId(Object* object, AnimationType animType, WeaponAnimation weaponAnimation, Rotation rotation);
-    FrmId(ObjectType objectType, int frmId, AnimationType animType = ANIM_STAND, WeaponAnimation weaponAnimation = WEAPON_ANIMATION_NONE, Rotation rotation = ROTATION_NE);
+    explicit FrmId(Object* object, AnimationType animType, WeaponAnimation weaponAnimation, Rotation rotation);
+    explicit FrmId(ObjectType objectType, int frmId, AnimationType animType = ANIM_STAND, WeaponAnimation weaponAnimation = WEAPON_ANIMATION_NONE, Rotation rotation = ROTATION_NE);
 
     constexpr FrmId(HeadFrameId head, HeadAnimation headAnimation = HEAD_ANIMATION_VERY_GOOD_REACTION, int fidget = 0)
         : _objectType(OBJ_TYPE_HEAD)

--- a/src/art.h
+++ b/src/art.h
@@ -249,15 +249,22 @@ public:
         return !(*this == other);
     }
 
-    template <typename TFrameId,
-        typename = std::void_t<
-            decltype(MapFrameIdToObjectType<TFrameId>::value)>>
-    constexpr bool operator==(TFrameId frameId) const { return _fid == buildFid(MapFrameIdToObjectType<TFrameId>::value, static_cast<int>(frameId)); }
+template <typename TFrameId,
+    typename = std::void_t<
+        decltype(MapFrameIdToObjectType<TFrameId>::value)>>
+constexpr bool operator==(TFrameId frameId) const
+{
+    // Path-backed IDs are not comparable to enum FrameIds via FID.
+    return _path == nullptr && _fid == buildFid(MapFrameIdToObjectType<TFrameId>::value, static_cast<int>(frameId));
+}
 
-    template <typename TFrameId,
-        typename = std::void_t<
-            decltype(MapFrameIdToObjectType<TFrameId>::value)>>
-    constexpr bool operator!=(TFrameId frameId) const { return !(*this == frameId); }
+template <typename TFrameId,
+    typename = std::void_t<
+        decltype(MapFrameIdToObjectType<TFrameId>::value)>>
+constexpr bool operator!=(TFrameId frameId) const
+{
+    return !(*this == frameId);
+}
 
 private:
     ObjectType _objectType;

--- a/src/art.h
+++ b/src/art.h
@@ -86,7 +86,7 @@ public:
     {
     }
 
-    constexpr explicit FrmId(MiscFrameId misc, AnimationType animType = ANIM_STAND)
+    constexpr FrmId(MiscFrameId misc, AnimationType animType = ANIM_STAND)
         : _objectType(OBJ_TYPE_MISC)
         , _fid(buildFid(OBJ_TYPE_MISC, static_cast<int>(misc), animType))
         , _frameId { buildFrameId(static_cast<int>(misc)) }
@@ -94,7 +94,7 @@ public:
     {
     }
 
-    constexpr explicit FrmId(SceneryFrameId scenery)
+    constexpr FrmId(SceneryFrameId scenery)
         : _objectType(OBJ_TYPE_SCENERY)
         , _fid(buildFid(OBJ_TYPE_SCENERY, static_cast<int>(scenery)))
         , _frameId { buildFrameId(static_cast<int>(scenery)) }
@@ -102,7 +102,7 @@ public:
     {
     }
 
-    constexpr explicit FrmId(WallFrameId wall)
+    constexpr FrmId(WallFrameId wall)
         : _objectType(OBJ_TYPE_WALL)
         , _fid(buildFid(OBJ_TYPE_WALL, static_cast<int>(wall)))
         , _frameId { buildFrameId(static_cast<int>(wall)) }
@@ -110,7 +110,7 @@ public:
     {
     }
 
-    constexpr explicit FrmId(ItemFrameId item)
+    constexpr FrmId(ItemFrameId item)
         : _objectType(OBJ_TYPE_ITEM)
         , _fid(buildFid(OBJ_TYPE_ITEM, static_cast<int>(item)))
         , _frameId { buildFrameId(static_cast<int>(item)) }
@@ -118,7 +118,7 @@ public:
     {
     }
 
-    constexpr explicit FrmId(TileFrameId tile)
+    constexpr FrmId(TileFrameId tile)
         : _objectType(OBJ_TYPE_TILE)
         , _fid(buildFid(OBJ_TYPE_TILE, static_cast<int>(tile)))
         , _frameId { buildFrameId(static_cast<int>(tile)) }
@@ -126,7 +126,7 @@ public:
     {
     }
 
-    constexpr explicit FrmId(SkillDexFrameId skilldex)
+    constexpr FrmId(SkillDexFrameId skilldex)
         : _objectType(OBJ_TYPE_SKILLDEX)
         , _fid(buildFid(OBJ_TYPE_SKILLDEX, static_cast<int>(skilldex)))
         , _frameId { buildFrameId(static_cast<int>(skilldex)) }
@@ -134,7 +134,7 @@ public:
     {
     }
 
-    constexpr explicit FrmId(InterfaceFrameId interface)
+    constexpr FrmId(InterfaceFrameId interface)
         : _objectType(OBJ_TYPE_INTERFACE)
         , _fid(buildFid(OBJ_TYPE_INTERFACE, static_cast<int>(interface)))
         , _frameId { buildFrameId(static_cast<int>(interface)) }
@@ -143,11 +143,11 @@ public:
     }
 
     // cannot be made constexpr as internally calls exists which cannot be constexpr
-    explicit FrmId(CritterFrameId critter, AnimationType animType = ANIM_STAND, WeaponAnimation weaponAnimation = WEAPON_ANIMATION_NONE, Rotation rotation = ROTATION_NE);
-    explicit FrmId(Object* object, AnimationType animType, WeaponAnimation weaponAnimation, Rotation rotation);
-    explicit FrmId(ObjectType objectType, int frmId, AnimationType animType = ANIM_STAND, WeaponAnimation weaponAnimation = WEAPON_ANIMATION_NONE, Rotation rotation = ROTATION_NE);
+    FrmId(CritterFrameId critter, AnimationType animType = ANIM_STAND, WeaponAnimation weaponAnimation = WEAPON_ANIMATION_NONE, Rotation rotation = ROTATION_NE);
+    FrmId(Object* object, AnimationType animType, WeaponAnimation weaponAnimation, Rotation rotation);
+    FrmId(ObjectType objectType, int frmId, AnimationType animType = ANIM_STAND, WeaponAnimation weaponAnimation = WEAPON_ANIMATION_NONE, Rotation rotation = ROTATION_NE);
 
-    constexpr explicit FrmId(HeadFrameId head, HeadAnimation headAnimation = HEAD_ANIMATION_VERY_GOOD_REACTION, int fidget = 0)
+    constexpr FrmId(HeadFrameId head, HeadAnimation headAnimation = HEAD_ANIMATION_VERY_GOOD_REACTION, int fidget = 0)
         : _objectType(OBJ_TYPE_HEAD)
         , _fid(buildFid(OBJ_TYPE_HEAD, static_cast<int>(head), headAnimation, fidget))
         , _frameId { buildFrameId(static_cast<int>(head)) }
@@ -155,7 +155,7 @@ public:
     {
     }
 
-    constexpr explicit FrmId(BackgroundFrameId background)
+    constexpr FrmId(BackgroundFrameId background)
         : _objectType(OBJ_TYPE_BACKGROUND)
         , _fid(buildFid(OBJ_TYPE_BACKGROUND, static_cast<int>(background)))
         , _frameId { buildFrameId(static_cast<int>(background)) }
@@ -163,7 +163,7 @@ public:
     {
     }
 
-    constexpr explicit FrmId(ObjectType objType, const char* path)
+    constexpr FrmId(ObjectType objType, const char* path)
         : _objectType(objType)
         , _fid(kEmptyFid)
         , _frameId { kInvalidFrameId }

--- a/src/art.h
+++ b/src/art.h
@@ -302,7 +302,6 @@ private:
     static bool exist(int fid, char* path);
 };
 
-
 template <ObjectType ObjType, typename TFrameId>
 class TypedFrmId : public FrmId {
 public:

--- a/src/character_editor.cc
+++ b/src/character_editor.cc
@@ -794,10 +794,10 @@ static int gCharacterEditorOldTaggedSkillCount;
 static int gCharacterEditorLastLevelBackup;
 
 // 0x5709E8 old_fid2
-static FrmId gPerkDialogCardFrmId;
+static SkillDexFrmId gPerkDialogCardFrmId;
 
 // 0x5709EC old_fid1
-static FrmId gCharacterEditorCardFrmId;
+static SkillDexFrmId gCharacterEditorCardFrmId;
 
 // 0x5709D0 glblmode
 static bool gCharacterEditorIsCreationMode;
@@ -1290,8 +1290,8 @@ static int characterEditorWindowInit()
     gCharacterEditorOldFont = fontGetCurrent();
     gCharacterEditorOldTaggedSkillCount = 0;
     gCharacterEditorIsoWasEnabled = 0;
-    gPerkDialogCardFrmId = FrmId::Empty();
-    gCharacterEditorCardFrmId = FrmId::Empty();
+    gPerkDialogCardFrmId = SkillDexFrameId::Invalid;
+    gCharacterEditorCardFrmId = SkillDexFrameId::Invalid;
     gPerkDialogCardDrawn = false;
     gCharacterEditorCardDrawn = false;
     gCharacterEditorIsSkillsFirstDraw = 1;
@@ -1355,8 +1355,8 @@ static int characterEditorWindowInit()
     }
     messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_EDITOR, &gCharacterEditorMessageList);
 
-    const FrmId fid = gCharacterEditorIsCreationMode ? FrmId(InterfaceFrameId::CharacterEditorCreateBackground) : FrmId(InterfaceFrameId::CharacterEditorEditBackground);
-    if (!_editorBackgroundFrmImage.lock(fid)) {
+    const InterfaceFrmId frmId = gCharacterEditorIsCreationMode ? InterfaceFrameId::CharacterEditorCreateBackground : InterfaceFrameId::CharacterEditorEditBackground;
+    if (!_editorBackgroundFrmImage.lock(frmId)) {
         characterEditorMessageListReset();
         characterEditorWindowRestoreState();
         return -1;
@@ -6127,7 +6127,7 @@ static int perkDialogShow()
 {
     gPerkDialogTopLine = 0;
     gPerkDialogCurrentLine = 0;
-    gPerkDialogCardFrmId = FrmId::Empty();
+    gPerkDialogCardFrmId = SkillDexFrameId::Invalid;
     gPerkDialogCardTitle[0] = '\0';
     gPerkDialogCardDrawn = false;
     int previousPerkRanks[PERK_COUNT];
@@ -6135,7 +6135,7 @@ static int perkDialogShow()
         previousPerkRanks[perk] = perkGetRank(gDude, perk);
     }
 
-    if (!_perkDialogBackgroundFrmImage.lock(FrmId(InterfaceFrameId::PerkDialogBackground))) {
+    if (!_perkDialogBackgroundFrmImage.lock(InterfaceFrameId::PerkDialogBackground)) {
         debugPrint("\n *** Error running perks dialog window ***\n");
         return -1;
     }
@@ -6718,7 +6718,7 @@ static void perkDialogRefreshTraits()
 // 0x43D38C GetMutateTrait
 static bool perkDialogHandleMutatePerk()
 {
-    gPerkDialogCardFrmId = FrmId::Empty();
+    gPerkDialogCardFrmId = SkillDexFrameId::Invalid;
     gPerkDialogCardTitle[0] = '\0';
     gPerkDialogCardDrawn = false;
 
@@ -6869,7 +6869,7 @@ static bool perkDialogHandleTagPerk()
 
     gPerkDialogCurrentLine = 0;
     gPerkDialogTopLine = 0;
-    gPerkDialogCardFrmId = FrmId::Empty();
+    gPerkDialogCardFrmId = SkillDexFrameId::Invalid;
     gPerkDialogCardTitle[0] = '\0';
     gPerkDialogCardDrawn = false;
     perkDialogRefreshSkills();

--- a/src/character_selector.cc
+++ b/src/character_selector.cc
@@ -295,7 +295,7 @@ static bool characterSelectorWindowInit()
     }
 
     FrmImage backgroundFrmImage;
-    if (!backgroundFrmImage.lock(FrmId(InterfaceFrameId::CharacterSelectorBackground))) {
+    if (!backgroundFrmImage.lock(InterfaceFrameId::CharacterSelectorBackground)) {
         return characterSelectorWindowFatalError(false);
     }
 
@@ -320,11 +320,11 @@ static bool characterSelectorWindowInit()
     backgroundFrmImage.unlock();
 
     // Setup "Previous" button.
-    if (!_previousButtonNormalFrmImage.lock(FrmId(InterfaceFrameId::LeftArrowUp))) {
+    if (!_previousButtonNormalFrmImage.lock(InterfaceFrameId::LeftArrowUp)) {
         return characterSelectorWindowFatalError(false);
     }
 
-    if (!_previousButtonPressedFrmImage.lock(FrmId(InterfaceFrameId::LeftArrowDown))) {
+    if (!_previousButtonPressedFrmImage.lock(InterfaceFrameId::LeftArrowDown)) {
         return characterSelectorWindowFatalError(false);
     }
 
@@ -348,11 +348,11 @@ static bool characterSelectorWindowInit()
     buttonSetCallbacks(gCharacterSelectorWindowPreviousButton, _gsound_med_butt_press, _gsound_med_butt_release);
 
     // Setup "Next" button.
-    if (!_nextButtonNormalFrmImage.lock(FrmId(InterfaceFrameId::RightArrowUp))) {
+    if (!_nextButtonNormalFrmImage.lock(InterfaceFrameId::RightArrowUp)) {
         return characterSelectorWindowFatalError(false);
     }
 
-    if (!_nextButtonPressedFrmImage.lock(FrmId(InterfaceFrameId::RightArrowDown))) {
+    if (!_nextButtonPressedFrmImage.lock(InterfaceFrameId::RightArrowDown)) {
         return characterSelectorWindowFatalError(false);
     }
 
@@ -376,11 +376,11 @@ static bool characterSelectorWindowInit()
     buttonSetCallbacks(gCharacterSelectorWindowNextButton, _gsound_med_butt_press, _gsound_med_butt_release);
 
     // Setup "Take" button.
-    if (!_takeButtonNormalFrmImage.lock(FrmId(InterfaceFrameId::LittleRedButtonUp))) {
+    if (!_takeButtonNormalFrmImage.lock(InterfaceFrameId::LittleRedButtonUp)) {
         return characterSelectorWindowFatalError(false);
     }
 
-    if (!_takeButtonPressedFrmImage.lock(FrmId(InterfaceFrameId::LittleRedButtonDown))) {
+    if (!_takeButtonPressedFrmImage.lock(InterfaceFrameId::LittleRedButtonDown)) {
         return characterSelectorWindowFatalError(false);
     }
 
@@ -404,10 +404,10 @@ static bool characterSelectorWindowInit()
     buttonSetCallbacks(gCharacterSelectorWindowTakeButton, _gsound_red_butt_press, _gsound_red_butt_release);
 
     // Setup "Modify" button.
-    if (!_modifyButtonNormalFrmImage.lock(FrmId(InterfaceFrameId::LittleRedButtonUp)))
+    if (!_modifyButtonNormalFrmImage.lock(InterfaceFrameId::LittleRedButtonUp))
         return characterSelectorWindowFatalError(false);
 
-    if (!_modifyButtonPressedFrmImage.lock(FrmId(InterfaceFrameId::LittleRedButtonDown))) {
+    if (!_modifyButtonPressedFrmImage.lock(InterfaceFrameId::LittleRedButtonDown)) {
         return characterSelectorWindowFatalError(false);
     }
 
@@ -431,11 +431,11 @@ static bool characterSelectorWindowInit()
     buttonSetCallbacks(gCharacterSelectorWindowModifyButton, _gsound_red_butt_press, _gsound_red_butt_release);
 
     // Setup "Create" button.
-    if (!_createButtonNormalFrmImage.lock(FrmId(InterfaceFrameId::LittleRedButtonUp))) {
+    if (!_createButtonNormalFrmImage.lock(InterfaceFrameId::LittleRedButtonUp)) {
         return characterSelectorWindowFatalError(false);
     }
 
-    if (!_createButtonPressedFrmImage.lock(FrmId(InterfaceFrameId::LittleRedButtonDown))) {
+    if (!_createButtonPressedFrmImage.lock(InterfaceFrameId::LittleRedButtonDown)) {
         return characterSelectorWindowFatalError(false);
     }
 
@@ -459,11 +459,11 @@ static bool characterSelectorWindowInit()
     buttonSetCallbacks(gCharacterSelectorWindowCreateButton, _gsound_red_butt_press, _gsound_red_butt_release);
 
     // Setup "Back" button.
-    if (!_backButtonNormalFrmImage.lock(FrmId(InterfaceFrameId::LittleRedButtonUp))) {
+    if (!_backButtonNormalFrmImage.lock(InterfaceFrameId::LittleRedButtonUp)) {
         return characterSelectorWindowFatalError(false);
     }
 
-    if (!_backButtonPressedFrmImage.lock(FrmId(InterfaceFrameId::LittleRedButtonDown))) {
+    if (!_backButtonPressedFrmImage.lock(InterfaceFrameId::LittleRedButtonDown)) {
         return characterSelectorWindowFatalError(false);
     }
 

--- a/src/combat.cc
+++ b/src/combat.cc
@@ -5530,7 +5530,7 @@ static void _combat_standup(Object* a1)
 static void _print_tohit(unsigned char* dest, int destPitch, int accuracy)
 {
     FrmImage numbersFrmImage;
-    if (!numbersFrmImage.lock(FrmId(InterfaceFrameId::HitPointsNumbers))) {
+    if (!numbersFrmImage.lock(InterfaceFrameId::HitPointsNumbers)) {
         return;
     }
 
@@ -5618,7 +5618,7 @@ static int calledShotSelectHitLocation(Object* critter, HitLocation* hitLocation
     unsigned char* windowBuffer = windowGetBuffer(gCalledShotWindow);
 
     FrmImage backgroundFrm;
-    if (!backgroundFrm.lock(FrmId(InterfaceFrameId::CalledShotWindow))) {
+    if (!backgroundFrm.lock(InterfaceFrameId::CalledShotWindow)) {
         windowDestroy(gCalledShotWindow);
         return -1;
     }
@@ -5642,13 +5642,13 @@ static int calledShotSelectHitLocation(Object* critter, HitLocation* hitLocation
     }
 
     FrmImage cancelButtonNormalFrmImage;
-    if (!cancelButtonNormalFrmImage.lock(FrmId(InterfaceFrameId::LittleRedButtonUp))) {
+    if (!cancelButtonNormalFrmImage.lock(InterfaceFrameId::LittleRedButtonUp)) {
         windowDestroy(gCalledShotWindow);
         return -1;
     }
 
     FrmImage cancelButtonPressedFrmImage;
-    if (!cancelButtonPressedFrmImage.lock(FrmId(InterfaceFrameId::LittleRedButtonDown))) {
+    if (!cancelButtonPressedFrmImage.lock(InterfaceFrameId::LittleRedButtonDown)) {
         windowDestroy(gCalledShotWindow);
         return -1;
     }

--- a/src/credits.cc
+++ b/src/credits.cc
@@ -91,8 +91,8 @@ void creditsOpen(const char* filePath, int backgroundFid, bool useReversedStyle)
                         soundContinueAll();
 
                         memset(backgroundBuffer, COLOR_BLACK, windowWidth * windowHeight);
-                        FrmId backgroundFrmId = FrmId(backgroundFid);
-                        if (!backgroundFrmId.empty()) {
+                        const FrmId backgroundFrmId = FrmId(backgroundFid);
+                        if (backgroundFrmId.valid()) {
                             FrmImage backgroundFrmImage;
                             if (backgroundFrmImage.lock(backgroundFrmId)) {
                                 blitBufferToBuffer(backgroundFrmImage.getData(),

--- a/src/dbox.cc
+++ b/src/dbox.cc
@@ -229,19 +229,19 @@ int showDialogBox(const char* title, const char** body, int bodyLength, int x, i
     FrmImage buttonPressedFrmImage;
 
     if ((flags & DIALOG_BOX_NO_BUTTONS) == 0) {
-        if (!doneBoxFrmImage.lock(FrmId(InterfaceFrameId::DoneBox))) {
+        if (!doneBoxFrmImage.lock(InterfaceFrameId::DoneBox)) {
             fontSetCurrent(savedFont);
             windowDestroy(win);
             return -1;
         }
 
-        if (!buttonPressedFrmImage.lock(FrmId(InterfaceFrameId::LittleRedButtonDown))) {
+        if (!buttonPressedFrmImage.lock(InterfaceFrameId::LittleRedButtonDown)) {
             fontSetCurrent(savedFont);
             windowDestroy(win);
             return -1;
         }
 
-        if (!buttonNormalFrmImage.lock(FrmId(InterfaceFrameId::LittleRedButtonUp))) {
+        if (!buttonNormalFrmImage.lock(InterfaceFrameId::LittleRedButtonUp)) {
             fontSetCurrent(savedFont);
             windowDestroy(win);
             return -1;
@@ -343,19 +343,19 @@ int showDialogBox(const char* title, const char** body, int bodyLength, int x, i
                 buttonSetCallbacks(btn, _gsound_red_butt_press, _gsound_red_butt_release);
             }
         } else {
-            if (!doneBoxFrmImage.lock(FrmId(InterfaceFrameId::DoneBox))) {
+            if (!doneBoxFrmImage.lock(InterfaceFrameId::DoneBox)) {
                 fontSetCurrent(savedFont);
                 windowDestroy(win);
                 return -1;
             }
 
-            if (!buttonPressedFrmImage.lock(FrmId(InterfaceFrameId::LittleRedButtonDown))) {
+            if (!buttonPressedFrmImage.lock(InterfaceFrameId::LittleRedButtonDown)) {
                 fontSetCurrent(savedFont);
                 windowDestroy(win);
                 return -1;
             }
 
-            if (!buttonNormalFrmImage.lock(FrmId(InterfaceFrameId::LittleRedButtonUp))) {
+            if (!buttonNormalFrmImage.lock(InterfaceFrameId::LittleRedButtonUp)) {
                 fontSetCurrent(savedFont);
                 windowDestroy(win);
                 return -1;

--- a/src/display_monitor.cc
+++ b/src/display_monitor.cc
@@ -133,7 +133,7 @@ int displayMonitorInit()
                 DISPLAY_MONITOR_WIDTH);
         } else {
             FrmImage backgroundFrmImage;
-            if (!backgroundFrmImage.lock(FrmId(InterfaceFrameId::MainInterface))) {
+            if (!backgroundFrmImage.lock(InterfaceFrameId::MainInterface)) {
                 internal_free(gDisplayMonitorBackgroundFrmData);
                 return -1;
             }

--- a/src/elevator.cc
+++ b/src/elevator.cc
@@ -541,10 +541,10 @@ static int elevatorWindowInit(int elevator)
     const ElevatorBackground* elevatorBackground = &(gElevatorBackgrounds[elevator]);
     bool backgroundsLoaded = true;
 
-    const FrmId backgroundFrmId = FrmId(elevatorBackground->backgroundFrmId);
+    const InterfaceFrmId backgroundFrmId = elevatorBackground->backgroundFrmId;
     if (_elevatorBackgroundFrmImage.lock(backgroundFrmId)) {
         if (elevatorBackground->panelFrmId != InterfaceFrameId::Invalid) {
-            const FrmId panelFrmId = FrmId(elevatorBackground->panelFrmId);
+            const InterfaceFrmId panelFrmId = elevatorBackground->panelFrmId;
             if (!_elevatorPanelFrmImage.lock(panelFrmId)) {
                 backgroundsLoaded = false;
             }

--- a/src/endgame.cc
+++ b/src/endgame.cc
@@ -228,7 +228,7 @@ void endgamePlaySlideshow()
             if (ending->art_num == InterfaceFrameId::PanningDesertImage) {
                 endgameEndingRenderPanningScene(ending->direction, ending->voiceOverBaseName);
             } else {
-                const FrmId frmId = FrmId(ending->art_num);
+                const InterfaceFrmId frmId = ending->art_num;
                 endgameEndingRenderStaticScene(frmId.fid(), ending->voiceOverBaseName);
             }
         }
@@ -350,7 +350,7 @@ static int endgameEndingHandleContinuePlaying()
 static void endgameEndingRenderPanningScene(int direction, const char* narratorFileName)
 {
     CacheEntry* backgroundHandle;
-    Art* background = artLock(FrmId(InterfaceFrameId::PanningDesertImage), &backgroundHandle);
+    Art* background = artLock(InterfaceFrameId::PanningDesertImage, &backgroundHandle);
     if (background != nullptr) {
         int width = artGetWidth(background);
         int height = artGetHeight(background);

--- a/src/game.cc
+++ b/src/game.cc
@@ -1240,7 +1240,7 @@ void showHelp()
         unsigned char* windowBuffer = windowGetBuffer(win);
         if (windowBuffer != nullptr) {
             FrmImage backgroundFrmImage;
-            if (backgroundFrmImage.lock(FrmId(InterfaceFrameId::HelpBackground))) {
+            if (backgroundFrmImage.lock(InterfaceFrameId::HelpBackground)) {
                 paletteSetEntries(gPaletteBlack);
                 blitBufferToBuffer(backgroundFrmImage.getData(), HELP_SCREEN_WIDTH, HELP_SCREEN_HEIGHT, HELP_SCREEN_WIDTH, windowBuffer, HELP_SCREEN_WIDTH);
 

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -2692,7 +2692,7 @@ void _gdSetupFidget(const HeadFrmId& headFrmId, HeadFidget reaction)
         break;
     }
 
-    if (_lipsFrmId != HeadFrmId(HeadFrameId::None)) {
+    if (_lipsFrmId != HeadFrameId::None) {
         if (anim != _phone_anim) {
             if (artUnlock(_lipsKey) == -1) {
                 debugPrint("failure unlocking lips frame!\n");
@@ -2707,7 +2707,7 @@ void _gdSetupFidget(const HeadFrmId& headFrmId, HeadFidget reaction)
         _lipsFrmId = HeadFrameId::None;
     }
 
-    if (_lipsFrmId == HeadFrmId(HeadFrameId::None)) {
+    if (_lipsFrmId == HeadFrameId::None) {
         _phone_anim = anim;
         _lipsFrmId = HeadFrmId(headFrmId.frameId().head, anim);
         _lipsFp = artLock(_lipsFrmId, &_lipsKey);

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -256,7 +256,7 @@ static CacheEntry* gGameDialogFidgetFrmHandle = nullptr;
 static Art* gGameDialogFidgetFrm = nullptr;
 
 // 0x518700 backgroundFrmId
-static FrmId gGameDialogBackgroundFrmId = FrmId(BackgroundFrameId::RustyMetal);
+static BackgroundFrmId gGameDialogBackgroundFrmId = BackgroundFrameId::RustyMetal;
 
 // 0x518704 lipsFID
 static HeadFrmId _lipsFrmId = HeadFrameId::None;
@@ -1507,7 +1507,7 @@ int gameDialogReviewWindowInit(int* win)
     }
 
     FrmImage backgroundFrmImage;
-    if (!backgroundFrmImage.lock(FrmId(InterfaceFrameId::DialogReviewBackground))) {
+    if (!backgroundFrmImage.lock(InterfaceFrameId::DialogReviewBackground)) {
         windowDestroy(*win);
         *win = -1;
         return -1;
@@ -1602,7 +1602,7 @@ int gameDialogReviewWindowInit(int* win)
 
     tickersRemove(gameDialogTicker);
 
-    if (!_reviewBackgroundFrmImage.lock(FrmId(InterfaceFrameId::DialogReviewBackground))) {
+    if (!_reviewBackgroundFrmImage.lock(InterfaceFrameId::DialogReviewBackground)) {
         gameDialogReviewWindowFree(win);
         return -1;
     }
@@ -3473,9 +3473,9 @@ int gameDialogCreateBarterWindow()
     gBarterWindowExpanded = gExpandedBarterEnabled && backgroundFrmImage.lock(OBJ_TYPE_INTERFACE, expandedBarterFrmName());
 
     if (!gBarterWindowExpanded) {
-        const FrmId backgroundFid = gGameDialogSpeakerIsPartyMember
-            ? FrmId(InterfaceFrameId::TradeWindow)
-            : FrmId(InterfaceFrameId::BarterWindow);
+        const InterfaceFrmId backgroundFid = gGameDialogSpeakerIsPartyMember
+            ? InterfaceFrameId::TradeWindow
+            : InterfaceFrameId::BarterWindow;
         backgroundFrmImage.lock(backgroundFid);
     }
 
@@ -3633,7 +3633,7 @@ void gameDialogBarterCleanupTables()
 int partyMemberControlWindowInit()
 {
     FrmImage backgroundFrmImage;
-    if (!backgroundFrmImage.lock(FrmId(InterfaceFrameId::PartyControlInterface))) {
+    if (!backgroundFrmImage.lock(InterfaceFrameId::PartyControlInterface)) {
         return -1;
     }
 
@@ -3699,10 +3699,8 @@ int partyMemberControlWindowInit()
 
     for (int index = 0; index < 5; index++) {
         GameDialogButtonData* buttonData = &(gGameDialogDispositionButtonsData[index]);
-        FrmId fid;
 
-        fid = FrmId(buttonData->upFrmId);
-        Art* upButtonFrm = artLock(fid, &(buttonData->upFrmHandle));
+        Art* upButtonFrm = artLock(buttonData->upFrmId, &(buttonData->upFrmHandle));
         if (upButtonFrm == nullptr) {
             partyMemberControlWindowFree();
             return -1;
@@ -3712,8 +3710,7 @@ int partyMemberControlWindowInit()
         int height = artGetHeight(upButtonFrm);
         unsigned char* upButtonFrmData = artGetFrameData(upButtonFrm);
 
-        fid = FrmId(buttonData->downFrmId);
-        Art* downButtonFrm = artLock(fid, &(buttonData->downFrmHandle));
+        Art* downButtonFrm = artLock(buttonData->downFrmId, &(buttonData->downFrmHandle));
         if (downButtonFrm == nullptr) {
             partyMemberControlWindowFree();
             return -1;
@@ -3721,8 +3718,7 @@ int partyMemberControlWindowInit()
 
         unsigned char* downButtonFrmData = artGetFrameData(downButtonFrm);
 
-        fid = FrmId(buttonData->disabledFrmId);
-        Art* disabledButtonFrm = artLock(fid, &(buttonData->disabledFrmHandle));
+        Art* disabledButtonFrm = artLock(buttonData->disabledFrmId, &(buttonData->disabledFrmHandle));
         if (disabledButtonFrm == nullptr) {
             partyMemberControlWindowFree();
             return -1;
@@ -3804,7 +3800,7 @@ void partyMemberControlWindowFree()
     }
 
     FrmImage backgroundFrmImage;
-    if (backgroundFrmImage.lock(FrmId(InterfaceFrameId::PartyControlInterface))) {
+    if (backgroundFrmImage.lock(InterfaceFrameId::PartyControlInterface)) {
         _gdialog_scroll_subwin(gGameDialogWindow, false, backgroundFrmImage.getData(), windowGetBuffer(gGameDialogWindow), windowGetBuffer(gGameDialogBackgroundWindow) + (GAME_DIALOG_WINDOW_WIDTH) * (480 - _dialogue_subwin_len), _dialogue_subwin_len);
     }
 
@@ -3822,7 +3818,7 @@ void partyMemberControlWindowUpdate()
     int windowWidth = windowGetWidth(gGameDialogWindow);
 
     FrmImage backgroundFrmImage;
-    if (backgroundFrmImage.lock(FrmId(InterfaceFrameId::PartyControlInterface))) {
+    if (backgroundFrmImage.lock(InterfaceFrameId::PartyControlInterface)) {
         int width = backgroundFrmImage.getWidth();
         unsigned char* buffer = backgroundFrmImage.getData();
 
@@ -4083,7 +4079,7 @@ int partyMemberCustomizationWindowInit()
     messageListRepositorySetStandardMessageList(STANDARD_MESSAGE_LIST_CUSTOM, &gCustomMessageList);
 
     FrmImage backgroundFrmImage;
-    if (!backgroundFrmImage.lock(FrmId(InterfaceFrameId::PartyCustomInterface))) {
+    if (!backgroundFrmImage.lock(InterfaceFrameId::PartyCustomInterface)) {
         partyMemberCustomizationMessageListReset();
         return -1;
     }
@@ -4136,8 +4132,7 @@ int partyMemberCustomizationWindowInit()
     for (auto& buttonDataRef : _custom_button_info) {
         GameDialogButtonData* buttonData = &buttonDataRef;
 
-        FrmId upButtonFid = FrmId(buttonData->upFrmId);
-        Art* upButtonFrm = artLock(upButtonFid, &(buttonData->upFrmHandle));
+        Art* upButtonFrm = artLock(buttonData->upFrmId, &(buttonData->upFrmHandle));
         if (upButtonFrm == nullptr) {
             partyMemberCustomizationWindowFree();
             return -1;
@@ -4147,8 +4142,7 @@ int partyMemberCustomizationWindowInit()
         int height = artGetHeight(upButtonFrm);
         unsigned char* upButtonFrmData = artGetFrameData(upButtonFrm);
 
-        FrmId downButtonFid = FrmId(buttonData->downFrmId);
-        Art* downButtonFrm = artLock(downButtonFid, &(buttonData->downFrmHandle));
+        Art* downButtonFrm = artLock(buttonData->downFrmId, &(buttonData->downFrmHandle));
         if (downButtonFrm == nullptr) {
             partyMemberCustomizationWindowFree();
             return -1;
@@ -4225,7 +4219,7 @@ void partyMemberCustomizationWindowFree()
     }
 
     FrmImage backgroundFrmImage;
-    if (backgroundFrmImage.lock(FrmId(InterfaceFrameId::PartyCustomInterface))) {
+    if (backgroundFrmImage.lock(InterfaceFrameId::PartyCustomInterface)) {
         _gdialog_scroll_subwin(gGameDialogWindow, false, backgroundFrmImage.getData(), windowGetBuffer(gGameDialogWindow), windowGetBuffer(gGameDialogBackgroundWindow) + (GAME_DIALOG_WINDOW_WIDTH) * (480 - _dialogue_subwin_len), _dialogue_subwin_len);
     }
 
@@ -4277,7 +4271,7 @@ void partyMemberCustomizationWindowUpdate()
     int windowWidth = windowGetWidth(gGameDialogWindow);
 
     FrmImage backgroundFrmImage;
-    if (!backgroundFrmImage.lock(FrmId(InterfaceFrameId::PartyCustomInterface))) {
+    if (!backgroundFrmImage.lock(InterfaceFrameId::PartyCustomInterface)) {
         return;
     }
 
@@ -4383,7 +4377,7 @@ int _gdCustomSelect(int option)
     int oldFont = fontGetCurrent();
 
     FrmImage backgroundFrmImage;
-    if (!backgroundFrmImage.lock(FrmId(InterfaceFrameId::PartyCustomSelect))) {
+    if (!backgroundFrmImage.lock(InterfaceFrameId::PartyCustomSelect)) {
         return -1;
     }
 
@@ -4625,8 +4619,8 @@ int _gdialog_window_create()
         btn = -1;
 
     FrmImage backgroundFrmImage;
-    const FrmId backgroundFid = gGameDialogSpeakerIsPartyMember ? FrmId(InterfaceFrameId::DialogTalkSubwindowParty) : FrmId(InterfaceFrameId::DialogTalkSubwindow);
-    if (!backgroundFrmImage.lock(backgroundFid)) return -1;
+    const InterfaceFrmId backgroundFrmId = gGameDialogSpeakerIsPartyMember ? InterfaceFrameId::DialogTalkSubwindowParty : InterfaceFrameId::DialogTalkSubwindow;
+    if (!backgroundFrmImage.lock(backgroundFrmId)) return -1;
 
     unsigned char* backgroundFrmData = backgroundFrmImage.getData();
     if (backgroundFrmData == nullptr) return -1;
@@ -4691,10 +4685,10 @@ void _gdialog_window_destroy()
     int offset = (GAME_DIALOG_WINDOW_WIDTH) * (480 - _dialogue_subwin_len);
     unsigned char* backgroundWindowBuffer = windowGetBuffer(gGameDialogBackgroundWindow) + offset;
 
-    const FrmId backgroundFid = gGameDialogSpeakerIsPartyMember ? FrmId(InterfaceFrameId::DialogTalkSubwindowParty) : FrmId(InterfaceFrameId::DialogTalkSubwindow);
+    const InterfaceFrmId backgroundFrmId = gGameDialogSpeakerIsPartyMember ? InterfaceFrameId::DialogTalkSubwindowParty : InterfaceFrameId::DialogTalkSubwindow;
 
     FrmImage backgroundFrmImage;
-    if (backgroundFrmImage.lock(backgroundFid)) {
+    if (backgroundFrmImage.lock(backgroundFrmId)) {
         unsigned char* windowBuffer = windowGetBuffer(gGameDialogWindow);
         _gdialog_scroll_subwin(gGameDialogWindow, false, backgroundFrmImage.getData(), windowBuffer, backgroundWindowBuffer, _dialogue_subwin_len);
         windowDestroy(gGameDialogWindow);
@@ -4752,7 +4746,7 @@ int gameDialogWindowRenderBackground()
     }
 
     if (!backgroundFrmImage.isLocked()) {
-        const FrmId backgroundFrmId(InterfaceFrameId::DialogScreenBackground);
+        const InterfaceFrmId backgroundFrmId = InterfaceFrameId::DialogScreenBackground;
         if (!backgroundFrmImage.lock(backgroundFrmId)) {
             return -1;
         }
@@ -4774,7 +4768,7 @@ int gameDialogWindowRenderBackground()
 int _talkToRefreshDialogWindowRect(Rect* rect)
 {
     FrmImage backgroundFrmImage;
-    const FrmId backgroundFrmId = gGameDialogSpeakerIsPartyMember ? FrmId(InterfaceFrameId::DialogTalkSubwindowParty) : FrmId(InterfaceFrameId::DialogTalkSubwindow);
+    const InterfaceFrmId backgroundFrmId = gGameDialogSpeakerIsPartyMember ? InterfaceFrameId::DialogTalkSubwindowParty : InterfaceFrameId::DialogTalkSubwindow;
     if (!backgroundFrmImage.lock(backgroundFrmId)) {
         return -1;
     }
@@ -4965,8 +4959,8 @@ void gameDialogHighlightsInit()
     _light_BlendTable = _getColorBlendTable(COLOR_GREY);
     _dark_BlendTable = _getColorBlendTable(COLOR_OLIVE);
 
-    _upperHighlightFrmImage.lock(FrmId(InterfaceFrameId::DialogueUpperHighlight));
-    _lowerHighlightFrmImage.lock(FrmId(InterfaceFrameId::DialogueLowerHighlight));
+    _upperHighlightFrmImage.lock(InterfaceFrameId::DialogueUpperHighlight);
+    _lowerHighlightFrmImage.lock(InterfaceFrameId::DialogueLowerHighlight);
 }
 
 // NOTE: Inlined.

--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -1450,7 +1450,7 @@ void gameMouseSetMode(int mode)
 
     gameMouseSetBouncingCursorFrmId(InterfaceFrameId::Blank);
 
-    const FrmId frmId = FrmId(gGameMouseModeFrmIds[mode]);
+    const InterfaceFrmId frmId = gGameMouseModeFrmIds[mode];
 
     Rect rect;
     // NOTE: Uninline.
@@ -1756,7 +1756,7 @@ int gameMouseRenderPrimaryAction(int x, int y, int menuItem, int width, int heig
     }
 
     CacheEntry* arrowFrmHandle;
-    const FrmId arrowFrmId = FrmId(gGameMouseModeFrmIds[GAME_MOUSE_MODE_ARROW]);
+    const InterfaceFrmId arrowFrmId = gGameMouseModeFrmIds[GAME_MOUSE_MODE_ARROW];
     Art* arrowFrm = artLock(arrowFrmId, &arrowFrmHandle);
     if (arrowFrm == nullptr) {
         artUnlock(menuItemFrmHandle);
@@ -1818,7 +1818,7 @@ int gameMouseRenderPrimaryAction(int x, int y, int menuItem, int width, int heig
         // mirrored cursor for far-right side of screen
         artUnlock(arrowFrmHandle);
 
-        arrowFrm = artLock(FrmId(InterfaceFrameId::ActionArrowMirrored), &arrowFrmHandle);
+        arrowFrm = artLock(InterfaceFrameId::ActionArrowMirrored, &arrowFrmHandle);
         if (arrowFrm == nullptr) {
             artUnlock(menuItemFrmHandle);
             return -1;
@@ -1900,7 +1900,7 @@ int gameMouseRenderActionMenuItems(int x, int y, const int* menuItems, int menuI
         }
     }
 
-    const FrmId frmId = FrmId(gGameMouseModeFrmIds[GAME_MOUSE_MODE_ARROW]);
+    const InterfaceFrmId frmId = gGameMouseModeFrmIds[GAME_MOUSE_MODE_ARROW];
     CacheEntry* arrowFrmHandle;
     Art* arrowFrm = artLock(frmId, &arrowFrmHandle);
     if (arrowFrm == nullptr) {
@@ -1965,7 +1965,7 @@ int gameMouseRenderActionMenuItems(int x, int y, const int* menuItems, int menuI
     } else {
         // Mirrored arrow (from left to right).
         artUnlock(arrowFrmHandle);
-        arrowFrm = artLock(FrmId(InterfaceFrameId::ActionArrowMirrored), &arrowFrmHandle);
+        arrowFrm = artLock(InterfaceFrameId::ActionArrowMirrored, &arrowFrmHandle);
         if (arrowFrm == nullptr) {
             for (int index = 0; index < menuItemsLength; index++) {
                 artUnlock(menuItemFrmHandles[index]);
@@ -2114,7 +2114,7 @@ int gameMouseHighlightActionMenuItemAtIndex(int menuItemIndex)
 int gameMouseRenderAccuracy(const char* string, Color color)
 {
     CacheEntry* crosshairFrmHandle;
-    const FrmId frmId = FrmId(gGameMouseModeFrmIds[GAME_MOUSE_MODE_CROSSHAIR]);
+    const InterfaceFrmId frmId = gGameMouseModeFrmIds[GAME_MOUSE_MODE_CROSSHAIR];
     Art* crosshairFrm = artLock(frmId, &crosshairFrmHandle);
     if (crosshairFrm == nullptr) {
         return -1;
@@ -2283,27 +2283,27 @@ void gameMouseObjectsFree()
 // 0x44DB78 gmouse_3d_lock_frames
 int gameMouseActionMenuInit()
 {
-    gGameMouseActionMenuFrm = artLock(FrmId(InterfaceFrameId::ActionMenu), &gGameMouseActionMenuFrmHandle);
+    gGameMouseActionMenuFrm = artLock(InterfaceFrameId::ActionMenu, &gGameMouseActionMenuFrmHandle);
     if (gGameMouseActionMenuFrm == nullptr) {
         goto err;
     }
 
-    gGameMouseActionPickFrm = artLock(FrmId(InterfaceFrameId::ActionPick), &gGameMouseActionPickFrmHandle);
+    gGameMouseActionPickFrm = artLock(InterfaceFrameId::ActionPick, &gGameMouseActionPickFrmHandle);
     if (gGameMouseActionPickFrm == nullptr) {
         goto err;
     }
 
-    gGameMouseActionHitFrm = artLock(FrmId(InterfaceFrameId::ActionToHit), &gGameMouseActionHitFrmHandle);
+    gGameMouseActionHitFrm = artLock(InterfaceFrameId::ActionToHit, &gGameMouseActionHitFrmHandle);
     if (gGameMouseActionHitFrm == nullptr) {
         goto err;
     }
 
-    gGameMouseBouncingCursorFrm = artLock(FrmId(InterfaceFrameId::Blank), &gGameMouseBouncingCursorFrmHandle);
+    gGameMouseBouncingCursorFrm = artLock(InterfaceFrameId::Blank, &gGameMouseBouncingCursorFrmHandle);
     if (gGameMouseBouncingCursorFrm == nullptr) {
         goto err;
     }
 
-    gGameMouseHexCursorFrm = artLock(FrmId(InterfaceFrameId::HexMouseCursor), &gGameMouseHexCursorFrmHandle);
+    gGameMouseHexCursorFrm = artLock(InterfaceFrameId::HexMouseCursor, &gGameMouseHexCursorFrmHandle);
     if (gGameMouseHexCursorFrm == nullptr) {
         goto err;
     }
@@ -2416,7 +2416,7 @@ static int gmouse_3d_set_flat_fid(int fid, Rect* rect)
 // 0x44DF40 gmouse_3d_reset_flat_fid
 int gameMouseUpdateHexCursorFid(Rect* rect)
 {
-    const FrmId frmId = FrmId(gGameMouseModeFrmIds[gGameMouseMode]);
+    const InterfaceFrmId frmId = gGameMouseModeFrmIds[gGameMouseMode];
     if (gGameMouseHexCursor->fid == frmId.fid()) {
         return -1;
     }

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -412,7 +412,7 @@ int interfaceInit()
         blitBufferToBuffer(customInterfaceBarGetBackgroundImageData(), gInterfaceBarWidth, INTERFACE_BAR_HEIGHT - 1, gInterfaceBarWidth, gInterfaceWindowBuffer, gInterfaceBarWidth);
     } else {
         FrmImage backgroundFrmImage;
-        if (!backgroundFrmImage.lock(FrmId(InterfaceFrameId::MainInterface))) {
+        if (!backgroundFrmImage.lock(InterfaceFrameId::MainInterface)) {
             return intface_fatal_error(-1);
         }
 
@@ -422,12 +422,12 @@ int interfaceInit()
 
     extendedApBarInitToWindow();
 
-    if (!_inventoryButtonNormalFrmImage.lock(FrmId(InterfaceFrameId::InventoryButtonUp))) {
+    if (!_inventoryButtonNormalFrmImage.lock(InterfaceFrameId::InventoryButtonUp)) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    if (!_inventoryButtonPressedFrmImage.lock(FrmId(InterfaceFrameId::InventoryButtonDown))) {
+    if (!_inventoryButtonPressedFrmImage.lock(InterfaceFrameId::InventoryButtonDown)) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
@@ -440,12 +440,12 @@ int interfaceInit()
 
     buttonSetCallbacks(gInventoryButton, _gsound_med_butt_press, _gsound_med_butt_release);
 
-    if (!_optionsButtonNormalFrmImage.lock(FrmId(InterfaceFrameId::OptionsButtonUp))) {
+    if (!_optionsButtonNormalFrmImage.lock(InterfaceFrameId::OptionsButtonUp)) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    if (!_optionsButtonPressedFrmImage.lock(FrmId(InterfaceFrameId::OptionsButtonDown))) {
+    if (!_optionsButtonPressedFrmImage.lock(InterfaceFrameId::OptionsButtonDown)) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
@@ -458,17 +458,17 @@ int interfaceInit()
 
     buttonSetCallbacks(gOptionsButton, _gsound_med_butt_press, _gsound_med_butt_release);
 
-    if (!_skilldexButtonNormalFrmImage.lock(FrmId(InterfaceFrameId::BigRedButtonUp))) {
+    if (!_skilldexButtonNormalFrmImage.lock(InterfaceFrameId::BigRedButtonUp)) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    if (!_skilldexButtonPressedFrmImage.lock(FrmId(InterfaceFrameId::BigRedButtonDown))) {
+    if (!_skilldexButtonPressedFrmImage.lock(InterfaceFrameId::BigRedButtonDown)) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    if (!_skilldexButtonMaskFrmImage.lock(FrmId(InterfaceFrameId::BigRedButtonUp))) {
+    if (!_skilldexButtonMaskFrmImage.lock(InterfaceFrameId::BigRedButtonUp)) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
@@ -482,17 +482,17 @@ int interfaceInit()
     buttonSetMask(gSkilldexButton, _skilldexButtonMaskFrmImage.getData());
     buttonSetCallbacks(gSkilldexButton, _gsound_med_butt_press, _gsound_med_butt_release);
 
-    if (!_mapButtonNormalFrmImage.lock(FrmId(InterfaceFrameId::AutomapButtonUp))) {
+    if (!_mapButtonNormalFrmImage.lock(InterfaceFrameId::AutomapButtonUp)) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    if (!_mapButtonPressedFrmImage.lock(FrmId(InterfaceFrameId::AutomapButtonDown))) {
+    if (!_mapButtonPressedFrmImage.lock(InterfaceFrameId::AutomapButtonDown)) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    if (!_mapButtonMaskFrmImage.lock(FrmId(InterfaceFrameId::AutomapButtonUp))) {
+    if (!_mapButtonMaskFrmImage.lock(InterfaceFrameId::AutomapButtonUp)) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
@@ -506,12 +506,12 @@ int interfaceInit()
     buttonSetMask(gMapButton, _mapButtonMaskFrmImage.getData());
     buttonSetCallbacks(gMapButton, _gsound_med_butt_press, _gsound_med_butt_release);
 
-    if (!_pipboyButtonNormalFrmImage.lock(FrmId(InterfaceFrameId::PipBoyButtonUp))) {
+    if (!_pipboyButtonNormalFrmImage.lock(InterfaceFrameId::PipBoyButtonUp)) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    if (!_pipboyButtonPressedFrmImage.lock(FrmId(InterfaceFrameId::PipBoyButtonDown))) {
+    if (!_pipboyButtonPressedFrmImage.lock(InterfaceFrameId::PipBoyButtonDown)) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
@@ -525,12 +525,12 @@ int interfaceInit()
     buttonSetMask(gPipboyButton, _mapButtonMaskFrmImage.getData());
     buttonSetCallbacks(gPipboyButton, _gsound_med_butt_press, _gsound_med_butt_release);
 
-    if (!_characterButtonNormalFrmImage.lock(FrmId(InterfaceFrameId::CharacterButtonUp))) {
+    if (!_characterButtonNormalFrmImage.lock(InterfaceFrameId::CharacterButtonUp)) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    if (!_characterButtonPressedFrmImage.lock(FrmId(InterfaceFrameId::CharacterButtonDown))) {
+    if (!_characterButtonPressedFrmImage.lock(InterfaceFrameId::CharacterButtonDown)) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
@@ -544,17 +544,17 @@ int interfaceInit()
     buttonSetMask(gCharacterButton, _mapButtonMaskFrmImage.getData());
     buttonSetCallbacks(gCharacterButton, _gsound_med_butt_press, _gsound_med_butt_release);
 
-    if (!_itemButtonNormalFrmImage.lock(FrmId(InterfaceFrameId::SingleAttackBigUp))) {
+    if (!_itemButtonNormalFrmImage.lock(InterfaceFrameId::SingleAttackBigUp)) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    if (!_itemButtonPressedFrmImage.lock(FrmId(InterfaceFrameId::SingleAttackBigDown))) {
+    if (!_itemButtonPressedFrmImage.lock(InterfaceFrameId::SingleAttackBigDown)) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    if (!_itemButtonDisabledFrmImage.lock(FrmId(InterfaceFrameId::SingleAttackBigUpUnreadied))) {
+    if (!_itemButtonDisabledFrmImage.lock(InterfaceFrameId::SingleAttackBigUpUnreadied)) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
@@ -571,17 +571,17 @@ int interfaceInit()
     buttonSetRightMouseCallbacks(gSingleAttackButton, -1, KEY_LOWERCASE_N, nullptr, nullptr);
     buttonSetCallbacks(gSingleAttackButton, _gsound_lrg_butt_press, _gsound_lrg_butt_release);
 
-    if (!_changeHandsButtonNormalFrmImage.lock(FrmId(InterfaceFrameId::BigRedButtonUp))) {
+    if (!_changeHandsButtonNormalFrmImage.lock(InterfaceFrameId::BigRedButtonUp)) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    if (!_changeHandsButtonPressedFrmImage.lock(FrmId(InterfaceFrameId::BigRedButtonDown))) {
+    if (!_changeHandsButtonPressedFrmImage.lock(InterfaceFrameId::BigRedButtonDown)) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    if (!_changeHandsButtonMaskFrmImage.lock(FrmId(InterfaceFrameId::BigRedButtonUp))) {
+    if (!_changeHandsButtonMaskFrmImage.lock(InterfaceFrameId::BigRedButtonUp)) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
@@ -596,22 +596,22 @@ int interfaceInit()
     buttonSetMask(gChangeHandsButton, _changeHandsButtonMaskFrmImage.getData());
     buttonSetCallbacks(gChangeHandsButton, _gsound_med_butt_press, _gsound_med_butt_release);
 
-    if (!_numbersFrmImage.lock(FrmId(InterfaceFrameId::HitPointsNumbers))) {
+    if (!_numbersFrmImage.lock(InterfaceFrameId::HitPointsNumbers)) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    if (!_greenLightFrmImage.lock(FrmId(InterfaceFrameId::HealthGreenLight))) {
+    if (!_greenLightFrmImage.lock(InterfaceFrameId::HealthGreenLight)) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    if (!_yellowLightFrmImage.lock(FrmId(InterfaceFrameId::HealthYellowLight))) {
+    if (!_yellowLightFrmImage.lock(InterfaceFrameId::HealthYellowLight)) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
 
-    if (!_redLightFrmImage.lock(FrmId(InterfaceFrameId::HealthRedLight))) {
+    if (!_redLightFrmImage.lock(InterfaceFrameId::HealthRedLight)) {
         // NOTE: Uninline.
         return intface_fatal_error(-1);
     }
@@ -1466,7 +1466,7 @@ void interfaceBarEndButtonsShow(bool animated)
     }
 
     CacheEntry* handle;
-    Art* art = artLock(FrmId(InterfaceFrameId::EndTurnWindowAnimation), &handle);
+    Art* art = artLock(InterfaceFrameId::EndTurnWindowAnimation, &handle);
     if (art == nullptr) {
         return;
     }
@@ -1523,7 +1523,7 @@ void interfaceBarEndButtonsHide(bool animated)
     }
 
     CacheEntry* handle;
-    Art* art = artLock(FrmId(InterfaceFrameId::EndTurnWindowAnimation), &handle);
+    Art* art = artLock(InterfaceFrameId::EndTurnWindowAnimation, &handle);
     if (art == nullptr) {
         return;
     }
@@ -1576,7 +1576,7 @@ void interfaceBarEndButtonsRenderGreenLights()
         buttonEnable(gEndCombatButton);
 
         FrmImage lightsFrmImage;
-        if (!lightsFrmImage.lock(FrmId(InterfaceFrameId::EndTurnGreenLight))) {
+        if (!lightsFrmImage.lock(InterfaceFrameId::EndTurnGreenLight)) {
             return;
         }
 
@@ -1594,7 +1594,7 @@ void interfaceBarEndButtonsRenderRedLights()
         buttonDisable(gEndCombatButton);
 
         FrmImage lightsFrmImage;
-        if (!lightsFrmImage.lock(FrmId(InterfaceFrameId::EndTurnRedLight))) {
+        if (!lightsFrmImage.lock(InterfaceFrameId::EndTurnRedLight)) {
             return;
         }
 
@@ -1637,16 +1637,16 @@ static int interfaceBarRefreshMainAction()
         memcpy(_itemButtonDown, _itemButtonPressedFrmImage.getData(), sizeof(_itemButtonDown));
 
         if (itemState->isWeapon == 0) {
-            FrmId frmId;
+            InterfaceFrmId frmId;
             if (_proto_action_can_use_on(itemState->item->pid)) {
-                frmId = FrmId(InterfaceFrameId::UseOnText);
+                frmId = InterfaceFrameId::UseOnText;
             } else if (_obj_action_can_use(itemState->item)) {
-                frmId = FrmId(InterfaceFrameId::UseText);
+                frmId = InterfaceFrameId::UseText;
             } else {
-                frmId = FrmId::Empty();
+                frmId = InterfaceFrameId::Invalid;
             }
 
-            if (!frmId.empty()) {
+            if (frmId.valid()) {
                 FrmImage useTextFrmImage;
                 if (useTextFrmImage.lock(frmId)) {
                     int width = useTextFrmImage.getWidth();
@@ -1658,34 +1658,34 @@ static int interfaceBarRefreshMainAction()
                 actionPoints = itemGetActionPointCost(gDude, itemState->primaryHitMode, false);
             }
         } else {
-            FrmId primaryFrmId = FrmId::Empty();
-            FrmId bullseyeFrmId = FrmId::Empty();
+            InterfaceFrmId primaryFrmId = InterfaceFrameId::Invalid;
+            InterfaceFrmId bullseyeFrmId = InterfaceFrameId::Invalid;
             HitMode hitMode = HIT_MODE_INVALID;
 
             // NOTE: This value is decremented at 0x45FEAC, probably to build
             // jump table.
             switch (itemState->action) {
             case INTERFACE_ITEM_ACTION_PRIMARY_AIMING:
-                bullseyeFrmId = FrmId(InterfaceFrameId::Bullseye);
+                bullseyeFrmId = InterfaceFrameId::Bullseye;
                 // FALLTHROUGH
             case INTERFACE_ITEM_ACTION_PRIMARY:
                 hitMode = itemState->primaryHitMode;
                 break;
             case INTERFACE_ITEM_ACTION_SECONDARY_AIMING:
-                bullseyeFrmId = FrmId(InterfaceFrameId::Bullseye);
+                bullseyeFrmId = InterfaceFrameId::Bullseye;
                 // FALLTHROUGH
             case INTERFACE_ITEM_ACTION_SECONDARY:
                 hitMode = itemState->secondaryHitMode;
                 break;
             case INTERFACE_ITEM_ACTION_RELOAD:
                 actionPoints = itemGetActionPointCost(gDude, gInterfaceCurrentHand == HAND_LEFT ? HIT_MODE_LEFT_WEAPON_RELOAD : HIT_MODE_RIGHT_WEAPON_RELOAD, false);
-                primaryFrmId = FrmId(InterfaceFrameId::ReloadText);
+                primaryFrmId = InterfaceFrameId::ReloadText;
                 break;
             default:
                 break;
             }
 
-            if (!bullseyeFrmId.empty()) {
+            if (bullseyeFrmId.valid()) {
                 FrmImage bullseyeFrmImage;
                 if (bullseyeFrmImage.lock(bullseyeFrmId)) {
                     int width = bullseyeFrmImage.getWidth();
@@ -1696,87 +1696,87 @@ static int interfaceBarRefreshMainAction()
             }
 
             if (hitMode != HIT_MODE_INVALID) {
-                actionPoints = weaponGetActionPointCost(gDude, hitMode, !bullseyeFrmId.empty());
+                actionPoints = weaponGetActionPointCost(gDude, hitMode, bullseyeFrmId.valid());
 
-                FrmId frmId = FrmId::Empty();
+                InterfaceFrmId frmId = InterfaceFrameId::Invalid;
                 AnimationType anim = critterGetAnimationForHitMode(gDude, hitMode);
                 switch (anim) {
                 case ANIM_THROW_PUNCH:
                     switch (hitMode) {
                     case HIT_MODE_STRONG_PUNCH:
-                        frmId = FrmId(InterfaceFrameId::StrongPunch);
+                        frmId = InterfaceFrameId::StrongPunch;
                         break;
                     case HIT_MODE_HAMMER_PUNCH:
-                        frmId = FrmId(InterfaceFrameId::HammerPunch);
+                        frmId = InterfaceFrameId::HammerPunch;
                         break;
                     case HIT_MODE_HAYMAKER:
-                        frmId = FrmId(InterfaceFrameId::LightningPunch);
+                        frmId = InterfaceFrameId::LightningPunch;
                         break;
                     case HIT_MODE_JAB:
-                        frmId = FrmId(InterfaceFrameId::ChopPunch);
+                        frmId = InterfaceFrameId::ChopPunch;
                         break;
                     case HIT_MODE_PALM_STRIKE:
-                        frmId = FrmId(InterfaceFrameId::DragonPunch);
+                        frmId = InterfaceFrameId::DragonPunch;
                         break;
                     case HIT_MODE_PIERCING_STRIKE:
-                        frmId = FrmId(InterfaceFrameId::ForcePunch);
+                        frmId = InterfaceFrameId::ForcePunch;
                         break;
                     default:
-                        frmId = FrmId(InterfaceFrameId::PunchText);
+                        frmId = InterfaceFrameId::PunchText;
                         break;
                     }
                     break;
                 case ANIM_KICK_LEG:
                     switch (hitMode) {
                     case HIT_MODE_STRONG_KICK:
-                        frmId = FrmId(InterfaceFrameId::StrongKick);
+                        frmId = InterfaceFrameId::StrongKick;
                         break;
                     case HIT_MODE_SNAP_KICK:
-                        frmId = FrmId(InterfaceFrameId::SnapKick);
+                        frmId = InterfaceFrameId::SnapKick;
                         break;
                     case HIT_MODE_POWER_KICK:
-                        frmId = FrmId(InterfaceFrameId::RoundhouseKick);
+                        frmId = InterfaceFrameId::RoundhouseKick;
                         break;
                     case HIT_MODE_HIP_KICK:
-                        frmId = FrmId(InterfaceFrameId::HipKick);
+                        frmId = InterfaceFrameId::HipKick;
                         break;
                     case HIT_MODE_HOOK_KICK:
-                        frmId = FrmId(InterfaceFrameId::JumpKick);
+                        frmId = InterfaceFrameId::JumpKick;
                         break;
                     case HIT_MODE_PIERCING_KICK:
-                        frmId = FrmId(InterfaceFrameId::DeathBlossomKick);
+                        frmId = InterfaceFrameId::DeathBlossomKick;
                         break;
                     default:
-                        frmId = FrmId(InterfaceFrameId::KickText);
+                        frmId = InterfaceFrameId::KickText;
                         break;
                     }
                     break;
                 case ANIM_THROW_ANIM:
-                    frmId = FrmId(InterfaceFrameId::ThrowText);
+                    frmId = InterfaceFrameId::ThrowText;
                     break;
                 case ANIM_THRUST_ANIM:
-                    frmId = FrmId(InterfaceFrameId::ThrustText);
+                    frmId = InterfaceFrameId::ThrustText;
                     break;
                 case ANIM_SWING_ANIM:
-                    frmId = FrmId(InterfaceFrameId::SwingText);
+                    frmId = InterfaceFrameId::SwingText;
                     break;
                 case ANIM_FIRE_SINGLE:
-                    frmId = FrmId(InterfaceFrameId::SingleText);
+                    frmId = InterfaceFrameId::SingleText;
                     break;
                 case ANIM_FIRE_BURST:
                 case ANIM_FIRE_CONTINUOUS:
-                    frmId = FrmId(InterfaceFrameId::BurstText);
+                    frmId = InterfaceFrameId::BurstText;
                     break;
                 default:
                     break;
                 }
 
-                if (!frmId.empty()) {
+                if (frmId.valid()) {
                     primaryFrmId = frmId;
                 }
             }
 
-            if (!primaryFrmId.empty()) {
+            if (primaryFrmId.valid()) {
                 FrmImage primaryFrmImage;
                 if (primaryFrmImage.lock(primaryFrmId)) {
                     int width = primaryFrmImage.getWidth();
@@ -1791,7 +1791,7 @@ static int interfaceBarRefreshMainAction()
     if (actionPoints >= 0 && actionPoints < 10) {
         // movement point text
         FrmImage apFrmImage;
-        if (apFrmImage.lock(FrmId(InterfaceFrameId::MovementPointText))) {
+        if (apFrmImage.lock(InterfaceFrameId::MovementPointText)) {
             int width = apFrmImage.getWidth();
             int height = apFrmImage.getHeight();
             unsigned char* data = apFrmImage.getData();
@@ -1802,7 +1802,7 @@ static int interfaceBarRefreshMainAction()
 
             FrmImage apNumbersFrmImage;
             // movement point numbers - ten numbers 0 to 9, each 10 pixels wide.
-            if (apNumbersFrmImage.lock(FrmId(InterfaceFrameId::MovementPointsNumbers))) {
+            if (apNumbersFrmImage.lock(InterfaceFrameId::MovementPointsNumbers)) {
                 int width = apNumbersFrmImage.getWidth();
                 int height = apNumbersFrmImage.getHeight();
                 unsigned char* data = apNumbersFrmImage.getData();
@@ -1816,7 +1816,7 @@ static int interfaceBarRefreshMainAction()
     }
 
     const FrmId itemFrmId = FrmId(itemState->itemFid);
-    if (!itemFrmId.empty()) {
+    if (itemFrmId.valid()) {
         FrmImage itemFrmImage;
         if (itemFrmImage.lock(itemFrmId)) {
             int width = itemFrmImage.getWidth();
@@ -1953,11 +1953,11 @@ static int endTurnButtonInit()
         return -1;
     }
 
-    if (!_endTurnButtonNormalFrmImage.lock(FrmId(InterfaceFrameId::EndTurnButtonUp))) {
+    if (!_endTurnButtonNormalFrmImage.lock(InterfaceFrameId::EndTurnButtonUp)) {
         return -1;
     }
 
-    if (!_endTurnButtonPressedFrmImage.lock(FrmId(InterfaceFrameId::EndTurnButtonDown))) {
+    if (!_endTurnButtonPressedFrmImage.lock(InterfaceFrameId::EndTurnButtonDown)) {
         return -1;
     }
 
@@ -2001,11 +2001,11 @@ static int endCombatButtonInit()
         return -1;
     }
 
-    if (!_endCombatButtonNormalFrmImage.lock(FrmId(InterfaceFrameId::EndCombatButtonUp))) {
+    if (!_endCombatButtonNormalFrmImage.lock(InterfaceFrameId::EndCombatButtonUp)) {
         return -1;
     }
 
-    if (!_endCombatButtonPressedFrmImage.lock(FrmId(InterfaceFrameId::EndCombatButtonDown))) {
+    if (!_endCombatButtonPressedFrmImage.lock(InterfaceFrameId::EndCombatButtonDown)) {
         return -1;
     }
 
@@ -2177,7 +2177,7 @@ static void interfaceRestoreAlternateAmmoMeterBackground(int x)
     if (gInterfaceBarIsCustom) {
         src = customInterfaceBarGetBackgroundImageData();
     } else {
-        if (!backgroundFrmImage.lock(FrmId(InterfaceFrameId::MainInterface))) {
+        if (!backgroundFrmImage.lock(InterfaceFrameId::MainInterface)) {
             return;
         }
         src = backgroundFrmImage.getData();
@@ -2426,7 +2426,7 @@ static int indicatorBarInit()
     }
 
     FrmImage indicatorBoxFrmImage;
-    if (!indicatorBoxFrmImage.lock(FrmId(InterfaceFrameId::WarningBox))) {
+    if (!indicatorBoxFrmImage.lock(InterfaceFrameId::WarningBox)) {
         debugPrint("\nINTRFACE: Error initializing indicator box graphics! **\n");
         messageListFree(&messageList);
         return -1;

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -423,7 +423,7 @@ int correctFidForRemovedItem(Object* critter, Object* item, ObjectFlags flags)
     }
 
     WeaponAnimation weaponCode = weaponAnimationFromFid(critter->fid);
-    FrmId newFid = FrmId::Empty();
+    FrmId newFid;
 
     if ((flags & OBJECT_IN_ANY_HAND) != OBJECT_NONE) {
         if (critter == gDude) {
@@ -453,7 +453,7 @@ int correctFidForRemovedItem(Object* critter, Object* item, ObjectFlags flags)
         adjustCritterStatsOnArmorChange(critter, item, nullptr);
     }
 
-    if (!newFid.empty()) {
+    if (newFid.valid()) {
         Rect rect;
         objectSetFid(critter, newFid.fid(), &rect);
         tileWindowRefreshRect(&rect, gElevation);

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -3358,7 +3358,7 @@ static void opMetarule(Program* program)
                     break;
                 }
             } else {
-                if (MiscFrmId(MiscFrameId::RocketExplosion) == FrmId(object->fid)) {
+                if (FrmId(object->fid) == MiscFrameId::RocketExplosion) {
                     result = DAMAGE_TYPE_EXPLOSION;
                     break;
                 }

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -687,7 +687,7 @@ static bool inventoryBackgroundLoad(FrmImage& image, InterfaceFrameId col1FrmId,
     image.unlock();
 
     if (columns == 1) {
-        return image.lock(FrmId(col1FrmId));
+        return image.lock(col1FrmId);
     }
 
     if (columns == 2) {
@@ -743,7 +743,7 @@ static ConstBuffer2D inventoryGetBackgroundBuffer(int inventoryWindowType, Inter
             windowGetHeight(gInventoryBarterBackgroundWindow) };
     }
 
-    if (fallbackImage.lock(FrmId(fallbackFrmId))) {
+    if (fallbackImage.lock(fallbackFrmId)) {
         return fallbackImage.getBuffer();
     }
 
@@ -1810,7 +1810,7 @@ static bool _setup_inventory(int inventoryWindowType)
             blitBuffer2D(inventoryLootFrmImage.getBuffer(), destBuf);
         } else {
             FrmImage backgroundFrmImage;
-            if (backgroundFrmImage.lock(FrmId(windowDescription->frmId))) {
+            if (backgroundFrmImage.lock(windowDescription->frmId)) {
                 blitBuffer2D(backgroundFrmImage.getBuffer(), destBuf);
             }
         }
@@ -2241,7 +2241,7 @@ static void _display_inventory(int stackOffset, int dragSlotIndex, int inventory
         pitch = INVENTORY_USE_ON_WINDOW_WIDTH;
 
         FrmImage backgroundFrmImage;
-        if (backgroundFrmImage.lock(FrmId(InterfaceFrameId::UseItemOnWindow))) {
+        if (backgroundFrmImage.lock(InterfaceFrameId::UseItemOnWindow)) {
             // Clear scroll view background.
             blitBufferToBuffer(backgroundFrmImage.getData() + pitch * INVENTORY_SCROLLER_Y + INVENTORY_SCROLLER_X,
                 INVENTORY_SLOT_WIDTH,
@@ -2560,7 +2560,7 @@ static void _display_body(int fid, int inventoryWindowType)
             rect.bottom = rect.top + INVENTORY_BODY_VIEW_HEIGHT - 1;
 
             FrmImage backgroundFrmImage;
-            const FrmId backgroundFid = gGameDialogSpeakerIsPartyMember ? FrmId(InterfaceFrameId::TradeWindow) : FrmId(InterfaceFrameId::BarterWindow);
+            const InterfaceFrmId backgroundFid = gGameDialogSpeakerIsPartyMember ? InterfaceFrameId::TradeWindow : InterfaceFrameId::BarterWindow;
             if (backgroundFrmImage.lock(backgroundFid)) {
                 blitBufferToBuffer(backgroundFrmImage.getData() + rect.top * 640 + rect.left,
                     INVENTORY_BODY_VIEW_WIDTH,
@@ -6231,7 +6231,7 @@ static InventoryAmmoMoveResult _drop_ammo_into_weapon(Object* weapon, Object* am
 static void _draw_amount(int value, int inventoryWindowType)
 {
     FrmImage numbersFrmImage;
-    if (!numbersFrmImage.lock(FrmId(InterfaceFrameId::BigNum))) {
+    if (!numbersFrmImage.lock(InterfaceFrameId::BigNum)) {
         return;
     }
 
@@ -6487,7 +6487,7 @@ static int inventoryQuantityWindowInit(int inventoryWindowType, Object* item)
 
         // Timer overlay
         FrmImage overlayFrmImage;
-        if (overlayFrmImage.lock(FrmId(InterfaceFrameId::TimerOverlay))) {
+        if (overlayFrmImage.lock(InterfaceFrameId::TimerOverlay)) {
             blitBufferToBuffer(overlayFrmImage.getData(),
                 105, 81, 105,
                 windowBuffer + 34 * windowDescription->width + 113, windowDescription->width);
@@ -6521,8 +6521,8 @@ static int inventoryQuantityWindowInit(int inventoryWindowType, Object* item)
         148, 128, -1, KEY_ESCAPE, InterfaceFrameId::LittleRedButtonUp, InterfaceFrameId::LittleRedButtonDown);
 
     if (inventoryWindowType == INVENTORY_WINDOW_TYPE_MOVE_ITEMS) {
-        _moveFrmImages[6].lock(FrmId(InterfaceFrameId::AllButtonPressed));
-        _moveFrmImages[7].lock(FrmId(InterfaceFrameId::AllButtonUnpressed));
+        _moveFrmImages[6].lock(InterfaceFrameId::AllButtonPressed);
+        _moveFrmImages[7].lock(InterfaceFrameId::AllButtonUnpressed);
 
         if (_moveFrmImages[6].isLocked() && _moveFrmImages[7].isLocked()) {
             // ALL

--- a/src/main.cc
+++ b/src/main.cc
@@ -501,7 +501,7 @@ static void showDeath()
             }
 
             FrmImage backgroundFrmImage;
-            if (!backgroundFrmImage.lock(FrmId(InterfaceFrameId::DeathScene))) {
+            if (!backgroundFrmImage.lock(InterfaceFrameId::DeathScene)) {
                 break;
             }
 

--- a/src/mainmenu.cc
+++ b/src/mainmenu.cc
@@ -187,13 +187,13 @@ static bool mainMenuShouldUseVanillaArtForLayout(int backgroundWidth, int backgr
 static bool mainMenuLoadArt()
 {
     bool canUseHiresArt = screenGetWidth() != MAIN_MENU_LOGICAL_WIDTH || screenGetHeight() != MAIN_MENU_LOGICAL_HEIGHT;
-    if (canUseHiresArt && mainMenuBackgroundFrmImage.lock(FrmId(OBJ_TYPE_INTERFACE, "HR_MAINMENU.FRM"))) {
+    if (canUseHiresArt && mainMenuBackgroundFrmImage.lock(InterfaceFrmId("HR_MAINMENU.FRM"))) {
         if (mainMenuShouldUseVanillaArtForLayout(mainMenuBackgroundFrmImage.getWidth(), mainMenuBackgroundFrmImage.getHeight())) {
             // use Vanilla art if not scaling to reduce artifacts
             mainMenuBackgroundFrmImage.unlock();
         } else {
             // for highres main menu art, use separate panel art
-            if (!mainMenuButtonPanelFrmImage.lock(FrmId(OBJ_TYPE_INTERFACE, "HR_MENU_BG.FRM"))) {
+            if (!mainMenuButtonPanelFrmImage.lock(InterfaceFrmId("HR_MENU_BG.FRM"))) {
                 debugPrint("MAINMENU: failed to load hires HR_MENU_BG.FRM, falling back to vanilla mainmenu.frm\n");
                 mainMenuBackgroundFrmImage.unlock();
             }

--- a/src/mainmenu.cc
+++ b/src/mainmenu.cc
@@ -201,17 +201,17 @@ static bool mainMenuLoadArt()
     }
 
     if (!mainMenuBackgroundFrmImage.isLocked()) {
-        if (!mainMenuBackgroundFrmImage.lock(FrmId(InterfaceFrameId::MainMenuBackgroundImage))) {
+        if (!mainMenuBackgroundFrmImage.lock(InterfaceFrameId::MainMenuBackgroundImage)) {
             debugPrint("MAINMENU: failed to load vanilla mainmenu.frm\n");
             return false;
         }
     }
 
-    if (!mainMenuButtonNormalFrmImage.lock(FrmId(InterfaceFrameId::MainMenuButtonUp))) {
+    if (!mainMenuButtonNormalFrmImage.lock(InterfaceFrameId::MainMenuButtonUp)) {
         return false;
     }
 
-    if (!mainMenuButtonPressedFrmImage.lock(FrmId(InterfaceFrameId::MainMenuButtonDown))) {
+    if (!mainMenuButtonPressedFrmImage.lock(InterfaceFrameId::MainMenuButtonDown)) {
         return false;
     }
 

--- a/src/map.cc
+++ b/src/map.cc
@@ -1482,12 +1482,12 @@ static int _map_save_file(File* stream)
             TileFrmId frmId;
 
             frmId = static_cast<TileFrameId>(frameIdFromFid(_square[elevation]->fid[tile]));
-            if (frmId != TileFrmId(TileFrameId::Grid)) {
+            if (frmId != TileFrameId::Grid) {
                 break;
             }
 
             frmId = static_cast<TileFrameId>(frameIdFromFid(_square[elevation]->fid[tile] >> 16));
-            if (frmId != TileFrmId(TileFrameId::Grid)) {
+            if (frmId != TileFrameId::Grid) {
                 break;
             }
         }

--- a/src/mapper/map_func.cc
+++ b/src/mapper/map_func.cc
@@ -954,7 +954,7 @@ void eraseObject()
 
                     if (hit != nullptr) {
                         // Don't destroy exit-grid markers (interface art, id=3).
-                        if (hit->fid != FrmId(InterfaceFrameId::ExitGridMarker).fid()) {
+                        if (FrmId(hit->fid) != InterfaceFrameId::ExitGridMarker) {
                             Rect rect;
                             int elev = hit->elevation;
                             reg_anim_clear(hit);

--- a/src/mapper/mapper.cc
+++ b/src/mapper/mapper.cc
@@ -2604,7 +2604,7 @@ static int mapperPickTile(int* outOffset)
     } else {
         tileFrmId = static_cast<TileFrameId>(frameIdFromFid(packedTile));
     }
-    const FrmId artFrmId = FrmId(tileFrmId);
+    const TileFrmId artFrmId = tileFrmId;
 
     for (int idx = 0; idx < maxId; idx++) {
         int pid = (OBJ_TYPE_TILE << 24) | idx;

--- a/src/mapper/mp_scrpt.cc
+++ b/src/mapper/mp_scrpt.cc
@@ -45,7 +45,7 @@ int map_scr_remove_spatial(int tile, int elevation)
 
     obj = objectFindFirstAtElevation(elevation);
     while (obj != NULL) {
-        if (obj->tile == tile && FrmId(InterfaceFrameId::ExitGridMarker).fid() == obj->fid) {
+        if (obj->tile == tile && FrmId(obj->fid) == InterfaceFrameId::ExitGridMarker) {
             objectDestroy(obj, &rect);
             tileWindowRefreshRect(&rect, elevation);
 
@@ -77,7 +77,7 @@ int map_scr_remove_all_spatials()
 
         obj = objectFindFirstAtElevation(elevation);
         while (obj != NULL) {
-            if (FrmId(InterfaceFrameId::ExitGridMarker).fid() == obj->fid) {
+            if (FrmId(obj->fid) == InterfaceFrameId::ExitGridMarker) {
                 objectDestroy(obj, NULL);
 
                 obj = objectFindFirstAtElevation(elevation);

--- a/src/mapper/mp_scrpt.cc
+++ b/src/mapper/mp_scrpt.cc
@@ -109,7 +109,7 @@ static int _scr_show_toggled = 0;
 // 0x4C26D0
 void map_scr_toggle_hexes()
 {
-    constexpr FrmId kMarkerFrmId = FrmId(InterfaceFrameId::ExitGridMarker);
+    constexpr InterfaceFrmId kMarkerFrmId = InterfaceFrameId::ExitGridMarker;
 
     if (!_scr_show_toggled) {
         // REMOVE mode: erase all existing spatial marker objects
@@ -312,7 +312,7 @@ int map_scr_add_spatial(int tile, int elevation)
         return -1;
     }
 
-    constexpr FrmId kMarkerFrmId = FrmId(InterfaceFrameId::ExitGridMarker);
+    constexpr InterfaceFrmId kMarkerFrmId = InterfaceFrameId::ExitGridMarker;
     Object* obj;
     if (objectCreateWithFidPid(&obj, kMarkerFrmId.fid(), -1) != -1) {
         obj->flags |= OBJECT_NO_SAVE;
@@ -421,7 +421,7 @@ void scr_debug_print_scripts()
     }
 
     // Phase 2: Scripts WITHOUT owners — find marker object at script's built_tile
-    constexpr FrmId kMarkerFrmId = FrmId(InterfaceFrameId::ExitGridMarker);
+    constexpr InterfaceFrmId kMarkerFrmId = InterfaceFrameId::ExitGridMarker;
     for (int type = 0; type < SCRIPT_TYPE_COUNT; type++) {
         for (int id = 0; id < kMaxScriptId; id++) {
             int sid = (type << 24) | id;

--- a/src/object.cc
+++ b/src/object.cc
@@ -302,7 +302,7 @@ static char _obj_seen[5001];
 int objectsInit(unsigned char* buf, int width, int height, int pitch)
 {
     const FrmId dudeFrmId = FrmId(_art_vault_guy_num, ANIM_STAND, WEAPON_ANIMATION_NONE, ROTATION_NE);
-    const FrmId eggFrmId = FrmId(InterfaceFrameId::Egg);
+    const InterfaceFrmId eggFrmId = InterfaceFrameId::Egg;
 
     memset(_obj_seen, 0, 5001);
     gObjectsUpdateAreaPixelBounds.right = width + 320;
@@ -1477,7 +1477,7 @@ int objectSetLocation(Object* obj, int tile, int elevation, Rect* rect)
             int previousSquare = _obj_last_roof_x != -1 && _obj_last_roof_y != -1
                 ? _square[elevation]->fid[_obj_last_roof_x + 100 * _obj_last_roof_y]
                 : 0;
-            bool isEmpty = TileFrmId(TileFrameId::Grid) == currentSquareFrmId;
+            bool isEmpty = currentSquareFrmId == TileFrameId::Grid;
 
             if (isEmpty != _obj_last_is_empty || (((currentSquare >> 16) & 0xF000) >> 12) != (((previousSquare >> 16) & 0xF000) >> 12)) {
                 if (!_obj_last_is_empty) {
@@ -1530,7 +1530,7 @@ int objectSetLocation(Object* obj, int tile, int elevation, Rect* rect)
 int _obj_reset_roof()
 {
     const TileFrmId frmId = static_cast<TileFrameId>(frameIdFromFid(_square[gDude->elevation]->fid[_obj_last_roof_x + 100 * _obj_last_roof_y] >> 16));
-    if (frmId != TileFrmId(TileFrameId::Grid)) {
+    if (frmId != TileFrameId::Grid) {
         tile_fill_roof(_obj_last_roof_x, _obj_last_roof_y, gDude->elevation, 1);
     }
     return 0;

--- a/src/object.cc
+++ b/src/object.cc
@@ -3250,7 +3250,7 @@ void _obj_preload_art_cache(MapHeaderFlags flags)
 
     for (int i = FrmId::kMinFrameId; i <= FrmId::kMaxFrameId; i++) {
         if (arr[i] != 0) {
-            if (artLock(TileFrmId(static_cast<TileFrameId>(i)), &cache_handle) != nullptr) {
+            if (artLock(static_cast<TileFrameId>(i), &cache_handle) != nullptr) {
                 artUnlock(cache_handle);
             }
         }

--- a/src/tile.cc
+++ b/src/tile.cc
@@ -1317,7 +1317,7 @@ void tileRenderRoofsInRect(Rect* rect, int elevation)
             fid >>= 16;
             if ((((fid & 0xF000) >> 12) & 0x01) == 0) {
                 const TileFrmId frmId = static_cast<TileFrameId>(frameIdFromFid(fid));
-                if (frmId != TileFrmId(TileFrameId::Grid)) {
+                if (frmId != TileFrameId::Grid) {
                     int screenX;
                     int screenY;
                     squareTileToRoofScreenXY(squareTile, &screenX, &screenY, elevation);
@@ -1346,7 +1346,7 @@ static void roof_fill_off_process_task(std::stack<roof_fill_task>& tasks_stack, 
     int roof = (squareTile >> 16) & 0xFFFF;
 
     const TileFrmId frmId = FrmId(roof).frameId().tile;
-    if (frmId != TileFrmId(TileFrameId::Grid)) {
+    if (frmId != TileFrameId::Grid) {
         int flag = (roof & 0xF000) >> 12;
 
         if (on ? ((flag & 0x01) != 0) : ((flag & 0x03) == 0)) {
@@ -1603,7 +1603,7 @@ bool _square_roof_intersect(int x, int y, int elevation)
     int idx = gSquareGridWidth * tileY + tileX;
     int upper = ptr->fid[gSquareGridWidth * tileY + tileX] >> 16;
     TileFrmId frmId = static_cast<TileFrameId>(frameIdFromFid(upper));
-    if (frmId != TileFrmId(TileFrameId::Grid)) {
+    if (frmId != TileFrameId::Grid) {
         if ((((upper & 0xF000) >> 12) & 1) == 0) {
             frmId = static_cast<TileFrameId>(frameIdFromFid(upper));
             CacheEntry* handle;

--- a/src/worldmap.cc
+++ b/src/worldmap.cc
@@ -1310,13 +1310,13 @@ int wmParseAreasConfig(Config* cfg, int startAreaIdx)
     }
 
     City area_idx = static_cast<City>(startAreaIdx);
-    InterfaceFrameId frmId;
+    InterfaceFrameId frameId;
 
     int loop_safety_counter = 0;
 
     while (loop_safety_counter < 5000) {
         snprintf(section, sizeof(section), "Area %02d", area_idx);
-        if (!configGetEnum<InterfaceFrameId>(cfg, section, "townmap_art_idx", &frmId)) {
+        if (!configGetEnum<InterfaceFrameId>(cfg, section, "townmap_art_idx", &frameId)) {
             break;
         }
 
@@ -1336,20 +1336,20 @@ int wmParseAreasConfig(Config* cfg, int startAreaIdx)
 
         city->areaId = City(area_idx);
 
-        FrmId fid = FrmId::Empty();
-        if (frmId != InterfaceFrameId::Invalid) {
-            fid = FrmId(frmId);
+        InterfaceFrmId frmId = InterfaceFrameId::Invalid;
+        if (frameId != InterfaceFrameId::Invalid) {
+            frmId = frameId;
         }
 
-        city->mapFid = fid.fid();
+        city->mapFid = frmId.fid();
 
-        fid = FrmId::Empty();
-        if (configGetEnum<InterfaceFrameId>(cfg, section, "townmap_label_art_idx", &frmId)) {
-            if (frmId != InterfaceFrameId::Invalid) {
-                fid = FrmId(frmId);
+        frmId = InterfaceFrameId::Invalid;
+        if (configGetEnum<InterfaceFrameId>(cfg, section, "townmap_label_art_idx", &frameId)) {
+            if (frameId != InterfaceFrameId::Invalid) {
+                frmId = frameId;
             }
 
-            city->labelFid = fid.fid();
+            city->labelFid = frmId.fid();
         }
 
         if (!configGetString(cfg, section, "area_name", &str)) {
@@ -5067,7 +5067,7 @@ static int wmInterfaceInit()
         return -1;
     }
 
-    if (!_backgroundFrmImage.lock(FrmId(InterfaceFrameId::WorldMapDialogBox))) {
+    if (!_backgroundFrmImage.lock(InterfaceFrameId::WorldMapDialogBox)) {
         return -1;
     }
 
@@ -5096,19 +5096,19 @@ static int wmInterfaceInit()
         }
     }
 
-    if (!wmGenData.hotspotNormalFrmImage.lock(FrmId(InterfaceFrameId::TownMapHotspot1))) {
+    if (!wmGenData.hotspotNormalFrmImage.lock(InterfaceFrameId::TownMapHotspot1)) {
         return -1;
     }
 
-    if (!wmGenData.hotspotPressedFrmImage.lock(FrmId(InterfaceFrameId::TownMapHotspot2))) {
+    if (!wmGenData.hotspotPressedFrmImage.lock(InterfaceFrameId::TownMapHotspot2)) {
         return -1;
     }
 
-    if (!wmGenData.destinationMarkerFrmImage.lock(FrmId(InterfaceFrameId::WorldMapMoveTargetMarker1))) {
+    if (!wmGenData.destinationMarkerFrmImage.lock(InterfaceFrameId::WorldMapMoveTargetMarker1)) {
         return -1;
     }
 
-    if (!wmGenData.locationMarkerFrmImage.lock(FrmId(InterfaceFrameId::WorldMapLocationMarker))) {
+    if (!wmGenData.locationMarkerFrmImage.lock(InterfaceFrameId::WorldMapLocationMarker)) {
         return -1;
     }
 
@@ -5122,15 +5122,15 @@ static int wmInterfaceInit()
         wmTileInfoList[index].handle = INVALID_CACHE_ENTRY;
     }
 
-    if (!wmGenData.tabsBackgroundFrmImage.lock(FrmId(InterfaceFrameId::WorldMapTownTabsUnderlay))) {
+    if (!wmGenData.tabsBackgroundFrmImage.lock(InterfaceFrameId::WorldMapTownTabsUnderlay)) {
         return -1;
     }
 
-    if (!wmGenData.tabsBorderFrmImage.lock(FrmId(InterfaceFrameId::WorldMapTownTabsEdgingOverlay))) {
+    if (!wmGenData.tabsBorderFrmImage.lock(InterfaceFrameId::WorldMapTownTabsEdgingOverlay)) {
         return -1;
     }
 
-    wmGenData.dialFrm = artLock(FrmId(InterfaceFrameId::WorldMapNightDayDial), &(wmGenData.dialFrmHandle));
+    wmGenData.dialFrm = artLock(InterfaceFrameId::WorldMapNightDayDial, &(wmGenData.dialFrmHandle));
     if (wmGenData.dialFrm == nullptr) {
         return -1;
     }
@@ -5138,23 +5138,23 @@ static int wmInterfaceInit()
     wmGenData.dialFrmWidth = artGetWidth(wmGenData.dialFrm);
     wmGenData.dialFrmHeight = artGetHeight(wmGenData.dialFrm);
 
-    if (!wmGenData.carOverlayFrmImage.lock(FrmId(InterfaceFrameId::WorldMapOverlayScreen))) {
+    if (!wmGenData.carOverlayFrmImage.lock(InterfaceFrameId::WorldMapOverlayScreen)) {
         return -1;
     }
 
-    if (!wmGenData.globeOverlayFrmImage.lock(FrmId(InterfaceFrameId::WorldMapGlobeStampOverlay))) {
+    if (!wmGenData.globeOverlayFrmImage.lock(InterfaceFrameId::WorldMapGlobeStampOverlay)) {
         return -1;
     }
 
-    wmGenData.redButtonNormalFrmImage.lock(FrmId(InterfaceFrameId::LittleRedButtonUp));
+    wmGenData.redButtonNormalFrmImage.lock(InterfaceFrameId::LittleRedButtonUp);
 
-    wmGenData.redButtonPressedFrmImage.lock(FrmId(InterfaceFrameId::LittleRedButtonDown));
+    wmGenData.redButtonPressedFrmImage.lock(InterfaceFrameId::LittleRedButtonDown);
 
-    if (!wmGenData.monthsFrmImage.lock(FrmId(InterfaceFrameId::PipBoyMonthStrings))) {
+    if (!wmGenData.monthsFrmImage.lock(InterfaceFrameId::PipBoyMonthStrings)) {
         return -1;
     }
 
-    if (!wmGenData.numbersFrmImage.lock(FrmId(InterfaceFrameId::HitPointsNumbers))) {
+    if (!wmGenData.numbersFrmImage.lock(InterfaceFrameId::HitPointsNumbers)) {
         return -1;
     }
 
@@ -6911,8 +6911,7 @@ static bool wmLockCarInterfaceArt(InterfaceFrameId artIndex, Art** artPtr, Cache
     }
 
     CacheEntry* handle = INVALID_CACHE_ENTRY;
-    const FrmId frmId = FrmId(artIndex);
-    Art* art = artLock(frmId, &handle);
+    Art* art = artLock(artIndex, &handle);
     if (art == nullptr) {
         return false;
     }
@@ -7209,7 +7208,7 @@ static int wmRefreshTabs()
     if (firstVisibleLabelIndex < wmLabelCount) {
         city = &(wmAreaInfoList[wmLabelList[firstVisibleLabelIndex]]);
         const FrmId cityLabelFrmId = FrmId(city->labelFid);
-        if (!cityLabelFrmId.empty()) {
+        if (cityLabelFrmId.valid()) {
             if (!labelFrm.lock(cityLabelFrmId)) {
                 return -1;
             }
@@ -7240,7 +7239,7 @@ static int wmRefreshTabs()
         if (labelIndex < wmLabelCount) {
             city = &(wmAreaInfoList[wmLabelList[labelIndex]]);
             const FrmId cityLabelFrmId = FrmId(city->labelFid);
-            if (!cityLabelFrmId.empty()) {
+            if (cityLabelFrmId.valid()) {
                 if (!labelFrm.lock(cityLabelFrmId)) {
                     return -1;
                 }
@@ -7261,7 +7260,7 @@ static int wmRefreshTabs()
     if (lastLabelIndexToDraw < wmLabelCount) {
         city = &(wmAreaInfoList[wmLabelList[lastLabelIndexToDraw]]);
         const FrmId cityLabelFrmId = FrmId(city->labelFid);
-        if (!cityLabelFrmId.empty()) {
+        if (cityLabelFrmId.valid()) {
             if (!labelFrm.lock(cityLabelFrmId)) {
                 return -1;
             }


### PR DESCRIPTION
### Description
Since all FrameId enums have been converted to scoped enums this PR is enabling implicit `FrmId` ctors from `FrameId` values. `FrmId(int fid)` is still kept `explicit` for purpose..
```cpp
const FrmId frmId = MiscFrameId::Invalid;
```

Also added new `==` and `!=` for direct comparison between `FrmId` and `FrameId`.
So we can write now conditions in this way 
```cpp
if (FrmId(obj->fid) == MiscFrameId::Invalid)
```
Since the new operators `==` and `!=` are build on top of FrameId enum values there was no need to do a full comparison like in existing `==` or `!=` operator but just compare `_fid` vs computed `buildFid` from FrameId value. Benefit of this is that it can be `constexpr`.