### PR TITLE
Replace Fid usages by FrmId vol3

### DIFF
--- a/src/actions.cc
+++ b/src/actions.cc
@@ -1245,7 +1245,7 @@ int actionPickUp(Object* critter, Object* item)
         }
 
         char sfx[16];
-        if (artCopyFileName(objectTypeFromFid(item->fid), frameIdFromFid(item->fid), sfx) == 0) {
+        if (artCopyFileName(FrmId(item->fid), sfx) == 0) {
             // NOTE: looks like they copy sfx one more time, what for?
             animationRegisterPlaySoundEffect(item, sfx, actionFrame);
         }

--- a/src/animation.cc
+++ b/src/animation.cc
@@ -2662,7 +2662,7 @@ static void _object_move(int index)
     int frameY;
 
     CacheEntry* cacheHandle;
-    Art* art = artLock(object->fid, &cacheHandle);
+    Art* art = artLock(FrmId(object->fid), &cacheHandle);
     if (art != nullptr) {
         artGetFrameOffsets(art, object->frame, object->rotation, &frameX, &frameY);
         artUnlock(cacheHandle);
@@ -2774,7 +2774,7 @@ static void _object_straight_move(int index)
     }
 
     CacheEntry* cacheHandle;
-    Art* art = artLock(object->fid, &cacheHandle);
+    Art* art = artLock(FrmId(object->fid), &cacheHandle);
     if (art != nullptr) {
         int lastFrame = artGetFrameCount(art) - 1;
         artUnlock(cacheHandle);
@@ -2907,7 +2907,7 @@ void _object_animate()
         if (object->fid == sad->fid) {
             if ((sad->flags & ANIM_SAD_REVERSE) == 0) {
                 CacheEntry* cacheHandle;
-                Art* art = artLock(object->fid, &cacheHandle);
+                Art* art = artLock(FrmId(object->fid), &cacheHandle);
                 if (art != nullptr) {
                     if ((sad->flags & ANIM_SAD_FOREVER) == 0 && object->frame == artGetFrameCount(art) - 1) {
                         sad->step = ANIM_COMPLETE;
@@ -2945,7 +2945,7 @@ void _object_animate()
                 int y = 0;
 
                 CacheEntry* cacheHandle;
-                Art* art = artLock(object->fid, &cacheHandle);
+                Art* art = artLock(FrmId(object->fid), &cacheHandle);
                 if (art != nullptr) {
                     artGetFrameOffsets(art, object->frame, object->rotation, &x, &y);
                     artUnlock(cacheHandle);
@@ -2968,7 +2968,7 @@ void _object_animate()
             int y;
 
             CacheEntry* cacheHandle;
-            Art* art = artLock(object->fid, &cacheHandle);
+            Art* art = artLock(FrmId(object->fid), &cacheHandle);
             if (art != nullptr) {
                 artGetRotationOffsets(art, object->rotation, &x, &y);
                 artUnlock(cacheHandle);
@@ -2980,7 +2980,7 @@ void _object_animate()
             objectSetFrmId(object, FrmId(sad->fid), &tempRect);
             rectUnion(&dirtyRect, &tempRect, &dirtyRect);
 
-            art = artLock(object->fid, &cacheHandle);
+            art = artLock(FrmId(object->fid), &cacheHandle);
             if (art != nullptr) {
                 int frame;
                 if ((sad->flags & ANIM_SAD_REVERSE) != 0) {

--- a/src/animation.cc
+++ b/src/animation.cc
@@ -3194,7 +3194,7 @@ void _dude_fidget()
         } else {
             char fileName[16];
             fileName[0] = '\0';
-            artCopyFileName(OBJ_TYPE_CRITTER, FrmId(object->fid).frameId().id, fileName);
+            artCopyFileName(FrmId(object->fid), fileName);
             if (fileName[0] == 'm' || fileName[0] == 'M') {
                 if (objectGetDistanceBetween(object, gDude) < critterGetStat(gDude, STAT_PERCEPTION) * 2) {
                     shoudPlaySound = true;

--- a/src/art.cc
+++ b/src/art.cc
@@ -568,7 +568,7 @@ int artCopyFileName(const FrmId& frmId, char* dest)
 
     ptr = &(gArtListDescriptions[frmId.objectType()]);
 
-    if (frmId.frameId().id >= ptr->fileNamesLength) {
+    if (!frmId.hasFid() || frmId.frameId().id >= ptr->fileNamesLength) {
         return -1;
     }
 

--- a/src/art.cc
+++ b/src/art.cc
@@ -423,7 +423,7 @@ int artGetFidgetCount(const HeadFrmId& frmId)
 }
 
 // 0x418FFC
-void artRender(int fid, unsigned char* dest, int width, int height, int pitch)
+void artRender(const FrmId& frmId, unsigned char* dest, int width, int height, int pitch)
 {
     // NOTE: Original code is different. For unknown reason it directly calls
     // many art functions, for example instead of [artLock] it calls lower level
@@ -432,15 +432,15 @@ void artRender(int fid, unsigned char* dest, int width, int height, int pitch)
     // not. I've replaced these calls with higher level functions where
     // appropriate.
 
-    CacheEntry* handle;
-    Art* frm = artLock(fid, &handle);
-    if (frm == nullptr) {
+    FrmImage frmImage;
+
+    if (!frmImage.lock(frmId)) {
         return;
     }
 
-    unsigned char* frameData = artGetFrameData(frm);
-    int frameWidth = artGetWidth(frm);
-    int frameHeight = artGetHeight(frm);
+    unsigned char* frameData = frmImage.getData();
+    int frameWidth = frmImage.getWidth();
+    int frameHeight = frmImage.getHeight();
 
     int remainingWidth = width - frameWidth;
     int remainingHeight = height - frameHeight;
@@ -473,7 +473,7 @@ void artRender(int fid, unsigned char* dest, int width, int height, int pitch)
             pitch);
     }
 
-    artUnlock(handle);
+    frmImage.unlock();
 }
 
 // mapper2.exe: 0x40A03C

--- a/src/art.cc
+++ b/src/art.cc
@@ -254,7 +254,7 @@ int artInit()
             _art_vault_person_nums[DUDE_NATIVE_LOOK_TRIBAL][GENDER_FEMALE] = critterFrameId;
         }
 
-        critterFileNames += 13;
+        critterFileNames += ART_NAME_SIZE;
     }
 
     for (int critterIndex = 0; critterIndex < gArtListDescriptions[OBJ_TYPE_CRITTER].fileNamesLength; critterIndex++) {
@@ -285,7 +285,7 @@ int artInit()
         if (compat_stricmp(tileFileNames, "grid001.frm") == 0) {
             _art_mapper_blank_tile = tileIndex;
         }
-        tileFileNames += 13;
+        tileFileNames += ART_NAME_SIZE;
     }
 
     gHeadDescriptions = (HeadDescription*)internal_malloc(sizeof(*gHeadDescriptions) * gArtListDescriptions[OBJ_TYPE_HEAD].fileNamesLength);
@@ -489,20 +489,20 @@ int artListIndex(ObjectType objectType, const char* name)
     if (!objectTypeIsValid(objectType)) return -1;
     if (gArtListDescriptions[objectType].fileNames == nullptr) return -1;
 
-    char upperName[13] = { 0 };
-    strncpy(upperName, name, 12);
-    upperName[12] = '\0';
+    char upperName[ART_NAME_SIZE] = { 0 };
+    strncpy(upperName, name, ART_NAME_SIZE - 1);
+    upperName[ART_NAME_SIZE - 1] = '\0';
     compat_strupr(upperName);
 
     int length = gArtListDescriptions[objectType].fileNamesLength;
     const char* fileNames = gArtListDescriptions[objectType].fileNames;
 
     for (int index = 0; index < length; index++) {
-        const char* entry = fileNames + index * 13;
+        const char* entry = fileNames + index * ART_NAME_SIZE;
 
-        char upperEntry[13];
-        strncpy(upperEntry, entry, 12);
-        upperEntry[12] = '\0';
+        char upperEntry[ART_NAME_SIZE];
+        strncpy(upperEntry, entry, ART_NAME_SIZE - 1);
+        upperEntry[ART_NAME_SIZE - 1] = '\0';
         compat_strupr(upperEntry);
 
         char* p = upperEntry;
@@ -570,21 +570,21 @@ int artCacheFlush()
 }
 
 // 0x4192B0
-int artCopyFileName(ObjectType objectType, int id, char* dest)
+int artCopyFileName(const FrmId& frmId, char* dest)
 {
     ArtListDescription* ptr;
 
-    if (!objectTypeIsValid(objectType) || id < FrmId::kMinFrameId) {
+    if (!frmId.valid()) {
         return -1;
     }
 
-    ptr = &(gArtListDescriptions[objectType]);
+    ptr = &(gArtListDescriptions[frmId.objectType()]);
 
-    if (id >= ptr->fileNamesLength) {
+    if (frmId.frameId().id >= ptr->fileNamesLength) {
         return -1;
     }
 
-    strcpy(dest, ptr->fileNames + id * 13);
+    strcpy(dest, ptr->fileNames + frmId.frameId().id * ART_NAME_SIZE);
 
     return 0;
 }
@@ -704,7 +704,7 @@ char* FrmId::buildPath(int fid, char* path)
         return nullptr;
     }
 
-    int fileNameOffset = frmId * 13;
+    int fileNameOffset = frmId * ART_NAME_SIZE;
 
     if (objectType == OBJ_TYPE_CRITTER) {
         char critterWeaponCode;
@@ -750,7 +750,7 @@ static int artReadList(const char* path, char** artListPtr, int* artListSizePtr)
 
     *artListSizePtr = count;
 
-    char* artList = (char*)internal_malloc(13 * count);
+    char* artList = (char*)internal_malloc(ART_NAME_SIZE * count);
     *artListPtr = artList;
     if (artList == nullptr) {
         fileClose(stream);
@@ -763,10 +763,10 @@ static int artReadList(const char* path, char** artListPtr, int* artListSizePtr)
             *brk = '\0';
         }
 
-        strncpy(artList, string, 12);
-        artList[12] = '\0';
+        strncpy(artList, string, ART_NAME_SIZE - 1);
+        artList[ART_NAME_SIZE - 1] = '\0';
 
-        artList += 13;
+        artList += ART_NAME_SIZE;
 
         count--;
     }
@@ -944,10 +944,10 @@ CritterFrameId _art_alias_num(CritterFrameId index)
 }
 
 // 0x4199AC
-int artCritterFidShouldRun(int fid)
+int artCritterFrmIdShouldRun(const FrmId& frmId)
 {
-    if (objectTypeFromFid(fid) == OBJ_TYPE_CRITTER) {
-        return gArtCritterFidShoudRunData[frameIdFromFid(fid)];
+    if (frmId.objectType() == OBJ_TYPE_CRITTER && frmId.valid()) {
+        return gArtCritterFidShoudRunData[frmId.frameId().id];
     }
 
     return 0;

--- a/src/art.cc
+++ b/src/art.cc
@@ -49,7 +49,7 @@ static int artReadHeader(Art* art, File* stream);
 static int artGetDataSize(const Art* art);
 static int paddingForSize(int size);
 static char artGetCritterWeaponCode(WeaponAnimation weaponType);
-static Art* artLock(int fid, CacheEntry** cache_entry);
+static Art* artLock(int fid, CacheEntry** handlePtr);
 
 // A frame is laid out like [ArtFrame header][pixel bytes][padding].
 // These functions return a pointer to the pixel bytes, but must be given a pointer to a frame header,
@@ -564,6 +564,8 @@ int artCopyFileName(const FrmId& frmId, char* dest)
         return -1;
     }
 
+    assert(frmId.hasFid() && "artCopyFileName(const FrmId& frmId, char* dest) called with path based FrmId which is not supported!");
+
     ptr = &(gArtListDescriptions[frmId.objectType()]);
 
     if (frmId.frameId().id >= ptr->fileNamesLength) {
@@ -932,7 +934,7 @@ CritterFrameId _art_alias_num(CritterFrameId index)
 // 0x4199AC
 int artCritterFrmIdShouldRun(const FrmId& frmId)
 {
-    if (frmId.objectType() == OBJ_TYPE_CRITTER && frmId.valid()) {
+    if (frmId.objectType() == OBJ_TYPE_CRITTER && frmId.valid() && frmId.hasFid()) {
         return gArtCritterFidShoudRunData[frmId.frameId().id];
     }
 

--- a/src/art.cc
+++ b/src/art.cc
@@ -477,14 +477,6 @@ void artRender(const FrmId& frmId, unsigned char* dest, int width, int height, i
     frmImage.unlock();
 }
 
-// mapper2.exe: 0x40A03C
-int art_list_str(int fid, char* name)
-{
-    // TODO: Incomplete.
-
-    return -1;
-}
-
 int artListIndex(ObjectType objectType, const char* name)
 {
     if (!objectTypeIsValid(objectType)) return -1;

--- a/src/art.cc
+++ b/src/art.cc
@@ -551,28 +551,6 @@ Art* artLock(const FrmId& frmId, CacheEntry** handlePtr)
     return artLock(frmId.fid(), handlePtr);
 }
 
-// 0x419188
-unsigned char* artLockFrameData(int fid, int frame, Rotation rotation, CacheEntry** handlePtr)
-{
-    Art* art;
-    ArtFrame* frm;
-
-    art = nullptr;
-    if (handlePtr) {
-        cacheLock(&gArtCache, fid, (void**)&art, handlePtr);
-    }
-
-    if (art != nullptr) {
-        frm = artGetFrame(art, frame, rotation);
-        if (frm != nullptr) {
-
-            return artFrameData(frm);
-        }
-    }
-
-    return nullptr;
-}
-
 // 0x419260
 int artUnlock(CacheEntry* handle)
 {

--- a/src/art.cc
+++ b/src/art.cc
@@ -49,6 +49,7 @@ static int artReadHeader(Art* art, File* stream);
 static int artGetDataSize(const Art* art);
 static int paddingForSize(int size);
 static char artGetCritterWeaponCode(WeaponAnimation weaponType);
+static Art* artLock(int fid, CacheEntry** cache_entry);
 
 // A frame is laid out like [ArtFrame header][pixel bytes][padding].
 // These functions return a pointer to the pixel bytes, but must be given a pointer to a frame header,
@@ -519,7 +520,7 @@ int artListIndex(ObjectType objectType, const char* name)
 }
 
 // 0x419160
-Art* artLock(int fid, CacheEntry** handlePtr)
+static Art* artLock(int fid, CacheEntry** handlePtr)
 {
     if (handlePtr == nullptr) {
         return nullptr;
@@ -533,6 +534,21 @@ Art* artLock(int fid, CacheEntry** handlePtr)
     Art* art = nullptr;
     cacheLock(&gArtCache, fid, (void**)&art, handlePtr);
     return art;
+}
+
+// works for fid based FrmIds only, to be replaced by FrmImage::lock
+Art* artLock(const FrmId& frmId, CacheEntry** handlePtr)
+{
+    if (!frmId.valid()) {
+        if (handlePtr != nullptr) {
+            *handlePtr = nullptr;
+        }
+        return nullptr;
+    }
+
+    assert(frmId.hasFid() && "artLock(const FrmId& frmId, CacheEntry** handlePtr) called with path based FrmId which is not supported!");
+
+    return artLock(frmId.fid(), handlePtr);
 }
 
 // 0x419188

--- a/src/art.h
+++ b/src/art.h
@@ -421,7 +421,7 @@ char* artGetObjectTypeName(ObjectType objectType);
 int artIsObjectTypeHidden(ObjectType objectType);
 void artToggleObjectTypeHidden(ObjectType objectType);
 int artGetFidgetCount(const HeadFrmId& frmId);
-void artRender(int fid, unsigned char* dest, int width, int height, int pitch);
+void artRender(const FrmId& frmId, unsigned char* dest, int width, int height, int pitch);
 int art_list_str(int fid, char* name);
 Art* artLock(int fid, CacheEntry** cache_entry);
 

--- a/src/art.h
+++ b/src/art.h
@@ -220,15 +220,11 @@ public:
     constexpr bool hasFid() const { return _fid > kEmptyFid; }
     constexpr bool hasObjectType() const { return objectTypeIsValid(_objectType); }
 
-    constexpr ObjectType objectType() const
-    {
-        assert(hasObjectType());
-        return _objectType;
-    }
+    constexpr ObjectType objectType() const { return hasObjectType() ? _objectType : OBJ_TYPE_INVALID; }
 
     const char* filePath() const { return _path != nullptr ? _path : buildPath(_fid, _builtPath); }
 
-    bool valid() const { return !empty() && ((_frameId.id >= kMinFrameId && _frameId.id <= kMaxFrameId) || _path != nullptr); }
+    bool valid() const { return !empty() && hasObjectType() && ((_frameId.id >= kMinFrameId && _frameId.id <= kMaxFrameId) || _path != nullptr); }
 
     bool exist() const { return hasFid() && valid() && exist(_fid, _builtPath); }
 

--- a/src/art.h
+++ b/src/art.h
@@ -424,7 +424,6 @@ int artIsObjectTypeHidden(ObjectType objectType);
 void artToggleObjectTypeHidden(ObjectType objectType);
 int artGetFidgetCount(const HeadFrmId& frmId);
 void artRender(const FrmId& frmId, unsigned char* dest, int width, int height, int pitch);
-int art_list_str(int fid, char* name);
 
 // works for fid based FrmIds only, to be replaced by FrmImage::lock
 Art* artLock(const FrmId& frmId, CacheEntry** handlePtr);

--- a/src/art.h
+++ b/src/art.h
@@ -429,7 +429,6 @@ int art_list_str(int fid, char* name);
 // works for fid based FrmIds only, to be replaced by FrmImage::lock
 Art* artLock(const FrmId& frmId, CacheEntry** handlePtr);
 
-unsigned char* artLockFrameData(int fid, int frame, Rotation rotation, CacheEntry** out_cache_entry);
 int artUnlock(CacheEntry* cache_entry);
 int artCacheFlush();
 int artCopyFileName(const FrmId& frmId, char* dest);

--- a/src/art.h
+++ b/src/art.h
@@ -41,7 +41,7 @@ extern CritterFrameId _art_vault_person_nums[DUDE_NATIVE_LOOK_COUNT][GENDER_COUN
 
 extern Cache gArtCache;
 
-#define ART_NAME_SIZE (13) 
+#define ART_NAME_SIZE (13)
 
 class NamedCacheEntry;
 std::shared_ptr<NamedCacheEntry> artLockNamedFrameData(const char* path);

--- a/src/art.h
+++ b/src/art.h
@@ -41,6 +41,8 @@ extern CritterFrameId _art_vault_person_nums[DUDE_NATIVE_LOOK_COUNT][GENDER_COUN
 
 extern Cache gArtCache;
 
+#define ART_NAME_SIZE (13) 
+
 class NamedCacheEntry;
 std::shared_ptr<NamedCacheEntry> artLockNamedFrameData(const char* path);
 
@@ -443,7 +445,7 @@ inline Art* artLock(const FrmId& frmId, CacheEntry** handlePtr)
 unsigned char* artLockFrameData(int fid, int frame, Rotation rotation, CacheEntry** out_cache_entry);
 int artUnlock(CacheEntry* cache_entry);
 int artCacheFlush();
-int artCopyFileName(ObjectType objectType, int id, char* dest);
+int artCopyFileName(const FrmId& frmId, char* dest);
 int _art_get_code(AnimationType animation, WeaponAnimation weaponType, char* weaponCodePtr, char* animationCodePtr);
 int artGetFramesPerSecond(Art* art);
 int artGetActionFrame(Art* art);
@@ -458,7 +460,7 @@ unsigned char* artGetFrameData(const Art* art, int frame, Rotation rotation, int
 ArtFrame* artGetFrame(const Art* art, int frame, Rotation rotation);
 ConstBuffer2D artGetFrameBuffer(const Art* art, int frame, Rotation rotation);
 CritterFrameId _art_alias_num(CritterFrameId index);
-int artCritterFidShouldRun(int fid);
+int artCritterFrmIdShouldRun(const FrmId& frmId);
 int artListIndex(ObjectType objectType, const char* name);
 Art* artLoad(const char* path);
 int artRead(const char* path, unsigned char* data);

--- a/src/art.h
+++ b/src/art.h
@@ -425,22 +425,9 @@ void artToggleObjectTypeHidden(ObjectType objectType);
 int artGetFidgetCount(const HeadFrmId& frmId);
 void artRender(const FrmId& frmId, unsigned char* dest, int width, int height, int pitch);
 int art_list_str(int fid, char* name);
-Art* artLock(int fid, CacheEntry** cache_entry);
 
 // works for fid based FrmIds only, to be replaced by FrmImage::lock
-inline Art* artLock(const FrmId& frmId, CacheEntry** handlePtr)
-{
-    if (!frmId.valid()) {
-        if (handlePtr != nullptr) {
-            *handlePtr = nullptr;
-        }
-        return nullptr;
-    }
-
-    assert(frmId.hasFid() && "artLock(const FrmId& frmId, CacheEntry** handlePtr) called with path based FrmId which is not supported!");
-
-    return artLock(frmId.fid(), handlePtr);
-}
+Art* artLock(const FrmId& frmId, CacheEntry** handlePtr);
 
 unsigned char* artLockFrameData(int fid, int frame, Rotation rotation, CacheEntry** out_cache_entry);
 int artUnlock(CacheEntry* cache_entry);

--- a/src/combat_ai.cc
+++ b/src/combat_ai.cc
@@ -2549,7 +2549,7 @@ static int _ai_move_steps_closer(Object* critter, Object* target, int actionPoin
         _cai_retargetTileFromFriendlyFire(critter, target, &tile);
     }
 
-    if (actionPoints >= critterGetStat(critter, STAT_MAXIMUM_ACTION_POINTS) / 2 && artCritterFidShouldRun(critter->fid)) {
+    if (actionPoints >= critterGetStat(critter, STAT_MAXIMUM_ACTION_POINTS) / 2 && artCritterFrmIdShouldRun(FrmId(critter->fid))) {
         if ((target->flags & OBJECT_MULTIHEX) != OBJECT_NONE) {
             animationRegisterRunToObject(critter, target, actionPoints, 0);
         } else {

--- a/src/endgame.cc
+++ b/src/endgame.cc
@@ -802,8 +802,8 @@ static void endgameEndingVoiceOverFree()
 // 0x440378 endgame_load_palette
 static void endgameEndingLoadPalette(const InterfaceFrmId& frmId)
 {
-    char fileName[13];
-    if (artCopyFileName(frmId.objectType(), frmId.frameId().id, fileName) != 0) {
+    char fileName[ART_NAME_SIZE];
+    if (artCopyFileName(frmId, fileName) != 0) {
         return;
     }
 

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -979,7 +979,7 @@ void gameDialogStartLips(const char* audioFileName)
     }
 
     char name[16];
-    if (artCopyFileName(OBJ_TYPE_HEAD, gGameDialogHeadFrmId.frameId().id, name) == -1) {
+    if (artCopyFileName(gGameDialogHeadFrmId, name) == -1) {
         return;
     }
 

--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -2434,7 +2434,7 @@ int _gmouse_3d_move_to(int x, int y, int elevation, Rect* rect)
             int offsetX = 0;
             int offsetY = 0;
             CacheEntry* hexCursorFrmHandle;
-            Art* hexCursorFrm = artLock(gGameMouseHexCursor->fid, &hexCursorFrmHandle);
+            Art* hexCursorFrm = artLock(FrmId(gGameMouseHexCursor->fid), &hexCursorFrmHandle);
             if (hexCursorFrm != nullptr) {
                 artGetRotationOffsets(hexCursorFrm, ROTATION_NE, &offsetX, &offsetY);
 
@@ -2519,7 +2519,7 @@ int _gmouse_3d_move_to(int x, int y, int elevation, Rect* rect)
             int offsetX = 0;
             int offsetY = 0;
             CacheEntry* hexCursorFrmHandle;
-            Art* hexCursorFrm = artLock(gGameMouseHexCursor->fid, &hexCursorFrmHandle);
+            Art* hexCursorFrm = artLock(FrmId(gGameMouseHexCursor->fid), &hexCursorFrmHandle);
             if (hexCursorFrm != nullptr) {
                 artGetRotationOffsets(hexCursorFrm, ROTATION_NE, &offsetX, &offsetY);
 

--- a/src/game_sound.cc
+++ b/src/game_sound.cc
@@ -1334,11 +1334,11 @@ int _gsound_compute_relative_volume(Object* obj)
 // 0x451604
 char* sfxBuildCharName(Object* a1, AnimationType anim, WeaponAnimation weaponType)
 {
-    char artName[13];
+    char artName[ART_NAME_SIZE];
     char weaponCode;
     char animationCode;
 
-    if (artCopyFileName(objectTypeFromFid(a1->fid), frameIdFromFid(a1->fid), artName) == -1) {
+    if (artCopyFileName(FrmId(a1->fid), artName) == -1) {
         return nullptr;
     }
 

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -1124,7 +1124,7 @@ int interfaceUpdateItems(bool animated, InterfaceItemAction leftItemAction, Inte
     if (item1 == leftItemState->item && leftItemState->item != nullptr) {
         if (leftItemState->item != nullptr) {
             leftItemState->isDisabled = dudeIsWeaponDisabled(item1);
-            leftItemState->itemFid = itemGetInventoryFid(item1);
+            leftItemState->itemFid = itemGetInventoryFrmId(item1).fid();
         }
     } else {
         Object* oldItem = leftItemState->item;
@@ -1148,7 +1148,7 @@ int interfaceUpdateItems(bool animated, InterfaceItemAction leftItemAction, Inte
                 leftItemState->action = leftItemAction;
             }
 
-            leftItemState->itemFid = itemGetInventoryFid(item1);
+            leftItemState->itemFid = itemGetInventoryFrmId(item1).fid();
         } else {
             leftItemState->isDisabled = 0;
             leftItemState->isWeapon = 1;
@@ -1173,7 +1173,7 @@ int interfaceUpdateItems(bool animated, InterfaceItemAction leftItemAction, Inte
     if (item2 == rightItemState->item && rightItemState->item != nullptr) {
         if (rightItemState->item != nullptr) {
             rightItemState->isDisabled = dudeIsWeaponDisabled(rightItemState->item);
-            rightItemState->itemFid = itemGetInventoryFid(rightItemState->item);
+            rightItemState->itemFid = itemGetInventoryFrmId(rightItemState->item).fid();
         }
     } else {
         Object* oldItem = rightItemState->item;
@@ -1196,7 +1196,7 @@ int interfaceUpdateItems(bool animated, InterfaceItemAction leftItemAction, Inte
             } else {
                 rightItemState->action = rightItemAction;
             }
-            rightItemState->itemFid = itemGetInventoryFid(item2);
+            rightItemState->itemFid = itemGetInventoryFrmId(item2).fid();
         } else {
             rightItemState->isDisabled = 0;
             rightItemState->isWeapon = 1;

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -1226,7 +1226,7 @@ static void renderPartySlots()
     if (armor != nullptr) {
         int itemX = armorRect.left + (kPartySlotWidth - INVENTORY_LARGE_SLOT_WIDTH) / 2;
         int itemY = armorRect.top + (kPartySlotHeight - INVENTORY_LARGE_SLOT_HEIGHT) / 2 + 3;
-        artRender(itemGetInventoryFid(armor),
+        artRender(itemGetInventoryFrmId(armor),
             windowBuffer + pitch * itemY + itemX,
             INVENTORY_LARGE_SLOT_WIDTH,
             INVENTORY_LARGE_SLOT_HEIGHT,
@@ -1237,7 +1237,7 @@ static void renderPartySlots()
     if (weapon != nullptr) {
         int itemX = weaponRect.left + (kPartySlotWidth - INVENTORY_LARGE_SLOT_WIDTH) / 2;
         int itemY = weaponRect.top + (kPartySlotHeight - INVENTORY_LARGE_SLOT_HEIGHT) / 2 - 3;
-        artRender(itemGetInventoryFid(weapon),
+        artRender(itemGetInventoryFrmId(weapon),
             windowBuffer + pitch * itemY + itemX,
             INVENTORY_LARGE_SLOT_WIDTH,
             INVENTORY_LARGE_SLOT_HEIGHT,
@@ -2306,8 +2306,8 @@ static void _display_inventory(int stackOffset, int dragSlotIndex, int inventory
 
             InventoryItem* inventoryItem = &(_pud->items[_pud->length - itemIndex]);
 
-            int inventoryFid = itemGetInventoryFid(inventoryItem->item);
-            artRender(inventoryFid, windowBuffer + offset, INVENTORY_SLOT_WIDTH_PAD, INVENTORY_SLOT_HEIGHT_PAD, pitch);
+            const FrmId inventoryFrmId = itemGetInventoryFrmId(inventoryItem->item);
+            artRender(inventoryFrmId, windowBuffer + offset, INVENTORY_SLOT_WIDTH_PAD, INVENTORY_SLOT_HEIGHT_PAD, pitch);
             _display_inventory_info(inventoryItem->item, inventoryItem->quantity, windowBuffer + offset, pitch, slotIndex == dragSlotIndex);
         }
     } else {
@@ -2328,8 +2328,8 @@ static void _display_inventory(int stackOffset, int dragSlotIndex, int inventory
 
             InventoryItem* inventoryItem = &(_pud->items[_pud->length - itemIndex]);
 
-            int inventoryFid = itemGetInventoryFid(inventoryItem->item);
-            artRender(inventoryFid, windowBuffer + offset, INVENTORY_SLOT_WIDTH_PAD, INVENTORY_SLOT_HEIGHT_PAD, pitch);
+            const FrmId inventoryFrmId = itemGetInventoryFrmId(inventoryItem->item);
+            artRender(inventoryFrmId, windowBuffer + offset, INVENTORY_SLOT_WIDTH_PAD, INVENTORY_SLOT_HEIGHT_PAD, pitch);
             _display_inventory_info(inventoryItem->item, inventoryItem->quantity, windowBuffer + offset, pitch, slotIndex == dragSlotIndex);
 
             if (inventoryWindowType != INVENTORY_WINDOW_TYPE_LOOT) {
@@ -2341,18 +2341,18 @@ static void _display_inventory(int stackOffset, int dragSlotIndex, int inventory
     if (inventoryWindowType == INVENTORY_WINDOW_TYPE_NORMAL) {
         if (gInventoryRightHandItem != nullptr) {
             int width = gInventoryRightHandItem == gInventoryLeftHandItem ? INVENTORY_LARGE_SLOT_WIDTH * 2 : INVENTORY_LARGE_SLOT_WIDTH;
-            int inventoryFid = itemGetInventoryFid(gInventoryRightHandItem);
-            artRender(inventoryFid, windowBuffer + pitch * INVENTORY_RIGHT_HAND_SLOT_Y + inventoryLayout.rightHandSlotX, width, INVENTORY_LARGE_SLOT_HEIGHT, pitch);
+            const FrmId inventoryFrmId = itemGetInventoryFrmId(gInventoryRightHandItem);
+            artRender(inventoryFrmId, windowBuffer + pitch * INVENTORY_RIGHT_HAND_SLOT_Y + inventoryLayout.rightHandSlotX, width, INVENTORY_LARGE_SLOT_HEIGHT, pitch);
         }
 
         if (gInventoryLeftHandItem != nullptr && gInventoryLeftHandItem != gInventoryRightHandItem) {
-            int inventoryFid = itemGetInventoryFid(gInventoryLeftHandItem);
-            artRender(inventoryFid, windowBuffer + pitch * INVENTORY_LEFT_HAND_SLOT_Y + inventoryLayout.leftHandSlotX, INVENTORY_LARGE_SLOT_WIDTH, INVENTORY_LARGE_SLOT_HEIGHT, pitch);
+            const FrmId inventoryFrmId = itemGetInventoryFrmId(gInventoryLeftHandItem);
+            artRender(inventoryFrmId, windowBuffer + pitch * INVENTORY_LEFT_HAND_SLOT_Y + inventoryLayout.leftHandSlotX, INVENTORY_LARGE_SLOT_WIDTH, INVENTORY_LARGE_SLOT_HEIGHT, pitch);
         }
 
         if (gInventoryArmor != nullptr) {
-            int inventoryFid = itemGetInventoryFid(gInventoryArmor);
-            artRender(inventoryFid, windowBuffer + pitch * INVENTORY_ARMOR_SLOT_Y + inventoryLayout.armorSlotX, INVENTORY_LARGE_SLOT_WIDTH, INVENTORY_LARGE_SLOT_HEIGHT, pitch);
+            const FrmId inventoryFrmId = itemGetInventoryFrmId(gInventoryArmor);
+            artRender(inventoryFrmId, windowBuffer + pitch * INVENTORY_ARMOR_SLOT_Y + inventoryLayout.armorSlotX, INVENTORY_LARGE_SLOT_WIDTH, INVENTORY_LARGE_SLOT_HEIGHT, pitch);
         }
     }
 
@@ -2414,8 +2414,8 @@ static void _display_target_inventory(int stackOffset, int dragSlotIndex, Invent
         }
 
         InventoryItem* inventoryItem = &(inventory->items[inventory->length - (itemIndex + 1)]);
-        int inventoryFid = itemGetInventoryFid(inventoryItem->item);
-        artRender(inventoryFid, windowBuffer + offset, INVENTORY_SLOT_WIDTH_PAD, INVENTORY_SLOT_HEIGHT_PAD, pitch);
+        const FrmId inventoryFrmId = itemGetInventoryFrmId(inventoryItem->item);
+        artRender(inventoryFrmId, windowBuffer + offset, INVENTORY_SLOT_WIDTH_PAD, INVENTORY_SLOT_HEIGHT_PAD, pitch);
         _display_inventory_info(inventoryItem->item, inventoryItem->quantity, windowBuffer + offset, pitch, slotIndex == dragSlotIndex);
 
         if (inventoryWindowType == INVENTORY_WINDOW_TYPE_TRADE) {
@@ -5439,8 +5439,8 @@ static void _drag_item_loop(Object* item, bool immediate)
     }
 
     FrmImage itemInventoryFrmImage;
-    int itemInventoryFid = itemGetInventoryFid(item);
-    if (itemInventoryFrmImage.lock(FrmId(itemInventoryFid))) {
+    const FrmId itemInventoryFrmId = itemGetInventoryFrmId(item);
+    if (itemInventoryFrmImage.lock(itemInventoryFrmId)) {
         int width = itemInventoryFrmImage.getWidth();
         int height = itemInventoryFrmImage.getHeight();
         unsigned char* data = itemInventoryFrmImage.getData();
@@ -5600,8 +5600,8 @@ static void barterDisplayTables(int win, Object* leftTable, Object* rightTable, 
         Inventory* inventory = &(leftTable->data.inventory);
         for (int index = 0; index < gInventorySlotsCount && index + gPlayerTableOffset < inventory->length; index++) {
             InventoryItem* inventoryItem = &(inventory->items[inventory->length - (index + gPlayerTableOffset + 1)]);
-            int inventoryFid = itemGetInventoryFid(inventoryItem->item);
-            artRender(inventoryFid, dest, INVENTORY_SLOT_WIDTH_PAD, INVENTORY_SLOT_HEIGHT_PAD, INVENTORY_TRADE_WINDOW_WIDTH);
+            const FrmId inventoryFrmId = itemGetInventoryFrmId(inventoryItem->item);
+            artRender(inventoryFrmId, dest, INVENTORY_SLOT_WIDTH_PAD, INVENTORY_SLOT_HEIGHT_PAD, INVENTORY_TRADE_WINDOW_WIDTH);
             _display_inventory_info(inventoryItem->item, inventoryItem->quantity, dest, INVENTORY_TRADE_WINDOW_WIDTH, index == draggedSlotIndex);
 
             dest += INVENTORY_TRADE_WINDOW_WIDTH * INVENTORY_SLOT_HEIGHT;
@@ -5637,8 +5637,8 @@ static void barterDisplayTables(int win, Object* leftTable, Object* rightTable, 
         Inventory* inventory = &(rightTable->data.inventory);
         for (int index = 0; index < gInventorySlotsCount && index + gBartererTableOffset < inventory->length; index++) {
             InventoryItem* inventoryItem = &(inventory->items[inventory->length - (index + gBartererTableOffset + 1)]);
-            int inventoryFid = itemGetInventoryFid(inventoryItem->item);
-            artRender(inventoryFid, dest, INVENTORY_SLOT_WIDTH_PAD, INVENTORY_SLOT_HEIGHT_PAD, INVENTORY_TRADE_WINDOW_WIDTH);
+            const FrmId inventoryFrmId = itemGetInventoryFrmId(inventoryItem->item);
+            artRender(inventoryFrmId, dest, INVENTORY_SLOT_WIDTH_PAD, INVENTORY_SLOT_HEIGHT_PAD, INVENTORY_TRADE_WINDOW_WIDTH);
             _display_inventory_info(inventoryItem->item, inventoryItem->quantity, dest, INVENTORY_TRADE_WINDOW_WIDTH, index == draggedSlotIndex);
 
             dest += INVENTORY_TRADE_WINDOW_WIDTH * INVENTORY_SLOT_HEIGHT;
@@ -6494,8 +6494,8 @@ static int inventoryQuantityWindowInit(int inventoryWindowType, Object* item)
         }
     }
 
-    int inventoryFid = itemGetInventoryFid(item);
-    artRender(inventoryFid, windowBuffer + windowDescription->width * 46 + 16, INVENTORY_LARGE_SLOT_WIDTH, INVENTORY_LARGE_SLOT_HEIGHT, windowDescription->width);
+    const FrmId inventoryFrmId = itemGetInventoryFrmId(item);
+    artRender(inventoryFrmId, windowBuffer + windowDescription->width * 46 + 16, INVENTORY_LARGE_SLOT_WIDTH, INVENTORY_LARGE_SLOT_HEIGHT, windowDescription->width);
 
     int x = 194;
     int y = 64;

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -4740,7 +4740,7 @@ int inventoryOpenLooting(Object* looter, Object* target)
     if (objectTypeFromFid(target->fid) == OBJ_TYPE_ITEM && itemGetType(target) == ITEM_TYPE_CONTAINER) {
         if (target->frame == 0) {
             CacheEntry* handle;
-            Art* frm = artLock(target->fid, &handle);
+            Art* frm = artLock(FrmId(target->fid), &handle);
             if (frm != nullptr) {
                 int frameCount = artGetFrameCount(frm);
                 artUnlock(handle);

--- a/src/item.cc
+++ b/src/item.cc
@@ -1047,16 +1047,16 @@ bool dudeIsWeaponDisabled(Object* weapon)
 }
 
 // 0x477FB0
-int itemGetInventoryFid(Object* item)
+FrmId itemGetInventoryFrmId(Object* item)
 {
     if (item == nullptr) {
-        return -1;
+        return FrmId::Empty();
     }
 
     Proto* proto;
     protoGetProto(item->pid, &proto);
 
-    return proto->item.inventoryFid;
+    return FrmId(proto->item.inventoryFid);
 }
 
 // 0x477FF8

--- a/src/item.h
+++ b/src/item.h
@@ -68,7 +68,7 @@ int itemGetCost(Object* obj);
 int objectGetCost(Object* obj);
 int objectGetInventoryWeight(Object* obj);
 bool dudeIsWeaponDisabled(Object* weapon);
-int itemGetInventoryFid(Object* obj);
+FrmId itemGetInventoryFrmId(Object* obj);
 Object* critterGetWeaponForHitMode(Object* critter, HitMode hitMode);
 int itemGetActionPointCost(Object* obj, HitMode hitMode, bool aiming);
 int itemGetQuantity(Object* obj, Object* item);

--- a/src/mapper/mapper.cc
+++ b/src/mapper/mapper.cc
@@ -2532,7 +2532,7 @@ void update_art(ObjectType type, int offset)
             if (protoGetProto(pid, &proto) == -1) continue;
             frmId = FrmId(proto->fid);
         }
-        artRender(frmId.fid(), p, art_scale_width, art_scale_height, screen_width);
+        artRender(frmId, p, art_scale_width, art_scale_height, screen_width);
     }
 
     // Draw selection box around the active slot.

--- a/src/mapper/mp_instance.cc
+++ b/src/mapper/mp_instance.cc
@@ -149,7 +149,7 @@ static int protoInstSetupEdit(int* pWinId, Object* obj, ObjectType* pObjType, in
     unsigned char* buf = windowGetBuffer(win);
     bufferDrawRect(buf + 12899, kWinWidth, 0, 0, 65, 49, COLOR_BLACK);
     bufferFill(buf + *pBufOff, kArtWidth, kArtHeight, kWinWidth, COLOR_BLUE_2);
-    artRender(obj->fid, buf + *pBufOff, kArtWidth, kArtHeight, kWinWidth);
+    artRender(FrmId(obj->fid), buf + *pBufOff, kArtWidth, kArtHeight, kWinWidth);
 
     // Script section
     int scriptY = y + 83;

--- a/src/mapper/mp_proto.cc
+++ b/src/mapper/mp_proto.cc
@@ -283,6 +283,14 @@ int proto_subdata_setup_int_button(const char* title, int key, int value, int mi
     return 0;
 }
 
+// 0x40A03C
+int art_list_str(int fid, char* name)
+{
+    // TODO: Incomplete.
+
+    return -1;
+}
+
 // 0x492B28
 int proto_subdata_setup_fid_button(const char* title, int key, int fid, int* y, int itemIndex)
 {

--- a/src/mapper/mp_proto.cc
+++ b/src/mapper/mp_proto.cc
@@ -679,7 +679,7 @@ static void protoChooseMultiPidsUpdate(int win, int pidType, int scrollOffset, p
             Proto* proto;
             if (protoGetProto(pid, &proto) != -1) {
                 int fid = fidFunc ? fidFunc(proto) : proto->fid;
-                artRender(fid, buf + cellY * pitch + cellX, kArtW, kArtH, pitch);
+                artRender(FrmId(fid), buf + cellY * pitch + cellX, kArtW, kArtH, pitch);
 
                 const char* name = protoGetName(pid);
                 int textY = cellY + kArtH + 5;

--- a/src/object.cc
+++ b/src/object.cc
@@ -1345,7 +1345,7 @@ int _obj_move(Object* a1, int a2, int a3, int elevation, Rect* a5)
     CacheEntry* cacheHandle;
     int width;
     int height;
-    Art* art = artLock(a1->fid, &cacheHandle);
+    Art* art = artLock(FrmId(a1->fid), &cacheHandle);
     if (art != nullptr) {
         artGetSize(art, a1->frame, a1->rotation, &width, &height);
         a1->sx = a2 - width / 2;
@@ -1584,7 +1584,7 @@ int objectSetFrame(Object* obj, int frame, Rect* rect)
         return -1;
     }
 
-    art = artLock(obj->fid, &cache_entry);
+    art = artLock(FrmId(obj->fid), &cache_entry);
     if (art == nullptr) {
         return -1;
     }
@@ -1621,7 +1621,7 @@ int objectSetNextFrame(Object* obj, Rect* dirtyRect)
         return -1;
     }
 
-    art = artLock(obj->fid, &cache_entry);
+    art = artLock(FrmId(obj->fid), &cache_entry);
     if (art == nullptr) {
         return -1;
     }
@@ -1665,7 +1665,7 @@ int objectSetPrevFrame(Object* obj, Rect* dirtyRect)
         return -1;
     }
 
-    art = artLock(obj->fid, &cache_entry);
+    art = artLock(FrmId(obj->fid), &cache_entry);
     if (art == nullptr) {
         return -1;
     }
@@ -2357,7 +2357,7 @@ void objectGetRect(Object* obj, Rect* rect)
     bool isOutlined = objectHasOutline(obj);
 
     CacheEntry* artHandle;
-    Art* art = artLock(obj->fid, &artHandle);
+    Art* art = artLock(FrmId(obj->fid), &artHandle);
     if (art == nullptr) {
         rect->left = 0;
         rect->top = 0;
@@ -2953,7 +2953,7 @@ ObjectFlags _obj_intersects_with(Object* object, int x, int y)
 
     if (object == gEgg || (object->flags & OBJECT_HIDDEN) == OBJECT_NONE) {
         CacheEntry* handle;
-        Art* art = artLock(object->fid, &handle);
+        Art* art = artLock(FrmId(object->fid), &handle);
         if (art != nullptr) {
             int width;
             int height;
@@ -3245,13 +3245,13 @@ void _obj_preload_art_cache(MapHeaderFlags flags)
     }
 
     CacheEntry* cache_handle;
-    if (artLock(*gObjectFids, &cache_handle) != nullptr) {
+    if (artLock(FrmId(*gObjectFids), &cache_handle) != nullptr) {
         artUnlock(cache_handle);
     }
 
     for (int i = 1; i < v11; i++) {
         if (gObjectFids[i - 1] != gObjectFids[i]) {
-            if (artLock(gObjectFids[i], &cache_handle) != nullptr) {
+            if (artLock(FrmId(gObjectFids[i]), &cache_handle) != nullptr) {
                 artUnlock(cache_handle);
             }
         }
@@ -3267,7 +3267,7 @@ void _obj_preload_art_cache(MapHeaderFlags flags)
 
     for (int i = v11; i < gObjectFidsLength; i++) {
         if (gObjectFids[i - 1] != gObjectFids[i]) {
-            if (artLock(gObjectFids[i], &cache_handle) != nullptr) {
+            if (artLock(FrmId(gObjectFids[i]), &cache_handle) != nullptr) {
                 artUnlock(cache_handle);
             }
         }
@@ -3917,11 +3917,11 @@ static void _obj_insert(ObjectListNode* objectListNode)
                 if ((obj->flags & OBJECT_FLAT) == (objectListNode->obj->flags & OBJECT_FLAT)) {
                     bool v11 = false;
                     CacheEntry* a2;
-                    Art* v12 = artLock(obj->fid, &a2);
+                    Art* v12 = artLock(FrmId(obj->fid), &a2);
                     if (v12 != nullptr) {
 
                         if (art == nullptr) {
-                            art = artLock(objectListNode->obj->fid, &cacheHandle);
+                            art = artLock(FrmId(objectListNode->obj->fid), &cacheHandle);
                         }
 
                         // TODO: Incomplete.
@@ -4691,7 +4691,7 @@ static int _obj_adjust_light(Object* obj, int a2, Rect* rect)
 static void objectDrawOutline(Object* object, Rect* rect)
 {
     CacheEntry* cacheEntry;
-    Art* art = artLock(object->fid, &cacheEntry);
+    Art* art = artLock(FrmId(object->fid), &cacheEntry);
     if (art == nullptr) {
         return;
     }
@@ -4962,7 +4962,7 @@ static void _obj_render_object(Object* object, Rect* rect, int light)
     }
 
     CacheEntry* cacheEntry;
-    Art* art = artLock(object->fid, &cacheEntry);
+    Art* art = artLock(FrmId(object->fid), &cacheEntry);
     if (art == nullptr) {
         return;
     }
@@ -5057,7 +5057,7 @@ static void _obj_render_object(Object* object, Rect* rect, int light)
 
             if (v17) {
                 CacheEntry* eggHandle;
-                Art* egg = artLock(gEgg->fid, &eggHandle);
+                Art* egg = artLock(FrmId(gEgg->fid), &eggHandle);
                 if (egg == nullptr) {
                     return;
                 }

--- a/src/proto_instance.cc
+++ b/src/proto_instance.cc
@@ -1674,7 +1674,7 @@ static int _check_door_state(Object* door, Object* obj2)
         }
 
         CacheEntry* artHandle;
-        Art* art = artLock(door->fid, &artHandle);
+        Art* art = artLock(FrmId(door->fid), &artHandle);
         if (art == nullptr) {
             return -1;
         }
@@ -1708,7 +1708,7 @@ static int _check_door_state(Object* door, Object* obj2)
         tileWindowRefresh();
 
         CacheEntry* artHandle;
-        Art* art = artLock(door->fid, &artHandle);
+        Art* art = artLock(FrmId(door->fid), &artHandle);
         if (art == nullptr) {
             return -1;
         }
@@ -2076,7 +2076,7 @@ bool objectIsOpenable(Object* obj)
 
     // Sfall: stricter "openable" check.  In Sfall it is implemented in the obj_is_openable opcode.
     CacheEntry* artHandle;
-    Art* art = artLock(obj->fid, &artHandle);
+    Art* art = artLock(FrmId(obj->fid), &artHandle);
     if (art == nullptr) {
         return false;
     }

--- a/src/tile.cc
+++ b/src/tile.cc
@@ -1401,7 +1401,7 @@ static void tileRenderRoof(const TileFrmId& frmId, int x, int y, Rect* rect, int
         tileFrmBuffer += tileWidth * (tileRect.top - y) + (tileRect.left - x);
 
         CacheEntry* eggFrmHandle;
-        Art* eggFrm = artLock(gEgg->fid, &eggFrmHandle);
+        Art* eggFrm = artLock(FrmId(gEgg->fid), &eggFrmHandle);
         if (eggFrm != nullptr) {
             int eggWidth = artGetWidth(eggFrm);
             int eggHeight = artGetHeight(eggFrm);

--- a/src/worldmap.cc
+++ b/src/worldmap.cc
@@ -5757,9 +5757,12 @@ static int wmTileGrabArt(int tileIdx)
         return 0;
     }
 
-    tile->data = artLockFrameData(tile->fid, 0, ROTATION_NE, &(tile->handle));
-    if (tile->data != nullptr) {
-        return 0;
+    Art* art = artLock(FrmId(tile->fid), &(tile->handle));
+    if (art != nullptr) {
+        tile->data = artGetFrameData(art, 0, ROTATION_NE);
+        if (tile->data != nullptr) {
+            return 0;
+        }
     }
 
     wmInterfaceExit();


### PR DESCRIPTION
### Description
Third batch of changes to get rid of `int fid` from module APIs and replaced by `FrmId` instead.
Mostly `art.h/cc` related changes.

`artLock(int fid, CacheEntry** handerPtr)` changed as private `art.cc` method and all the usages changed to `artLock(const FrmId& frmId, CacheEntry** handerPtr)`. This is unification work before `artLock` is replaced by `FrmImage::lock` everywhere.

`artCopyFileName` changed to use `FrmId` instead of combination of `objectType` and `FrameId`.
`artRender` now supports `FrmId` including path based one.
`itemGetInventoryFrmId` changed to return `FrmId` instead of `fid`.

New macro `ART_NAME_SIZE (13)` to get rid of multiple constants (12, 13) in the code, mostly int `artListIndex`. Some of the callers are using as name buffer length `16` and and some of `13`. I've replaced only those with `13`.

`artLockFrameData` had only one usage in worldmap thus changed to more common variant.

 Unimplemented mapper function `art_list_str` moved to mapper exclusive files.

