### PR TITLE
Replace Fid usages by FrmId vol1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ include("cmake/gitver.cmake")
 set(FALLOUT_ENGINE_SOURCES
     "src/actions.cc"
     "src/actions.h"
+    "src/animation_defs.h"
     "src/animation.cc"
     "src/animation.h"
     "src/art_defs.h"

--- a/src/actions.cc
+++ b/src/actions.cc
@@ -448,7 +448,7 @@ void showDamageToObject(Object* defender, int damage, int flags, Object* weapon,
                 animationRegisterAnimate(defender, ANIM_FIRE_DANCE, delay);
 
                 frmId = FrmId(defender, ANIM_STAND, weaponAnimationFromFid(defender->fid), defender->rotation + 1);
-                animationRegisterSetFid(defender, frmId.fid(), -1);
+                animationRegisterSetFrmId(defender, frmId, -1);
             } else {
                 if (knockbackDistance != 0) {
                     anim = hitFromFront ? ANIM_FALL_BACK : ANIM_FALL_FRONT;
@@ -483,7 +483,7 @@ void showDamageToObject(Object* defender, int damage, int flags, Object* weapon,
     if (weapon != nullptr) {
         if ((flags & DAM_EXPLODE) != DAM_NONE) {
             animationRegisterCallbackForced(defender, weapon, (AnimationCallback*)objectDrop, -1);
-            animationRegisterSetFid(weapon, MiscFrmId(MiscFrameId::RocketExplosion).fid(), 0);
+            animationRegisterSetFrmId(weapon, MiscFrameId::RocketExplosion, 0);
             animationRegisterAnimateAndHide(weapon, ANIM_STAND, 0);
 
             sfx_name = sfxBuildWeaponName(WEAPON_SOUND_EFFECT_HIT, weapon, HIT_MODE_RIGHT_WEAPON_PRIMARY, defender);
@@ -739,7 +739,7 @@ int _action_ranged(Attack* attack, AnimationType anim)
 
     Object* projectile = nullptr;
     Object* replacedWeapon = nullptr;
-    int weaponFid = -1;
+    FrmId weaponFrmId = FrmId::Empty();
 
     Proto* weaponProto;
     Object* weapon = attack->weapon;
@@ -790,7 +790,7 @@ int _action_ranged(Attack* attack, AnimationType anim)
             if (protoGetProto(projectilePid, &projectileProto) != -1 && projectileProto->fid != -1) {
                 if (anim == ANIM_THROW_ANIM) {
                     projectile = weapon;
-                    weaponFid = weapon->fid;
+                    weaponFrmId = FrmId(weapon->fid);
                     ObjectFlags weaponFlags = weapon->flags;
 
                     InterfaceItemAction leftItemAction;
@@ -876,10 +876,10 @@ int _action_ranged(Attack* attack, AnimationType anim)
                         }
 
                         if (isGrenade) {
-                            animationRegisterSetFid(projectile, weaponFid, -1);
+                            animationRegisterSetFrmId(projectile, weaponFrmId, -1);
                         }
 
-                        animationRegisterSetFid(projectile, explosionFrmId.fid(), -1);
+                        animationRegisterSetFrmId(projectile, explosionFrmId, -1);
 
                         const char* sfx = sfxBuildWeaponName(WEAPON_SOUND_EFFECT_HIT, weapon, attack->hitMode, attack->defender);
                         animationRegisterPlaySoundEffect(projectile, sfx, 0);
@@ -972,7 +972,7 @@ int _action_ranged(Attack* attack, AnimationType anim)
         // no-save).
         animationRegisterCallbackForced(attack, projectile, hideProjectile, -1);
     } else if (anim == ANIM_THROW_ANIM && projectile != nullptr) {
-        animationRegisterSetFid(projectile, weaponFid, -1);
+        animationRegisterSetFrmId(projectile, weaponFrmId, -1);
     }
 
     for (Rotation rotation = ROTATION_FIRST; rotation < ROTATION_COUNT; rotation++) {
@@ -994,7 +994,7 @@ int _action_ranged(Attack* attack, AnimationType anim)
 
             if (!takeOutAnimationRegistered) {
                 const FrmId frmId = FrmId(attack->attacker, ANIM_STAND, WEAPON_ANIMATION_NONE, attack->attacker->rotation + 1);
-                animationRegisterSetFid(attack->attacker, frmId.fid(), -1);
+                animationRegisterSetFrmId(attack->attacker, frmId, -1);
             }
         } else {
             animationRegisterAnimate(attack->attacker, ANIM_UNPOINT, -1);

--- a/src/actions.cc
+++ b/src/actions.cc
@@ -5,6 +5,7 @@
 
 #include <assert.h>
 
+#include "animation_defs.h"
 #include "animation.h"
 #include "art.h"
 #include "color.h"

--- a/src/actions.cc
+++ b/src/actions.cc
@@ -5,8 +5,8 @@
 
 #include <assert.h>
 
-#include "animation_defs.h"
 #include "animation.h"
+#include "animation_defs.h"
 #include "art.h"
 #include "color.h"
 #include "combat.h"

--- a/src/animation.cc
+++ b/src/animation.cc
@@ -320,7 +320,7 @@ typedef struct AnimationSad {
 #define ANIM_COMPLETE -1000
 
 static int _anim_free_slot(AnimationRequestOptions requestOptions);
-static int _anim_preload(Object* object, int fid, CacheEntry** cacheEntryPtr);
+static int _anim_preload(Object* object, const FrmId& frmId, CacheEntry** cacheEntryPtr);
 static void _anim_cleanup();
 static int _check_registry(Object* obj);
 static int animationRunSequence(int a1);
@@ -341,9 +341,9 @@ static int _anim_animate(Object* obj, AnimationType anim, int animationSequenceI
 static void _object_anim_compact();
 static int actionRotate(Object* obj, int delta, int animationSequenceIndex);
 static int _anim_hide(Object* object, int animationSequenceIndex);
-static int _anim_change_fid(Object* obj, int animationSequenceIndex, int fid);
+static int animationChangeFrmId(Object* obj, int animationSequenceIndex, const FrmId& frmId);
 static int _check_gravity(int tile, int elevation);
-static unsigned int animationComputeTicksPerFrame(Object* object, int fid);
+static unsigned int animationComputeTicksPerFrame(Object* object, const FrmId& frmId);
 
 static void reportOverloaded(Object* critter);
 
@@ -564,11 +564,11 @@ int reg_anim_end()
 // NOTE: Inlined.
 //
 // 0x413D6C
-static int _anim_preload(Object* object, int fid, CacheEntry** cacheEntryPtr)
+static int _anim_preload(Object* object, const FrmId& frmId, CacheEntry** cacheEntryPtr)
 {
     *cacheEntryPtr = nullptr;
 
-    if (artLock(fid, cacheEntryPtr) != nullptr) {
+    if (artLock(frmId, cacheEntryPtr) != nullptr) {
         artUnlock(*cacheEntryPtr);
         *cacheEntryPtr = nullptr;
         return 0;
@@ -692,10 +692,10 @@ int animationRegisterMoveToObject(Object* owner, Object* destination, int action
     animationDescription->actionPoints = actionPoints;
     animationDescription->delay = delay;
 
-    FrmId fid = FrmId(owner, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
+    const FrmId frmId = FrmId(owner, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
 
     // NOTE: Uninline.
-    if (_anim_preload(owner, fid.fid(), &(animationDescription->artCacheKey)) == -1) {
+    if (_anim_preload(owner, frmId, &(animationDescription->artCacheKey)) == -1) {
         _anim_cleanup();
         return -1;
     }
@@ -741,10 +741,10 @@ int animationRegisterRunToObject(Object* owner, Object* destination, int actionP
     animationDescription->actionPoints = actionPoints;
     animationDescription->delay = delay;
 
-    FrmId fid = FrmId(owner, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
+    const FrmId frmId = FrmId(owner, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
 
     // NOTE: Uninline.
-    if (_anim_preload(owner, fid.fid(), &(animationDescription->artCacheKey)) == -1) {
+    if (_anim_preload(owner, frmId, &(animationDescription->artCacheKey)) == -1) {
         _anim_cleanup();
         return -1;
     }
@@ -774,10 +774,10 @@ int animationRegisterMoveToTile(Object* owner, int tile, int elevation, int acti
     animationDescription->actionPoints = actionPoints;
     animationDescription->delay = delay;
 
-    FrmId fid = FrmId(owner, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
+    const FrmId frmId = FrmId(owner, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
 
     // NOTE: Uninline.
-    if (_anim_preload(owner, fid.fid(), &(animationDescription->artCacheKey)) == -1) {
+    if (_anim_preload(owner, frmId, &(animationDescription->artCacheKey)) == -1) {
         _anim_cleanup();
         return -1;
     }
@@ -824,10 +824,10 @@ int animationRegisterRunToTile(Object* owner, int tile, int elevation, int actio
     animationDescription->actionPoints = actionPoints;
     animationDescription->delay = delay;
 
-    FrmId fid = FrmId(owner, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
+    const FrmId frmId = FrmId(owner, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
 
     // NOTE: Uninline.
-    if (_anim_preload(owner, fid.fid(), &(animationDescription->artCacheKey)) == -1) {
+    if (_anim_preload(owner, frmId, &(animationDescription->artCacheKey)) == -1) {
         _anim_cleanup();
         return -1;
     }
@@ -859,10 +859,10 @@ int animationRegisterMoveToTileStraight(Object* object, int tile, int elevation,
     animationDescription->anim = anim;
     animationDescription->delay = delay;
 
-    FrmId fid = FrmId(object, animationDescription->anim, weaponAnimationFromFid(object->fid), object->rotation + 1);
+    const FrmId frmId = FrmId(object, animationDescription->anim, weaponAnimationFromFid(object->fid), object->rotation + 1);
 
     // NOTE: Uninline.
-    if (_anim_preload(object, fid.fid(), &(animationDescription->artCacheKey)) == -1) {
+    if (_anim_preload(object, frmId, &(animationDescription->artCacheKey)) == -1) {
         _anim_cleanup();
         return -1;
     }
@@ -893,10 +893,10 @@ int animationRegisterMoveToTileStraightAndWaitForComplete(Object* owner, int til
     animationDescription->anim = anim;
     animationDescription->delay = delay;
 
-    FrmId fid = FrmId(owner, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
+    const FrmId frmId = FrmId(owner, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
 
     // NOTE: Uninline.
-    if (_anim_preload(owner, fid.fid(), &(animationDescription->artCacheKey)) == -1) {
+    if (_anim_preload(owner, frmId, &(animationDescription->artCacheKey)) == -1) {
         _anim_cleanup();
         return -1;
     }
@@ -921,10 +921,10 @@ int animationRegisterAnimate(Object* owner, AnimationType anim, int delay)
     animationDescription->anim = anim;
     animationDescription->delay = delay;
 
-    FrmId fid = FrmId(owner, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
+    const FrmId frmId = FrmId(owner, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
 
     // NOTE: Uninline.
-    if (_anim_preload(owner, fid.fid(), &(animationDescription->artCacheKey)) == -1) {
+    if (_anim_preload(owner, frmId, &(animationDescription->artCacheKey)) == -1) {
         _anim_cleanup();
         return -1;
     }
@@ -950,10 +950,10 @@ int animationRegisterAnimateReversed(Object* owner, AnimationType anim, int dela
     animationDescription->delay = delay;
     animationDescription->artCacheKey = nullptr;
 
-    FrmId fid = FrmId(owner, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
+    const FrmId frmId = FrmId(owner, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
 
     // NOTE: Uninline.
-    if (_anim_preload(owner, fid.fid(), &(animationDescription->artCacheKey)) == -1) {
+    if (_anim_preload(owner, frmId, &(animationDescription->artCacheKey)) == -1) {
         _anim_cleanup();
         return -1;
     }
@@ -979,10 +979,10 @@ int animationRegisterAnimateAndHide(Object* owner, AnimationType anim, int delay
     animationDescription->delay = delay;
     animationDescription->artCacheKey = nullptr;
 
-    FrmId fid = FrmId(owner, anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
+    const FrmId frmId = FrmId(owner, anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
 
     // NOTE: Uninline.
-    if (_anim_preload(owner, fid.fid(), &(animationDescription->artCacheKey)) == -1) {
+    if (_anim_preload(owner, frmId, &(animationDescription->artCacheKey)) == -1) {
         _anim_cleanup();
         return -1;
     }
@@ -1221,7 +1221,7 @@ int animationRegisterUnsetFlag(Object* object, ObjectFlags flag, int delay)
 }
 
 // 0x41518C
-int animationRegisterSetFid(Object* owner, int fid, int delay)
+int animationRegisterSetFrmId(Object* owner, const FrmId& frmId, int delay)
 {
     if (_check_registry(owner) == -1) {
         _anim_cleanup();
@@ -1232,11 +1232,11 @@ int animationRegisterSetFid(Object* owner, int fid, int delay)
     AnimationDescription* animationDescription = &(animationSequence->animations[gAnimationDescriptionCurrentIndex]);
     animationDescription->kind = ANIM_KIND_SET_FID;
     animationDescription->owner = owner;
-    animationDescription->fid = fid;
+    animationDescription->fid = frmId.fid();
     animationDescription->delay = delay;
 
     // NOTE: Uninline.
-    if (_anim_preload(owner, fid, &(animationDescription->artCacheKey)) == -1) {
+    if (_anim_preload(owner, frmId, &(animationDescription->artCacheKey)) == -1) {
         _anim_cleanup();
         return -1;
     }
@@ -1267,10 +1267,10 @@ int animationRegisterTakeOutWeapon(Object* owner, WeaponAnimation weaponAnimatio
     animationDescription->owner = owner;
     animationDescription->weaponAnimationCode = weaponAnimationCode;
 
-    FrmId fid = FrmId(owner, ANIM_TAKE_OUT, weaponAnimationCode, owner->rotation + 1);
+    const FrmId frmId = FrmId(owner, ANIM_TAKE_OUT, weaponAnimationCode, owner->rotation + 1);
 
     // NOTE: Uninline.
-    if (_anim_preload(owner, fid.fid(), &(animationDescription->artCacheKey)) == -1) {
+    if (_anim_preload(owner, frmId, &(animationDescription->artCacheKey)) == -1) {
         _anim_cleanup();
         return -1;
     }
@@ -1371,10 +1371,10 @@ int animationRegisterAnimateForever(Object* owner, AnimationType anim, int delay
     animationDescription->anim = anim;
     animationDescription->delay = delay;
 
-    FrmId fid = FrmId(owner, anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
+    const FrmId frmId = FrmId(owner, anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
 
     // NOTE: Uninline.
-    if (_anim_preload(owner, fid.fid(), &(animationDescription->artCacheKey)) == -1) {
+    if (_anim_preload(owner, frmId, &(animationDescription->artCacheKey)) == -1) {
         _anim_cleanup();
         return -1;
     }
@@ -1477,7 +1477,7 @@ static int animationRunSequence(int animationSequenceIndex)
         case ANIM_KIND_ROTATE_TO_TILE:
             if (!critterIsProne(animationDescription->owner)) {
                 Rotation rotation = tileGetRotationTo(animationDescription->owner->tile, animationDescription->tile);
-                _dude_stand(animationDescription->owner, rotation, -1);
+                _dude_stand(animationDescription->owner, rotation, FrmId::Empty());
             }
             _anim_set_continue(animationSequenceIndex, 0);
             rc = 0;
@@ -1541,7 +1541,7 @@ static int animationRunSequence(int animationSequenceIndex)
             rc = _anim_set_continue(animationSequenceIndex, 0);
             break;
         case ANIM_KIND_SET_FID:
-            rc = _anim_change_fid(animationDescription->owner, animationSequenceIndex, animationDescription->fid);
+            rc = animationChangeFrmId(animationDescription->owner, animationSequenceIndex, FrmId(animationDescription->fid));
             break;
         case ANIM_KIND_TAKE_OUT_WEAPON:
             rc = _anim_animate(animationDescription->owner, ANIM_TAKE_OUT, animationSequenceIndex, animationDescription->tile);
@@ -1713,7 +1713,7 @@ static int _anim_set_end(int animationSequenceIndex)
                             }
 
                             if ((animationSequence->flags & ANIM_SEQ_NO_STAND) == 0 && !critterIsProne(owner)) {
-                                _dude_stand(owner, owner->rotation, -1);
+                                _dude_stand(owner, owner->rotation, FrmId::Empty());
                             }
                         }
                     }
@@ -2503,7 +2503,7 @@ static int _anim_move(Object* obj, int tile, int elev, int a3, AnimationType ani
     sad->step = SAD_INIT;
     sad->fid = FrmId(obj, anim, weaponAnimationFromFid(obj->fid), obj->rotation + 1).fid();
     sad->animationTimestamp = 0;
-    sad->ticksPerFrame = animationComputeTicksPerFrame(obj, sad->fid);
+    sad->ticksPerFrame = animationComputeTicksPerFrame(obj, FrmId(sad->fid));
     sad->targetTile = tile;
     sad->animationSequenceIndex = animationSequenceIndex;
     sad->anim = anim;
@@ -2541,7 +2541,7 @@ static int animateMoveObjectToTileStraight(Object* obj, int tile, int elevation,
     }
     sad->step = SAD_INIT;
     sad->animationTimestamp = 0;
-    sad->ticksPerFrame = animationComputeTicksPerFrame(obj, sad->fid);
+    sad->ticksPerFrame = animationComputeTicksPerFrame(obj, FrmId(sad->fid));
     sad->animationSequenceIndex = animationSequenceIndex;
 
     int v15;
@@ -2583,7 +2583,7 @@ static int _anim_move_on_stairs(Object* obj, int tile, int elevation, AnimationT
     }
     sad->step = SAD_INIT;
     sad->animationTimestamp = 0;
-    sad->ticksPerFrame = animationComputeTicksPerFrame(obj, sad->fid);
+    sad->ticksPerFrame = animationComputeTicksPerFrame(obj, FrmId(sad->fid));
     sad->animationSequenceIndex = animationSequenceIndex;
     sad->length = _make_stair_path(obj, obj->tile, obj->elevation, tile, elevation, sad->straightPathNodeList, nullptr);
     if (sad->length == 0) {
@@ -2618,7 +2618,7 @@ static int _check_for_falling(Object* obj, AnimationType anim, int a3)
     }
     sad->step = SAD_INIT;
     sad->animationTimestamp = 0;
-    sad->ticksPerFrame = animationComputeTicksPerFrame(obj, sad->fid);
+    sad->ticksPerFrame = animationComputeTicksPerFrame(obj, FrmId(sad->fid));
     sad->animationSequenceIndex = a3;
     sad->length = _make_straight_path_func(obj, obj->tile, obj->tile, sad->straightPathNodeList, nullptr, 16, _obj_blocking_at);
     if (sad->length == 0) {
@@ -2838,7 +2838,7 @@ static int _anim_animate(Object* obj, AnimationType anim, int animationSequenceI
     sad->fid = frmId.fid();
     sad->animationSequenceIndex = animationSequenceIndex;
     sad->animationTimestamp = 0;
-    sad->ticksPerFrame = animationComputeTicksPerFrame(obj, sad->fid);
+    sad->ticksPerFrame = animationComputeTicksPerFrame(obj, FrmId(sad->fid));
     sad->step = 0;
     sad->length = 0;
 
@@ -3225,7 +3225,7 @@ void _dude_fidget()
 }
 
 // 0x418378
-void _dude_stand(Object* obj, Rotation rotation, int fid)
+void _dude_stand(Object* obj, Rotation rotation, const FrmId& frmId)
 {
     Rect rect;
 
@@ -3236,10 +3236,10 @@ void _dude_stand(Object* obj, Rotation rotation, int fid)
 
     WeaponAnimation weaponAnimationCode = weaponAnimationFromFid(obj->fid);
     if (weaponAnimationCode != WEAPON_ANIMATION_NONE) {
-        if (fid == -1) {
-            FrmId takeOutFid = FrmId(obj, ANIM_TAKE_OUT, weaponAnimationCode, obj->rotation + 1);
+        if (!frmId.valid()) {
+            FrmId takeOutFrmId = FrmId(obj, ANIM_TAKE_OUT, weaponAnimationCode, obj->rotation + 1);
             CacheEntry* takeOutFrmHandle;
-            Art* takeOutFrm = artLock(takeOutFid, &takeOutFrmHandle);
+            Art* takeOutFrm = artLock(takeOutFrmId, &takeOutFrmHandle);
             if (takeOutFrm != nullptr) {
                 int frameCount = artGetFrameCount(takeOutFrm);
                 for (int frame = 0; frame < frameCount; frame++) {
@@ -3267,14 +3267,15 @@ void _dude_stand(Object* obj, Rotation rotation, int fid)
         }
     }
 
-    if (fid == -1) {
+    FrmId finalFrmId = frmId;
+    if (!finalFrmId.valid()) {
         AnimationType anim;
         if (animationTypeFromFid(obj->fid) == ANIM_FIRE_DANCE) {
             anim = ANIM_FIRE_DANCE;
         } else {
             anim = ANIM_STAND;
         }
-        fid = FrmId(obj, anim, weaponAnimationFromFid(obj->fid), obj->rotation + 1).fid();
+        finalFrmId = FrmId(obj, anim, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
     }
 
     Rect temp;
@@ -3321,7 +3322,7 @@ static int actionRotate(Object* obj, int delta, int animationSequenceIndex)
             rotation = ROTATION_NW;
         }
 
-        _dude_stand(obj, rotation, -1);
+        _dude_stand(obj, rotation, FrmId::Empty());
     }
 
     _anim_set_continue(animationSequenceIndex, 0);
@@ -3348,18 +3349,18 @@ static int _anim_hide(Object* object, int animationSequenceIndex)
 }
 
 // 0x418660
-static int _anim_change_fid(Object* obj, int animationSequenceIndex, int fid)
+static int animationChangeFrmId(Object* obj, int animationSequenceIndex, const FrmId& frmId)
 {
-    if (animationTypeFromFid(fid)) {
+    if (animationTypeFromFid(frmId.fid())) {
         Rect dirtyRect;
         Rect tempRect;
 
-        objectSetFid(obj, fid, &dirtyRect);
+        objectSetFid(obj, frmId.fid(), &dirtyRect);
         objectSetFrame(obj, 0, &tempRect);
         rectUnion(&dirtyRect, &tempRect, &dirtyRect);
         tileWindowRefreshRect(&dirtyRect, obj->elevation);
     } else {
-        _dude_stand(obj, obj->rotation, fid);
+        _dude_stand(obj, obj->rotation, frmId);
     }
 
     _anim_set_continue(animationSequenceIndex, 0);
@@ -3399,12 +3400,12 @@ static int _check_gravity(int tile, int elevation)
 }
 
 // 0x418794
-static unsigned int animationComputeTicksPerFrame(Object* object, int fid)
+static unsigned int animationComputeTicksPerFrame(Object* object, const FrmId& frmId)
 {
     int fps;
 
     CacheEntry* handle;
-    Art* frm = artLock(fid, &handle);
+    Art* frm = artLock(frmId, &handle);
     if (frm != nullptr) {
         fps = artGetFramesPerSecond(frm);
         artUnlock(handle);
@@ -3413,7 +3414,7 @@ static unsigned int animationComputeTicksPerFrame(Object* object, int fid)
     }
 
     if (isInCombat()) {
-        if (animationTypeFromFid(fid) == ANIM_WALK) {
+        if (animationTypeFromFid(frmId.fid()) == ANIM_WALK) {
             if (object != gDude || settings.preferences.player_speedup) {
                 fps += settings.preferences.combat_speed;
             }

--- a/src/animation.cc
+++ b/src/animation.cc
@@ -3279,7 +3279,7 @@ void _dude_stand(Object* obj, Rotation rotation, const FrmId& frmId)
     }
 
     Rect temp;
-    objectSetFid(obj, fid, &temp);
+    objectSetFid(obj, finalFrmId.fid(), &temp);
     rectUnion(&rect, &temp, &rect);
 
     objectSetLocation(obj, obj->tile, obj->elevation, &temp);

--- a/src/animation.cc
+++ b/src/animation.cc
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "animation_defs.h"
 #include "art.h"
 #include "color.h"
 #include "combat.h"

--- a/src/animation.h
+++ b/src/animation.h
@@ -2,6 +2,7 @@
 #define ANIMATION_H
 
 #include "animation_defs.h"
+#include "art.h"
 #include "art_defs.h"
 #include "combat_defs.h"
 #include "obj_types.h"
@@ -53,7 +54,7 @@ int animationRegisterCallback3(void* a1, void* a2, void* a3, AnimationCallback3*
 int animationRegisterCallbackForced(void* a1, void* a2, AnimationCallback* proc, int delay);
 int animationRegisterSetFlag(Object* object, ObjectFlags flag, int delay);
 int animationRegisterUnsetFlag(Object* object, ObjectFlags flag, int delay);
-int animationRegisterSetFid(Object* owner, int fid, int delay);
+int animationRegisterSetFrmId(Object* owner, const FrmId& frmId, int delay);
 int animationRegisterTakeOutWeapon(Object* owner, WeaponAnimation weaponAnimationCode, int delay);
 int animationRegisterSetLightDistance(Object* owner, int lightDistance, int delay);
 int animationRegisterToggleOutline(Object* object, bool outline, int delay);
@@ -69,7 +70,7 @@ int _check_move(int* actionPointsPtr);
 int _dude_move(int actionPoints);
 int _dude_run(int actionPoints);
 void _dude_fidget();
-void _dude_stand(Object* obj, Rotation rotation, int fid);
+void _dude_stand(Object* obj, Rotation rotation, const FrmId& frmId);
 void _dude_standup(Object* a1);
 void animationStop();
 

--- a/src/animation.h
+++ b/src/animation.h
@@ -1,121 +1,12 @@
 #ifndef ANIMATION_H
 #define ANIMATION_H
 
+#include "animation_defs.h"
 #include "art_defs.h"
 #include "combat_defs.h"
 #include "obj_types.h"
 
 namespace fallout {
-
-enum AnimationRequestOptions : int {
-    ANIMATION_REQUEST_NONE = 0x00,
-    ANIMATION_REQUEST_UNRESERVED = 0x01,
-    ANIMATION_REQUEST_RESERVED = 0x02,
-    ANIMATION_REQUEST_NO_STAND = 0x04,
-    ANIMATION_REQUEST_PING = 0x100,
-    ANIMATION_REQUEST_INSIGNIFICANT = 0x200,
-};
-
-constexpr inline AnimationRequestOptions operator|(AnimationRequestOptions lhs, AnimationRequestOptions rhs)
-{
-    return static_cast<AnimationRequestOptions>(static_cast<int>(lhs) | static_cast<int>(rhs));
-}
-
-inline AnimationRequestOptions& operator|=(AnimationRequestOptions& lhs, AnimationRequestOptions rhs)
-{
-    return lhs = lhs | rhs;
-}
-
-// Basic animations: 0-19
-// Knockdown and death: 20-35
-// Change positions: 36-37
-// Weapon: 38-47
-// Single-frame death animations (the last frame of knockdown and death animations): 48-63
-enum AnimationType : int {
-    ANIM_INVALID = -1,
-    ANIM_STAND = 0,
-    ANIM_WALK = 1,
-    ANIM_JUMP_BEGIN = 2,
-    ANIM_JUMP_END = 3,
-    ANIM_CLIMB_LADDER = 4,
-    ANIM_FALLING = 5,
-    ANIM_UP_STAIRS_RIGHT = 6,
-    ANIM_UP_STAIRS_LEFT = 7,
-    ANIM_DOWN_STAIRS_RIGHT = 8,
-    ANIM_DOWN_STAIRS_LEFT = 9,
-    ANIM_MAGIC_HANDS_GROUND = 10,
-    ANIM_MAGIC_HANDS_MIDDLE = 11,
-    ANIM_MAGIC_HANDS_UP = 12,
-    ANIM_DODGE_ANIM = 13,
-    ANIM_HIT_FROM_FRONT = 14,
-    ANIM_HIT_FROM_BACK = 15,
-    ANIM_THROW_PUNCH = 16,
-    ANIM_KICK_LEG = 17,
-    ANIM_THROW_ANIM = 18,
-    ANIM_RUNNING = 19,
-    ANIM_FALL_BACK = 20,
-    ANIM_FALL_FRONT = 21,
-    ANIM_BAD_LANDING = 22,
-    ANIM_BIG_HOLE = 23,
-    ANIM_CHARRED_BODY = 24,
-    ANIM_CHUNKS_OF_FLESH = 25,
-    ANIM_DANCING_AUTOFIRE = 26,
-    ANIM_ELECTRIFY = 27,
-    ANIM_SLICED_IN_HALF = 28,
-    ANIM_BURNED_TO_NOTHING = 29,
-    ANIM_ELECTRIFIED_TO_NOTHING = 30,
-    ANIM_EXPLODED_TO_NOTHING = 31,
-    ANIM_MELTED_TO_NOTHING = 32,
-    ANIM_FIRE_DANCE = 33,
-    ANIM_FALL_BACK_BLOOD = 34,
-    ANIM_FALL_FRONT_BLOOD = 35,
-    ANIM_PRONE_TO_STANDING = 36,
-    ANIM_BACK_TO_STANDING = 37,
-    ANIM_TAKE_OUT = 38,
-    ANIM_PUT_AWAY = 39,
-    ANIM_PARRY_ANIM = 40,
-    ANIM_THRUST_ANIM = 41,
-    ANIM_SWING_ANIM = 42,
-    ANIM_POINT = 43,
-    ANIM_UNPOINT = 44,
-    ANIM_FIRE_SINGLE = 45,
-    ANIM_FIRE_BURST = 46,
-    ANIM_FIRE_CONTINUOUS = 47,
-    ANIM_FALL_BACK_SF = 48,
-    ANIM_FALL_FRONT_SF = 49,
-    ANIM_BAD_LANDING_SF = 50,
-    ANIM_BIG_HOLE_SF = 51,
-    ANIM_CHARRED_BODY_SF = 52,
-    ANIM_CHUNKS_OF_FLESH_SF = 53,
-    ANIM_DANCING_AUTOFIRE_SF = 54,
-    ANIM_ELECTRIFY_SF = 55,
-    ANIM_SLICED_IN_HALF_SF = 56,
-    ANIM_BURNED_TO_NOTHING_SF = 57,
-    ANIM_ELECTRIFIED_TO_NOTHING_SF = 58,
-    ANIM_EXPLODED_TO_NOTHING_SF = 59,
-    ANIM_MELTED_TO_NOTHING_SF = 60,
-    ANIM_FIRE_DANCE_SF = 61,
-    ANIM_FALL_BACK_BLOOD_SF = 62,
-    ANIM_FALL_FRONT_BLOOD_SF = 63,
-    ANIM_CALLED_SHOT_PIC = 64,
-    ANIM_COUNT = 65,
-    ANIM_FIRST = ANIM_STAND,
-    FIRST_KNOCKDOWN_AND_DEATH_ANIM = ANIM_FALL_BACK,
-    LAST_KNOCKDOWN_AND_DEATH_ANIM = ANIM_FALL_FRONT_BLOOD,
-    FIRST_SF_DEATH_ANIM = ANIM_FALL_BACK_SF,
-    LAST_SF_DEATH_ANIM = ANIM_FALL_FRONT_BLOOD_SF,
-};
-
-inline bool animationTypeIsValid(int anim)
-{
-    return anim >= ANIM_FIRST && anim < ANIM_COUNT;
-}
-
-inline AnimationType animationTypeFromFid(int fid)
-{
-    int anim = (fid & 0xFF0000) >> 16;
-    return static_cast<AnimationType>(anim);
-}
 
 // Signature of animation callback accepting 2 parameters.
 typedef int(AnimationCallback)(void* a1, void* a2);

--- a/src/animation_defs.h
+++ b/src/animation_defs.h
@@ -1,0 +1,118 @@
+#ifndef ANIMATION_DEFS_H
+#define ANIMATION_DEFS_H
+
+namespace fallout {
+
+enum AnimationRequestOptions : int {
+    ANIMATION_REQUEST_NONE = 0x00,
+    ANIMATION_REQUEST_UNRESERVED = 0x01,
+    ANIMATION_REQUEST_RESERVED = 0x02,
+    ANIMATION_REQUEST_NO_STAND = 0x04,
+    ANIMATION_REQUEST_PING = 0x100,
+    ANIMATION_REQUEST_INSIGNIFICANT = 0x200,
+};
+
+constexpr inline AnimationRequestOptions operator|(AnimationRequestOptions lhs, AnimationRequestOptions rhs)
+{
+    return static_cast<AnimationRequestOptions>(static_cast<int>(lhs) | static_cast<int>(rhs));
+}
+
+inline AnimationRequestOptions& operator|=(AnimationRequestOptions& lhs, AnimationRequestOptions rhs)
+{
+    return lhs = lhs | rhs;
+}
+
+// Basic animations: 0-19
+// Knockdown and death: 20-35
+// Change positions: 36-37
+// Weapon: 38-47
+// Single-frame death animations (the last frame of knockdown and death animations): 48-63
+enum AnimationType : int {
+    ANIM_INVALID = -1,
+    ANIM_STAND = 0,
+    ANIM_WALK = 1,
+    ANIM_JUMP_BEGIN = 2,
+    ANIM_JUMP_END = 3,
+    ANIM_CLIMB_LADDER = 4,
+    ANIM_FALLING = 5,
+    ANIM_UP_STAIRS_RIGHT = 6,
+    ANIM_UP_STAIRS_LEFT = 7,
+    ANIM_DOWN_STAIRS_RIGHT = 8,
+    ANIM_DOWN_STAIRS_LEFT = 9,
+    ANIM_MAGIC_HANDS_GROUND = 10,
+    ANIM_MAGIC_HANDS_MIDDLE = 11,
+    ANIM_MAGIC_HANDS_UP = 12,
+    ANIM_DODGE_ANIM = 13,
+    ANIM_HIT_FROM_FRONT = 14,
+    ANIM_HIT_FROM_BACK = 15,
+    ANIM_THROW_PUNCH = 16,
+    ANIM_KICK_LEG = 17,
+    ANIM_THROW_ANIM = 18,
+    ANIM_RUNNING = 19,
+    ANIM_FALL_BACK = 20,
+    ANIM_FALL_FRONT = 21,
+    ANIM_BAD_LANDING = 22,
+    ANIM_BIG_HOLE = 23,
+    ANIM_CHARRED_BODY = 24,
+    ANIM_CHUNKS_OF_FLESH = 25,
+    ANIM_DANCING_AUTOFIRE = 26,
+    ANIM_ELECTRIFY = 27,
+    ANIM_SLICED_IN_HALF = 28,
+    ANIM_BURNED_TO_NOTHING = 29,
+    ANIM_ELECTRIFIED_TO_NOTHING = 30,
+    ANIM_EXPLODED_TO_NOTHING = 31,
+    ANIM_MELTED_TO_NOTHING = 32,
+    ANIM_FIRE_DANCE = 33,
+    ANIM_FALL_BACK_BLOOD = 34,
+    ANIM_FALL_FRONT_BLOOD = 35,
+    ANIM_PRONE_TO_STANDING = 36,
+    ANIM_BACK_TO_STANDING = 37,
+    ANIM_TAKE_OUT = 38,
+    ANIM_PUT_AWAY = 39,
+    ANIM_PARRY_ANIM = 40,
+    ANIM_THRUST_ANIM = 41,
+    ANIM_SWING_ANIM = 42,
+    ANIM_POINT = 43,
+    ANIM_UNPOINT = 44,
+    ANIM_FIRE_SINGLE = 45,
+    ANIM_FIRE_BURST = 46,
+    ANIM_FIRE_CONTINUOUS = 47,
+    ANIM_FALL_BACK_SF = 48,
+    ANIM_FALL_FRONT_SF = 49,
+    ANIM_BAD_LANDING_SF = 50,
+    ANIM_BIG_HOLE_SF = 51,
+    ANIM_CHARRED_BODY_SF = 52,
+    ANIM_CHUNKS_OF_FLESH_SF = 53,
+    ANIM_DANCING_AUTOFIRE_SF = 54,
+    ANIM_ELECTRIFY_SF = 55,
+    ANIM_SLICED_IN_HALF_SF = 56,
+    ANIM_BURNED_TO_NOTHING_SF = 57,
+    ANIM_ELECTRIFIED_TO_NOTHING_SF = 58,
+    ANIM_EXPLODED_TO_NOTHING_SF = 59,
+    ANIM_MELTED_TO_NOTHING_SF = 60,
+    ANIM_FIRE_DANCE_SF = 61,
+    ANIM_FALL_BACK_BLOOD_SF = 62,
+    ANIM_FALL_FRONT_BLOOD_SF = 63,
+    ANIM_CALLED_SHOT_PIC = 64,
+    ANIM_COUNT = 65,
+    ANIM_FIRST = ANIM_STAND,
+    FIRST_KNOCKDOWN_AND_DEATH_ANIM = ANIM_FALL_BACK,
+    LAST_KNOCKDOWN_AND_DEATH_ANIM = ANIM_FALL_FRONT_BLOOD,
+    FIRST_SF_DEATH_ANIM = ANIM_FALL_BACK_SF,
+    LAST_SF_DEATH_ANIM = ANIM_FALL_FRONT_BLOOD_SF,
+};
+
+inline bool animationTypeIsValid(int anim)
+{
+    return anim >= ANIM_FIRST && anim < ANIM_COUNT;
+}
+
+inline AnimationType animationTypeFromFid(int fid)
+{
+    int anim = (fid & 0xFF0000) >> 16;
+    return static_cast<AnimationType>(anim);
+}
+
+} // namespace fallout
+
+#endif /* ANIMATION_DEFS_H */

--- a/src/art.cc
+++ b/src/art.cc
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "animation.h"
+#include "animation_defs.h"
 #include "art_defs.h"
 #include "content_config.h"
 #include "datafile.h"

--- a/src/art.cc
+++ b/src/art.cc
@@ -521,7 +521,7 @@ int artListIndex(ObjectType objectType, const char* name)
 // 0x419160
 Art* artLock(int fid, CacheEntry** handlePtr)
 {
-    if (handlePtr == nullptr) {
+    if (handlePtr == nullptr || fid == FrmId::kEmptyFid) {
         return nullptr;
     }
 

--- a/src/art.cc
+++ b/src/art.cc
@@ -521,7 +521,12 @@ int artListIndex(ObjectType objectType, const char* name)
 // 0x419160
 Art* artLock(int fid, CacheEntry** handlePtr)
 {
-    if (handlePtr == nullptr || fid == FrmId::kEmptyFid) {
+    if (handlePtr == nullptr) {
+        return nullptr;
+    }
+
+    if (fid == FrmId::kEmptyFid) {
+        *handlePtr = nullptr;
         return nullptr;
     }
 

--- a/src/art.h
+++ b/src/art.h
@@ -425,8 +425,15 @@ void artRender(int fid, unsigned char* dest, int width, int height, int pitch);
 int art_list_str(int fid, char* name);
 Art* artLock(int fid, CacheEntry** cache_entry);
 
+// works for fid based FrmIds only, to be replaced by FrmImage::lock
 inline Art* artLock(const FrmId& frmId, CacheEntry** cache_entry)
 {
+    if (!frmId.valid()) {
+        return nullptr;
+    }
+
+    assert(frmId.fid() != FrmId::kEmptyFid && "artLock(const FrmId& frmId, CacheEntry** cache_entry) called with path based FrmId which is not supported!");
+
     return artLock(frmId.fid(), cache_entry);
 }
 

--- a/src/art.h
+++ b/src/art.h
@@ -6,7 +6,7 @@
 #include <memory>
 #include <type_traits>
 
-#include "animation.h"
+#include "animation_defs.h"
 #include "art_defs.h"
 #include "cache.h"
 #include "draw.h"

--- a/src/art.h
+++ b/src/art.h
@@ -426,15 +426,18 @@ int art_list_str(int fid, char* name);
 Art* artLock(int fid, CacheEntry** cache_entry);
 
 // works for fid based FrmIds only, to be replaced by FrmImage::lock
-inline Art* artLock(const FrmId& frmId, CacheEntry** cache_entry)
+inline Art* artLock(const FrmId& frmId, CacheEntry** handlePtr)
 {
     if (!frmId.valid()) {
+        if (handlePtr != nullptr) {
+            *handlePtr = nullptr;
+        }
         return nullptr;
     }
 
-    assert(frmId.fid() != FrmId::kEmptyFid && "artLock(const FrmId& frmId, CacheEntry** cache_entry) called with path based FrmId which is not supported!");
+    assert(frmId.fid() != FrmId::kEmptyFid && "artLock(const FrmId& frmId, CacheEntry** handlePtr) called with path based FrmId which is not supported!");
 
-    return artLock(frmId.fid(), cache_entry);
+    return artLock(frmId.fid(), handlePtr);
 }
 
 unsigned char* artLockFrameData(int fid, int frame, Rotation rotation, CacheEntry** out_cache_entry);

--- a/src/combat.cc
+++ b/src/combat.cc
@@ -5,8 +5,8 @@
 #include <string.h>
 
 #include "actions.h"
-#include "animation_defs.h"
 #include "animation.h"
+#include "animation_defs.h"
 #include "art.h"
 #include "color.h"
 #include "combat_ai.h"

--- a/src/combat.cc
+++ b/src/combat.cc
@@ -3393,7 +3393,7 @@ static void queueGorisCombatBeginEndAnimation(Object* critter, CritterFrameId ba
     reg_anim_clear(critter);
     reg_anim_begin(ANIMATION_REQUEST_RESERVED);
     animationRegisterAnimate(critter, ANIM_UP_STAIRS_RIGHT, -1);
-    animationRegisterSetFid(critter, critterBuildGorisFrmId(critter, baseFrameId).fid(), -1);
+    animationRegisterSetFrmId(critter, critterBuildGorisFrmId(critter, baseFrameId), -1);
     reg_anim_end();
 }
 

--- a/src/combat.cc
+++ b/src/combat.cc
@@ -5,6 +5,7 @@
 #include <string.h>
 
 #include "actions.h"
+#include "animation_defs.h"
 #include "animation.h"
 #include "art.h"
 #include "color.h"

--- a/src/combat_ai.cc
+++ b/src/combat_ai.cc
@@ -7,6 +7,7 @@
 #include <unordered_set>
 
 #include "actions.h"
+#include "animation_defs.h"
 #include "animation.h"
 #include "art.h"
 #include "color.h"

--- a/src/combat_ai.cc
+++ b/src/combat_ai.cc
@@ -7,8 +7,8 @@
 #include <unordered_set>
 
 #include "actions.h"
-#include "animation_defs.h"
 #include "animation.h"
+#include "animation_defs.h"
 #include "art.h"
 #include "color.h"
 #include "combat.h"

--- a/src/credits.cc
+++ b/src/credits.cc
@@ -45,7 +45,7 @@ static int gCreditsWindowNameFont;
 static Color gCreditsWindowTitleColor;
 
 // 0x42C860 credits
-void creditsOpen(const char* filePath, int backgroundFid, bool useReversedStyle)
+void creditsOpen(const char* filePath, const InterfaceFrmId& backgroundFrmId, bool useReversedStyle)
 {
     int oldFont = fontGetCurrent();
 
@@ -91,7 +91,6 @@ void creditsOpen(const char* filePath, int backgroundFid, bool useReversedStyle)
                         soundContinueAll();
 
                         memset(backgroundBuffer, COLOR_BLACK, windowWidth * windowHeight);
-                        const FrmId backgroundFrmId = FrmId(backgroundFid);
                         if (backgroundFrmId.valid()) {
                             FrmImage backgroundFrmImage;
                             if (backgroundFrmImage.lock(backgroundFrmId)) {

--- a/src/credits.h
+++ b/src/credits.h
@@ -1,9 +1,11 @@
 #ifndef CREDITS_H
 #define CREDITS_H
 
+#include "art.h"
+
 namespace fallout {
 
-void creditsOpen(const char* path, int fid, bool useReversedStyle);
+void creditsOpen(const char* path, const InterfaceFrmId& backgroundFrmId, bool useReversedStyle);
 
 } // namespace fallout
 

--- a/src/critter.cc
+++ b/src/critter.cc
@@ -4,8 +4,8 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "animation_defs.h"
 #include "animation.h"
+#include "animation_defs.h"
 #include "art.h"
 #include "character_editor.h"
 #include "combat.h"

--- a/src/critter.cc
+++ b/src/critter.cc
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "animation_defs.h"
 #include "animation.h"
 #include "art.h"
 #include "character_editor.h"

--- a/src/critter.h
+++ b/src/critter.h
@@ -1,7 +1,7 @@
 #ifndef CRITTER_H
 #define CRITTER_H
 
-#include "animation.h"
+#include "animation_defs.h"
 #include "art.h"
 #include "art_defs.h"
 #include "combat_defs.h"

--- a/src/endgame.cc
+++ b/src/endgame.cc
@@ -70,7 +70,7 @@ typedef struct EndgameEnding {
 } EndgameEnding;
 
 static void endgameEndingRenderPanningScene(int direction, const char* narratorFileName);
-static void endgameEndingRenderStaticScene(int fid, const char* narratorFileName);
+static void endgameEndingRenderStaticScene(const InterfaceFrmId& frmId, const char* narratorFileName);
 static int endgameEndingHandleContinuePlaying();
 static int endgameEndingSlideshowWindowInit();
 static void endgameEndingSlideshowWindowFree();
@@ -78,7 +78,7 @@ static void endgameEndingRenderFrame(const unsigned char* data, int width, int h
 static void endgameEndingVoiceOverInit(const char* fname);
 static void endgameEndingVoiceOverReset();
 static void endgameEndingVoiceOverFree();
-static void endgameEndingLoadPalette(ObjectType type, int id);
+static void endgameEndingLoadPalette(const InterfaceFrmId& frmId);
 static void _endgame_voiceover_callback();
 static int endgameEndingSubtitlesLoad(const char* filePath);
 static void endgameEndingRefreshSubtitles();
@@ -229,7 +229,7 @@ void endgamePlaySlideshow()
                 endgameEndingRenderPanningScene(ending->direction, ending->voiceOverBaseName);
             } else {
                 const InterfaceFrmId frmId = ending->art_num;
-                endgameEndingRenderStaticScene(frmId.fid(), ending->voiceOverBaseName);
+                endgameEndingRenderStaticScene(frmId, ending->voiceOverBaseName);
             }
         }
     }
@@ -257,7 +257,7 @@ void endgamePlayMovie()
         creditsFilePath = configuredCreditsFilePath;
     }
     if (creditsFilePath[0] != '\0') {
-        creditsOpen(creditsFilePath, -1, false);
+        creditsOpen(creditsFilePath, InterfaceFrameId::Invalid, false);
     }
 
     backgroundSoundDelete();
@@ -349,18 +349,18 @@ static int endgameEndingHandleContinuePlaying()
 // 0x43FBDC endgame_pan_desert
 static void endgameEndingRenderPanningScene(int direction, const char* narratorFileName)
 {
-    CacheEntry* backgroundHandle;
-    Art* background = artLock(InterfaceFrameId::PanningDesertImage, &backgroundHandle);
-    if (background != nullptr) {
-        int width = artGetWidth(background);
-        int height = artGetHeight(background);
-        unsigned char* backgroundData = artGetFrameData(background);
+    FrmImage backgroundFrmImage;
+    constexpr InterfaceFrmId backgroundFrmId = InterfaceFrameId::PanningDesertImage;
+    if (backgroundFrmImage.lock(backgroundFrmId)) {
+        int width = backgroundFrmImage.getWidth();
+        int height = backgroundFrmImage.getHeight();
+        unsigned char* backgroundData = backgroundFrmImage.getData();
         if (width <= 0 || height <= 0 || backgroundData == nullptr) {
-            artUnlock(backgroundHandle);
+            backgroundFrmImage.unlock();
             return;
         }
 
-        endgameEndingLoadPalette(OBJ_TYPE_INTERFACE, static_cast<int>(InterfaceFrameId::PanningDesertImage));
+        endgameEndingLoadPalette(backgroundFrmId);
         bufferFill(gEndgameEndingSlideshowWindowBuffer, screenGetWidth(), screenGetHeight(), screenGetWidth(), COLOR_BLACK);
 
         // CE: Update overlay.
@@ -480,7 +480,7 @@ static void endgameEndingRenderPanningScene(int direction, const char* narratorF
         }
 
         tickersEnable();
-        artUnlock(backgroundHandle);
+        backgroundFrmImage.unlock();
 
         paletteFadeTo(gPaletteBlack);
         bufferFill(gEndgameEndingSlideshowWindowBuffer, screenGetWidth(), screenGetHeight(), screenGetWidth(), COLOR_BLACK);
@@ -498,19 +498,18 @@ static void endgameEndingRenderPanningScene(int direction, const char* narratorF
 }
 
 // 0x440004 endgame_display_image
-static void endgameEndingRenderStaticScene(int fid, const char* narratorFileName)
+static void endgameEndingRenderStaticScene(const InterfaceFrmId& frmId, const char* narratorFileName)
 {
-    CacheEntry* backgroundHandle;
-    Art* background = artLock(fid, &backgroundHandle);
-    if (background == nullptr) {
+    FrmImage backgroundFrmImage;
+    if (!backgroundFrmImage.lock(frmId)) {
         return;
     }
 
-    int width = artGetWidth(background);
-    int height = artGetHeight(background);
-    unsigned char* backgroundData = artGetFrameData(background);
+    int width = backgroundFrmImage.getWidth();
+    int height = backgroundFrmImage.getHeight();
+    unsigned char* backgroundData = backgroundFrmImage.getData();
     if (backgroundData != nullptr) {
-        endgameEndingLoadPalette(objectTypeFromFid(fid), frameIdFromFid(fid));
+        endgameEndingLoadPalette(frmId);
 
         // CE: Update overlay.
         endgameEndingUpdateOverlay();
@@ -590,7 +589,7 @@ static void endgameEndingRenderStaticScene(int fid, const char* narratorFileName
         }
     }
 
-    artUnlock(backgroundHandle);
+    backgroundFrmImage.unlock();
 }
 
 // 0x43F99C endgame_init
@@ -801,10 +800,10 @@ static void endgameEndingVoiceOverFree()
 }
 
 // 0x440378 endgame_load_palette
-static void endgameEndingLoadPalette(ObjectType type, int id)
+static void endgameEndingLoadPalette(const InterfaceFrmId& frmId)
 {
     char fileName[13];
-    if (artCopyFileName(type, id, fileName) != 0) {
+    if (artCopyFileName(frmId.objectType(), frmId.frameId().id, fileName) != 0) {
         return;
     }
 

--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -11,8 +11,8 @@
 #include <algorithm>
 
 #include "actions.h"
-#include "animation_defs.h"
 #include "animation.h"
+#include "animation_defs.h"
 #include "art.h"
 #include "color.h"
 #include "combat.h"

--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -11,6 +11,7 @@
 #include <algorithm>
 
 #include "actions.h"
+#include "animation_defs.h"
 #include "animation.h"
 #include "art.h"
 #include "color.h"

--- a/src/game_sound.cc
+++ b/src/game_sound.cc
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "animation.h"
+#include "animation_defs.h"
 #include "art.h"
 #include "art_defs.h"
 #include "audio.h"

--- a/src/game_sound.h
+++ b/src/game_sound.h
@@ -1,7 +1,7 @@
 #ifndef GAME_SOUND_H
 #define GAME_SOUND_H
 
-#include "animation.h"
+#include "animation_defs.h"
 #include "combat_defs.h"
 #include "obj_types.h"
 #include "sound.h"

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -1903,7 +1903,7 @@ static void interfaceBarSwapHandsAnimatePutAwayTakeOutSequence(WeaponAnimation p
         animationRegisterTakeOutWeapon(gDude, weaponAnimationCode, -1);
     } else {
         const FrmId frmId = FrmId(gDude, ANIM_STAND, WEAPON_ANIMATION_NONE, gDude->rotation + 1);
-        animationRegisterSetFid(gDude, frmId.fid(), -1);
+        animationRegisterSetFrmId(gDude, frmId, -1);
     }
 
     // TODO: Get rid of cast.

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -1,7 +1,7 @@
 #ifndef INTERPRETER_H
 #define INTERPRETER_H
 
-#include "animation.h"
+#include "animation_defs.h"
 #include "combat_defs.h"
 #include "game.h"
 #include "object.h"

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -3450,28 +3450,28 @@ static void opAnim(Program* program)
         if (frame == 0) { // ANIMATE_FORWARD
             animationRegisterAnimate(obj, anim, 0);
             if (anim >= ANIM_FALL_BACK && anim <= ANIM_FALL_FRONT_BLOOD) {
-                FrmId fid = FrmId(obj, static_cast<AnimationType>(anim + 28), weaponAnimationFromFid(obj->fid), rotationFromFid(obj->fid));
-                animationRegisterSetFid(obj, fid.fid(), -1);
+                const FrmId frmId = FrmId(obj, static_cast<AnimationType>(anim + 28), weaponAnimationFromFid(obj->fid), rotationFromFid(obj->fid));
+                animationRegisterSetFrmId(obj, frmId, -1);
             }
 
             if (combatData != nullptr) {
                 combatData->results &= ~DAM_KNOCKED_DOWN;
             }
         } else { // ANIMATE_REVERSE == 1
-            FrmId fid = FrmId(obj, anim, weaponAnimationFromFid(obj->fid), rotationFromFid(obj->fid));
+            FrmId frmId = FrmId(obj, anim, weaponAnimationFromFid(obj->fid), rotationFromFid(obj->fid));
             animationRegisterAnimateReversed(obj, anim, 0);
 
             if (anim == ANIM_PRONE_TO_STANDING) {
-                fid = FrmId(obj, ANIM_FALL_FRONT_SF, weaponAnimationFromFid(obj->fid), rotationFromFid(obj->fid));
+                frmId = FrmId(obj, ANIM_FALL_FRONT_SF, weaponAnimationFromFid(obj->fid), rotationFromFid(obj->fid));
             } else if (anim == ANIM_BACK_TO_STANDING) {
-                fid = FrmId(obj, ANIM_FALL_BACK_SF, weaponAnimationFromFid(obj->fid), rotationFromFid(obj->fid));
+                frmId = FrmId(obj, ANIM_FALL_BACK_SF, weaponAnimationFromFid(obj->fid), rotationFromFid(obj->fid));
             }
 
             if (combatData != nullptr) {
                 combatData->results |= DAM_KNOCKED_DOWN;
             }
 
-            animationRegisterSetFid(obj, fid.fid(), -1);
+            animationRegisterSetFrmId(obj, frmId, -1);
         }
 
         reg_anim_end();

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -3892,7 +3892,7 @@ int inventoryEquipFunc(Object* critter, Object* item, Hand handIndex, bool anima
         if (critter == gDude) {
             if (!isoIsDisabled()) {
                 const CritterFrmId frmId = CritterFrmId(baseFrameId, ANIM_STAND, weaponAnimationFromFid(critter->fid), critter->rotation + 1);
-                animationRegisterSetFid(critter, frmId.fid(), 0);
+                animationRegisterSetFrmId(critter, frmId, 0);
             }
         } else {
             adjustCritterStatsOnArmorChange(critter, armor, item);
@@ -3983,11 +3983,11 @@ int inventoryEquipFunc(Object* critter, Object* item, Hand handIndex, bool anima
                     animationRegisterTakeOutWeapon(critter, weaponAnimationCode, -1);
                 } else {
                     const FrmId frmId = FrmId(critter, ANIM_STAND, WEAPON_ANIMATION_NONE, critter->rotation + 1);
-                    animationRegisterSetFid(critter, frmId.fid(), -1);
+                    animationRegisterSetFrmId(critter, frmId, -1);
                 }
             } else {
                 const FrmId frmId = FrmId(critter, ANIM_STAND, weaponAnimationCode, critter->rotation + 1);
-                _dude_stand(critter, critter->rotation, frmId.fid());
+                _dude_stand(critter, critter->rotation, frmId);
             }
         }
     }
@@ -4048,13 +4048,13 @@ int inventoryUnequipFunc(Object* critter, Hand hand, bool animate)
             animationRegisterAnimate(critter, ANIM_PUT_AWAY, 0);
 
             const FrmId frmId = FrmId(critter, ANIM_STAND, WEAPON_ANIMATION_NONE, critter->rotation + 1);
-            animationRegisterSetFid(critter, frmId.fid(), -1);
+            animationRegisterSetFrmId(critter, frmId, -1);
 
             return reg_anim_end();
         }
 
         const FrmId frmId = FrmId(critter, ANIM_STAND, WEAPON_ANIMATION_NONE, critter->rotation + 1);
-        _dude_stand(critter, critter->rotation, frmId.fid());
+        _dude_stand(critter, critter->rotation, frmId);
     }
 
     return 0;

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -1,7 +1,7 @@
 #ifndef INVENTORY_H
 #define INVENTORY_H
 
-#include "animation.h"
+#include "animation_defs.h"
 #include "obj_types.h"
 #include "proto_types.h"
 

--- a/src/item.cc
+++ b/src/item.cc
@@ -6,7 +6,7 @@
 #include <unordered_set>
 #include <vector>
 
-#include "animation.h"
+#include "animation_defs.h"
 #include "art.h"
 #include "art_defs.h"
 #include "automap.h"

--- a/src/item.h
+++ b/src/item.h
@@ -1,7 +1,7 @@
 #ifndef ITEM_H
 #define ITEM_H
 
-#include "animation.h"
+#include "animation_defs.h"
 #include "art.h"
 #include "art_defs.h"
 #include "combat_defs.h"

--- a/src/main.cc
+++ b/src/main.cc
@@ -224,14 +224,14 @@ int falloutMain(int argc, char** argv)
                 break;
             case MAIN_MENU_CREDITS:
                 mainMenuWindowHide(true);
-                creditsOpen("credits.txt", -1, false);
+                creditsOpen("credits.txt", InterfaceFrameId::Invalid, false);
                 break;
             case MAIN_MENU_QUOTES:
                 // NOTE: There is a strange cmp at 0x480C50. Both operands are
                 // zero, set before the loop and do not modify afterwards. For
                 // clarity this condition is omitted.
                 mainMenuWindowHide(true);
-                creditsOpen("quotes.txt", -1, true);
+                creditsOpen("quotes.txt", InterfaceFrameId::Invalid, true);
                 break;
             case MAIN_MENU_EXIT:
             case -1:

--- a/src/map.cc
+++ b/src/map.cc
@@ -396,7 +396,7 @@ int mapSetElevation(int elevation)
     gElevation = elevation;
 
     reg_anim_clear(gDude);
-    _dude_stand(gDude, gDude->rotation, gDude->fid);
+    _dude_stand(gDude, gDude->rotation, FrmId(gDude->fid));
     _partyMemberSyncPosition();
 
     if (gMapSid != -1) {
@@ -1806,7 +1806,7 @@ static void _map_place_dude_and_mouse()
         objectSetLight(gDude, 4, 0x10000, nullptr);
         gDude->flags |= OBJECT_NO_SAVE;
 
-        _dude_stand(gDude, gDude->rotation, gDude->fid);
+        _dude_stand(gDude, gDude->rotation, FrmId(gDude->fid));
         _partyMemberSyncPosition();
     }
 

--- a/src/mapper/mapper.cc
+++ b/src/mapper/mapper.cc
@@ -2674,7 +2674,7 @@ int mapper_inven_unwield(Object* obj, int right_hand)
     animationRegisterAnimate(obj, ANIM_PUT_AWAY, 0);
 
     const FrmId frmId = FrmId(obj, ANIM_STAND, WEAPON_ANIMATION_NONE, rotationFromFid(obj->fid));
-    animationRegisterSetFid(obj, frmId.fid(), 0);
+    animationRegisterSetFrmId(obj, frmId, 0);
 
     return reg_anim_end();
 }

--- a/src/mapper/mapper.cc
+++ b/src/mapper/mapper.cc
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #include "actions.h"
+#include "animation_defs.h"
 #include "animation.h"
 #include "art.h"
 #include "automap.h"

--- a/src/mapper/mapper.cc
+++ b/src/mapper/mapper.cc
@@ -8,8 +8,8 @@
 #include <string.h>
 
 #include "actions.h"
-#include "animation_defs.h"
 #include "animation.h"
+#include "animation_defs.h"
 #include "art.h"
 #include "automap.h"
 #include "character_editor.h"

--- a/src/object.cc
+++ b/src/object.cc
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <vector>
 
+#include "animation_defs.h"
 #include "animation.h"
 #include "art.h"
 #include "color.h"

--- a/src/object.cc
+++ b/src/object.cc
@@ -6,8 +6,8 @@
 #include <algorithm>
 #include <vector>
 
-#include "animation_defs.h"
 #include "animation.h"
+#include "animation_defs.h"
 #include "art.h"
 #include "color.h"
 #include "combat.h"

--- a/src/party_member.cc
+++ b/src/party_member.cc
@@ -612,7 +612,7 @@ static int _partyMemberPrepLoadInstance(PartyMemberListItem* a1)
     scriptRemove(script->sid);
 
     if (objectTypeFromPid(obj->pid) == OBJ_TYPE_CRITTER) {
-        _dude_stand(obj, obj->rotation, -1);
+        _dude_stand(obj, obj->rotation, FrmId::Empty());
     }
 
     return 0;

--- a/src/proto_instance.cc
+++ b/src/proto_instance.cc
@@ -7,8 +7,8 @@
 
 #include <string>
 
-#include "animation_defs.h"
 #include "animation.h"
+#include "animation_defs.h"
 #include "art.h"
 #include "color.h"
 #include "combat.h"

--- a/src/proto_instance.cc
+++ b/src/proto_instance.cc
@@ -7,6 +7,7 @@
 
 #include <string>
 
+#include "animation_defs.h"
 #include "animation.h"
 #include "art.h"
 #include "color.h"

--- a/src/sfall_animation.cc
+++ b/src/sfall_animation.cc
@@ -69,7 +69,7 @@ void op_reg_anim_change_fid(Program* program)
     Object* object = static_cast<Object*>(programStackPopPointer(program));
 
     if (object != nullptr && !animationCheckCombatMode()) {
-        animationRegisterSetFid(object, fid, delay);
+        animationRegisterSetFrmId(object, FrmId(fid), delay);
     }
 }
 

--- a/src/sfall_animation.cc
+++ b/src/sfall_animation.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <stdint.h>
 
+#include "animation_defs.h"
 #include "animation.h"
 #include "interpreter.h"
 #include "opcode_context.h"

--- a/src/sfall_animation.cc
+++ b/src/sfall_animation.cc
@@ -3,8 +3,8 @@
 #include <algorithm>
 #include <stdint.h>
 
-#include "animation_defs.h"
 #include "animation.h"
+#include "animation_defs.h"
 #include "interpreter.h"
 #include "opcode_context.h"
 #include "scripts.h"

--- a/src/sfall_opcodes.cc
+++ b/src/sfall_opcodes.cc
@@ -4,6 +4,7 @@
 #include <math.h>
 #include <string.h>
 
+#include "animation_defs.h"
 #include "animation.h"
 #include "art.h"
 #include "character_editor.h"

--- a/src/sfall_opcodes.cc
+++ b/src/sfall_opcodes.cc
@@ -4,8 +4,8 @@
 #include <math.h>
 #include <string.h>
 
-#include "animation_defs.h"
 #include "animation.h"
+#include "animation_defs.h"
 #include "art.h"
 #include "character_editor.h"
 #include "color.h"

--- a/src/sfall_script_hooks.cc
+++ b/src/sfall_script_hooks.cc
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-#include "animation.h"
+#include "animation_defs.h"
 #include "db.h"
 #include "debug.h"
 #include "game.h"

--- a/src/sfall_script_hooks.h
+++ b/src/sfall_script_hooks.h
@@ -1,7 +1,7 @@
 #ifndef FALLOUT_SFALL_SCRIPT_HOOKS_H_
 #define FALLOUT_SFALL_SCRIPT_HOOKS_H_
 
-#include "animation.h"
+#include "animation_defs.h"
 #include "interpreter.h"
 #include "interpreter_extra.h"
 #include "queue.h"


### PR DESCRIPTION
### Description

First batch of changes to get rid of `int fid` from module APIs and replaced by `FrmId` instead.
Had to move enums from `animation.h` into `animation_defs.h` due to the circular dependencies in the `art.h` header.