### PR TITLE
Replace Fid usages by FrmId vol4

### DIFF
--- a/src/actions.cc
+++ b/src/actions.cc
@@ -117,7 +117,7 @@ static bool actionRegisterUseAnimObj(Object* user, Object* targetObj, AnimationT
     }
 
     if (hookAnim != originalAnim) {
-        const FrmId frmId = FrmId(user, hookAnim, weaponAnimationFromFid(user->fid), user->rotation + 1);
+        const FrmId frmId = FrmId(user, hookAnim, user->rotation + 1);
         if (!frmId.exist()) {
             hookAnim = originalAnim;
         }
@@ -137,7 +137,7 @@ int actionKnockdown(Object* obj, AnimationType* anim, int maxDistance, Rotation 
     }
 
     if (*anim == ANIM_FALL_FRONT) {
-        const FrmId frmId = FrmId(obj, *anim, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
+        const FrmId frmId = FrmId(obj, *anim, obj->rotation + 1);
         if (!frmId.exist()) {
             *anim = ANIM_FALL_BACK;
         }
@@ -202,7 +202,7 @@ AnimationType actionBlood(Object* obj, AnimationType anim, int delay)
         return anim;
     }
 
-    const FrmId frmId = FrmId(obj, bloodyAnim, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
+    const FrmId frmId = FrmId(obj, bloodyAnim, obj->rotation + 1);
     if (frmId.exist()) {
         animationRegisterAnimate(obj, bloodyAnim, delay);
     } else {
@@ -308,7 +308,7 @@ AnimationType checkDeathAnim(Object* obj, AnimationType anim, int minViolenceLev
     FrmId frmId;
 
     if (settings.preferences.violence_level >= minViolenceLevel) {
-        frmId = FrmId(obj, anim, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
+        frmId = FrmId(obj, anim, obj->rotation + 1);
         if (frmId.exist()) {
             return anim;
         }
@@ -318,7 +318,7 @@ AnimationType checkDeathAnim(Object* obj, AnimationType anim, int minViolenceLev
         return ANIM_FALL_BACK;
     }
 
-    frmId = FrmId(obj, ANIM_FALL_FRONT, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
+    frmId = FrmId(obj, ANIM_FALL_FRONT, obj->rotation + 1);
     // CE: fixed vanilla logic that returned ANIM_FALL_BACK if artExists for ANIM_FALL_FRONT returned true.
     if (!frmId.exist()) {
         return ANIM_FALL_BACK;
@@ -367,7 +367,7 @@ void showDamageToObject(Object* defender, int damage, int flags, Object* weapon,
                     }
                 }
             } else {
-                frmId = FrmId(defender, ANIM_FIRE_DANCE, weaponAnimationFromFid(defender->fid), defender->rotation + 1);
+                frmId = FrmId(defender, ANIM_FIRE_DANCE, defender->rotation + 1);
                 if (frmId.exist()) {
                     sfx_name = sfxBuildCharName(defender, anim, CHARACTER_SOUND_EFFECT_UNUSED);
                     animationRegisterPlaySoundEffect(defender, sfx_name, delay);
@@ -445,10 +445,10 @@ void showDamageToObject(Object* defender, int damage, int flags, Object* weapon,
                     anim = pickFallAnim(defender, anim);
                     animationRegisterAnimate(defender, anim, 0);
                 }
-            } else if ((flags & DAM_ON_FIRE) != DAM_NONE && FrmId(defender, ANIM_FIRE_DANCE, weaponAnimationFromFid(defender->fid), defender->rotation + 1).exist()) {
+            } else if ((flags & DAM_ON_FIRE) != DAM_NONE && FrmId(defender, ANIM_FIRE_DANCE, defender->rotation + 1).exist()) {
                 animationRegisterAnimate(defender, ANIM_FIRE_DANCE, delay);
 
-                frmId = FrmId(defender, ANIM_STAND, weaponAnimationFromFid(defender->fid), defender->rotation + 1);
+                frmId = FrmId(defender, ANIM_STAND, defender->rotation + 1);
                 animationRegisterSetFrmId(defender, frmId, -1);
             } else {
                 if (knockbackDistance != 0) {
@@ -460,7 +460,7 @@ void showDamageToObject(Object* defender, int damage, int flags, Object* weapon,
                         animationRegisterAnimate(defender, ANIM_PRONE_TO_STANDING, -1);
                     }
                 } else {
-                    if (hitFromFront || !FrmId(defender, ANIM_HIT_FROM_BACK, weaponAnimationFromFid(defender->fid), defender->rotation + 1).exist()) {
+                    if (hitFromFront || !FrmId(defender, ANIM_HIT_FROM_BACK, defender->rotation + 1).exist()) {
                         anim = ANIM_HIT_FROM_FRONT;
                     } else {
                         anim = ANIM_HIT_FROM_BACK;
@@ -512,7 +512,7 @@ int _show_death(Object* obj, AnimationType anim)
 
     objectGetRect(obj, &dirtyRect);
     if (anim < ANIM_FALL_BACK_SF && anim > ANIM_FALL_FRONT_BLOOD_SF) {
-        const FrmId frmId = FrmId(obj, static_cast<AnimationType>(anim + 28), weaponAnimationFromFid(obj->fid), obj->rotation + 1);
+        const FrmId frmId = FrmId(obj, static_cast<AnimationType>(anim + 28), obj->rotation + 1);
         if (objectSetFrmId(obj, frmId, &tempRect) == 0) {
             rectUnion(&dirtyRect, &tempRect, &dirtyRect);
         }
@@ -646,7 +646,7 @@ int _action_melee(Attack* attack, AnimationType anim)
     reg_anim_begin(ANIMATION_REQUEST_RESERVED);
     _register_priority(1);
 
-    frmId = FrmId(attack->attacker, anim, weaponAnimationFromFid(attack->attacker->fid), attack->attacker->rotation + 1);
+    frmId = FrmId(attack->attacker, anim, attack->attacker->rotation + 1);
     art = artLock(frmId, &cache_entry);
     if (art != nullptr) {
         delay = artGetActionFrame(art);
@@ -686,7 +686,7 @@ int _action_melee(Attack* attack, AnimationType anim)
             animationRegisterPlaySoundEffect(attack->attacker, sfx_name_temp, -1);
             animationRegisterAnimate(attack->attacker, anim, 0);
         } else {
-            frmId = FrmId(attack->defender, ANIM_DODGE_ANIM, weaponAnimationFromFid(attack->defender->fid), attack->defender->rotation + 1);
+            frmId = FrmId(attack->defender, ANIM_DODGE_ANIM, attack->defender->rotation + 1);
             art = artLock(frmId, &cache_entry);
             if (art != nullptr) {
                 int dodgeDelay = artGetActionFrame(art);
@@ -746,7 +746,7 @@ int _action_ranged(Attack* attack, AnimationType anim)
     Object* weapon = attack->weapon;
     protoGetProto(weapon->pid, &weaponProto);
 
-    const FrmId frmId = FrmId(attack->attacker, anim, weaponAnimationFromFid(attack->attacker->fid), attack->attacker->rotation + 1);
+    const FrmId frmId = FrmId(attack->attacker, anim, attack->attacker->rotation + 1);
     CacheEntry* artHandle;
     Art* art = artLock(frmId, &artHandle);
     int delay = (art != nullptr) ? artGetActionFrame(art) : 0;
@@ -773,7 +773,7 @@ int _action_ranged(Attack* attack, AnimationType anim)
     _combatai_msg(attack->attacker, attack, AI_MESSAGE_TYPE_ATTACK, 0);
 
     const char* sfx;
-    if ((weaponAnimationFromFid(attack->attacker->fid)) != WEAPON_ANIMATION_NONE) {
+    if ((FrmId(attack->attacker->fid).weaponAnimation()) != WEAPON_ANIMATION_NONE) {
         sfx = sfxBuildWeaponName(WEAPON_SOUND_EFFECT_ATTACK, weapon, attack->hitMode, attack->defender);
     } else {
         sfx = sfxBuildCharName(attack->attacker, anim, CHARACTER_SOUND_EFFECT_UNUSED);
@@ -1085,7 +1085,7 @@ int _action_climb_ladder(Object* critter, Object* ladder)
     animationRegisterRotateToTile(critter, ladder->tile);
     animationRegisterCallbackForced(critter, ladder, (AnimationCallback*)checkSceneryUseActionPointCost, -1);
 
-    WeaponAnimation weaponAnimationCode = weaponAnimationFromFid(critter->fid);
+    WeaponAnimation weaponAnimationCode = FrmId(critter->fid).weaponAnimation();
     if (weaponAnimationCode != 0) {
         const char* puttingAwaySfx = sfxBuildCharName(critter, ANIM_PUT_AWAY, CHARACTER_SOUND_EFFECT_UNUSED);
         animationRegisterPlaySoundEffect(critter, puttingAwaySfx, -1);
@@ -1154,7 +1154,7 @@ int _action_use_an_item_on_object(Object* user, Object* targetObj, Object* item)
             animationRegisterCallback(user, targetObj, (AnimationCallback*)checkSceneryUseActionPointCost, -1);
         }
 
-        WeaponAnimation weaponAnimCode = weaponAnimationFromFid(user->fid);
+        WeaponAnimation weaponAnimCode = FrmId(user->fid).weaponAnimation();
         if (weaponAnimCode != WEAPON_ANIMATION_NONE) {
             const char* sfx = sfxBuildCharName(user, ANIM_PUT_AWAY, CHARACTER_SOUND_EFFECT_UNUSED);
             animationRegisterPlaySoundEffect(user, sfx, -1);
@@ -1233,7 +1233,7 @@ int actionPickUp(Object* critter, Object* item)
     if (itemProto->item.type != ITEM_TYPE_CONTAINER || _proto_action_can_pickup(item->pid)) {
         animationRegisterAnimate(critter, ANIM_MAGIC_HANDS_GROUND, 0);
 
-        const FrmId frmId = FrmId(critter, ANIM_MAGIC_HANDS_GROUND, weaponAnimationFromFid(critter->fid), critter->rotation + 1);
+        const FrmId frmId = FrmId(critter, ANIM_MAGIC_HANDS_GROUND, critter->rotation + 1);
 
         int actionFrame;
         CacheEntry* cacheEntry;
@@ -1252,8 +1252,8 @@ int actionPickUp(Object* critter, Object* item)
 
         animationRegisterCallback(critter, item, (AnimationCallback*)objectPickup, actionFrame);
     } else {
-        WeaponAnimation weaponAnimationCode = weaponAnimationFromFid(critter->fid);
-        if (weaponAnimationCode != 0) {
+        WeaponAnimation weaponAnimationCode = FrmId(critter->fid).weaponAnimation();
+        if (weaponAnimationCode != WEAPON_ANIMATION_NONE) {
             const char* sfx = sfxBuildCharName(critter, ANIM_PUT_AWAY, CHARACTER_SOUND_EFFECT_UNUSED);
             animationRegisterPlaySoundEffect(critter, sfx, -1);
             animationRegisterAnimate(critter, ANIM_PUT_AWAY, -1);
@@ -1611,7 +1611,7 @@ AnimationType pickFallAnim(Object* obj, AnimationType anim)
     }
 
     if (anim == ANIM_FALL_FRONT) {
-        frmId = FrmId(obj, ANIM_FALL_FRONT, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
+        frmId = FrmId(obj, ANIM_FALL_FRONT, obj->rotation + 1);
         if (!frmId.exist()) {
             anim = ANIM_FALL_BACK;
         }

--- a/src/actions.cc
+++ b/src/actions.cc
@@ -345,7 +345,7 @@ void showDamageToObject(Object* defender, int damage, int flags, Object* weapon,
         knockbackDistance = 0;
     }
 
-    AnimationType anim = animationTypeFromFid(defender->fid);
+    AnimationType anim = FrmId(defender->fid).animationType();
     if (!critterIsProne(defender)) {
         if ((flags & DAM_DEAD) != DAM_NONE) {
             anim = pickDeathAnim(attacker, defender, weapon, damage, attackerAnimation, hitFromFront);
@@ -1044,7 +1044,7 @@ int _is_next_to(Object* obj1, Object* obj2)
 int _action_climb_ladder(Object* critter, Object* ladder)
 {
     if (critter == gDude) {
-        AnimationType anim = animationTypeFromFid(gDude->fid);
+        AnimationType anim = FrmId(gDude->fid).animationType();
         if (anim == ANIM_WALK || anim == ANIM_RUNNING) {
             reg_anim_clear(gDude);
         }
@@ -1120,7 +1120,7 @@ int _action_use_an_item_on_object(Object* user, Object* targetObj, Object* item)
 
     if (sceneryType != SCENERY_TYPE_LADDER_UP || item != nullptr) {
         if (user == gDude) {
-            AnimationType anim = animationTypeFromFid(gDude->fid);
+            AnimationType anim = FrmId(gDude->fid).animationType();
             if (anim == ANIM_WALK || anim == ANIM_RUNNING) {
                 reg_anim_clear(gDude);
             }
@@ -1206,7 +1206,7 @@ int actionPickUp(Object* critter, Object* item)
     }
 
     if (critter == gDude) {
-        AnimationType animationCode = animationTypeFromFid(gDude->fid);
+        AnimationType animationCode = FrmId(gDude->fid).animationType();
         if (animationCode == ANIM_WALK || animationCode == ANIM_RUNNING) {
             reg_anim_clear(gDude);
         }
@@ -1309,7 +1309,7 @@ int actionLootCritter(Object* critter, Object* target)
     }
 
     if (critter == gDude) {
-        AnimationType anim = animationTypeFromFid(gDude->fid);
+        AnimationType anim = FrmId(gDude->fid).animationType();
         if (anim == ANIM_WALK || anim == ANIM_RUNNING) {
             reg_anim_clear(gDude);
         }
@@ -1486,7 +1486,7 @@ int actionUseSkill(Object* user, Object* target, Skill skill)
 
         if (partyMember != nullptr) {
             performer = partyMember;
-            AnimationType anim = animationTypeFromFid(partyMember->fid);
+            AnimationType anim = FrmId(partyMember->fid).animationType();
             if (anim != ANIM_WALK && anim != ANIM_RUNNING) {
                 if (anim != ANIM_STAND) {
                     performer = gDude;
@@ -1517,7 +1517,7 @@ int actionUseSkill(Object* user, Object* target, Skill skill)
         }
 
         if (partyMember == nullptr) {
-            AnimationType anim = animationTypeFromFid(performer->fid);
+            AnimationType anim = FrmId(performer->fid).animationType();
             if (anim == ANIM_WALK || anim == ANIM_RUNNING) {
                 reg_anim_clear(performer);
             }
@@ -1886,7 +1886,7 @@ int actionTalk(Object* obj, Object* critter)
         return -1;
     }
 
-    AnimationType anim = animationTypeFromFid(gDude->fid);
+    AnimationType anim = FrmId(gDude->fid).animationType();
     if (anim == ANIM_WALK || anim == ANIM_RUNNING) {
         reg_anim_clear(gDude);
     }

--- a/src/animation.cc
+++ b/src/animation.cc
@@ -692,7 +692,7 @@ int animationRegisterMoveToObject(Object* owner, Object* destination, int action
     animationDescription->actionPoints = actionPoints;
     animationDescription->delay = delay;
 
-    const FrmId frmId = FrmId(owner, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
+    const FrmId frmId = FrmId(owner, animationDescription->anim, owner->rotation + 1);
 
     // NOTE: Uninline.
     if (_anim_preload(owner, frmId, &(animationDescription->artCacheKey)) == -1) {
@@ -741,7 +741,7 @@ int animationRegisterRunToObject(Object* owner, Object* destination, int actionP
     animationDescription->actionPoints = actionPoints;
     animationDescription->delay = delay;
 
-    const FrmId frmId = FrmId(owner, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
+    const FrmId frmId = FrmId(owner, animationDescription->anim, owner->rotation + 1);
 
     // NOTE: Uninline.
     if (_anim_preload(owner, frmId, &(animationDescription->artCacheKey)) == -1) {
@@ -774,7 +774,7 @@ int animationRegisterMoveToTile(Object* owner, int tile, int elevation, int acti
     animationDescription->actionPoints = actionPoints;
     animationDescription->delay = delay;
 
-    const FrmId frmId = FrmId(owner, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
+    const FrmId frmId = FrmId(owner, animationDescription->anim, owner->rotation + 1);
 
     // NOTE: Uninline.
     if (_anim_preload(owner, frmId, &(animationDescription->artCacheKey)) == -1) {
@@ -824,7 +824,7 @@ int animationRegisterRunToTile(Object* owner, int tile, int elevation, int actio
     animationDescription->actionPoints = actionPoints;
     animationDescription->delay = delay;
 
-    const FrmId frmId = FrmId(owner, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
+    const FrmId frmId = FrmId(owner, animationDescription->anim, owner->rotation + 1);
 
     // NOTE: Uninline.
     if (_anim_preload(owner, frmId, &(animationDescription->artCacheKey)) == -1) {
@@ -859,7 +859,7 @@ int animationRegisterMoveToTileStraight(Object* object, int tile, int elevation,
     animationDescription->anim = anim;
     animationDescription->delay = delay;
 
-    const FrmId frmId = FrmId(object, animationDescription->anim, weaponAnimationFromFid(object->fid), object->rotation + 1);
+    const FrmId frmId = FrmId(object, animationDescription->anim, object->rotation + 1);
 
     // NOTE: Uninline.
     if (_anim_preload(object, frmId, &(animationDescription->artCacheKey)) == -1) {
@@ -893,7 +893,7 @@ int animationRegisterMoveToTileStraightAndWaitForComplete(Object* owner, int til
     animationDescription->anim = anim;
     animationDescription->delay = delay;
 
-    const FrmId frmId = FrmId(owner, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
+    const FrmId frmId = FrmId(owner, animationDescription->anim, owner->rotation + 1);
 
     // NOTE: Uninline.
     if (_anim_preload(owner, frmId, &(animationDescription->artCacheKey)) == -1) {
@@ -921,7 +921,7 @@ int animationRegisterAnimate(Object* owner, AnimationType anim, int delay)
     animationDescription->anim = anim;
     animationDescription->delay = delay;
 
-    const FrmId frmId = FrmId(owner, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
+    const FrmId frmId = FrmId(owner, animationDescription->anim, owner->rotation + 1);
 
     // NOTE: Uninline.
     if (_anim_preload(owner, frmId, &(animationDescription->artCacheKey)) == -1) {
@@ -950,7 +950,7 @@ int animationRegisterAnimateReversed(Object* owner, AnimationType anim, int dela
     animationDescription->delay = delay;
     animationDescription->artCacheKey = nullptr;
 
-    const FrmId frmId = FrmId(owner, animationDescription->anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
+    const FrmId frmId = FrmId(owner, animationDescription->anim, owner->rotation + 1);
 
     // NOTE: Uninline.
     if (_anim_preload(owner, frmId, &(animationDescription->artCacheKey)) == -1) {
@@ -979,7 +979,7 @@ int animationRegisterAnimateAndHide(Object* owner, AnimationType anim, int delay
     animationDescription->delay = delay;
     animationDescription->artCacheKey = nullptr;
 
-    const FrmId frmId = FrmId(owner, anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
+    const FrmId frmId = FrmId(owner, anim, owner->rotation + 1);
 
     // NOTE: Uninline.
     if (_anim_preload(owner, frmId, &(animationDescription->artCacheKey)) == -1) {
@@ -1371,7 +1371,7 @@ int animationRegisterAnimateForever(Object* owner, AnimationType anim, int delay
     animationDescription->anim = anim;
     animationDescription->delay = delay;
 
-    const FrmId frmId = FrmId(owner, anim, weaponAnimationFromFid(owner->fid), owner->rotation + 1);
+    const FrmId frmId = FrmId(owner, anim, owner->rotation + 1);
 
     // NOTE: Uninline.
     if (_anim_preload(owner, frmId, &(animationDescription->artCacheKey)) == -1) {
@@ -2501,7 +2501,7 @@ static int _anim_move(Object* obj, int tile, int elev, int a3, AnimationType ani
     }
 
     sad->step = SAD_INIT;
-    sad->fid = FrmId(obj, anim, weaponAnimationFromFid(obj->fid), obj->rotation + 1).fid();
+    sad->fid = FrmId(obj, anim, obj->rotation + 1).fid();
     sad->animationTimestamp = 0;
     sad->ticksPerFrame = animationComputeTicksPerFrame(obj, FrmId(sad->fid));
     sad->targetTile = tile;
@@ -2537,7 +2537,7 @@ static int animateMoveObjectToTileStraight(Object* obj, int tile, int elevation,
         sad->fid = obj->fid;
         sad->flags |= ANIM_SAD_NO_ANIM;
     } else {
-        sad->fid = FrmId(obj, anim, weaponAnimationFromFid(obj->fid), obj->rotation + 1).fid();
+        sad->fid = FrmId(obj, anim, obj->rotation + 1).fid();
     }
     sad->step = SAD_INIT;
     sad->animationTimestamp = 0;
@@ -2579,7 +2579,7 @@ static int _anim_move_on_stairs(Object* obj, int tile, int elevation, AnimationT
         sad->fid = obj->fid;
         sad->flags |= ANIM_SAD_NO_ANIM;
     } else {
-        sad->fid = FrmId(obj, anim, weaponAnimationFromFid(obj->fid), obj->rotation + 1).fid();
+        sad->fid = FrmId(obj, anim, obj->rotation + 1).fid();
     }
     sad->step = SAD_INIT;
     sad->animationTimestamp = 0;
@@ -2614,7 +2614,7 @@ static int _check_for_falling(Object* obj, AnimationType anim, int a3)
         sad->fid = obj->fid;
         sad->flags |= ANIM_SAD_NO_ANIM;
     } else {
-        sad->fid = FrmId(obj, anim, weaponAnimationFromFid(obj->fid), obj->rotation + 1).fid();
+        sad->fid = FrmId(obj, anim, obj->rotation + 1).fid();
     }
     sad->step = SAD_INIT;
     sad->animationTimestamp = 0;
@@ -2649,7 +2649,7 @@ static void _object_move(int index)
         objectSetRotation(object, static_cast<Rotation>(sad->rotations[0]), &tempRect);
         rectUnion(&dirtyRect, &tempRect, &dirtyRect);
 
-        const FrmId fid = FrmId(object, sad->anim, weaponAnimationFromFid(object->fid), object->rotation + 1);
+        const FrmId fid = FrmId(object, sad->anim, object->rotation + 1);
         objectSetFrmId(object, fid, &tempRect);
         rectUnion(&dirtyRect, &tempRect, &dirtyRect);
 
@@ -2827,7 +2827,7 @@ static int _anim_animate(Object* obj, AnimationType anim, int animationSequenceI
         frmId = FrmId(obj, ANIM_TAKE_OUT, static_cast<WeaponAnimation>(flags), obj->rotation + 1);
     } else {
         sad->flags = flags;
-        frmId = FrmId(obj, anim, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
+        frmId = FrmId(obj, anim, obj->rotation + 1);
     }
 
     if (!frmId.exist()) {
@@ -3234,7 +3234,7 @@ void _dude_stand(Object* obj, Rotation rotation, const FrmId& frmId)
     int x = 0;
     int y = 0;
 
-    WeaponAnimation weaponAnimationCode = weaponAnimationFromFid(obj->fid);
+    WeaponAnimation weaponAnimationCode = FrmId(obj->fid).weaponAnimation();
     if (weaponAnimationCode != WEAPON_ANIMATION_NONE) {
         if (!frmId.valid()) {
             FrmId takeOutFrmId = FrmId(obj, ANIM_TAKE_OUT, weaponAnimationCode, obj->rotation + 1);
@@ -3275,7 +3275,7 @@ void _dude_stand(Object* obj, Rotation rotation, const FrmId& frmId)
         } else {
             anim = ANIM_STAND;
         }
-        finalFrmId = FrmId(obj, anim, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
+        finalFrmId = FrmId(obj, anim, obj->rotation + 1);
     }
 
     Rect temp;

--- a/src/animation.cc
+++ b/src/animation.cc
@@ -2545,8 +2545,9 @@ static int animateMoveObjectToTileStraight(Object* obj, int tile, int elevation,
     sad->animationSequenceIndex = animationSequenceIndex;
 
     int v15;
-    if (objectTypeFromFid(obj->fid) == OBJ_TYPE_CRITTER) {
-        if (animationTypeFromFid(obj->fid) == ANIM_JUMP_BEGIN)
+    const FrmId frmId = FrmId(obj->fid);
+    if (frmId.objectType() == OBJ_TYPE_CRITTER) {
+        if (frmId.animationType() == ANIM_JUMP_BEGIN)
             v15 = 16;
         else
             v15 = 4;
@@ -3168,7 +3169,8 @@ void _dude_fidget()
             break;
         }
 
-        if ((object->flags & OBJECT_HIDDEN) == OBJECT_NONE && objectTypeFromFid(object->fid) == OBJ_TYPE_CRITTER && animationTypeFromFid(object->fid) == ANIM_STAND && !critterIsDead(object)) {
+        const FrmId frmId = FrmId(object->fid);
+        if ((object->flags & OBJECT_HIDDEN) == OBJECT_NONE && frmId.objectType() == OBJ_TYPE_CRITTER && frmId.animationType() == ANIM_STAND && !critterIsDead(object)) {
             Rect rect;
             objectGetRect(object, &rect);
 
@@ -3270,7 +3272,7 @@ void _dude_stand(Object* obj, Rotation rotation, const FrmId& frmId)
     FrmId finalFrmId = frmId;
     if (!finalFrmId.valid()) {
         AnimationType anim;
-        if (animationTypeFromFid(obj->fid) == ANIM_FIRE_DANCE) {
+        if (FrmId(obj->fid).animationType() == ANIM_FIRE_DANCE) {
             anim = ANIM_FIRE_DANCE;
         } else {
             anim = ANIM_STAND;
@@ -3300,7 +3302,7 @@ void _dude_standup(Object* a1)
     reg_anim_begin(ANIMATION_REQUEST_RESERVED);
 
     AnimationType anim;
-    if (animationTypeFromFid(a1->fid) == ANIM_FALL_BACK) {
+    if (FrmId(a1->fid).animationType() == ANIM_FALL_BACK) {
         anim = ANIM_BACK_TO_STANDING;
     } else {
         anim = ANIM_PRONE_TO_STANDING;
@@ -3351,7 +3353,7 @@ static int _anim_hide(Object* object, int animationSequenceIndex)
 // 0x418660
 static int animationChangeFrmId(Object* obj, int animationSequenceIndex, const FrmId& frmId)
 {
-    if (animationTypeFromFid(frmId.fid())) {
+    if (frmId.animationType()) {
         Rect dirtyRect;
         Rect tempRect;
 
@@ -3414,7 +3416,7 @@ static unsigned int animationComputeTicksPerFrame(Object* object, const FrmId& f
     }
 
     if (isInCombat()) {
-        if (animationTypeFromFid(frmId.fid()) == ANIM_WALK) {
+        if (frmId.animationType() == ANIM_WALK) {
             if (object != gDude || settings.preferences.player_speedup) {
                 fps += settings.preferences.combat_speed;
             }

--- a/src/animation_defs.h
+++ b/src/animation_defs.h
@@ -107,12 +107,6 @@ inline bool animationTypeIsValid(int anim)
     return anim >= ANIM_FIRST && anim < ANIM_COUNT;
 }
 
-inline AnimationType animationTypeFromFid(int fid)
-{
-    int anim = (fid & 0xFF0000) >> 16;
-    return static_cast<AnimationType>(anim);
-}
-
 } // namespace fallout
 
 #endif /* ANIMATION_DEFS_H */

--- a/src/art.cc
+++ b/src/art.cc
@@ -1593,6 +1593,14 @@ FrmId::FrmId(Object* object, AnimationType animType, WeaponAnimation weaponAnima
 {
 }
 
+FrmId::FrmId(Object* object, AnimationType animType, Rotation rotation)
+    : _objectType(object == nullptr ? OBJ_TYPE_INVALID : objectTypeFromFid(object->fid))
+    , _fid(object == nullptr ? kEmptyFid : buildObjectFid(objectTypeFromFid(object->fid), frameIdFromFid(object->fid), animType, weaponAnimationFromFid(object->fid), rotation))
+    , _frameId { object == nullptr ? kInvalidFrameId : buildFrameId(object->fid) }
+    , _path(nullptr)
+{
+}
+
 // 0x419C88
 // animType doesn't have to be of AnimationType enum only but also HeadAnimation
 // weaponCode doesn't have to be WeaponAnimation enum only but also Fidget or flags

--- a/src/art.cc
+++ b/src/art.cc
@@ -1593,9 +1593,25 @@ FrmId::FrmId(Object* object, AnimationType animType, WeaponAnimation weaponAnima
 {
 }
 
+FrmId::FrmId(Object* object, AnimationType animType, WeaponAnimation weaponAnimation)
+    : _objectType(object == nullptr ? OBJ_TYPE_INVALID : objectTypeFromFid(object->fid))
+    , _fid(object == nullptr ? kEmptyFid : buildObjectFid(objectTypeFromFid(object->fid), frameIdFromFid(object->fid), animType, weaponAnimation, rotationFromFid(object->fid)))
+    , _frameId { object == nullptr ? kInvalidFrameId : buildFrameId(object->fid) }
+    , _path(nullptr)
+{
+}
+
 FrmId::FrmId(Object* object, AnimationType animType, Rotation rotation)
     : _objectType(object == nullptr ? OBJ_TYPE_INVALID : objectTypeFromFid(object->fid))
     , _fid(object == nullptr ? kEmptyFid : buildObjectFid(objectTypeFromFid(object->fid), frameIdFromFid(object->fid), animType, weaponAnimationFromFid(object->fid), rotation))
+    , _frameId { object == nullptr ? kInvalidFrameId : buildFrameId(object->fid) }
+    , _path(nullptr)
+{
+}
+
+FrmId::FrmId(Object* object, AnimationType animType)
+    : _objectType(object == nullptr ? OBJ_TYPE_INVALID : objectTypeFromFid(object->fid))
+    , _fid(object == nullptr ? kEmptyFid : buildObjectFid(objectTypeFromFid(object->fid), frameIdFromFid(object->fid), animType, weaponAnimationFromFid(object->fid), rotationFromFid(object->fid)))
     , _frameId { object == nullptr ? kInvalidFrameId : buildFrameId(object->fid) }
     , _path(nullptr)
 {

--- a/src/art.cc
+++ b/src/art.cc
@@ -1593,6 +1593,14 @@ FrmId::FrmId(Object* object, AnimationType animType, WeaponAnimation weaponAnima
 {
 }
 
+FrmId::FrmId(Object* object, WeaponAnimation weaponAnimation, Rotation rotation)
+    : _objectType(object == nullptr ? OBJ_TYPE_INVALID : objectTypeFromFid(object->fid))
+    , _fid(object == nullptr ? kEmptyFid : buildObjectFid(objectTypeFromFid(object->fid), frameIdFromFid(object->fid), animationTypeFromFid(object->fid), weaponAnimation, rotation))
+    , _frameId { object == nullptr ? kInvalidFrameId : buildFrameId(object->fid) }
+    , _path(nullptr)
+{
+}
+
 FrmId::FrmId(Object* object, AnimationType animType, WeaponAnimation weaponAnimation)
     : _objectType(object == nullptr ? OBJ_TYPE_INVALID : objectTypeFromFid(object->fid))
     , _fid(object == nullptr ? kEmptyFid : buildObjectFid(objectTypeFromFid(object->fid), frameIdFromFid(object->fid), animType, weaponAnimation, rotationFromFid(object->fid)))

--- a/src/art.h
+++ b/src/art.h
@@ -187,8 +187,10 @@ public:
 
     // cannot be made constexpr as internally calls FrmId::exist and that checks file system
     FrmId(CritterFrameId critter, AnimationType animType = ANIM_STAND, WeaponAnimation weaponAnimation = WEAPON_ANIMATION_NONE, Rotation rotation = ROTATION_NE);
-    explicit FrmId(Object* object, AnimationType animType, WeaponAnimation weaponAnimation, Rotation rotation);
     explicit FrmId(ObjectType objectType, int frmId, AnimationType animType = ANIM_STAND, WeaponAnimation weaponAnimation = WEAPON_ANIMATION_NONE, Rotation rotation = ROTATION_NE);
+
+    explicit FrmId(Object* object, AnimationType animType, WeaponAnimation weaponAnimation, Rotation rotation);
+    explicit FrmId(Object* object, AnimationType animType, Rotation rotation);
 
     constexpr FrmId(HeadFrameId head, HeadAnimation headAnimation = HEAD_ANIMATION_VERY_GOOD_REACTION, int fidget = 0)
         : _objectType(OBJ_TYPE_HEAD)
@@ -229,6 +231,15 @@ public:
     bool exist() const { return hasFid() && valid() && exist(_fid, _builtPath); }
 
     constexpr const FrameId& frameId() const { return _frameId; }
+
+    constexpr WeaponAnimation weaponAnimation() const
+    {
+        if (!hasFid()) {
+            return WEAPON_ANIMATION_INVALID;
+        }
+        
+        return weaponAnimationFromFid(_fid);
+    }
 
     bool operator==(const FrmId& other) const
     {
@@ -272,6 +283,12 @@ private:
     mutable char _builtPath[COMPAT_MAX_PATH] {};
 
     bool empty() const { return (*this) == Empty(); }
+
+    static constexpr WeaponAnimation weaponAnimationFromFid(int fid)
+    {
+        int anim = (fid & 0xF000) >> 12;
+        return static_cast<WeaponAnimation>(anim);
+    }
 
     static constexpr int buildFrameId(int id) { return id < kMinFrameId ? kInvalidFrameId : (id & kMaxFrameId); }
 

--- a/src/art.h
+++ b/src/art.h
@@ -224,6 +224,9 @@ public:
     constexpr int fid() const { return _fid; }
     constexpr bool hasFid() const { return _fid > kEmptyFid; }
     constexpr bool hasObjectType() const { return objectTypeIsValid(_objectType); }
+    constexpr bool hasWeaponAnimation() const { return hasFid() && weaponAnimationIsValid(weaponAnimationFromFid(_fid)); }
+    constexpr bool hasRotation() const { return hasFid() && rotationIsValid(rotationFromFid(_fid)); }
+    constexpr bool hasAnimationType() const { return hasFid() && animationTypeIsValid(animationTypeFromFid(_fid)); }
 
     constexpr ObjectType objectType() const { return hasObjectType() ? _objectType : OBJ_TYPE_INVALID; }
 
@@ -234,33 +237,9 @@ public:
     bool exist() const { return hasFid() && valid() && exist(_fid, _builtPath); }
 
     constexpr const FrameId& frameId() const { return _frameId; }
-
-    constexpr WeaponAnimation weaponAnimation() const
-    {
-        if (!hasFid()) {
-            return WEAPON_ANIMATION_INVALID;
-        }
-        
-        return weaponAnimationFromFid(_fid);
-    }
-
-    constexpr Rotation rotation() const
-    {
-        if (!hasFid()) {
-            return ROTATION_INVALID;
-        }
-        
-        return rotationFromFid(_fid);
-    }
-
-    constexpr AnimationType animationType() const
-    {
-        if (!hasFid()) {
-            return ANIM_INVALID;
-        }
-        
-        return animationTypeFromFid(_fid);
-    }
+    constexpr WeaponAnimation weaponAnimation() const { return hasWeaponAnimation() ? weaponAnimationFromFid(_fid) : WEAPON_ANIMATION_INVALID; }
+    constexpr Rotation rotation() const { return hasRotation() ? rotationFromFid(_fid) : ROTATION_INVALID; }
+    constexpr AnimationType animationType() const { return hasAnimationType() ? animationTypeFromFid(_fid) : ANIM_INVALID; }
 
     bool operator==(const FrmId& other) const
     {

--- a/src/art.h
+++ b/src/art.h
@@ -190,7 +190,9 @@ public:
     explicit FrmId(ObjectType objectType, int frmId, AnimationType animType = ANIM_STAND, WeaponAnimation weaponAnimation = WEAPON_ANIMATION_NONE, Rotation rotation = ROTATION_NE);
 
     explicit FrmId(Object* object, AnimationType animType, WeaponAnimation weaponAnimation, Rotation rotation);
+    explicit FrmId(Object* object, AnimationType animType, WeaponAnimation weaponAnimation);
     explicit FrmId(Object* object, AnimationType animType, Rotation rotation);
+    explicit FrmId(Object* object, AnimationType animType);
 
     constexpr FrmId(HeadFrameId head, HeadAnimation headAnimation = HEAD_ANIMATION_VERY_GOOD_REACTION, int fidget = 0)
         : _objectType(OBJ_TYPE_HEAD)
@@ -241,6 +243,15 @@ public:
         return weaponAnimationFromFid(_fid);
     }
 
+    constexpr Rotation rotation() const
+    {
+        if (!hasFid()) {
+            return ROTATION_INVALID;
+        }
+        
+        return rotationFromFid(_fid);
+    }
+
     bool operator==(const FrmId& other) const
     {
         if (_fid != other._fid) return false;
@@ -288,6 +299,12 @@ private:
     {
         int anim = (fid & 0xF000) >> 12;
         return static_cast<WeaponAnimation>(anim);
+    }
+
+    static constexpr Rotation rotationFromFid(int fid)
+    {
+        int rotation = (fid & 0x70000000) >> 28;
+        return static_cast<Rotation>(rotation);
     }
 
     static constexpr int buildFrameId(int id) { return id < kMinFrameId ? kInvalidFrameId : (id & kMaxFrameId); }

--- a/src/art.h
+++ b/src/art.h
@@ -189,6 +189,7 @@ public:
     FrmId(CritterFrameId critter, AnimationType animType = ANIM_STAND, WeaponAnimation weaponAnimation = WEAPON_ANIMATION_NONE, Rotation rotation = ROTATION_NE);
     explicit FrmId(ObjectType objectType, int frmId, AnimationType animType = ANIM_STAND, WeaponAnimation weaponAnimation = WEAPON_ANIMATION_NONE, Rotation rotation = ROTATION_NE);
 
+    explicit FrmId(Object* object, WeaponAnimation weaponAnimation, Rotation rotation);
     explicit FrmId(Object* object, AnimationType animType, WeaponAnimation weaponAnimation, Rotation rotation);
     explicit FrmId(Object* object, AnimationType animType, WeaponAnimation weaponAnimation);
     explicit FrmId(Object* object, AnimationType animType, Rotation rotation);
@@ -252,6 +253,15 @@ public:
         return rotationFromFid(_fid);
     }
 
+    constexpr AnimationType animationType() const
+    {
+        if (!hasFid()) {
+            return ANIM_INVALID;
+        }
+        
+        return animationTypeFromFid(_fid);
+    }
+
     bool operator==(const FrmId& other) const
     {
         if (_fid != other._fid) return false;
@@ -305,6 +315,12 @@ private:
     {
         int rotation = (fid & 0x70000000) >> 28;
         return static_cast<Rotation>(rotation);
+    }
+
+    static constexpr AnimationType animationTypeFromFid(int fid)
+    {
+        int anim = (fid & 0xFF0000) >> 16;
+        return static_cast<AnimationType>(anim);
     }
 
     static constexpr int buildFrameId(int id) { return id < kMinFrameId ? kInvalidFrameId : (id & kMaxFrameId); }

--- a/src/art.h
+++ b/src/art.h
@@ -221,21 +221,19 @@ public:
         assert(objectTypeIsValid(objType));
     }
 
-    constexpr int fid() const { return _fid; }
     constexpr bool hasFid() const { return _fid > kEmptyFid; }
     constexpr bool hasObjectType() const { return objectTypeIsValid(_objectType); }
     constexpr bool hasWeaponAnimation() const { return hasFid() && weaponAnimationIsValid(weaponAnimationFromFid(_fid)); }
     constexpr bool hasRotation() const { return hasFid() && rotationIsValid(rotationFromFid(_fid)); }
     constexpr bool hasAnimationType() const { return hasFid() && animationTypeIsValid(animationTypeFromFid(_fid)); }
 
-    constexpr ObjectType objectType() const { return hasObjectType() ? _objectType : OBJ_TYPE_INVALID; }
-
-    const char* filePath() const { return _path != nullptr ? _path : buildPath(_fid, _builtPath); }
-
     bool valid() const { return !empty() && hasObjectType() && ((_frameId.id >= kMinFrameId && _frameId.id <= kMaxFrameId) || _path != nullptr); }
 
     bool exist() const { return hasFid() && valid() && exist(_fid, _builtPath); }
 
+    constexpr int fid() const { return _fid; }
+    const char* filePath() const { return _path != nullptr ? _path : buildPath(_fid, _builtPath); }
+    constexpr ObjectType objectType() const { return hasObjectType() ? _objectType : OBJ_TYPE_INVALID; }
     constexpr const FrameId& frameId() const { return _frameId; }
     constexpr WeaponAnimation weaponAnimation() const { return hasWeaponAnimation() ? weaponAnimationFromFid(_fid) : WEAPON_ANIMATION_INVALID; }
     constexpr Rotation rotation() const { return hasRotation() ? rotationFromFid(_fid) : ROTATION_INVALID; }

--- a/src/art_defs.h
+++ b/src/art_defs.h
@@ -112,12 +112,6 @@ inline bool weaponAnimationIsValid(int weaponAnimation)
     return weaponAnimation >= WEAPON_ANIMATION_NONE && weaponAnimation < WEAPON_ANIMATION_COUNT;
 }
 
-inline WeaponAnimation weaponAnimationFromFid(int fid)
-{
-    int anim = (fid & 0xF000) >> 12;
-    return static_cast<WeaponAnimation>(anim);
-}
-
 enum class SkillDexFrameId : int {
     Invalid = -1, // invalid frame id
     Strength = 0, // strength.frm - strength (basic stat)

--- a/src/combat.cc
+++ b/src/combat.cc
@@ -3576,7 +3576,7 @@ void attackInit(Attack* attack, Object* attacker, Object* defender, HitMode hitM
 int _combat_attack(Object* attacker, Object* defender, HitMode hitMode, HitLocation hitLocation)
 {
     if (attacker != gDude && hitMode == HIT_MODE_PUNCH && randomBetween(1, 4) == 1) {
-        const FrmId frmId = FrmId(attacker, ANIM_KICK_LEG, rotationFromFid(attacker->fid));
+        const FrmId frmId = FrmId(attacker, ANIM_KICK_LEG);
         if (frmId.exist()) {
             hitMode = HIT_MODE_KICK;
         }

--- a/src/combat.cc
+++ b/src/combat.cc
@@ -3576,7 +3576,7 @@ void attackInit(Attack* attack, Object* attacker, Object* defender, HitMode hitM
 int _combat_attack(Object* attacker, Object* defender, HitMode hitMode, HitLocation hitLocation)
 {
     if (attacker != gDude && hitMode == HIT_MODE_PUNCH && randomBetween(1, 4) == 1) {
-        const FrmId frmId = FrmId(attacker, ANIM_KICK_LEG, weaponAnimationFromFid(attacker->fid), rotationFromFid(attacker->fid));
+        const FrmId frmId = FrmId(attacker, ANIM_KICK_LEG, rotationFromFid(attacker->fid));
         if (frmId.exist()) {
             hitMode = HIT_MODE_KICK;
         }

--- a/src/combat_ai.cc
+++ b/src/combat_ai.cc
@@ -2837,7 +2837,7 @@ static int _ai_try_attack(Object* attacker, Object* defender)
     int actionPointsToUse = 0;
     if (weapon != nullptr
         || (critterGetBodyType(defender) == BODY_TYPE_BIPED
-            && (weaponAnimationFromFid(defender->fid) == WEAPON_ANIMATION_NONE)
+            && (FrmId(defender->fid).weaponAnimation() == WEAPON_ANIMATION_NONE)
             && FrmId(attacker, ANIM_THROW_PUNCH, WEAPON_ANIMATION_NONE, attacker->rotation + 1).exist())) {
         // SFALL: Check the safety of weapons based on the selected attack mode
         // instead of always the primary weapon hit mode.

--- a/src/critter.cc
+++ b/src/critter.cc
@@ -845,14 +845,14 @@ void critterKill(Object* critter, AnimationType anim, bool refreshRect)
             if (current == ANIM_FALL_BACK) {
                 back = true;
             } else {
-                frmId = FrmId(critter, ANIM_FALL_FRONT_SF, weaponAnimationFromFid(critter->fid), critter->rotation + 1);
+                frmId = FrmId(critter, ANIM_FALL_FRONT_SF, critter->rotation + 1);
                 if (!frmId.exist()) {
                     back = true;
                 }
             }
 
             if (back) {
-                frmId = FrmId(critter, ANIM_FALL_BACK_SF, weaponAnimationFromFid(critter->fid), critter->rotation + 1);
+                frmId = FrmId(critter, ANIM_FALL_BACK_SF, critter->rotation + 1);
             }
 
             shouldChangeFid = true;
@@ -867,14 +867,14 @@ void critterKill(Object* critter, AnimationType anim, bool refreshRect)
             anim = LAST_SF_DEATH_ANIM;
         }
 
-        frmId = FrmId(critter, anim, weaponAnimationFromFid(critter->fid), critter->rotation + 1);
+        frmId = FrmId(critter, anim, critter->rotation + 1);
         int violenceFixedFid = frmId.fid();
         _obj_fix_violence_settings(&violenceFixedFid);
         frmId = FrmId(violenceFixedFid);
         if (!frmId.exist()) {
             debugPrint("\nError: Critter Kill: Can't match fid!");
 
-            frmId = FrmId(critter, ANIM_FALL_BACK_BLOOD_SF, weaponAnimationFromFid(critter->fid), critter->rotation + 1);
+            frmId = FrmId(critter, ANIM_FALL_BACK_BLOOD_SF, critter->rotation + 1);
             violenceFixedFid = frmId.fid();
             _obj_fix_violence_settings(&violenceFixedFid);
             frmId = FrmId(violenceFixedFid);
@@ -1065,7 +1065,7 @@ CritterFrmId critterBuildGorisFrmId(Object* critter, CritterFrameId frameId)
 
     // Goris needs the live critter FID preserved exactly as-is except for the
     // base FRM id swap between robe and claw body art.
-    return CritterFrmId(frameId, animationTypeFromFid(critter->fid), weaponAnimationFromFid(critter->fid), rotationFromFid(critter->fid));
+    return CritterFrmId(frameId, animationTypeFromFid(critter->fid), FrmId(critter->fid).weaponAnimation(), rotationFromFid(critter->fid));
 }
 
 // 0x42DE58 pc_load_data
@@ -1389,7 +1389,7 @@ int knockoutClear(Object* obj, void* data)
 
     obj->data.critter.combat.results &= ~(DAM_KNOCKED_OUT | DAM_KNOCKED_DOWN);
 
-    const FrmId frmId = FrmId(obj, ANIM_STAND, weaponAnimationFromFid(obj->fid), obj->rotation + 1);
+    const FrmId frmId = FrmId(obj, ANIM_STAND, obj->rotation + 1);
     objectSetFrmId(obj, frmId, nullptr);
 
     return 0;

--- a/src/critter.cc
+++ b/src/critter.cc
@@ -839,7 +839,7 @@ void critterKill(Object* critter, AnimationType anim, bool refreshRect)
     bool shouldChangeFid = false;
     FrmId frmId;
     if (critterIsProne(critter)) {
-        AnimationType current = animationTypeFromFid(critter->fid);
+        AnimationType current = FrmId(critter->fid).animationType();
         if (current == ANIM_FALL_BACK || current == ANIM_FALL_FRONT) {
             bool back = false;
             if (current == ANIM_FALL_BACK) {
@@ -1006,7 +1006,7 @@ bool critterIsProne(Object* critter)
         return false;
     }
 
-    AnimationType anim = animationTypeFromFid(critter->fid);
+    AnimationType anim = FrmId(critter->fid).animationType();
 
     return (critter->data.critter.combat.results & (DAM_KNOCKED_OUT | DAM_KNOCKED_DOWN)) != 0
         || (anim >= FIRST_KNOCKDOWN_AND_DEATH_ANIM && anim <= LAST_KNOCKDOWN_AND_DEATH_ANIM)
@@ -1067,7 +1067,7 @@ CritterFrmId critterBuildGorisFrmId(Object* critter, CritterFrameId frameId)
 
     // Goris needs the live critter FID preserved exactly as-is except for the
     // base FRM id swap between robe and claw body art.
-    return CritterFrmId(frameId, animationTypeFromFid(critter->fid), frmId.weaponAnimation(), frmId.rotation());
+    return CritterFrmId(frameId, frmId.animationType(), frmId.weaponAnimation(), frmId.rotation());
 }
 
 // 0x42DE58 pc_load_data

--- a/src/critter.cc
+++ b/src/critter.cc
@@ -1063,9 +1063,11 @@ CritterFrmId critterBuildGorisFrmId(Object* critter, CritterFrameId frameId)
 
     assert(critter->pid == PROTO_ID_GORIS);
 
+    const FrmId frmId = FrmId(critter->fid);
+
     // Goris needs the live critter FID preserved exactly as-is except for the
     // base FRM id swap between robe and claw body art.
-    return CritterFrmId(frameId, animationTypeFromFid(critter->fid), FrmId(critter->fid).weaponAnimation(), rotationFromFid(critter->fid));
+    return CritterFrmId(frameId, animationTypeFromFid(critter->fid), frmId.weaponAnimation(), frmId.rotation());
 }
 
 // 0x42DE58 pc_load_data

--- a/src/game_dialog.cc
+++ b/src/game_dialog.cc
@@ -3908,8 +3908,8 @@ void partyMemberControlWindowUpdate()
 
     // Render preview.
     CacheEntry* previewHandle;
-    FrmId previewFid = FrmId(gGameDialogSpeaker, ANIM_STAND, weaponAnimationFromFid(gGameDialogSpeaker->fid), ROTATION_SW);
-    Art* preview = artLock(previewFid, &previewHandle);
+    const FrmId previewFrmId = FrmId(gGameDialogSpeaker, ANIM_STAND, ROTATION_SW);
+    Art* preview = artLock(previewFrmId, &previewHandle);
     if (preview != nullptr) {
         int width = artGetWidth(preview, 0, ROTATION_SW);
         int height = artGetHeight(preview, 0, ROTATION_SW);

--- a/src/game_mouse.cc
+++ b/src/game_mouse.cc
@@ -1049,7 +1049,7 @@ void _gmouse_handle_event(int mouseX, int mouseY, int mouseState)
                     break;
                 case OBJ_TYPE_CRITTER:
                     if (targetObj == gDude) {
-                        if (animationTypeFromFid(gDude->fid) == ANIM_STAND) {
+                        if (FrmId(gDude->fid).animationType() == ANIM_STAND) {
                             Rect dudeRect;
                             if (objectRotateClockwise(targetObj, &dudeRect) == 0) {
                                 tileWindowRefreshRect(&dudeRect, targetObj->elevation);

--- a/src/game_sound.cc
+++ b/src/game_sound.cc
@@ -1338,7 +1338,8 @@ char* sfxBuildCharName(Object* a1, AnimationType anim, WeaponAnimation weaponTyp
     char weaponCode;
     char animationCode;
 
-    if (artCopyFileName(FrmId(a1->fid), artName) == -1) {
+    const FrmId frmId = FrmId(a1->fid);
+    if (artCopyFileName(frmId, artName) == -1) {
         return nullptr;
     }
 
@@ -1347,7 +1348,7 @@ char* sfxBuildCharName(Object* a1, AnimationType anim, WeaponAnimation weaponTyp
             return nullptr;
         }
     } else {
-        if (_art_get_code(anim, weaponAnimationFromFid(a1->fid), &weaponCode, &animationCode) == -1) {
+        if (_art_get_code(anim, frmId.weaponAnimation(), &weaponCode, &animationCode) == -1) {
             return nullptr;
         }
     }

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -1225,7 +1225,7 @@ int interfaceUpdateItems(bool animated, InterfaceItemAction leftItemAction, Inte
                 }
             }
 
-            interfaceBarSwapHandsAnimatePutAwayTakeOutSequence(weaponAnimationFromFid(gDude->fid), animationCode);
+            interfaceBarSwapHandsAnimatePutAwayTakeOutSequence(FrmId(gDude->fid).weaponAnimation(), animationCode);
 
             return 0;
         }
@@ -1254,7 +1254,7 @@ int interfaceBarSwapHands(bool animated)
             }
         }
 
-        interfaceBarSwapHandsAnimatePutAwayTakeOutSequence(weaponAnimationFromFid(gDude->fid), animationCode);
+        interfaceBarSwapHandsAnimatePutAwayTakeOutSequence(FrmId(gDude->fid).weaponAnimation(), animationCode);
     } else {
         interfaceBarRefreshMainAction();
     }

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -444,11 +444,11 @@ int correctFidForRemovedItem(Object* critter, Object* item, ObjectFlags flags)
         }
 
         if (weaponCode == WEAPON_ANIMATION_NONE) {
-            newFrmId = FrmId(critter, animationTypeFromFid(critter->fid), WEAPON_ANIMATION_NONE, frmId.rotation());
+            newFrmId = FrmId(critter, WEAPON_ANIMATION_NONE, frmId.rotation());
         }
     } else {
         if (critter == gDude) {
-            newFrmId = FrmId(_art_vault_guy_num, animationTypeFromFid(critter->fid), weaponCode, frmId.rotation());
+            newFrmId = FrmId(_art_vault_guy_num, frmId.animationType(), weaponCode, frmId.rotation());
         }
 
         adjustCritterStatsOnArmorChange(critter, item, nullptr);
@@ -2072,7 +2072,7 @@ static void opMetarule3(Program* program)
             const FrmId frmId = FrmId(obj->fid);
             const FrmId newFrmId = FrmId(frmId.objectType(),
                 frameId,
-                animationTypeFromFid(obj->fid),
+                frmId.animationType(),
                 frmId.weaponAnimation(),
                 frmId.rotation());
 
@@ -2434,7 +2434,7 @@ static void opKillCritterType(Program* program)
 
     Object* obj = objectFindFirst();
     while (obj != nullptr) {
-        if (animationTypeFromFid(obj->fid) < ANIM_FALL_BACK_SF) {
+        if (FrmId(obj->fid).animationType() < ANIM_FALL_BACK_SF) {
             if ((obj->flags & OBJECT_HIDDEN) == OBJECT_NONE && obj->pid == pid && !critterIsDead(obj)) {
                 if (obj == previousObj || count > 200) {
                     scriptPredefinedError(program, "kill_critter_type", SCRIPT_ERROR_FOLLOWS);
@@ -2780,7 +2780,7 @@ static void opGetCritterState(Program* program)
         if (critterIsActive(critter)) {
             state = CRITTER_STATE_NORMAL;
 
-            AnimationType anim = animationTypeFromFid(critter->fid);
+            AnimationType anim = FrmId(critter->fid).animationType();
             if (anim >= ANIM_FALL_BACK_SF && anim <= ANIM_FALL_FRONT_SF) {
                 state = CRITTER_STATE_PRONE;
             }

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -422,7 +422,8 @@ int correctFidForRemovedItem(Object* critter, Object* item, ObjectFlags flags)
         interfaceUpdateItems(animated, INTERFACE_ITEM_ACTION_DEFAULT, INTERFACE_ITEM_ACTION_DEFAULT);
     }
 
-    WeaponAnimation weaponCode = FrmId(critter->fid).weaponAnimation();
+    const FrmId frmId = FrmId(critter->fid);
+    WeaponAnimation weaponCode = frmId.weaponAnimation();
     FrmId newFrmId;
 
     if ((flags & OBJECT_IN_ANY_HAND) != OBJECT_NONE) {
@@ -443,11 +444,11 @@ int correctFidForRemovedItem(Object* critter, Object* item, ObjectFlags flags)
         }
 
         if (weaponCode == WEAPON_ANIMATION_NONE) {
-            newFrmId = FrmId(critter, animationTypeFromFid(critter->fid), WEAPON_ANIMATION_NONE, rotationFromFid(critter->fid));
+            newFrmId = FrmId(critter, animationTypeFromFid(critter->fid), WEAPON_ANIMATION_NONE, frmId.rotation());
         }
     } else {
         if (critter == gDude) {
-            newFrmId = FrmId(_art_vault_guy_num, animationTypeFromFid(critter->fid), weaponCode, rotationFromFid(critter->fid));
+            newFrmId = FrmId(_art_vault_guy_num, animationTypeFromFid(critter->fid), weaponCode, frmId.rotation());
         }
 
         adjustCritterStatsOnArmorChange(critter, item, nullptr);
@@ -2068,14 +2069,15 @@ static void opMetarule3(Program* program)
                 frameId = frameIdFromFid(frameId);
             }
 
-            const FrmId frmId = FrmId(objectTypeFromFid(obj->fid),
+            const FrmId frmId = FrmId(obj->fid);
+            const FrmId newFrmId = FrmId(frmId.objectType(),
                 frameId,
                 animationTypeFromFid(obj->fid),
-                FrmId(obj->fid).weaponAnimation(),
-                rotationFromFid(obj->fid));
+                frmId.weaponAnimation(),
+                frmId.rotation());
 
             Rect updatedRect;
-            objectSetFrmId(obj, frmId, &updatedRect);
+            objectSetFrmId(obj, newFrmId, &updatedRect);
             tileWindowRefreshRect(&updatedRect, gElevation);
         }
         break;
@@ -3450,7 +3452,7 @@ static void opAnim(Program* program)
         if (frame == 0) { // ANIMATE_FORWARD
             animationRegisterAnimate(obj, anim, 0);
             if (anim >= ANIM_FALL_BACK && anim <= ANIM_FALL_FRONT_BLOOD) {
-                const FrmId frmId = FrmId(obj, static_cast<AnimationType>(anim + 28), rotationFromFid(obj->fid));
+                const FrmId frmId = FrmId(obj, static_cast<AnimationType>(anim + 28));
                 animationRegisterSetFrmId(obj, frmId, -1);
             }
 
@@ -3458,13 +3460,13 @@ static void opAnim(Program* program)
                 combatData->results &= ~DAM_KNOCKED_DOWN;
             }
         } else { // ANIMATE_REVERSE == 1
-            FrmId frmId = FrmId(obj, anim, rotationFromFid(obj->fid));
+            FrmId frmId = FrmId(obj, anim);
             animationRegisterAnimateReversed(obj, anim, 0);
 
             if (anim == ANIM_PRONE_TO_STANDING) {
-                frmId = FrmId(obj, ANIM_FALL_FRONT_SF, rotationFromFid(obj->fid));
+                frmId = FrmId(obj, ANIM_FALL_FRONT_SF);
             } else if (anim == ANIM_BACK_TO_STANDING) {
-                frmId = FrmId(obj, ANIM_FALL_BACK_SF, rotationFromFid(obj->fid));
+                frmId = FrmId(obj, ANIM_FALL_BACK_SF);
             }
 
             if (combatData != nullptr) {

--- a/src/interpreter_extra.cc
+++ b/src/interpreter_extra.cc
@@ -422,7 +422,7 @@ int correctFidForRemovedItem(Object* critter, Object* item, ObjectFlags flags)
         interfaceUpdateItems(animated, INTERFACE_ITEM_ACTION_DEFAULT, INTERFACE_ITEM_ACTION_DEFAULT);
     }
 
-    WeaponAnimation weaponCode = weaponAnimationFromFid(critter->fid);
+    WeaponAnimation weaponCode = FrmId(critter->fid).weaponAnimation();
     FrmId newFrmId;
 
     if ((flags & OBJECT_IN_ANY_HAND) != OBJECT_NONE) {
@@ -2071,7 +2071,7 @@ static void opMetarule3(Program* program)
             const FrmId frmId = FrmId(objectTypeFromFid(obj->fid),
                 frameId,
                 animationTypeFromFid(obj->fid),
-                weaponAnimationFromFid(obj->fid),
+                FrmId(obj->fid).weaponAnimation(),
                 rotationFromFid(obj->fid));
 
             Rect updatedRect;
@@ -2374,7 +2374,7 @@ static AnimationType _correctDeath(Object* critter, AnimationType anim, bool for
         if (settings.preferences.violence_level < VIOLENCE_LEVEL_MAXIMUM_BLOOD) {
             useStandardDeath = true;
         } else {
-            const FrmId frmId = FrmId(critter, anim, weaponAnimationFromFid(critter->fid), critter->rotation + 1);
+            const FrmId frmId = FrmId(critter, anim, critter->rotation + 1);
             if (!frmId.exist()) {
                 useStandardDeath = true;
             }
@@ -2384,7 +2384,7 @@ static AnimationType _correctDeath(Object* critter, AnimationType anim, bool for
             if (forceBack) {
                 anim = ANIM_FALL_BACK;
             } else {
-                const FrmId frmId = FrmId(critter, ANIM_FALL_FRONT, weaponAnimationFromFid(critter->fid), critter->rotation + 1);
+                const FrmId frmId = FrmId(critter, ANIM_FALL_FRONT, critter->rotation + 1);
                 if (frmId.exist()) {
                     anim = ANIM_FALL_FRONT;
                 } else {
@@ -3450,7 +3450,7 @@ static void opAnim(Program* program)
         if (frame == 0) { // ANIMATE_FORWARD
             animationRegisterAnimate(obj, anim, 0);
             if (anim >= ANIM_FALL_BACK && anim <= ANIM_FALL_FRONT_BLOOD) {
-                const FrmId frmId = FrmId(obj, static_cast<AnimationType>(anim + 28), weaponAnimationFromFid(obj->fid), rotationFromFid(obj->fid));
+                const FrmId frmId = FrmId(obj, static_cast<AnimationType>(anim + 28), rotationFromFid(obj->fid));
                 animationRegisterSetFrmId(obj, frmId, -1);
             }
 
@@ -3458,13 +3458,13 @@ static void opAnim(Program* program)
                 combatData->results &= ~DAM_KNOCKED_DOWN;
             }
         } else { // ANIMATE_REVERSE == 1
-            FrmId frmId = FrmId(obj, anim, weaponAnimationFromFid(obj->fid), rotationFromFid(obj->fid));
+            FrmId frmId = FrmId(obj, anim, rotationFromFid(obj->fid));
             animationRegisterAnimateReversed(obj, anim, 0);
 
             if (anim == ANIM_PRONE_TO_STANDING) {
-                frmId = FrmId(obj, ANIM_FALL_FRONT_SF, weaponAnimationFromFid(obj->fid), rotationFromFid(obj->fid));
+                frmId = FrmId(obj, ANIM_FALL_FRONT_SF, rotationFromFid(obj->fid));
             } else if (anim == ANIM_BACK_TO_STANDING) {
-                frmId = FrmId(obj, ANIM_FALL_BACK_SF, weaponAnimationFromFid(obj->fid), rotationFromFid(obj->fid));
+                frmId = FrmId(obj, ANIM_FALL_BACK_SF, rotationFromFid(obj->fid));
             }
 
             if (combatData != nullptr) {

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -3891,7 +3891,7 @@ int inventoryEquipFunc(Object* critter, Object* item, Hand handIndex, bool anima
 
         if (critter == gDude) {
             if (!isoIsDisabled()) {
-                const CritterFrmId frmId = CritterFrmId(baseFrameId, ANIM_STAND, weaponAnimationFromFid(critter->fid), critter->rotation + 1);
+                const CritterFrmId frmId = CritterFrmId(baseFrameId, ANIM_STAND, FrmId(critter->fid).weaponAnimation(), critter->rotation + 1);
                 animationRegisterSetFrmId(critter, frmId, 0);
             }
         } else {
@@ -3968,7 +3968,7 @@ int inventoryEquipFunc(Object* critter, Object* item, Hand handIndex, bool anima
         }
 
         if (hand == handIndex) {
-            if (weaponAnimationFromFid(critter->fid) != WEAPON_ANIMATION_NONE) {
+            if (FrmId(critter->fid).weaponAnimation() != WEAPON_ANIMATION_NONE) {
                 if (animate) {
                     if (!isoIsDisabled()) {
                         const char* soundEffectName = sfxBuildCharName(critter, ANIM_PUT_AWAY, CHARACTER_SOUND_EFFECT_UNUSED);
@@ -4038,7 +4038,7 @@ int inventoryUnequipFunc(Object* critter, Hand hand, bool animate)
         item->flags &= ~OBJECT_IN_ANY_HAND;
     }
 
-    if (activeHand == hand && (weaponAnimationFromFid(critter->fid) != WEAPON_ANIMATION_NONE)) {
+    if (activeHand == hand && (FrmId(critter->fid).weaponAnimation() != WEAPON_ANIMATION_NONE)) {
         if (animate && !isoIsDisabled()) {
             reg_anim_begin(ANIMATION_REQUEST_RESERVED);
 

--- a/src/inventory.cc
+++ b/src/inventory.cc
@@ -5266,7 +5266,7 @@ static InventoryMoveResult _move_inventory(Object* item, int slotIndex, Object* 
                 if (!skipMove && result != INVENTORY_MOVE_RESULT_CAUGHT_STEALING) {
                     if (itemMove(targetObj, _inven_dude, item, quantityToMove) == 0) {
                         if ((item->flags & OBJECT_IN_RIGHT_HAND) != OBJECT_NONE) {
-                            targetObj->fid = FrmId(targetObj, animationTypeFromFid(targetObj->fid), WEAPON_ANIMATION_NONE, targetObj->rotation + 1).fid();
+                            targetObj->fid = FrmId(targetObj, WEAPON_ANIMATION_NONE, targetObj->rotation + 1).fid();
                         }
 
                         targetObj->flags &= ~OBJECT_EQUIPPED;

--- a/src/item.cc
+++ b/src/item.cc
@@ -675,8 +675,9 @@ int itemDropAll(Object* critter, int tile)
 
     if (hasEquippedItems) {
         Rect updatedRect;
-        const CritterFrmId frmId = CritterFrmId(frameId, animationTypeFromFid(critter->fid), WEAPON_ANIMATION_NONE, rotationFromFid(critter->fid));
-        objectSetFrmId(critter, frmId, &updatedRect);
+        const FrmId frmId = FrmId(critter->fid);
+        const CritterFrmId critterFrmId = CritterFrmId(frameId, animationTypeFromFid(critter->fid), WEAPON_ANIMATION_NONE, frmId.rotation());
+        objectSetFrmId(critter, critterFrmId, &updatedRect);
         if (animationTypeFromFid(critter->fid) == ANIM_STAND) {
             tileWindowRefreshRect(&updatedRect, gElevation);
         }

--- a/src/item.cc
+++ b/src/item.cc
@@ -676,9 +676,9 @@ int itemDropAll(Object* critter, int tile)
     if (hasEquippedItems) {
         Rect updatedRect;
         const FrmId frmId = FrmId(critter->fid);
-        const CritterFrmId critterFrmId = CritterFrmId(frameId, animationTypeFromFid(critter->fid), WEAPON_ANIMATION_NONE, frmId.rotation());
+        const CritterFrmId critterFrmId = CritterFrmId(frameId, frmId.animationType(), WEAPON_ANIMATION_NONE, frmId.rotation());
         objectSetFrmId(critter, critterFrmId, &updatedRect);
-        if (animationTypeFromFid(critter->fid) == ANIM_STAND) {
+        if (FrmId(critter->fid).animationType() == ANIM_STAND) {
             tileWindowRefreshRect(&updatedRect, gElevation);
         }
     }

--- a/src/map.cc
+++ b/src/map.cc
@@ -1795,7 +1795,7 @@ static void _map_place_dude_and_mouse()
     if (gDude != nullptr) {
         if (animationTypeFromFid(gDude->fid) != ANIM_STAND) {
             objectSetFrame(gDude, 0, nullptr);
-            gDude->fid = FrmId(gDude, ANIM_STAND, weaponAnimationFromFid(gDude->fid), gDude->rotation + 1).fid();
+            gDude->fid = FrmId(gDude, ANIM_STAND, gDude->rotation + 1).fid();
         }
 
         if (gDude->tile == -1) {

--- a/src/map.cc
+++ b/src/map.cc
@@ -1793,7 +1793,7 @@ static void _map_place_dude_and_mouse()
     _obj_clear_seen();
 
     if (gDude != nullptr) {
-        if (animationTypeFromFid(gDude->fid) != ANIM_STAND) {
+        if (FrmId(gDude->fid).animationType() != ANIM_STAND) {
             objectSetFrame(gDude, 0, nullptr);
             gDude->fid = FrmId(gDude, ANIM_STAND, gDude->rotation + 1).fid();
         }

--- a/src/mapper/mapper.cc
+++ b/src/mapper/mapper.cc
@@ -2673,7 +2673,7 @@ int mapper_inven_unwield(Object* obj, int right_hand)
 
     animationRegisterAnimate(obj, ANIM_PUT_AWAY, 0);
 
-    const FrmId frmId = FrmId(obj, ANIM_STAND, WEAPON_ANIMATION_NONE, rotationFromFid(obj->fid));
+    const FrmId frmId = FrmId(obj, ANIM_STAND, WEAPON_ANIMATION_NONE);
     animationRegisterSetFrmId(obj, frmId, 0);
 
     return reg_anim_end();

--- a/src/obj_types.h
+++ b/src/obj_types.h
@@ -52,12 +52,6 @@ constexpr inline bool rotationIsValid(int rotation)
     return rotation >= ROTATION_FIRST && rotation < ROTATION_COUNT;
 }
 
-inline Rotation rotationFromFid(int fid)
-{
-    int rotation = (fid & 0x70000000) >> 28;
-    return static_cast<Rotation>(rotation);
-}
-
 enum ObjectType : int {
     OBJ_TYPE_INVALID = -1,
     OBJ_TYPE_ITEM,

--- a/src/object.cc
+++ b/src/object.cc
@@ -5208,7 +5208,7 @@ void _obj_fix_violence_settings(int* fid)
             ? ANIM_FALL_BACK_SF
             : ANIM_FALL_FRONT_SF;
         const FrmId frmId = FrmId(*fid);
-        *fid = CritterFrmId(frmId.frameId().critter, anim, frmId.weaponAnimation(), rotationFromFid(*fid)).fid();
+        *fid = CritterFrmId(frmId.frameId().critter, anim, frmId.weaponAnimation(), frmId.rotation()).fid();
     }
 
     if (shouldResetViolenceLevel) {

--- a/src/object.cc
+++ b/src/object.cc
@@ -5207,7 +5207,8 @@ void _obj_fix_violence_settings(int* fid)
         anim = (anim == ANIM_FALL_BACK_BLOOD_SF)
             ? ANIM_FALL_BACK_SF
             : ANIM_FALL_FRONT_SF;
-        *fid = CritterFrmId(FrmId(*fid).frameId().critter, anim, weaponAnimationFromFid(*fid), rotationFromFid(*fid)).fid();
+        const FrmId frmId = FrmId(*fid);
+        *fid = CritterFrmId(frmId.frameId().critter, anim, frmId.weaponAnimation(), rotationFromFid(*fid)).fid();
     }
 
     if (shouldResetViolenceLevel) {

--- a/src/object.cc
+++ b/src/object.cc
@@ -462,7 +462,7 @@ int objectRead(Object* obj, File* stream)
             constexpr int kExitGridCount = kExit3Grid8FrameId - kExit2Grid1FrameId + 1;
             const FrmId frmId = FrmId(obj->fid);
             if (frmId.valid() && frmId.frameId().id < kExit2Grid1FrameId) {
-                obj->fid = MiscFrmId(static_cast<MiscFrameId>(frmId.frameId().id + kExitGridCount), animationTypeFromFid(obj->fid)).fid();
+                obj->fid = MiscFrmId(static_cast<MiscFrameId>(frmId.frameId().id + kExitGridCount), frmId.animationType()).fid();
             }
         }
     } else {
@@ -5202,12 +5202,12 @@ void _obj_fix_violence_settings(int* fid)
         break;
     }
 
-    AnimationType anim = animationTypeFromFid(*fid);
+    const FrmId frmId = FrmId(*fid);
+    AnimationType anim = frmId.animationType();
     if (anim >= start && anim <= end) {
         anim = (anim == ANIM_FALL_BACK_BLOOD_SF)
             ? ANIM_FALL_BACK_SF
             : ANIM_FALL_FRONT_SF;
-        const FrmId frmId = FrmId(*fid);
         *fid = CritterFrmId(frmId.frameId().critter, anim, frmId.weaponAnimation(), frmId.rotation()).fid();
     }
 

--- a/src/proto.cc
+++ b/src/proto.cc
@@ -879,7 +879,7 @@ int _proto_dude_update_gender()
     if (critterGetArmor(gDude) == nullptr) {
         WeaponAnimation weaponAnimationCode = WEAPON_ANIMATION_NONE;
         if (critterGetItem2(gDude) != nullptr || critterGetItem1(gDude) != nullptr) {
-            weaponAnimationCode = weaponAnimationFromFid(gDude->fid);
+            weaponAnimationCode = FrmId(gDude->fid).weaponAnimation();
         }
 
         const FrmId frmId = FrmId(_art_vault_guy_num, ANIM_STAND, weaponAnimationCode, ROTATION_NE);

--- a/src/proto_instance.cc
+++ b/src/proto_instance.cc
@@ -682,7 +682,7 @@ static int _obj_remove_from_inven(Object* critter, Object* item)
                     defaultFrameId = FrmId(proto->fid).frameId().critter;
                 }
 
-                frmId = FrmId(defaultFrameId, animationTypeFromFid(critter->fid), weaponAnimationFromFid(critter->fid), critter->rotation);
+                frmId = FrmId(defaultFrameId, animationTypeFromFid(critter->fid), FrmId(critter->fid).weaponAnimation(), critter->rotation);
                 objectSetFrmId(critter, frmId, &updatedRect);
                 appearanceUpdateType = 3;
             }

--- a/src/proto_instance.cc
+++ b/src/proto_instance.cc
@@ -659,7 +659,7 @@ static int _obj_remove_from_inven(Object* critter, Object* item)
         scriptHooks_InvenWield(critter, item, slot, 0, 1);
         if (slot == InvenSlot::RightHand) {
             if (critter != gDude || interfaceGetCurrentHand() == HAND_RIGHT) {
-                frmId = FrmId(critter, animationTypeFromFid(critter->fid), WEAPON_ANIMATION_NONE, critter->rotation);
+                frmId = FrmId(critter, WEAPON_ANIMATION_NONE, critter->rotation);
                 objectSetFrmId(critter, frmId, &updatedRect);
                 appearanceUpdateType = 2;
             } else {
@@ -667,7 +667,7 @@ static int _obj_remove_from_inven(Object* critter, Object* item)
             }
         } else if (slot == InvenSlot::LeftHand) {
             if (critter == gDude && interfaceGetCurrentHand() == HAND_LEFT) {
-                frmId = FrmId(critter, animationTypeFromFid(critter->fid), WEAPON_ANIMATION_NONE, critter->rotation);
+                frmId = FrmId(critter, WEAPON_ANIMATION_NONE, critter->rotation);
                 objectSetFrmId(critter, frmId, &updatedRect);
                 appearanceUpdateType = 2;
             } else {
@@ -682,7 +682,8 @@ static int _obj_remove_from_inven(Object* critter, Object* item)
                     defaultFrameId = FrmId(proto->fid).frameId().critter;
                 }
 
-                frmId = FrmId(defaultFrameId, animationTypeFromFid(critter->fid), FrmId(critter->fid).weaponAnimation(), critter->rotation);
+                const FrmId dudeFrmId = FrmId(critter->fid);
+                frmId = FrmId(defaultFrameId, dudeFrmId.animationType(), dudeFrmId.weaponAnimation(), critter->rotation);
                 objectSetFrmId(critter, frmId, &updatedRect);
                 appearanceUpdateType = 3;
             }

--- a/src/sfall_metarules.cc
+++ b/src/sfall_metarules.cc
@@ -1476,8 +1476,8 @@ static bool loadSfallArtImage(OpcodeContext& ctx, int artArg, int frame, Rotatio
         fid = ctx.arg(artArg).asInt();
         Rotation frameRotation = ROTATION_NE;
         FrmId lockFrmId = FrmId(fid);
-        if (objectTypeFromFid(fid) == OBJ_TYPE_CRITTER) {
-            frameRotation = rotationIsValid(rotation) ? rotation : rotationFromFid(fid);
+        if (lockFrmId.objectType() == OBJ_TYPE_CRITTER) {
+            frameRotation = rotationIsValid(rotation) ? rotation : lockFrmId.rotation();
             if (rotationIsValid(rotation)) {
                 lockFrmId = FrmId((rotation << 28) | (fid & 0x0FFFFFFF));
             }

--- a/src/sfall_opcodes.cc
+++ b/src/sfall_opcodes.cc
@@ -1230,8 +1230,9 @@ static void op_refresh_pc_art(Program* program)
     Rect rect;
     objectGetRect(gDude, &rect);
 
+    const FrmId dudeFrmId = FrmId(gDude->fid);
     AnimationType anim = animationTypeFromFid(gDude->fid);
-    Rotation rotation = rotationFromFid(gDude->fid);
+    Rotation rotation = dudeFrmId.rotation();
 
     _proto_dude_update_gender();
 

--- a/src/sfall_opcodes.cc
+++ b/src/sfall_opcodes.cc
@@ -1231,7 +1231,7 @@ static void op_refresh_pc_art(Program* program)
     objectGetRect(gDude, &rect);
 
     const FrmId dudeFrmId = FrmId(gDude->fid);
-    AnimationType anim = animationTypeFromFid(gDude->fid);
+    AnimationType anim = dudeFrmId.animationType();
     Rotation rotation = dudeFrmId.rotation();
 
     _proto_dude_update_gender();


### PR DESCRIPTION
### Description
Fourth batch of changes to get rid of `int fid` from module APIs and replaced by `FrmId` instead.

Mainly about moving `weaponAnimationFromFid`, `rotationFromFid` and `animationTypeFromFid` as private methods within `FrmId` class.

Added getter methods for `FrmId::weaponAniation`, `FrmId::rotation` and `FrmId::animationType` and used in instead of `xxxFromFid` functions.

Created few more object based `FrmId` ctors to make easier instantiations in different combinations.