### PR TITLE
HOOK_DESCRIPTIONOBJ

### DIFF
--- a/SFALL_COMPATIBILITY.md
+++ b/SFALL_COMPATIBILITY.md
@@ -171,7 +171,7 @@ CE defines several metarules that are not supported in Sfall.  Include [ce.h](fi
 | GameModeChange | `HOOK_GAMEMODECHANGE` | ✅ | - |
 | UseAnimObj | `HOOK_USEANIMOBJ` | ✅ | - |
 | ExplosiveTimer | `HOOK_EXPLOSIVETIMER` | ✅ | - |
-| DescriptionObj | `HOOK_DESCRIPTIONOBJ` | 🚫 | Et tu |
+| DescriptionObj | `HOOK_DESCRIPTIONOBJ` | ✅ | Deprecated integer string pointers are not supported; return strings directly. |
 | UseSkillOn | `HOOK_USESKILLON` | ✅ | - |
 | OnExplosion | `HOOK_ONEXPLOSION` | 🚫 | (maybe) |
 | SubCombatDamage | `HOOK_SUBCOMBATDAMAGE` | 🚫 | (maybe) |

--- a/files/fallout2.cfg
+++ b/files/fallout2.cfg
@@ -85,7 +85,7 @@ speech_volume=22281
 [system]
 ; Original installer set this to 50% of system ram, up to a max of 512 (mb).
 ; There's no reason to make this higher than 256.
-; Value is capped to 512 with a minimum of 8
+; Value is capped to 512 with a minimum of 32
 art_cache_size=32
 color_cycling=1
 critter_dat=critter.dat

--- a/sfall_testing/hooks/gl_descriptionobj.ssl
+++ b/sfall_testing/hooks/gl_descriptionobj.ssl
@@ -1,0 +1,22 @@
+#include "sfall.h"
+#include "../test_utils.h"
+
+variable descriptionobj_calls := 0;
+
+procedure descriptionobj_handler begin
+    variable object := get_sfall_arg_at(0);
+
+    descriptionobj_calls++;
+    call assertTrue("descriptionobj object is set", object != 0);
+
+    set_sfall_return(string_format1("HOOK_DESCRIPTIONOBJ: %s", obj_name(object)));
+end
+
+procedure start begin
+    if (not game_loaded) then return;
+
+    display_msg("descriptionobj manual test ready");
+    display_msg("examine an object; its description should be HOOK_DESCRIPTIONOBJ: <object name>");
+
+    register_hook_proc(HOOK_DESCRIPTIONOBJ, descriptionobj_handler);
+end

--- a/src/proto_instance.cc
+++ b/src/proto_instance.cc
@@ -5,6 +5,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <string>
+
 #include "animation.h"
 #include "art.h"
 #include "color.h"
@@ -276,21 +278,26 @@ int objectExamineFunc(Object* critter, Object* target, void (*fn)(const char* st
     }
 
     if (!scriptOverrides) {
-        char* description = objectGetDescription(target);
-        if (description != nullptr && strcmp(description, _proto_none_str) == 0) {
-            description = nullptr;
-        }
-
-        if (description == nullptr || *description == '\0') {
-            MessageListItem messageListItem;
-            messageListItem.num = 493;
-            if (!messageListGetItem(&gProtoMessageList, &messageListItem)) {
-                debugPrint("\nError: Can't find msg num!");
-            }
-            fn(messageListItem.text);
+        std::string hookDescription;
+        if (scriptHooks_DescriptionObject(target, hookDescription)) {
+            fn(hookDescription.c_str());
         } else {
-            if (objectTypeFromPid(target->pid) != OBJ_TYPE_CRITTER || !critterIsDead(target)) {
-                fn(description);
+            char* description = objectGetDescription(target);
+            if (description != nullptr && strcmp(description, _proto_none_str) == 0) {
+                description = nullptr;
+            }
+
+            if (description == nullptr || *description == '\0') {
+                MessageListItem messageListItem;
+                messageListItem.num = 493;
+                if (!messageListGetItem(&gProtoMessageList, &messageListItem)) {
+                    debugPrint("\nError: Can't find msg num!");
+                }
+                fn(messageListItem.text);
+            } else {
+                if (objectTypeFromPid(target->pid) != OBJ_TYPE_CRITTER || !critterIsDead(target)) {
+                    fn(description);
+                }
             }
         }
     }

--- a/src/scripts.cc
+++ b/src/scripts.cc
@@ -2882,6 +2882,8 @@ int _scr_remove_all_force()
     queueClearByEventType(EVENT_TYPE_SCRIPT, nullptr);
     _scr_message_free();
 
+    scriptSelfOverrides.clear();
+
     for (int type = 0; type < SCRIPT_TYPE_COUNT; type++) {
         ScriptList* scriptList = &(gScriptLists[type]);
         ScriptListExtent* extent = scriptList->head;

--- a/src/settings.cc
+++ b/src/settings.cc
@@ -150,7 +150,7 @@ void initSettingsRegistry(bool isMapper)
     SETTING(language);
     SETTING(scroll_lock);
     SETTING(interrupt_walk);
-    SETTING_P(art_cache_size, clamp(16, 512));
+    SETTING_P(art_cache_size, clamp(32, 512));
     SETTING(color_cycling);
     SETTING(cycle_speed_factor);
     SETTING(hashing);

--- a/src/sfall_global_scripts.cc
+++ b/src/sfall_global_scripts.cc
@@ -349,6 +349,11 @@ bool sfall_gl_scr_remove_all_timer_events(Program* program)
     return true;
 }
 
+bool sfall_gl_scr_is_global_script(Program* program)
+{
+    return state != nullptr && sfall_gl_scr_map_program_to_scr(program) != nullptr;
+}
+
 void sfall_gl_scr_set_repeat(Program* program, int frames)
 {
     GlobalScript* scr = sfall_gl_scr_map_program_to_scr(program);

--- a/src/sfall_global_scripts.h
+++ b/src/sfall_global_scripts.h
@@ -20,6 +20,7 @@ bool sfall_gl_scr_remove_all_timer_events(Program* program);
 void sfall_gl_scr_set_repeat(Program* program, int frames);
 void sfall_gl_scr_set_type(Program* program, int type);
 bool sfall_gl_scr_is_loaded(Program* program);
+bool sfall_gl_scr_is_global_script(Program* program);
 void sfall_gl_scr_update(int burstSize);
 
 } // namespace fallout

--- a/src/sfall_metarules.cc
+++ b/src/sfall_metarules.cc
@@ -174,7 +174,7 @@ namespace {
         if (hookCall != nullptr
             && hookCall->hookType() == HOOK_COMBATDAMAGE
             && hookCall->numArgs() > 12) {
-            ProgramValue attackArg = hookCall->getArgAt(12);
+            ProgramValue attackArg = hookCall->getArgAt(12, nullptr);
             if (attackArg.isPointer() && attackArg.pointerValue == value.pointerValue) {
                 return static_cast<Attack*>(value.pointerValue);
             }
@@ -1242,7 +1242,7 @@ void mf_get_sfall_arg_at(OpcodeContext& ctx)
     const auto hookCall = hookOpcodeGetCurrentCall(ctx.name());
     if (hookCall != nullptr) {
         if (argNum >= 0 && argNum < hookCall->numArgs()) {
-            result = hookCall->getArgAt(argNum);
+            result = hookCall->getArgAt(argNum, ctx.program());
         } else {
             ctx.printError("%s: argNum %d out of range [0, %d]", ctx.name(), argNum, hookCall->numArgs() - 1);
         }

--- a/src/sfall_opcodes.cc
+++ b/src/sfall_opcodes.cc
@@ -2060,6 +2060,10 @@ static void op_register_hook(Program* program)
         programPrintError("%s: invalid hook ID: %d", opcodeName, hookId);
         return;
     }
+    if (!sfall_gl_scr_is_global_script(program)) {
+        programPrintError("%s: can only be called from global scripts", opcodeName);
+        return;
+    }
     int startProcIndex = programFindProcedure(program, gScriptProcNames[SCRIPT_PROC_START]);
     if (startProcIndex == -1) {
         programPrintError("%s: 'start' procedure not found", opcodeName);
@@ -2078,6 +2082,10 @@ static void op_register_hook_proc(Program* program)
     int hookId = programStackPopInteger(program);
     if (hookId < 0 || hookId >= HOOK_COUNT) {
         programPrintError("%s: invalid hook ID: %d", opcodeName, hookId);
+        return;
+    }
+    if (!sfall_gl_scr_is_global_script(program)) {
+        programPrintError("%s: can only be called from global scripts", opcodeName);
         return;
     }
     if (procedureIndex < 0 || procedureIndex >= program->procedureCount()) {
@@ -2112,7 +2120,7 @@ static void op_get_sfall_arg(Program* program)
     constexpr char opcodeName[] = "get_sfall_arg";
 
     const auto hookCall = hookOpcodeGetCurrentCall(opcodeName);
-    programStackPushValue(program, hookCall != nullptr ? hookCall->getNextArgFromScript() : ProgramValue(0));
+    programStackPushValue(program, hookCall != nullptr ? hookCall->getNextArgFromScript(program) : ProgramValue(0));
 }
 
 static void op_get_sfall_args(Program* program)
@@ -2124,7 +2132,7 @@ static void op_get_sfall_args(Program* program)
     if (hookCall != nullptr) {
         result = CreateTempArray(hookCall->numArgs(), 0);
         for (int i = 0; i < hookCall->numArgs(); ++i) {
-            SetArray(result, i, hookCall->getArgAt(i), false, program);
+            SetArray(result, i, hookCall->getArgAt(i, program), false, program);
         }
     }
     programStackPushInteger(program, static_cast<int>(result));
@@ -2144,7 +2152,7 @@ static void op_set_sfall_arg(Program* program)
         programPrintError("%s: argNum %d out of range [0, %d]", opcodeName, argNum, hookCall->numArgs() - 1);
         return;
     }
-    hookCall->setArgAt(argNum, value);
+    hookCall->setArgAt(argNum, program, value);
 }
 
 static void op_set_sfall_return(Program* program)
@@ -2160,7 +2168,7 @@ static void op_set_sfall_return(Program* program)
         programPrintError("%s: trying to add next return value while only %d is expected", opcodeName, hookCall->maxReturnValues());
         return;
     }
-    hookCall->addReturnValueFromScript(value);
+    hookCall->addReturnValueFromScript(program, value);
 }
 
 static void op_fs_copy(Program* program)

--- a/src/sfall_script_hooks.cc
+++ b/src/sfall_script_hooks.cc
@@ -158,16 +158,6 @@ int ScriptHookCall::numReturnValues() const { return _numRetVals; }
 int ScriptHookCall::numScriptReturnValues() const { return _scriptRetVals; }
 HookType ScriptHookCall::hookType() const { return _hookType; }
 
-static bool scriptHookIsRegistered(HookType hookType, const ScriptHook& hook)
-{
-    const auto& hooksOfType = scriptHooks[hookType];
-    return std::any_of(hooksOfType.begin(), hooksOfType.end(),
-        [&hook](const ScriptHook& registeredHook) {
-            return registeredHook.program == hook.program
-                && registeredHook.procedureIndex == hook.procedureIndex;
-        });
-}
-
 void ScriptHookCall::call()
 {
     if (_callStack.size() == MAX_HOOK_CALL_DEPTH) {
@@ -176,13 +166,9 @@ void ScriptHookCall::call()
     }
     _callStack.push_back(this);
 
-    const auto hooksSnapshot = scriptHooks[_hookType];
-    // Iterate over a snapshot so reentrant registration changes cannot invalidate iteration.
-    for (int i = static_cast<int>(hooksSnapshot.size()) - 1; i >= 0; --i) {
-        const auto& hook = hooksSnapshot[i];
-        if (!scriptHookIsRegistered(_hookType, hook)) {
-            continue;
-        }
+    const auto& hooksOfType = scriptHooks[_hookType];
+    for (int i = static_cast<int>(hooksOfType.size()) - 1; i >= 0; --i) {
+        const auto& hook = hooksOfType[i];
         _scriptArgs = 0;
         _scriptRetVals = 0;
         programExecuteProcedure(hook.program, hook.procedureIndex);

--- a/src/sfall_script_hooks.cc
+++ b/src/sfall_script_hooks.cc
@@ -62,7 +62,10 @@ ScriptHookValue ScriptHookValue::fromProgramValue(Program* program, ProgramValue
 ProgramValue ScriptHookValue::toProgramValue(Program* program) const
 {
     if (_isString) {
-        assert(program != nullptr);
+        if (program == nullptr) {
+            debugPrint("ScriptHookValue::toProgramValue: cannot convert string without program");
+            return ProgramValue(0);
+        }
         return programMakeString(program, _stringValue.c_str());
     }
     return _value;

--- a/src/sfall_script_hooks.cc
+++ b/src/sfall_script_hooks.cc
@@ -43,6 +43,66 @@ constexpr size_t MAX_HOOK_CALL_DEPTH = 8;
 
 std::vector<ScriptHookCall*> ScriptHookCall::_callStack;
 
+ScriptHookValue::ScriptHookValue(ProgramValue value)
+    : _value(value)
+{
+}
+
+ScriptHookValue ScriptHookValue::fromProgramValue(Program* program, ProgramValue value)
+{
+    ScriptHookValue hookValue(value);
+    if (value.isString()) {
+        assert(program != nullptr);
+        hookValue._isString = true;
+        hookValue._stringValue = value.asString(program);
+    }
+    return hookValue;
+}
+
+ProgramValue ScriptHookValue::toProgramValue(Program* program) const
+{
+    if (_isString) {
+        assert(program != nullptr);
+        return programMakeString(program, _stringValue.c_str());
+    }
+    return _value;
+}
+
+bool ScriptHookValue::isString() const
+{
+    return _isString;
+}
+
+bool ScriptHookValue::isInt() const
+{
+    return !_isString && _value.isInt();
+}
+
+bool ScriptHookValue::isPointer() const
+{
+    return !_isString && _value.isPointer();
+}
+
+int ScriptHookValue::asInt() const
+{
+    return _isString ? 0 : _value.asInt();
+}
+
+float ScriptHookValue::asFloat() const
+{
+    return _isString ? 0.0f : _value.asFloat();
+}
+
+Object* ScriptHookValue::asObject() const
+{
+    return _isString ? nullptr : _value.asObject();
+}
+
+const char* ScriptHookValue::asString() const
+{
+    return _isString ? _stringValue.c_str() : "";
+}
+
 ScriptHookCall* ScriptHookCall::current()
 {
     return !_callStack.empty() ? _callStack.back() : nullptr;
@@ -54,36 +114,36 @@ ScriptHookCall::ScriptHookCall(HookType hookType, int maxReturnValues, std::init
 {
     assert(hookType >= 0 && hookType < HOOK_COUNT && maxReturnValues >= 0 && maxReturnValues <= HOOKS_MAX_RETURN_VALUES && args.size() <= HOOKS_MAX_ARGUMENTS);
     for (auto arg : args) {
-        _args[_numArgs++] = arg;
+        _args[_numArgs++] = ScriptHookValue(arg);
     }
 }
 
-void ScriptHookCall::setArgAt(int idx, ProgramValue value)
+void ScriptHookCall::setArgAt(int idx, Program* program, ProgramValue value)
 {
     assert(idx >= 0 && idx < _numArgs);
-    _args[idx] = value;
+    _args[idx] = ScriptHookValue::fromProgramValue(program, value);
 }
 
-void ScriptHookCall::addReturnValueFromScript(ProgramValue value)
+void ScriptHookCall::addReturnValueFromScript(Program* program, ProgramValue value)
 {
     assert(_scriptRetVals < HOOKS_MAX_RETURN_VALUES);
     if (_scriptRetVals >= _maxRetVals)
         return;
 
-    _retVals[_scriptRetVals++] = value;
+    _retVals[_scriptRetVals++] = ScriptHookValue::fromProgramValue(program, value);
 
     if (_scriptRetVals > _numRetVals) {
         _numRetVals = _scriptRetVals;
     }
 }
 
-ProgramValue ScriptHookCall::getArgAt(int idx) const
+ProgramValue ScriptHookCall::getArgAt(int idx, Program* program) const
 {
     assert(idx >= 0 && idx < _numArgs);
-    return _args[idx];
+    return _args[idx].toProgramValue(program);
 }
 
-ProgramValue ScriptHookCall::getReturnValueAt(int idx) const
+const ScriptHookValue& ScriptHookCall::getReturnValueAt(int idx) const
 {
     assert(idx >= 0 && idx < _numRetVals);
     return _retVals[idx];
@@ -95,6 +155,16 @@ int ScriptHookCall::numReturnValues() const { return _numRetVals; }
 int ScriptHookCall::numScriptReturnValues() const { return _scriptRetVals; }
 HookType ScriptHookCall::hookType() const { return _hookType; }
 
+static bool scriptHookIsRegistered(HookType hookType, const ScriptHook& hook)
+{
+    const auto& hooksOfType = scriptHooks[hookType];
+    return std::any_of(hooksOfType.begin(), hooksOfType.end(),
+        [&hook](const ScriptHook& registeredHook) {
+            return registeredHook.program == hook.program
+                && registeredHook.procedureIndex == hook.procedureIndex;
+        });
+}
+
 void ScriptHookCall::call()
 {
     if (_callStack.size() == MAX_HOOK_CALL_DEPTH) {
@@ -103,10 +173,13 @@ void ScriptHookCall::call()
     }
     _callStack.push_back(this);
 
-    const auto& hooksOfType = scriptHooks[_hookType];
-    // Iterate in reverse order. In case current hook is unregistered inside the call, we can just continue iteration.
-    for (int i = hooksOfType.size() - 1; i >= 0; --i) {
-        const auto& hook = hooksOfType[i];
+    const auto hooksSnapshot = scriptHooks[_hookType];
+    // Iterate over a snapshot so reentrant registration changes cannot invalidate iteration.
+    for (int i = static_cast<int>(hooksSnapshot.size()) - 1; i >= 0; --i) {
+        const auto& hook = hooksSnapshot[i];
+        if (!scriptHookIsRegistered(_hookType, hook)) {
+            continue;
+        }
         _scriptArgs = 0;
         _scriptRetVals = 0;
         programExecuteProcedure(hook.program, hook.procedureIndex);
@@ -116,12 +189,12 @@ void ScriptHookCall::call()
     _callStack.pop_back();
 }
 
-ProgramValue ScriptHookCall::getNextArgFromScript()
+ProgramValue ScriptHookCall::getNextArgFromScript(Program* program)
 {
     if (_scriptArgs >= _numArgs) {
         return { 0 };
     }
-    return _args[_scriptArgs++];
+    return _args[_scriptArgs++].toProgramValue(program);
 }
 
 bool scriptHooksRegister(Program* program, const HookType hookType, const int procedureIndex)
@@ -333,6 +406,31 @@ void scriptHooks_ItemDamage(Object* weapon, Object* critter, HitMode hitMode, bo
     } else {
         *maxDamagePtr = *minDamagePtr;
     }
+}
+
+/*
+Runs when the player examines an object. Returning a string replaces the object's base description.
+
+Obj    arg0 - The examined object
+
+string ret0 - The replacement description.
+*/
+bool scriptHooks_DescriptionObject(Object* object, std::string& description)
+{
+    ScriptHookCall hook(HOOK_DESCRIPTIONOBJ, 1, { object });
+    hook.call();
+
+    if (hook.numReturnValues() <= 0) {
+        return false;
+    }
+
+    const auto& value = hook.getReturnValueAt(0);
+    if (!value.isString()) {
+        return false;
+    }
+
+    description = value.asString();
+    return true;
 }
 
 /*
@@ -771,7 +869,7 @@ UseSkillOnHookResult scriptHooks_UseSkillOn(Object** userPtr, Object* target, Sk
         return result;
     }
 
-    ProgramValue userOverride = hook.getReturnValueAt(0);
+    const auto& userOverride = hook.getReturnValueAt(0);
     if (userOverride.isInt()) {
         int value = userOverride.asInt();
         if (value == -1) {

--- a/src/sfall_script_hooks.h
+++ b/src/sfall_script_hooks.h
@@ -10,6 +10,8 @@
 #include "worldmap.h"
 #include <initializer_list>
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace fallout {
 
@@ -193,6 +195,29 @@ typedef enum {
 constexpr size_t HOOKS_MAX_ARGUMENTS = 16;
 constexpr size_t HOOKS_MAX_RETURN_VALUES = 8;
 
+class ScriptHookValue {
+public:
+    ScriptHookValue() = default;
+    explicit ScriptHookValue(ProgramValue value);
+
+    static ScriptHookValue fromProgramValue(Program* program, ProgramValue value);
+
+    ProgramValue toProgramValue(Program* program) const;
+
+    bool isString() const;
+    bool isInt() const;
+    bool isPointer() const;
+    int asInt() const;
+    float asFloat() const;
+    Object* asObject() const;
+    const char* asString() const;
+
+private:
+    ProgramValue _value;
+    std::string _stringValue;
+    bool _isString = false;
+};
+
 /**
  * Allows to delegate some logic to scripts:
  * - Each hook type has different number of arguments and return values
@@ -212,14 +237,14 @@ public:
     ScriptHookCall& operator=(ScriptHookCall&& other) = delete;
 
     // Sets an argument value at given index.
-    void setArgAt(int idx, ProgramValue value);
+    void setArgAt(int idx, Program* program, ProgramValue value);
     // Adds return value from script.
     // numReturnValues will only increase if current script called this more times than the last one.
-    void addReturnValueFromScript(ProgramValue value);
+    void addReturnValueFromScript(Program* program, ProgramValue value);
 
     void call();
 
-    ProgramValue getNextArgFromScript();
+    ProgramValue getNextArgFromScript(Program* program);
 
     // Number of arguments supplied from the engine.
     int numArgs() const;
@@ -230,8 +255,8 @@ public:
     // Number of supplied values from the last script.
     int numScriptReturnValues() const;
 
-    ProgramValue getArgAt(int idx) const;
-    ProgramValue getReturnValueAt(int idx) const;
+    ProgramValue getArgAt(int idx, Program* program) const;
+    const ScriptHookValue& getReturnValueAt(int idx) const;
     HookType hookType() const;
 
 private:
@@ -240,9 +265,9 @@ private:
     HookType _hookType;
     int _maxRetVals = 0;
 
-    ProgramValue _args[HOOKS_MAX_ARGUMENTS] = {};
+    ScriptHookValue _args[HOOKS_MAX_ARGUMENTS] = {};
     int _numArgs = 0;
-    ProgramValue _retVals[HOOKS_MAX_RETURN_VALUES] = {};
+    ScriptHookValue _retVals[HOOKS_MAX_RETURN_VALUES] = {};
     int _numRetVals = 0;
 
     int _scriptArgs = 0;
@@ -329,6 +354,7 @@ bool scriptHooks_RestTimer(unsigned int gameTime, RestEventType eventType, int h
 void scriptHooks_OnDeath(Object* critter);
 int scriptHooks_ExplosiveTimer(Object* explosive, int delay, EventType eventType);
 EncounterHookResult scriptHooks_Encounter(EncounterHookEventType eventType, Map* mapIdPtr, bool isSpecial, int tableId, int entryId);
+bool scriptHooks_DescriptionObject(Object* object, std::string& description);
 bool scriptHooks_InventoryMove(HookInventoryMoveType actionType, Object* item, Object* targetItem);
 bool scriptHooks_CombatTurnStart(Object* critter, bool reloadedDuringCombat);
 bool scriptHooks_CombatTurnEnd(Object* critter, int turnResult, bool reloadedDuringCombat);


### PR DESCRIPTION
Also implement some robustness for hooks:
* limit to global scripts, like Sfall
* allow returning strings as set_sfall_return
* allow chaining strings as set_sfall_arg

Introduces `ScriptHookValue` which is similar to `ProgramValue`, but "owns" the string value.  This lets hooks pass string values as return values even if the Program is no longer running.


