### PR TITLE
Replace Fid usages by FrmId vol2

### DIFF
--- a/src/actions.cc
+++ b/src/actions.cc
@@ -8,6 +8,7 @@
 #include "animation.h"
 #include "animation_defs.h"
 #include "art.h"
+#include "art_defs.h"
 #include "color.h"
 #include "combat.h"
 #include "combat_ai.h"
@@ -512,7 +513,7 @@ int _show_death(Object* obj, AnimationType anim)
     objectGetRect(obj, &dirtyRect);
     if (anim < ANIM_FALL_BACK_SF && anim > ANIM_FALL_FRONT_BLOOD_SF) {
         const FrmId frmId = FrmId(obj, static_cast<AnimationType>(anim + 28), weaponAnimationFromFid(obj->fid), obj->rotation + 1);
-        if (objectSetFid(obj, frmId.fid(), &tempRect) == 0) {
+        if (objectSetFrmId(obj, frmId, &tempRect) == 0) {
             rectUnion(&dirtyRect, &tempRect, &dirtyRect);
         }
 
@@ -799,7 +800,7 @@ int _action_ranged(Attack* attack, AnimationType anim)
 
                     itemRemoveWithReason(attack->attacker, weapon, 1, RemoveInventoryObjectHookReason::Throw);
                     replacedWeapon = itemReplace(attack->attacker, weapon, weaponFlags & OBJECT_IN_ANY_HAND);
-                    objectSetFid(projectile, projectileProto->fid, nullptr);
+                    objectSetFrmId(projectile, FrmId(projectileProto->fid), nullptr);
                     _cAIPrepWeaponItem(attack->attacker, weapon);
 
                     if (attack->attacker == gDude) {
@@ -815,7 +816,7 @@ int _action_ranged(Attack* attack, AnimationType anim)
 
                     _obj_connect(weapon, attack->attacker->tile, attack->attacker->elevation, nullptr);
                 } else {
-                    objectCreateWithFidPid(&projectile, projectileProto->fid, -1);
+                    objectCreateWithFrmIdPid(&projectile, FrmId(projectileProto->fid), -1);
                 }
 
                 objectHide(projectile, nullptr);
@@ -901,7 +902,7 @@ int _action_ranged(Attack* attack, AnimationType anim)
                         explosionGetPattern(&startRotation, &endRotation);
 
                         for (Rotation rotation = startRotation; rotation < endRotation; rotation++) {
-                            if (objectCreateWithFidPid(&(adjacentObjects[rotation]), explosionFrmId.fid(), -1) != -1) {
+                            if (objectCreateWithFrmIdPid(&(adjacentObjects[rotation]), explosionFrmId, -1) != -1) {
                                 objectHide(adjacentObjects[rotation], nullptr);
 
                                 int adjacentTile = tileGetTileInDirection(explosionCenterTile, rotation, 1);
@@ -1639,7 +1640,7 @@ int actionExplode(int tile, int elevation, int minDamage, int maxDamage, Object*
     }
 
     Object* explosion;
-    if (objectCreateWithFidPid(&explosion, MiscFrmId(MiscFrameId::RocketExplosion).fid(), -1) == -1) {
+    if (objectCreateWithFrmIdPid(&explosion, MiscFrameId::RocketExplosion, -1) == -1) {
         internal_free(attack);
         return -1;
     }
@@ -1651,7 +1652,7 @@ int actionExplode(int tile, int elevation, int minDamage, int maxDamage, Object*
 
     Object* adjacentExplosions[ROTATION_COUNT];
     for (Rotation rotation = ROTATION_FIRST; rotation < ROTATION_COUNT; rotation++) {
-        if (objectCreateWithFidPid(&(adjacentExplosions[rotation]), MiscFrmId(MiscFrameId::RocketExplosion).fid(), -1) == -1) {
+        if (objectCreateWithFrmIdPid(&(adjacentExplosions[rotation]), MiscFrameId::RocketExplosion, -1) == -1) {
             while (--rotation >= ROTATION_FIRST) {
                 objectDestroy(adjacentExplosions[rotation], nullptr);
             }
@@ -1941,7 +1942,7 @@ void actionDamage(int tile, int elevation, int minDamage, int maxDamage, DamageT
     }
 
     Object* attacker;
-    if (objectCreateWithFidPid(&attacker, SceneryFrmId(SceneryFrameId::ForceField3).fid(), -1) == -1) {
+    if (objectCreateWithFrmIdPid(&attacker, SceneryFrameId::ForceField3, -1) == -1) {
         internal_free(attack);
         return;
     }

--- a/src/animation.cc
+++ b/src/animation.cc
@@ -2649,8 +2649,8 @@ static void _object_move(int index)
         objectSetRotation(object, static_cast<Rotation>(sad->rotations[0]), &tempRect);
         rectUnion(&dirtyRect, &tempRect, &dirtyRect);
 
-        FrmId fid = FrmId(object, sad->anim, weaponAnimationFromFid(object->fid), object->rotation + 1);
-        objectSetFid(object, fid.fid(), &tempRect);
+        const FrmId fid = FrmId(object, sad->anim, weaponAnimationFromFid(object->fid), object->rotation + 1);
+        objectSetFrmId(object, fid, &tempRect);
         rectUnion(&dirtyRect, &tempRect, &dirtyRect);
 
         sad->step = 0;
@@ -2767,7 +2767,7 @@ static void _object_straight_move(int index)
     Rect tempRect;
 
     if (sad->step == SAD_INIT) {
-        objectSetFid(object, sad->fid, &dirtyRect);
+        objectSetFrmId(object, FrmId(sad->fid), &dirtyRect);
         sad->step = 0;
     } else {
         objectGetRect(object, &dirtyRect);
@@ -2977,7 +2977,7 @@ void _object_animate()
                 y = 0;
             }
 
-            objectSetFid(object, sad->fid, &tempRect);
+            objectSetFrmId(object, FrmId(sad->fid), &tempRect);
             rectUnion(&dirtyRect, &tempRect, &dirtyRect);
 
             art = artLock(object->fid, &cacheHandle);
@@ -3279,7 +3279,7 @@ void _dude_stand(Object* obj, Rotation rotation, const FrmId& frmId)
     }
 
     Rect temp;
-    objectSetFid(obj, finalFrmId.fid(), &temp);
+    objectSetFrmId(obj, finalFrmId, &temp);
     rectUnion(&rect, &temp, &rect);
 
     objectSetLocation(obj, obj->tile, obj->elevation, &temp);
@@ -3355,7 +3355,7 @@ static int animationChangeFrmId(Object* obj, int animationSequenceIndex, const F
         Rect dirtyRect;
         Rect tempRect;
 
-        objectSetFid(obj, frmId.fid(), &dirtyRect);
+        objectSetFrmId(obj, frmId, &dirtyRect);
         objectSetFrame(obj, 0, &tempRect);
         rectUnion(&dirtyRect, &tempRect, &dirtyRect);
         tileWindowRefreshRect(&dirtyRect, obj->elevation);

--- a/src/art.h
+++ b/src/art.h
@@ -215,7 +215,7 @@ public:
     }
 
     constexpr int fid() const { return _fid; }
-
+    constexpr bool hasFid() const { return _fid > kEmptyFid; }
     constexpr bool hasObjectType() const { return objectTypeIsValid(_objectType); }
 
     constexpr ObjectType objectType() const
@@ -228,9 +228,7 @@ public:
 
     bool valid() const { return !empty() && ((_frameId.id >= kMinFrameId && _frameId.id <= kMaxFrameId) || _path != nullptr); }
 
-    bool empty() const { return (*this) == Empty(); }
-
-    bool exist() const { return _fid != kEmptyFid && valid() && exist(_fid, _builtPath); }
+    bool exist() const { return hasFid() && valid() && exist(_fid, _builtPath); }
 
     constexpr const FrameId& frameId() const { return _frameId; }
 
@@ -274,6 +272,8 @@ private:
 
     const char* _path;
     mutable char _builtPath[COMPAT_MAX_PATH] {};
+
+    bool empty() const { return (*this) == Empty(); }
 
     static constexpr int buildFrameId(int id) { return id < kMinFrameId ? kInvalidFrameId : (id & kMaxFrameId); }
 
@@ -382,7 +382,7 @@ public:
 
     constexpr HeadFidget fidget() const
     {
-        if (fid() == kEmptyFid) {
+        if (!hasFid()) {
             return FIDGET_INVALID;
         }
         int fidget = (fid() & 0xFF0000) >> 16;
@@ -435,7 +435,7 @@ inline Art* artLock(const FrmId& frmId, CacheEntry** handlePtr)
         return nullptr;
     }
 
-    assert(frmId.fid() != FrmId::kEmptyFid && "artLock(const FrmId& frmId, CacheEntry** handlePtr) called with path based FrmId which is not supported!");
+    assert(frmId.hasFid() && "artLock(const FrmId& frmId, CacheEntry** handlePtr) called with path based FrmId which is not supported!");
 
     return artLock(frmId.fid(), handlePtr);
 }

--- a/src/critter.cc
+++ b/src/critter.cc
@@ -889,7 +889,7 @@ void critterKill(Object* critter, AnimationType anim, bool refreshRect)
     if (shouldChangeFid) {
         objectSetFrame(critter, 0, &updatedRect);
 
-        objectSetFid(critter, frmId.fid(), &tempRect);
+        objectSetFrmId(critter, frmId, &tempRect);
         rectUnion(&updatedRect, &tempRect, &updatedRect);
     }
 
@@ -1389,8 +1389,8 @@ int knockoutClear(Object* obj, void* data)
 
     obj->data.critter.combat.results &= ~(DAM_KNOCKED_OUT | DAM_KNOCKED_DOWN);
 
-    FrmId fid = FrmId(obj, ANIM_STAND, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
-    objectSetFid(obj, fid.fid(), nullptr);
+    const FrmId frmId = FrmId(obj, ANIM_STAND, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
+    objectSetFrmId(obj, frmId, nullptr);
 
     return 0;
 }

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -3521,15 +3521,15 @@ int gameDialogCreateBarterWindow()
     if (talkBtn == -1) return -1;
 
     UniqueObject playerTableObj;
-    if (objectCreateWithFidPid(playerTableObj, -1, -1) == -1) return -1;
+    if (objectCreateWithFrmIdPid(playerTableObj, FrmId::Empty(), -1) == -1) return -1;
     playerTableObj->flags |= OBJECT_HIDDEN;
 
     UniqueObject bartererTableObj;
-    if (objectCreateWithFidPid(bartererTableObj, -1, -1) == -1) return -1;
+    if (objectCreateWithFrmIdPid(bartererTableObj, FrmId::Empty(), -1) == -1) return -1;
     bartererTableObj->flags |= OBJECT_HIDDEN;
 
     UniqueObject bartererTempObj;
-    if (objectCreateWithFidPid(bartererTempObj, gGameDialogSpeaker->fid, -1) == -1) return -1;
+    if (objectCreateWithFrmIdPid(bartererTempObj, FrmId(gGameDialogSpeaker->fid), -1) == -1) return -1;
     bartererTempObj->flags |= OBJECT_HIDDEN | OBJECT_NO_SAVE;
     bartererTempObj->sid = -1;
 

--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -330,7 +330,7 @@ static int gameMouseObjectsReset();
 static void gameMouseObjectsFree();
 static int gameMouseActionMenuInit();
 static void gameMouseActionMenuFree();
-static int gmouse_3d_set_flat_fid(int fid, Rect* rect);
+static int gameMouse3dSetFlatFrmId(const InterfaceFrmId& frmId, Rect* rect);
 static int gameMouseUpdateHexCursorFid(Rect* rect);
 static int _gmouse_3d_move_to(int x, int y, int elevation, Rect* rect);
 static int gameMouseHandleScrolling(int x, int y, int cursor);
@@ -780,7 +780,7 @@ void gameMouseRefresh()
                         if (gameMouseRenderPrimaryAction(mouseX, mouseY, primaryAction, _scr_size.right - _scr_size.left + 1, _scr_size.bottom - _scr_size.top - 99) == 0) {
                             Rect tmp;
                             // NOTE: Uninline.
-                            if (gmouse_3d_set_flat_fid(FrmId(InterfaceFrameId::ActionPick).fid(), &tmp) == 0) {
+                            if (gameMouse3dSetFlatFrmId(InterfaceFrameId::ActionPick, &tmp) == 0) {
                                 tileWindowRefreshRect(&tmp, gElevation);
                             }
                         }
@@ -841,7 +841,7 @@ void gameMouseRefresh()
                     if (gameMouseRenderAccuracy(formattedAccuracy, color) == 0) {
                         Rect tmp;
                         // NOTE: Uninline.
-                        if (gmouse_3d_set_flat_fid(FrmId(InterfaceFrameId::ActionToHit).fid(), &tmp) == 0) {
+                        if (gameMouse3dSetFlatFrmId(InterfaceFrameId::ActionToHit, &tmp) == 0) {
                             tileWindowRefreshRect(&tmp, gElevation);
                         }
                     }
@@ -1210,7 +1210,7 @@ void _gmouse_handle_event(int mouseX, int mouseY, int mouseState)
             if (gameMouseRenderActionMenuItems(mouseX, mouseY, actionMenuItems, actionMenuItemsCount, _scr_size.right - _scr_size.left + 1, _scr_size.bottom - _scr_size.top - 99) == 0) {
                 Rect cursorRect;
                 // NOTE: Uninline.
-                if (gmouse_3d_set_flat_fid(FrmId(InterfaceFrameId::ActionMenu).fid(), &cursorRect) == 0 && _gmouse_3d_move_to(mouseX, mouseY, gElevation, &cursorRect) == 0) {
+                if (gameMouse3dSetFlatFrmId(InterfaceFrameId::ActionMenu, &cursorRect) == 0 && _gmouse_3d_move_to(mouseX, mouseY, gElevation, &cursorRect) == 0) {
                     tileWindowRefreshRect(&cursorRect, gElevation);
                     isoDisable();
 
@@ -1455,7 +1455,7 @@ void gameMouseSetMode(int mode)
 
     Rect rect;
     // NOTE: Uninline.
-    if (gmouse_3d_set_flat_fid(frmId.fid(), &rect) == -1) {
+    if (gameMouse3dSetFlatFrmId(frmId, &rect) == -1) {
         return;
     }
 
@@ -1567,7 +1567,7 @@ int gameMouseSetBouncingCursorFrmId(const InterfaceFrmId& frmId)
     }
 
     if (!_gmouse_mapper_mode) {
-        return objectSetFid(gGameMouseBouncingCursor, frmId.fid(), nullptr);
+        return objectSetFrmId(gGameMouseBouncingCursor, frmId, nullptr);
     }
 
     int refreshFlags = 0;
@@ -1581,7 +1581,7 @@ int gameMouseSetBouncingCursorFrmId(const InterfaceFrmId& frmId)
     int rc = -1;
 
     Rect rect;
-    if (objectSetFid(gGameMouseBouncingCursor, frmId.fid(), &rect) == 0) {
+    if (objectSetFrmId(gGameMouseBouncingCursor, frmId, &rect) == 0) {
         rc = 0;
         refreshFlags |= REFRESH_HEX_CURSOR;
     }
@@ -2192,11 +2192,11 @@ int gameMouseObjectsInit()
         return -1;
     }
 
-    if (objectCreateWithFidPid(&gGameMouseBouncingCursor, FrmId(InterfaceFrameId::Blank).fid(), -1) != 0) {
+    if (objectCreateWithFrmIdPid(&gGameMouseBouncingCursor, InterfaceFrameId::Blank, -1) != 0) {
         return -1;
     }
 
-    if (objectCreateWithFidPid(&gGameMouseHexCursor, FrmId(InterfaceFrameId::HexMouseCursor).fid(), -1) != 0) {
+    if (objectCreateWithFrmIdPid(&gGameMouseHexCursor, InterfaceFrameId::HexMouseCursor, -1) != 0) {
         return -1;
     }
 
@@ -2405,9 +2405,9 @@ void gameMouseActionMenuFree()
 // NOTE: Inlined.
 //
 // 0x44DF1C gmouse_3d_set_flat_fid
-static int gmouse_3d_set_flat_fid(int fid, Rect* rect)
+static int gameMouse3dSetFlatFrmId(const InterfaceFrmId& frmId, Rect* rect)
 {
-    if (objectSetFid(gGameMouseHexCursor, fid, rect) == 0) {
+    if (objectSetFrmId(gGameMouseHexCursor, frmId, rect) == 0) {
         return 0;
     }
 
@@ -2418,12 +2418,12 @@ static int gmouse_3d_set_flat_fid(int fid, Rect* rect)
 int gameMouseUpdateHexCursorFid(Rect* rect)
 {
     const InterfaceFrmId frmId = gGameMouseModeFrmIds[gGameMouseMode];
-    if (gGameMouseHexCursor->fid == frmId.fid()) {
+    if (FrmId(gGameMouseHexCursor->fid) == frmId) {
         return -1;
     }
 
     // NOTE: Uninline.
-    return gmouse_3d_set_flat_fid(frmId.fid(), rect);
+    return gameMouse3dSetFlatFrmId(frmId, rect);
 }
 
 // 0x44DF94 gmouse_3d_move_to

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -423,7 +423,7 @@ int correctFidForRemovedItem(Object* critter, Object* item, ObjectFlags flags)
     }
 
     WeaponAnimation weaponCode = weaponAnimationFromFid(critter->fid);
-    FrmId newFid;
+    FrmId newFrmId;
 
     if ((flags & OBJECT_IN_ANY_HAND) != OBJECT_NONE) {
         if (critter == gDude) {
@@ -443,19 +443,19 @@ int correctFidForRemovedItem(Object* critter, Object* item, ObjectFlags flags)
         }
 
         if (weaponCode == WEAPON_ANIMATION_NONE) {
-            newFid = FrmId(critter, animationTypeFromFid(critter->fid), WEAPON_ANIMATION_NONE, rotationFromFid(critter->fid));
+            newFrmId = FrmId(critter, animationTypeFromFid(critter->fid), WEAPON_ANIMATION_NONE, rotationFromFid(critter->fid));
         }
     } else {
         if (critter == gDude) {
-            newFid = FrmId(_art_vault_guy_num, animationTypeFromFid(critter->fid), weaponCode, rotationFromFid(critter->fid));
+            newFrmId = FrmId(_art_vault_guy_num, animationTypeFromFid(critter->fid), weaponCode, rotationFromFid(critter->fid));
         }
 
         adjustCritterStatsOnArmorChange(critter, item, nullptr);
     }
 
-    if (newFid.valid()) {
+    if (newFrmId.valid()) {
         Rect rect;
-        objectSetFid(critter, newFid.fid(), &rect);
+        objectSetFrmId(critter, newFrmId, &rect);
         tileWindowRefreshRect(&rect, gElevation);
     }
 
@@ -879,7 +879,7 @@ static void opCreateObject(Program* program)
 
     Proto* proto;
     if (protoGetProto(pid, &proto) != -1) {
-        if (objectCreateWithFidPid(&object, proto->fid, pid) != -1) {
+        if (objectCreateWithFrmIdPid(&object, FrmId(proto->fid), pid) != -1) {
             if (tile == -1) {
                 tile = 0;
             }
@@ -2063,19 +2063,19 @@ static void opMetarule3(Program* program)
                 break;
             }
 
-            int frmId = param2.integerValue;
-            if (frmId > FrmId::kMaxFrameId) {
-                frmId = frameIdFromFid(frmId);
+            int frameId = param2.integerValue;
+            if (frameId > FrmId::kMaxFrameId) {
+                frameId = frameIdFromFid(frameId);
             }
 
-            FrmId fid = FrmId(objectTypeFromFid(obj->fid),
-                frmId,
+            const FrmId frmId = FrmId(objectTypeFromFid(obj->fid),
+                frameId,
                 animationTypeFromFid(obj->fid),
                 weaponAnimationFromFid(obj->fid),
                 rotationFromFid(obj->fid));
 
             Rect updatedRect;
-            objectSetFid(obj, fid.fid(), &updatedRect);
+            objectSetFrmId(obj, frmId, &updatedRect);
             tileWindowRefreshRect(&updatedRect, gElevation);
         }
         break;

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -354,7 +354,7 @@ static void _display_target_inventory(int stackOffset, int dragSlotIndex, Invent
 static void _display_inventory_info(Object* item, int quantity, unsigned char* dest, int pitch, bool isDragged);
 static void inventoryLootRenderPaneWeight(unsigned char* windowBuffer, int pitch, bool targetPane, Object* object, int extraWeight);
 static void inventoryScrollerHandleInput(const InventoryScroller& scroller, int keyCode, int mouseEvent);
-static void _display_body(int fid, int inventoryWindowType);
+static void _display_body(const FrmId& frmId, int inventoryWindowType);
 static int inventoryCommonInit();
 static void inventoryCommonFree();
 static void inventorySetCursor(int cursor);
@@ -409,8 +409,8 @@ static void handlePartySlotPickup(InvenSlot slot);
 static bool tryEquipPartyItem(Object* item, bool fromLeftPane);
 static bool tryUnequipPartyItem(InvenSlot slot);
 static bool tryMovePartyItemToLeftPane(InvenSlot slot, Object* item);
-static int buildPartyDisplayFid();
-static int getTargetDisplayFid();
+static FrmId buildPartyDisplayFrmId();
+static FrmId getTargetDisplayFrmId();
 static void setLootTarget(Object* target, Object* hiddenBox);
 static void refreshAfterTargetChange();
 static int inventoryWrapIndex(int index, int count, int direction);
@@ -645,7 +645,7 @@ static Object* gInventoryLeftHandItem;
 // Rotating character's fid.
 //
 // 0x59E95C i_fid
-static int gInventoryWindowDudeFid;
+static FrmId gInventoryWindowDudeFrmId;
 
 // 0x59E960 pud
 static Inventory* _pud;
@@ -1274,7 +1274,7 @@ static void createPartySlotButtons()
         inventoryItemSlotOnMouseExit);
 }
 
-static int buildPartyDisplayFid()
+static FrmId buildPartyDisplayFrmId()
 {
     WeaponAnimation weaponAnimationCode = WEAPON_ANIMATION_NONE;
     Object* rightHandItem = partyTargetEquipped->rightHand;
@@ -1282,16 +1282,16 @@ static int buildPartyDisplayFid()
         weaponAnimationCode = weaponGetAnimationCode(rightHandItem);
     }
 
-    return FrmId(partyBaseTarget, ANIM_STAND, weaponAnimationCode, ROTATION_NE).fid();
+    return FrmId(partyBaseTarget, ANIM_STAND, weaponAnimationCode, ROTATION_NE);
 }
 
-static int getTargetDisplayFid()
+static FrmId getTargetDisplayFrmId()
 {
     if (!hasPartySlots()) {
-        return _target_stack[_target_curr_stack]->fid;
+        return FrmId(_target_stack[_target_curr_stack]->fid);
     }
 
-    return buildPartyDisplayFid();
+    return buildPartyDisplayFrmId();
 }
 
 static void setLootTarget(Object* target, Object* hiddenBox)
@@ -1324,7 +1324,7 @@ static void refreshAfterTargetChange()
 {
     _display_target_inventory(0, -1, _target_pud, INVENTORY_WINDOW_TYPE_LOOT);
     _display_inventory(_stack_offset[_curr_stack], -1, INVENTORY_WINDOW_TYPE_LOOT);
-    _display_body(getTargetDisplayFid(), INVENTORY_WINDOW_TYPE_LOOT);
+    _display_body(getTargetDisplayFrmId(), INVENTORY_WINDOW_TYPE_LOOT);
 }
 
 static int inventoryWrapIndex(int index, int count, int direction)
@@ -1493,7 +1493,7 @@ static void handlePartySlotPickup(InvenSlot slot)
 
     _display_target_inventory(_target_stack_offset[_target_curr_stack], -1, _target_pud, INVENTORY_WINDOW_TYPE_LOOT);
     _display_inventory(_stack_offset[_curr_stack], -1, INVENTORY_WINDOW_TYPE_LOOT);
-    _display_body(getTargetDisplayFid(), INVENTORY_WINDOW_TYPE_LOOT);
+    _display_body(getTargetDisplayFrmId(), INVENTORY_WINDOW_TYPE_LOOT);
     windowRefresh(gInventoryWindow);
     inventorySetCursor(INVENTORY_WINDOW_CURSOR_HAND);
 }
@@ -1546,10 +1546,10 @@ void inventorySetDude(Object* obj, int pid)
 }
 
 // TODO(CE): move to more generic location
-int inventoryComputeCritterFid(Object* critter, int basePid, Object* rightHandItem, Object* leftHandItem, Object* armor, Hand activeHand, AnimationType anim, Rotation rotation)
+FrmId inventoryComputeCritterFrmId(Object* critter, int basePid, Object* rightHandItem, Object* leftHandItem, Object* armor, Hand activeHand, AnimationType anim, Rotation rotation)
 {
     if (objectTypeFromFid(critter->fid) != OBJ_TYPE_CRITTER) {
-        return critter->fid;
+        return FrmId(critter->fid);
     }
 
     Proto* proto = nullptr;
@@ -1583,7 +1583,7 @@ int inventoryComputeCritterFid(Object* critter, int basePid, Object* rightHandIt
         }
     }
 
-    return CritterFrmId(inventoryFrameId, anim, animationCode, rotation).fid();
+    return CritterFrmId(inventoryFrameId, anim, animationCode, rotation);
 }
 
 // inventory_msg_init
@@ -1698,7 +1698,7 @@ void inventoryOpen()
             break;
         }
 
-        _display_body(-1, INVENTORY_WINDOW_TYPE_NORMAL);
+        _display_body(FrmId::Empty(), INVENTORY_WINDOW_TYPE_NORMAL);
 
         if (gameGetState() == GAME_STATE_5) {
             break;
@@ -1739,7 +1739,7 @@ void inventoryOpen()
 
     if (_inven_dude == gDude) {
         Rect rect;
-        objectSetFid(_inven_dude, gInventoryWindowDudeFid, &rect);
+        objectSetFrmId(_inven_dude, gInventoryWindowDudeFrmId, &rect);
         tileWindowRefreshRect(&rect, _inven_dude->elevation);
     }
 
@@ -2486,7 +2486,7 @@ static void _display_inventory_info(Object* item, int quantity, unsigned char* d
 }
 
 // 0x470650 display_body displays both left and right character portraits
-static void _display_body(int fid, int inventoryWindowType)
+static void _display_body(const FrmId& frmId, int inventoryWindowType)
 {
     if (getTicksSince(gInventoryWindowDudeRotationTimestamp) < INVENTORY_NORMAL_WINDOW_PC_ROTATION_DELAY) {
         return;
@@ -2499,7 +2499,7 @@ static void _display_body(int fid, int inventoryWindowType)
     }
 
     Rotation rotations[2];
-    if (fid == -1) {
+    if (!frmId.valid()) {
         rotations[0] = gInventoryWindowDudeRotation;
         rotations[1] = ROTATION_SE;
     } else {
@@ -2509,17 +2509,17 @@ static void _display_body(int fid, int inventoryWindowType)
             : _target_stack[_target_curr_stack]->rotation;
     }
 
-    int fids[2] = {
-        gInventoryWindowDudeFid,
-        fid,
+    const FrmId frmIds[2] = {
+        gInventoryWindowDudeFrmId,
+        frmId,
     };
 
     for (int index = 0; index < 2; index += 1) {
-        int fid = fids[index];
+        FrmId fid = frmIds[index];
         if (inventoryWindowType == INVENTORY_WINDOW_TYPE_LOOT && index == 1) {
-            fid = getTargetDisplayFid();
+            fid = getTargetDisplayFrmId();
         }
-        if (fid == -1) {
+        if (!fid.valid()) {
             continue;
         }
 
@@ -3137,7 +3137,7 @@ void adjustCritterStatsOnArmorChange(Object* critter, Object* oldArmor, Object* 
 // 0x4716E8 adjust_fid
 static void _adjust_fid()
 {
-    int fid = inventoryComputeCritterFid(_inven_dude,
+    const FrmId frmId = inventoryComputeCritterFrmId(_inven_dude,
         _inven_pid,
         gInventoryRightHandItem,
         gInventoryLeftHandItem,
@@ -3145,7 +3145,7 @@ static void _adjust_fid()
         interfaceGetCurrentHand(),
         ANIM_STAND,
         ROTATION_NE);
-    gInventoryWindowDudeFid = scriptHooks_AdjustFid(fid, fid);
+    gInventoryWindowDudeFrmId = scriptHooks_AdjustFid(frmId, frmId);
 }
 
 // 0x4717E4 use_inventory_on
@@ -3166,7 +3166,7 @@ void inventoryOpenUseItemOn(Object* targetObj)
             break;
         }
 
-        _display_body(-1, INVENTORY_WINDOW_TYPE_USE_ITEM_ON);
+        _display_body(FrmId::Empty(), INVENTORY_WINDOW_TYPE_USE_ITEM_ON);
 
         int keyCode = inputGetInput();
         int mouseEvent = mouseGetEvent();
@@ -3411,10 +3411,10 @@ static void inventorySetLeftPaneCritter(Object* critter, Object* target, int inv
         }
     }
 
-    gInventoryWindowDudeFid = FrmId(critter, ANIM_STAND, animationCode, ROTATION_NE).fid();
+    gInventoryWindowDudeFrmId = FrmId(critter, ANIM_STAND, animationCode, ROTATION_NE);
     gInventoryWindowDudeRotationTimestamp = 0;
     _display_inventory(0, -1, inventoryWindowType);
-    _display_body(target->fid, inventoryWindowType);
+    _display_body(FrmId(target->fid), inventoryWindowType);
 }
 
 // 0x471CA0
@@ -4396,7 +4396,7 @@ static void inventoryWindowOpenContextMenu(int keyCode, int inventoryWindowType)
         inputGetInput();
 
         if (inventoryWindowType == INVENTORY_WINDOW_TYPE_NORMAL) {
-            _display_body(-1, INVENTORY_WINDOW_TYPE_NORMAL);
+            _display_body(FrmId::Empty(), INVENTORY_WINDOW_TYPE_NORMAL);
         }
 
         mouseState = mouseGetEvent();
@@ -4519,7 +4519,7 @@ static void inventoryWindowOpenContextMenu(int keyCode, int inventoryWindowType)
         inputGetInput();
 
         if (inventoryWindowType == INVENTORY_WINDOW_TYPE_NORMAL) {
-            _display_body(-1, INVENTORY_WINDOW_TYPE_NORMAL);
+            _display_body(FrmId::Empty(), INVENTORY_WINDOW_TYPE_NORMAL);
         }
 
         int x;
@@ -4769,7 +4769,7 @@ int inventoryOpenLooting(Object* looter, Object* target)
     }
 
     Object* hiddenBox = nullptr;
-    if (objectCreateWithFidPid(&hiddenBox, -1, PROTO_ID_JESSE_CONTAINER) == -1) {
+    if (objectCreateWithFrmIdPid(&hiddenBox, FrmId::Empty(), PROTO_ID_JESSE_CONTAINER) == -1) {
         return 0;
     }
     CritterEquipped stealTargetEquipped {};
@@ -4838,7 +4838,7 @@ int inventoryOpenLooting(Object* looter, Object* target)
     // switch whose inventory is shown on the left pane. In party quick-loot,
     // Left/Right instead cycles the active right-side party target.
     Object* const playerObj = _inven_dude;
-    int savedDudeFid = gInventoryWindowDudeFid;
+    FrmId savedDudeFrmId = gInventoryWindowDudeFrmId;
     bool switchActivePartyTarget = settings.qol.party_loot_and_barter
         && _gIsSteal
         && objectIsPartyMember(target);
@@ -4879,7 +4879,7 @@ int inventoryOpenLooting(Object* looter, Object* target)
     _display_target_inventory(_target_stack_offset[_target_curr_stack], -1, _target_pud, INVENTORY_WINDOW_TYPE_LOOT);
     _display_inventory(_stack_offset[_curr_stack], -1, INVENTORY_WINDOW_TYPE_LOOT);
     gInventoryWindowDudeRotationTimestamp = 0;
-    _display_body(target->fid, INVENTORY_WINDOW_TYPE_LOOT);
+    _display_body(FrmId(target->fid), INVENTORY_WINDOW_TYPE_LOOT);
     inventorySetCursor(INVENTORY_WINDOW_CURSOR_HAND);
 
     // Trigger game mode change _after_ window and loot_obj are set up
@@ -5036,7 +5036,7 @@ int inventoryOpenLooting(Object* looter, Object* target)
 
                             _display_target_inventory(_target_stack_offset[_target_curr_stack], -1, _target_pud, INVENTORY_WINDOW_TYPE_LOOT);
                             _display_inventory(_stack_offset[_curr_stack], -1, INVENTORY_WINDOW_TYPE_LOOT);
-                            _display_body(getTargetDisplayFid(), INVENTORY_WINDOW_TYPE_LOOT);
+                            _display_body(getTargetDisplayFrmId(), INVENTORY_WINDOW_TYPE_LOOT);
                         }
 
                         keyCode = -1;
@@ -5062,7 +5062,7 @@ int inventoryOpenLooting(Object* looter, Object* target)
 
                             _display_target_inventory(_target_stack_offset[_target_curr_stack], -1, _target_pud, INVENTORY_WINDOW_TYPE_LOOT);
                             _display_inventory(_stack_offset[_curr_stack], -1, INVENTORY_WINDOW_TYPE_LOOT);
-                            _display_body(getTargetDisplayFid(), INVENTORY_WINDOW_TYPE_LOOT);
+                            _display_body(getTargetDisplayFrmId(), INVENTORY_WINDOW_TYPE_LOOT);
                         }
                     }
                 } else if ((keyCode == PARTY_WEAPON_SLOT_KEY || keyCode == PARTY_ARMOR_SLOT_KEY)
@@ -5115,7 +5115,7 @@ int inventoryOpenLooting(Object* looter, Object* target)
     partyRightEquippedWeight = 0;
     partyTargetEquipped = nullptr;
     partyBaseTarget = nullptr;
-    gInventoryWindowDudeFid = savedDudeFid;
+    gInventoryWindowDudeFrmId = savedDudeFrmId;
 
     _exit_inventory(isoWasEnabled);
     _inven_dude = playerObj;
@@ -5705,7 +5705,7 @@ void barterProcessUI(int win, Object* barterer, Object* playerTable, Object* bar
     }
 
     Object* hiddenBox = nullptr;
-    if (objectCreateWithFidPid(&hiddenBox, -1, PROTO_ID_JESSE_CONTAINER) == -1) {
+    if (objectCreateWithFrmIdPid(&hiddenBox, FrmId::Empty(), PROTO_ID_JESSE_CONTAINER) == -1) {
         return;
     }
 
@@ -5730,7 +5730,7 @@ void barterProcessUI(int win, Object* barterer, Object* playerTable, Object* bar
     _target_stack_offset[0] = 0;
 
     Object* const playerObj = _inven_dude;
-    int savedDudeFid = gInventoryWindowDudeFid;
+    const FrmId savedDudeFrmId = gInventoryWindowDudeFrmId;
 
     std::vector<Object*> partyTargets = { _inven_dude };
     if (settings.qol.party_loot_and_barter) {
@@ -5746,7 +5746,7 @@ void barterProcessUI(int win, Object* barterer, Object* playerTable, Object* bar
 
     _display_target_inventory(_target_stack_offset[_target_curr_stack], -1, _target_pud, INVENTORY_WINDOW_TYPE_TRADE);
     _display_inventory(_stack_offset[0], -1, INVENTORY_WINDOW_TYPE_TRADE);
-    _display_body(barterer->fid, INVENTORY_WINDOW_TYPE_TRADE);
+    _display_body(FrmId(barterer->fid), INVENTORY_WINDOW_TYPE_TRADE);
     windowRefresh(gInventoryBarterBackgroundWindow);
     barterDisplayTables(win, playerTable, bartererTable, -1);
 
@@ -6001,7 +6001,7 @@ void barterProcessUI(int win, Object* barterer, Object* playerTable, Object* bar
         itemAdd(barterer, item1, 1);
     }
 
-    gInventoryWindowDudeFid = savedDudeFid;
+    gInventoryWindowDudeFrmId = savedDudeFrmId;
     _exit_inventory(isoWasEnabled);
     _inven_dude = playerObj;
 
@@ -6024,7 +6024,7 @@ static void _container_enter(int keyCode, int inventoryWindowType)
 
                 _target_pud = &(item->data.inventory);
 
-                _display_body(item->fid, inventoryWindowType);
+                _display_body(FrmId(item->fid), inventoryWindowType);
                 _display_target_inventory(_target_stack_offset[_target_curr_stack], -1, _target_pud, inventoryWindowType);
                 windowRefresh(gInventoryWindow);
             }
@@ -6044,7 +6044,7 @@ static void _container_enter(int keyCode, int inventoryWindowType)
                 _pud = &(item->data.inventory);
 
                 _adjust_fid();
-                _display_body(-1, inventoryWindowType);
+                _display_body(FrmId::Empty(), inventoryWindowType);
                 _display_inventory(_stack_offset[_curr_stack], -1, inventoryWindowType);
             }
         }
@@ -6060,7 +6060,7 @@ static void _container_exit(int keyCode, int inventoryWindowType)
             _inven_dude = _stack[_curr_stack];
             _pud = &_inven_dude->data.inventory;
             _adjust_fid();
-            _display_body(-1, inventoryWindowType);
+            _display_body(FrmId::Empty(), inventoryWindowType);
             _display_inventory(_stack_offset[_curr_stack], -1, inventoryWindowType);
         }
     } else if (keyCode == 2501) {
@@ -6068,7 +6068,7 @@ static void _container_exit(int keyCode, int inventoryWindowType)
             _target_curr_stack -= 1;
             Object* target = _target_stack[_target_curr_stack];
             _target_pud = &(target->data.inventory);
-            _display_body(target->fid, inventoryWindowType);
+            _display_body(FrmId(target->fid), inventoryWindowType);
             _display_target_inventory(_target_stack_offset[_target_curr_stack], -1, _target_pud, inventoryWindowType);
             windowRefresh(gInventoryWindow);
         }
@@ -6736,16 +6736,16 @@ int inventoryUnwieldSlot(Object* critter, InvenSlot slot)
         inventoryRenderSummary();
     }
 
-    int targetFid = -1;
+    FrmId targetFrmId = FrmId::Empty();
     if (inventoryWindowType == INVENTORY_WINDOW_TYPE_LOOT
         || inventoryWindowType == INVENTORY_WINDOW_TYPE_TRADE) {
-        targetFid = _target_stack[_target_curr_stack]->fid;
+        targetFrmId = FrmId(_target_stack[_target_curr_stack]->fid);
         _display_target_inventory(_target_stack_offset[_target_curr_stack], -1, _target_pud, inventoryWindowType);
     }
 
     _adjust_fid();
     _display_inventory(_stack_offset[_curr_stack], -1, inventoryWindowType);
-    _display_body(targetFid, inventoryWindowType);
+    _display_body(targetFrmId, inventoryWindowType);
     if (inventoryWindowType == INVENTORY_WINDOW_TYPE_TRADE) {
         barterDisplayTables(gInventoryBarterBackgroundWindow, gPlayerTableObj, gBartererTableObj, -1);
     }

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -2,6 +2,7 @@
 #define INVENTORY_H
 
 #include "animation_defs.h"
+#include "art.h"
 #include "obj_types.h"
 #include "proto_types.h"
 
@@ -32,7 +33,7 @@ int inventoryGetInvenApCost();
 void inventorySetInvenApCost(int cost);
 void inventoryResetInvenApCost();
 void adjustCritterStatsOnArmorChange(Object* critter, Object* oldArmor, Object* newArmor);
-int inventoryComputeCritterFid(Object* critter, int basePid, Object* rightHandItem, Object* leftHandItem, Object* armor, Hand activeHand, AnimationType anim, Rotation rotation);
+FrmId inventoryComputeCritterFrmId(Object* critter, int basePid, Object* rightHandItem, Object* leftHandItem, Object* armor, Hand activeHand, AnimationType anim, Rotation rotation);
 void inventoryOpenUseItemOn(Object* targetObj);
 Object* critterGetItem2(Object* critter);
 Object* critterGetItem1(Object* critter);

--- a/src/item.cc
+++ b/src/item.cc
@@ -676,7 +676,7 @@ int itemDropAll(Object* critter, int tile)
     if (hasEquippedItems) {
         Rect updatedRect;
         const CritterFrmId frmId = CritterFrmId(frameId, animationTypeFromFid(critter->fid), WEAPON_ANIMATION_NONE, rotationFromFid(critter->fid));
-        objectSetFid(critter, frmId.fid(), &updatedRect);
+        objectSetFrmId(critter, frmId, &updatedRect);
         if (animationTypeFromFid(critter->fid) == ANIM_STAND) {
             tileWindowRefreshRect(&updatedRect, gElevation);
         }

--- a/src/map.cc
+++ b/src/map.cc
@@ -1063,7 +1063,7 @@ static int mapLoad(File* stream)
         }
 
         Object* object;
-        objectCreateWithFidPid(&object, MiscFrmId(MiscFrameId::ScrollBlocker).fid(), -1);
+        objectCreateWithFrmIdPid(&object, MiscFrameId::ScrollBlocker, -1);
         object->flags |= (OBJECT_LIGHT_THRU | OBJECT_NO_SAVE | OBJECT_HIDDEN);
         objectSetLocation(object, 1, 0, nullptr);
         object->sid = gMapSid;

--- a/src/mapper/map_func.cc
+++ b/src/mapper/map_func.cc
@@ -429,7 +429,7 @@ ObjectType pickToolbar(int topY)
 }
 
 // place_object_
-void placeObject(int pid, int fid)
+void placeObject(int pid, const FrmId& frmId)
 {
     int x, y;
     mouseGetPosition(&x, &y);
@@ -439,7 +439,7 @@ void placeObject(int pid, int fid)
     }
 
     Object* obj;
-    if (objectCreateWithFidPid(&obj, fid, pid) == -1) {
+    if (objectCreateWithFrmIdPid(&obj, frmId, pid) == -1) {
         return;
     }
 

--- a/src/mapper/map_func.h
+++ b/src/mapper/map_func.h
@@ -32,7 +32,7 @@ void mapper_copy_map_elev();
 void mapper_flush_cache();
 int pickHex();
 ObjectType pickToolbar(int topY);
-void placeObject(int pid, int fid);
+void placeObject(int pid, const FrmId& frmId);
 void placeTile(int pid, const FrmId& frmId);
 // Pass the current toolbar type to filter the region copy by type, or -1 to copy all object
 // types in the picked region (mirrors the original mapper's `copy_object(arg1)` arg).

--- a/src/mapper/mapper.cc
+++ b/src/mapper/mapper.cc
@@ -1306,7 +1306,7 @@ void edit_mapper()
                             if (objectTypeFromPid(selectedPid) == OBJ_TYPE_TILE) {
                                 placeTile(selectedPid, FrmId(gGameMouseBouncingCursor->fid));
                             } else {
-                                placeObject(selectedPid, gGameMouseBouncingCursor->fid);
+                                placeObject(selectedPid, FrmId(gGameMouseBouncingCursor->fid));
                             }
                         }
                     } else if (_screen_obj != nullptr) {
@@ -1348,7 +1348,7 @@ void edit_mapper()
                             if (objectTypeFromPid(selectedPid) == OBJ_TYPE_TILE) {
                                 placeTile(selectedPid, FrmId(gGameMouseBouncingCursor->fid));
                             } else {
-                                placeObject(selectedPid, gGameMouseBouncingCursor->fid);
+                                placeObject(selectedPid, FrmId(gGameMouseBouncingCursor->fid));
                             }
                         }
                     } else {
@@ -1367,7 +1367,7 @@ void edit_mapper()
                             update_high_obj_name(_screen_obj);
 
                             Object* hlObj;
-                            if (objectCreateWithFidPid(&hlObj, FrmId(InterfaceFrameId::HexMouseCursor).fid(), -1) != -1) {
+                            if (objectCreateWithFrmIdPid(&hlObj, InterfaceFrameId::HexMouseCursor, -1) != -1) {
                                 hlObj->flags |= OBJECT_SHOOT_THRU | OBJECT_LIGHT_THRU | OBJECT_NO_SAVE;
                                 _obj_toggle_flat(hlObj, nullptr);
 

--- a/src/mapper/mp_instance.cc
+++ b/src/mapper/mp_instance.cc
@@ -433,7 +433,7 @@ static int protoInstAddToInven(int pid, int count)
     if (protoGetProto(pid, &proto) == -1) return 0;
 
     Object* newObj;
-    if (objectCreateWithFidPid(&newObj, proto->fid, pid) == -1) return 0;
+    if (objectCreateWithFrmIdPid(&newObj, FrmId(proto->fid), pid) == -1) return 0;
 
     objectSetLocation(newObj, 0, 0, nullptr);
 

--- a/src/mapper/mp_scrpt.cc
+++ b/src/mapper/mp_scrpt.cc
@@ -136,7 +136,7 @@ void map_scr_toggle_hexes()
                 }
 
                 Object* obj;
-                if (objectCreateWithFidPid(&obj, kMarkerFrmId.fid(), -1) != -1) {
+                if (objectCreateWithFrmIdPid(&obj, kMarkerFrmId, -1) != -1) {
                     obj->flags |= OBJECT_NO_SAVE;
                     Rect rect;
                     _obj_toggle_flat(obj, &rect);
@@ -314,7 +314,7 @@ int map_scr_add_spatial(int tile, int elevation)
 
     constexpr InterfaceFrmId kMarkerFrmId = InterfaceFrameId::ExitGridMarker;
     Object* obj;
-    if (objectCreateWithFidPid(&obj, kMarkerFrmId.fid(), -1) != -1) {
+    if (objectCreateWithFrmIdPid(&obj, kMarkerFrmId, -1) != -1) {
         obj->flags |= OBJECT_NO_SAVE;
         Rect rect;
         _obj_toggle_flat(obj, &rect);
@@ -342,7 +342,7 @@ void map_set_script(int scriptIndex)
     if (newIndex <= 0 || scriptAdd(&gMapSid, SCRIPT_TYPE_SYSTEM) == -1) return;
 
     Object* obj;
-    objectCreateWithFidPid(&obj, MiscFrmId(MiscFrameId::ScrollBlocker).fid(), -1);
+    objectCreateWithFrmIdPid(&obj, MiscFrameId::ScrollBlocker, -1);
     obj->flags |= (OBJECT_LIGHT_THRU | OBJECT_NO_SAVE | OBJECT_HIDDEN);
     objectSetLocation(obj, 1, 0, nullptr);
     obj->sid = gMapSid;

--- a/src/object.cc
+++ b/src/object.cc
@@ -924,6 +924,10 @@ int objectCreateWithFrmIdPid(Object** objectPtr, const FrmId& frmId, int pid)
         return -1;
     }
 
+    if (frmId.valid()) {
+        assert(frmId.hasFid() && "objectCreateWithFrmIdPid(Object** objectPtr, const FrmId& frmId, int pid) called with path based FrmId which is not supported!");
+    }
+
     objectListNode->obj->fid = frmId.fid();
     _obj_insert(objectListNode);
 
@@ -1546,6 +1550,10 @@ int objectSetFrmId(Object* obj, const FrmId& frmId, Rect* dirtyRect)
 
     if (obj == nullptr) {
         return -1;
+    }
+
+    if (frmId.valid()) {
+        assert(frmId.hasFid() && "objectSetFrmId(Object* obj, const FrmId& frmId, Rect* dirtyRect) called with path based FrmId which is not supported!");
     }
 
     if (dirtyRect != nullptr) {

--- a/src/object.cc
+++ b/src/object.cc
@@ -353,7 +353,7 @@ int objectsInit(unsigned char* buf, int width, int height, int pitch)
     gObjectsWindowBufferSize = height * width;
     gObjectsWindowPitch = pitch;
 
-    objectCreateWithFidPid(&gDude, dudeFrmId.fid(), 0x1000000);
+    objectCreateWithFrmIdPid(&gDude, dudeFrmId, 0x1000000);
 
     gDude->flags |= OBJECT_NO_REMOVE;
     gDude->flags |= OBJECT_NO_SAVE;
@@ -366,7 +366,7 @@ int objectsInit(unsigned char* buf, int width, int height, int pitch)
         exit(1);
     }
 
-    objectCreateWithFidPid(&gEgg, eggFrmId.fid(), -1);
+    objectCreateWithFrmIdPid(&gEgg, eggFrmId, -1);
     gEgg->flags |= OBJECT_NO_REMOVE;
     gEgg->flags |= OBJECT_NO_SAVE;
     gEgg->flags |= OBJECT_HIDDEN;
@@ -909,7 +909,7 @@ void _obj_render_post_roof(Rect* rect, int elevation)
 }
 
 // 0x489A84 obj_new
-int objectCreateWithFidPid(Object** objectPtr, int fid, int pid)
+int objectCreateWithFrmIdPid(Object** objectPtr, const FrmId& frmId, int pid)
 {
     ObjectListNode* objectListNode;
 
@@ -924,7 +924,7 @@ int objectCreateWithFidPid(Object** objectPtr, int fid, int pid)
         return -1;
     }
 
-    objectListNode->obj->fid = fid;
+    objectListNode->obj->fid = frmId.fid();
     _obj_insert(objectListNode);
 
     if (objectPtr) {
@@ -1010,7 +1010,7 @@ int objectCreateWithPid(Object** objectPtr, int pid)
         return -1;
     }
 
-    return objectCreateWithFidPid(objectPtr, proto->fid, pid);
+    return objectCreateWithFrmIdPid(objectPtr, FrmId(proto->fid), pid);
 }
 
 // 0x489CCC obj_copy
@@ -1540,7 +1540,7 @@ int _obj_reset_roof()
 // Sets object fid.
 //
 // 0x48AA3C obj_change_fid
-int objectSetFid(Object* obj, int fid, Rect* dirtyRect)
+int objectSetFrmId(Object* obj, const FrmId& frmId, Rect* dirtyRect)
 {
     Rect new_rect;
 
@@ -1551,12 +1551,12 @@ int objectSetFid(Object* obj, int fid, Rect* dirtyRect)
     if (dirtyRect != nullptr) {
         objectGetRect(obj, dirtyRect);
 
-        obj->fid = fid;
+        obj->fid = frmId.fid();
 
         objectGetRect(obj, &new_rect);
         rectUnion(dirtyRect, &new_rect, dirtyRect);
     } else {
-        obj->fid = fid;
+        obj->fid = frmId.fid();
     }
 
     return 0;
@@ -5299,10 +5299,10 @@ void UniqueObject::reset(Object* p)
     _ptr = p;
 }
 
-int objectCreateWithFidPid(UniqueObject& obj, int fid, int pid)
+int objectCreateWithFrmIdPid(UniqueObject& obj, const FrmId& frmId, int pid)
 {
     Object* raw;
-    int rc = objectCreateWithFidPid(&raw, fid, pid);
+    int rc = objectCreateWithFrmIdPid(&raw, frmId, pid);
     if (rc != -1) obj.reset(raw);
     return rc;
 }

--- a/src/object.h
+++ b/src/object.h
@@ -1,6 +1,7 @@
 #ifndef OBJECT_H
 #define OBJECT_H
 
+#include "art.h"
 #include "color.h"
 #include "db.h"
 #include "geometry.h"
@@ -31,7 +32,7 @@ int objectLoadAll(File* stream);
 int objectSaveAll(File* stream);
 void _obj_render_pre_roof(Rect* rect, int elevation);
 void _obj_render_post_roof(Rect* rect, int elevation);
-int objectCreateWithFidPid(Object** objectPtr, int fid, int pid);
+int objectCreateWithFrmIdPid(Object** objectPtr, const FrmId& frmId, int pid);
 int objectCreateWithPid(Object** objectPtr, int pid);
 int _obj_copy(Object** a1, Object* a2);
 int _obj_connect(Object* obj, int tile_index, int elev, Rect* rect);
@@ -40,7 +41,7 @@ int _obj_offset(Object* obj, int x, int y, Rect* rect);
 int _obj_move(Object* a1, int a2, int a3, int elevation, Rect* a5);
 int objectSetLocation(Object* obj, int tile, int elevation, Rect* rect);
 int _obj_reset_roof();
-int objectSetFid(Object* obj, int fid, Rect* rect);
+int objectSetFrmId(Object* obj, const FrmId& frmId, Rect* rect);
 int objectSetFrame(Object* obj, int frame, Rect* rect);
 int objectSetNextFrame(Object* obj, Rect* rect);
 int objectSetPrevFrame(Object* obj, Rect* rect);
@@ -135,7 +136,7 @@ private:
     Object* _ptr = nullptr;
 };
 
-int objectCreateWithFidPid(UniqueObject& obj, int fid, int pid);
+int objectCreateWithFrmIdPid(UniqueObject& obj, const FrmId& frmId, int pid);
 
 } // namespace fallout
 

--- a/src/proto.cc
+++ b/src/proto.cc
@@ -882,8 +882,8 @@ int _proto_dude_update_gender()
             weaponAnimationCode = weaponAnimationFromFid(gDude->fid);
         }
 
-        FrmId fid = FrmId(_art_vault_guy_num, ANIM_STAND, weaponAnimationCode, ROTATION_NE);
-        objectSetFid(gDude, fid.fid(), nullptr);
+        const FrmId frmId = FrmId(_art_vault_guy_num, ANIM_STAND, weaponAnimationCode, ROTATION_NE);
+        objectSetFrmId(gDude, frmId, nullptr);
     }
 
     proto->fid = FrmId(_art_vault_guy_num, ANIM_STAND, WEAPON_ANIMATION_NONE, ROTATION_NE).fid();

--- a/src/proto_instance.cc
+++ b/src/proto_instance.cc
@@ -639,7 +639,7 @@ int objectPickup(Object* critter, Object* item)
 static int _obj_remove_from_inven(Object* critter, Object* item)
 {
     Rect updatedRect;
-    FrmId fid;
+    FrmId frmId;
     int appearanceUpdateType = 0;
     InvenSlot slot = InvenSlot::Armor;
     bool hasSlot = false;
@@ -659,16 +659,16 @@ static int _obj_remove_from_inven(Object* critter, Object* item)
         scriptHooks_InvenWield(critter, item, slot, 0, 1);
         if (slot == InvenSlot::RightHand) {
             if (critter != gDude || interfaceGetCurrentHand() == HAND_RIGHT) {
-                fid = FrmId(critter, animationTypeFromFid(critter->fid), WEAPON_ANIMATION_NONE, critter->rotation);
-                objectSetFid(critter, fid.fid(), &updatedRect);
+                frmId = FrmId(critter, animationTypeFromFid(critter->fid), WEAPON_ANIMATION_NONE, critter->rotation);
+                objectSetFrmId(critter, frmId, &updatedRect);
                 appearanceUpdateType = 2;
             } else {
                 appearanceUpdateType = 1;
             }
         } else if (slot == InvenSlot::LeftHand) {
             if (critter == gDude && interfaceGetCurrentHand() == HAND_LEFT) {
-                fid = FrmId(critter, animationTypeFromFid(critter->fid), WEAPON_ANIMATION_NONE, critter->rotation);
-                objectSetFid(critter, fid.fid(), &updatedRect);
+                frmId = FrmId(critter, animationTypeFromFid(critter->fid), WEAPON_ANIMATION_NONE, critter->rotation);
+                objectSetFrmId(critter, frmId, &updatedRect);
                 appearanceUpdateType = 2;
             } else {
                 appearanceUpdateType = 1;
@@ -682,8 +682,8 @@ static int _obj_remove_from_inven(Object* critter, Object* item)
                     defaultFrameId = FrmId(proto->fid).frameId().critter;
                 }
 
-                fid = FrmId(defaultFrameId, animationTypeFromFid(critter->fid), weaponAnimationFromFid(critter->fid), critter->rotation);
-                objectSetFid(critter, fid.fid(), &updatedRect);
+                frmId = FrmId(defaultFrameId, animationTypeFromFid(critter->fid), weaponAnimationFromFid(critter->fid), critter->rotation);
+                objectSetFrmId(critter, frmId, &updatedRect);
                 appearanceUpdateType = 3;
             }
         }

--- a/src/scripts.cc
+++ b/src/scripts.cc
@@ -684,7 +684,7 @@ Object* scriptGetSelf(Program* program)
     }
 
     Object* object;
-    objectCreateWithFidPid(&object, FrmId(InterfaceFrameId::ExitGridMarker).fid(), -1);
+    objectCreateWithFrmIdPid(&object, InterfaceFrameId::ExitGridMarker, -1);
     objectHide(object, nullptr);
     _obj_toggle_flat(object, nullptr);
     object->sid = sid;

--- a/src/sfall_metarules.cc
+++ b/src/sfall_metarules.cc
@@ -593,7 +593,7 @@ namespace {
             return objectSetRotation(object, static_cast<Rotation>(intValue), nullptr) == 0;
         case ObjectDataField::Fid:
             if (!intDataValue(data, intValue)) return false;
-            return objectSetFid(object, intValue, nullptr) == 0;
+            return objectSetFrmId(object, FrmId(intValue), nullptr) == 0;
         case ObjectDataField::Flags:
             if (!intDataValue(data, intValue)) return false;
             object->flags = static_cast<ObjectFlags>(intValue);

--- a/src/sfall_opcodes.cc
+++ b/src/sfall_opcodes.cc
@@ -1235,7 +1235,7 @@ static void op_refresh_pc_art(Program* program)
 
     _proto_dude_update_gender();
 
-    int fid = inventoryComputeCritterFid(gDude,
+    const FrmId frmId = inventoryComputeCritterFrmId(gDude,
         gDude->pid,
         critterGetItem2(gDude),
         critterGetItem1(gDude),
@@ -1247,7 +1247,7 @@ static void op_refresh_pc_art(Program* program)
     // CE: When changing gender, the refreshed rect can be smaller than the original one,
     // which can leave a momentary ghost.  We union with old rect to avoid that.
     Rect newRect;
-    objectSetFid(gDude, fid, nullptr);
+    objectSetFrmId(gDude, frmId, nullptr);
     objectGetRect(gDude, &newRect);
     rectUnion(&rect, &newRect, &rect);
     tileWindowRefreshRect(&rect, gDude->elevation);

--- a/src/sfall_script_hooks.cc
+++ b/src/sfall_script_hooks.cc
@@ -1140,16 +1140,16 @@ void scriptHooks_BarterPrice(BarterPriceContext* ctx)
 
     int     ret0 - override FID
 */
-int scriptHooks_AdjustFid(int vanillaFid, int modifiedFid)
+FrmId scriptHooks_AdjustFid(const FrmId& vanillaFrmId, const FrmId& modifiedFrmId)
 {
-    ScriptHookCall hook(HOOK_ADJUSTFID, 1, { vanillaFid, modifiedFid });
+    ScriptHookCall hook(HOOK_ADJUSTFID, 1, { vanillaFrmId.fid(), modifiedFrmId.fid() });
     hook.call();
 
     if (hook.numReturnValues() > 0) {
-        return hook.getReturnValueAt(0).asInt();
+        return FrmId(hook.getReturnValueAt(0).asInt());
     }
 
-    return modifiedFid;
+    return modifiedFrmId;
 }
 
 /*

--- a/src/sfall_script_hooks.h
+++ b/src/sfall_script_hooks.h
@@ -2,6 +2,7 @@
 #define FALLOUT_SFALL_SCRIPT_HOOKS_H_
 
 #include "animation_defs.h"
+#include "art.h"
 #include "interpreter.h"
 #include "interpreter_extra.h"
 #include "queue.h"
@@ -374,7 +375,7 @@ void scriptHooks_RemoveInventoryObject(Object* owner, Object* item, int quantity
 void scriptHooks_ComputeDamage(Attack* attack, int numRounds, int baseDmgMult);
 void scriptHooks_BarterPrice(BarterPriceContext* ctx);
 
-int scriptHooks_AdjustFid(int vanillaFid, int modifiedFid);
+FrmId scriptHooks_AdjustFid(const FrmId& vanillaFrmId, const FrmId& modifiedFrmId);
 bool scriptHooks_InvenWield(Object* critter, Object* item, InvenSlot slot, int isWield, int isRemove, bool filterInactiveHand = true);
 bool scriptHooks_CanUseWeapon(bool result, Object* critter, Object* weapon, HitMode hitMode);
 


### PR DESCRIPTION
### Description
Second batch of changes to get rid of `int fid` from module APIs and replaced by `FrmId` instead.
New `FrmId::hasFid` for easier not path based FrmId checks.

Functions changed are `objectSetFrmId`, `objectCreateWithFrmIdPid`, `gameMouse3dSetFlatFrmId`, `scriptHooks_AdjustFid`,  `buildPartyDisplayFrmId`, `getTargetDisplayFrmId`, `_display_body`,  `inventoryComputeCritterFrmId` and `placeObject`.